### PR TITLE
fix(ci): incluye branch dev en triggers de ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problema

Los workflows en `.github/workflows/ci.yml` solo se disparaban en pull requests/push a `main`. La convencion del proyecto ([.claude/rules/git-workflow.md](.claude/rules/git-workflow.md)) usa `dev` como rama de integracion: las features van a `dev`, y solo despues `dev -> main`. Esto significaba que ningun PR a `dev` corria CI interno (solo el check externo de GitGuardian).

Se descubrio durante el merge de #2: el comando `gh run list --branch <feature-branch>` devolvio vacio porque el workflow no escuchaba sobre PRs a `dev`. Tuve que correr lint + typecheck + tests + build localmente como surrogate antes de mergear.

## Solucion

Agrego `dev` a ambos triggers en `ci.yml`:

```yaml
on:
  pull_request:
    branches: [main, dev]   # antes: [main]
  push:
    branches: [main, dev]   # antes: [main]
```

`deploy.yml` NO se modifica intencionalmente: production deploy a Cloudflare Pages debe seguir siendo solo desde `main`. Triggear desde `dev` desplegaria features a-medio-hacer a produccion.

## Como probar

Validacion automatica: el mismo workflow corre sobre este PR a `dev` y debe ejecutarse esta vez (a diferencia de #2). Verificar:

```bash
gh pr checks $(gh pr list --head fix/ci-includes-dev-branch --json number --jq ".[0].number")
```

Deberia listar los jobs de `CI` (Lint + Typecheck, Tests, Build) ademas del check externo de GitGuardian.

Validacion manual del cambio (sin esperar el run real):

```bash
grep -A2 "^on:" .github/workflows/ci.yml
# Esperado:
#   pull_request:
#     branches: [main, dev]
#   push:
#     branches: [main, dev]
```

## TODO

- Configurar `.git-hooks/pre-push` activando `git config core.hooksPath .git-hooks` para enforcement local de los mismos quality gates que el CI