### PR TITLE
docs: corrige ortografía en español (agrega tildes faltantes)

### DIFF
--- a/.claude/rules/verify-before-done.md
+++ b/.claude/rules/verify-before-done.md
@@ -1,39 +1,39 @@
-# Verify Before Done (CRITICO)
+# Verify Before Done (CRÍTICO)
 
 > NUNCA declarar que algo esta listo sin verificar que funciona. Cada cambio debe probarse antes de reportar exito.
 
 ## Regla principal
 
-Despues de CUALQUIER cambio de codigo, SIEMPRE ejecutar las verificaciones correspondientes ANTES de decirle al usuario que el trabajo esta completo. Declarar exito sin verificar es un desperdicio del tiempo del usuario.
+Después de CUALQUIER cambio de codigo, SIEMPRE ejecutar las verificaciones correspondientes ANTES de decirle al usuario que el trabajo esta completo. Declarar exito sin verificar es un desperdicio del tiempo del usuario.
 
 ## Verificaciones obligatorias por tipo de cambio
 
-### Componentes / paginas Astro (`src/pages/`, `src/components/`, `src/layouts/`)
+### Componentes / páginas Astro (`src/pages/`, `src/components/`, `src/layouts/`)
 
-| Cambio | Verificacion minima |
+| Cambio | Verificación mínima |
 |--------|---------------------|
 | Componente nuevo / modificado | `pnpm exec biome check .` + `pnpm exec astro check` |
-| Layout / pagina nueva | Lo anterior + `pnpm run build` (verifica que renderiza al SSG) |
-| Estilos en componente | Verificar tokens del DS (no hex inline) y `prefers-reduced-motion` si tiene animacion |
+| Layout / página nueva | Lo anterior + `pnpm run build` (verifica que renderiza al SSG) |
+| Estilos en componente | Verificar tokens del DS (no hex inline) y `prefers-reduced-motion` si tiene animación |
 
 ### Utilities / lib (`src/lib/`)
 
-| Cambio | Verificacion minima |
+| Cambio | Verificación mínima |
 |--------|---------------------|
-| Funcion nueva / modificada | Test mirror en `tests/unit/lib/<archivo>.test.ts` + `pnpm exec vitest run` |
+| Función nueva / modificada | Test mirror en `tests/unit/lib/<archivo>.test.ts` + `pnpm exec vitest run` |
 | Type / interface | `pnpm exec tsc --noEmit` |
 | Cambio que afecta consumers | Buscar usos con Grep y verificar que tipan correcto |
 
 ### Content collections (`src/content/`)
 
-| Cambio | Verificacion minima |
+| Cambio | Verificación mínima |
 |--------|---------------------|
-| Schema (config.ts) modificado | `pnpm run build` (Astro valida entries contra schema) |
+| Schema (config.ts) modificado | `pnpm run build` (Astro válida entries contra schema) |
 | Entry nueva | `pnpm run build` + verificar render visual en `pnpm run dev` |
 
 ### Config (`astro.config.*`, `biome.json`, `tsconfig.json`, `vitest.config.*`)
 
-| Cambio | Verificacion minima |
+| Cambio | Verificación mínima |
 |--------|---------------------|
 | `astro.config.ts` | `pnpm run build` exitoso |
 | `biome.json` | `pnpm exec biome check .` (verificar que reglas nuevas no rompen el repo) |
@@ -42,7 +42,7 @@ Despues de CUALQUIER cambio de codigo, SIEMPRE ejecutar las verificaciones corre
 
 ### Cualquier `.ts` / `.tsx` / `.astro`
 
-Siempre, como gate minimo:
+Siempre, como gate mínimo:
 
 ```bash
 pnpm exec biome check .
@@ -60,7 +60,7 @@ pnpm exec vitest run --changed
 
 Antes de `git push`, cuando los cambios tocan apps/* o packages/*, ejecutar
 SIEMPRE la suite Playwright. NO esta en CI (es lento), vive en el pre-push
-hook + verificacion local explicita.
+hook + verificación local explicita.
 
 ```bash
 # 1. Stack arriba
@@ -77,42 +77,42 @@ El pre-push hook automatiza estos pasos. Si Docker no esta disponible, el
 hook hace skip con [OMITIDO]. NUNCA usar `SKIP_STEPS="feature_tests"` en
 push final — solo en intermedios o cuando se prueban hooks en si.
 
-Errores comunes que esta verificacion detecta:
+Errores comunes que esta verificación detecta:
 - Subdominios con HTTP 502 (nginx upstream caido)
 - Astro dist sin `index.html` (build silenciosamente roto)
 - View transitions o theme toggle con bug visual
 - Mapping de subdominios mal alineado entre `astro.config.ts` y nginx
 
-### Configuracion `.claude/`
+### Configuración `.claude/`
 
-| Cambio | Verificacion minima |
+| Cambio | Verificación mínima |
 |--------|---------------------|
 | `settings.json` | `python3 -m json.tool .claude/settings.json > /dev/null` |
 | Hook bash | `bash -n .claude/hooks/<modificado>.sh` |
-| Skill/agent/rule | Validar segun `claude-config-testing.md` (claude -p en bypassPermissions) |
+| Skill/agent/rule | Validar según `claude-config-testing.md` (claude -p en bypassPermissions) |
 
 ## Flujo obligatorio
 
 ```text
-1. Implementar cambio (con TDD si es logica nueva — ver tdd-workflow)
-2. Ejecutar verificacion(es) correspondiente(s)
+1. Implementar cambio (con TDD si es lógica nueva — ver tdd-workflow)
+2. Ejecutar verificación(es) correspondiente(s)
 3. Si falla → corregir → volver a paso 2
 4. Si pasa → AHORA reportar al usuario que esta listo
 ```
 
 ## Reglas estrictas
 
-- NUNCA decir "listo", "done", "implementado", "creado" sin haber ejecutado la verificacion
+- NUNCA decir "listo", "done", "implementado", "creado" sin haber ejecutado la verificación
 - NUNCA asumir que un cambio funciona solo porque el codigo "se ve correcto"
 - Si hay tests existentes para el archivo afectado, ejecutarlos
 - Si se crean archivos nuevos, verificar que importan correctamente
 - Si se modifica `astro.config.ts`, verificar que el build sigue funcionando
-- Reportar al usuario tanto el resultado de la verificacion como el del cambio
+- Reportar al usuario tanto el resultado de la verificación como el del cambio
 
 ## Errores comunes que esta regla previene
 
 - TypeScript errors no detectados (imports rotos, props mal tipadas, generics mal usados)
-- Astro components con frontmatter invalido
+- Astro components con frontmatter inválido
 - Tests rotos por cambios en la interfaz
 - `astro check` warnings que no se ven en el editor
 - Tokens del DS que dejaron de existir y rompen estilos
@@ -121,6 +121,6 @@ Errores comunes que esta verificacion detecta:
 
 ## Cuando NO aplica
 
-- Cambios exclusivamente en documentacion (`.md`)
-- Cambios en configuracion de Claude (`.claude/`) que no son `settings.json` ni hooks ejecutables
-- El usuario explicitamente dice que no quiere verificacion
+- Cambios exclusivamente en documentación (`.md`)
+- Cambios en configuración de Claude (`.claude/`) que no son `settings.json` ni hooks ejecutables
+- El usuario explicitamente dice que no quiere verificación

--- a/.git-hooks/_common.py
+++ b/.git-hooks/_common.py
@@ -2,11 +2,11 @@
 
 Provee:
   - Output con colores (info, ok, err, skip, tip, header, section)
-  - Configuracion de pasos (config.json + SKIP_STEPS env)
+  - Configuración de pasos (config.json + SKIP_STEPS env)
   - Deteccion de archivos staged/unmerged via git plumbing
   - Helpers para correr pnpm directamente en host (sin Docker)
 
-Diseno: autocontenido. NO depende de devtools/.venv. Solo requiere pnpm y
+Diseño: autocontenido. NO depende de devtools/.venv. Solo requiere pnpm y
 node en PATH (corepack ya lo activa). Esto mantiene el hook ejecutable en
 cualquier entorno (local, CI) sin bootstrap pesado.
 """
@@ -121,7 +121,7 @@ def cyan(msg: str) -> str:
 
 
 # =============================================================================
-# CONFIGURACION DE PASOS
+# CONFIGURACIÓN DE PASOS
 # =============================================================================
 
 def should_run_step(step_name: str, hook_name: str) -> bool:
@@ -250,7 +250,7 @@ def detect_modified_packages(files: list[str]) -> list[str]:
 
 
 # =============================================================================
-# FRONTEND PURITY (no .js/.jsx/.mjs/.cjs salvo configs en raiz)
+# FRONTEND PURITY (no .js/.jsx/.mjs/.cjs salvo configs en raíz)
 # =============================================================================
 
 def find_forbidden_js_files(files: list[str]) -> list[str]:
@@ -271,7 +271,7 @@ def find_forbidden_js_files(files: list[str]) -> list[str]:
 
 
 # =============================================================================
-# EJECUCION DE COMANDOS (pnpm en host)
+# EJECUCIÓN DE COMANDOS (pnpm en host)
 # =============================================================================
 
 def run_pnpm(args: list[str], *, cwd: Path | None = None,

--- a/.git-hooks/config.json
+++ b/.git-hooks/config.json
@@ -1,5 +1,5 @@
 {
-  "_descripcion": "Configuracion de hooks Git compartidos para portfolio (Astro 6 monorepo).",
+  "_descripcion": "Configuración de hooks Git compartidos para portfolio (Astro 6 monorepo).",
   "_documentacion": "Pre-commit liviano (Biome lint sobre staged, <10s). Pre-push estricto (lint + typecheck + tests + coverage + build + feature E2E).",
   "_nota": "Archivo compartido en el repositorio. Cambios afectan a todo el equipo y CI/CD.",
   "pre-commit": {
@@ -13,7 +13,7 @@
       "frontend_purity": {
         "name": "Frontend Type Purity (TypeScript only)",
         "enabled": true,
-        "description": "Prohibe archivos .js/.jsx/.mjs/.cjs en apps/* y packages/* excepto allowlist: *.config.{js,mjs,cjs} y vitest.config.{js,mjs,cjs} en raiz del modulo."
+        "description": "Prohibe archivos .js/.jsx/.mjs/.cjs en apps/* y packages/* excepto allowlist: *.config.{js,mjs,cjs} y vitest.config.{js,mjs,cjs} en raíz del módulo."
       }
     }
   },
@@ -28,7 +28,7 @@
       "frontend_purity": {
         "name": "Frontend Type Purity (TypeScript only)",
         "enabled": true,
-        "description": "Prohibe .js/.jsx/.mjs/.cjs en frontend, salvo configs en raiz."
+        "description": "Prohibe .js/.jsx/.mjs/.cjs en frontend, salvo configs en raíz."
       },
       "mirror_enforcement": {
         "name": "TDD Mirror Enforcement (source <-> test)",
@@ -53,7 +53,7 @@
       "build": {
         "name": "Static Build (pnpm build)",
         "enabled": true,
-        "description": "Build estatico de todas las apps Astro. Falla si Astro/Vite no genera dist/."
+        "description": "Build estático de todas las apps Astro. Falla si Astro/Vite no genera dist/."
       },
       "feature_tests": {
         "name": "Feature tests (Playwright E2E via Docker)",

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -3,9 +3,9 @@
 
 Ejecuta validaciones livianas sobre archivos staged:
   1. Conformance: Biome lint + format check
-  2. Frontend purity: prohibe .js/.jsx/.mjs/.cjs salvo configs en raiz
+  2. Frontend purity: prohibe .js/.jsx/.mjs/.cjs salvo configs en raíz
 
-Objetivo: <10s en commits tipicos. Coverage, typecheck y build se ejecutan
+Objetivo: <10s en commits típicos. Coverage, typecheck y build se ejecutan
 en pre-push (mas pesado).
 
 Skip por env:
@@ -81,7 +81,7 @@ def step_purity(files: list[str], step_label: str) -> int:
     err(f'{len(violations)} archivo(s) JavaScript prohibido(s):')
     for f in violations:
         out(f'  - {f}')
-    tip('Renombrar a .ts (o .astro). Configs en raiz con sufijo .config.{js,mjs,cjs} estan permitidos.')
+    tip('Renombrar a .ts (o .astro). Configs en raíz con sufijo .config.{js,mjs,cjs} están permitidos.')
     return fail(
         f'Paso {step_label}: Frontend Purity - FALLO',
         'COMMIT BLOQUEADO',

--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -3,7 +3,7 @@
 
 Ejecuta validaciones estrictas vs base branch (origin/main por default):
   1. Conformance: Biome lint + format check sobre todos los archivos modificados
-  2. Frontend purity: prohibe .js/.jsx/.mjs/.cjs salvo configs en raiz
+  2. Frontend purity: prohibe .js/.jsx/.mjs/.cjs salvo configs en raíz
   3. Typecheck: tsc --noEmit + astro check
   4. Unit tests + coverage per-file >= 80% (packages modificados)
   5. Build: pnpm run build (todas las apps)
@@ -109,8 +109,8 @@ def step_typecheck(modified_apps: list[str],
                 HOOK_NAME,
             )
 
-    # tsc --noEmit global (cubre packages tambien)
-    info('tsc --noEmit en raiz (recursivo en workspaces)')
+    # tsc --noEmit global (cubre packages también)
+    info('tsc --noEmit en raíz (recursivo en workspaces)')
     rc = run_pnpm(['run', 'typecheck'], cwd=PROJECT_ROOT)
     if rc != 0:
         return fail(
@@ -166,7 +166,7 @@ def step_unit_tests(modified_packages: list[str], step_label: str) -> int:
 
 def step_build(step_label: str) -> int:
     section(f'[PASO {step_label}] Static Build (pnpm run build)')
-    info('Build estatico de todas las apps Astro')
+    info('Build estático de todas las apps Astro')
     rc = run_pnpm(['run', 'build'], cwd=PROJECT_ROOT, timeout=600)
     if rc != 0:
         return fail(

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-Template estandar de PRs del portfolio. Las 4 secciones son obligatorias.
+Template estándar de PRs del portfolio. Las 4 secciones son obligatorias.
 Reglas en .claude/rules/git-workflow.md.
 -->
 
@@ -10,11 +10,11 @@ Que problema resuelve este PR. Conciso. Si son varios, enumerar 1., 2., 3.
 con tarea de tracker al lado si aplica.
 -->
 
-## Solucion
+## Solución
 
 <!--
 Que se hizo. Si arriba enumeraste problemas, mantener la misma numeracion
-paralela (Problema 1 -> Solucion 1) para que el reviewer pueda saltar
+paralela (Problema 1 -> Solución 1) para que el reviewer pueda saltar
 puntualmente.
 -->
 
@@ -31,6 +31,6 @@ Incluir:
 ## TODO
 
 <!--
-Tareas pendientes que escapan del scope pero no afectan la solucion
-(refactors, optimizaciones). Vacio si no aplica.
+Tareas pendientes que escapan del scope pero no afectan la solución
+(refactors, optimizaciones). Vacío si no aplica.
 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   # --------------------------------------------------------------------------
-  # Quality gates: lint + typecheck + unit + build estatico.
+  # Quality gates: lint + typecheck + unit + build estático.
   # E2E (Playwright) NO corre en CI: es lento y los tests reales viven en
   # pre-push del hook local. Ver .claude/rules/verify-before-done.md.
   # --------------------------------------------------------------------------

--- a/.github/workflows/clean-pr-attribution.yml
+++ b/.github/workflows/clean-pr-attribution.yml
@@ -1,6 +1,6 @@
 name: Clean PR Attribution
 
-# Limpia atribucion de IA del cuerpo del PR cada vez que se crea o edita.
+# Limpia atribución de IA del cuerpo del PR cada vez que se crea o edita.
 # Es defensa en profundidad — los hooks locales ya lo previenen para
 # commits y settings.json para PRs creados por Claude Code.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # portfolio
 
 > Monorepo de 6 sitios Astro (pnpm workspaces) para el portfolio multi-niche
-> de Pablo Contreras (bypabloc). Output estatico desplegado en Cloudflare Pages.
+> de Pablo Contreras (bypabloc). Output estático desplegado en Cloudflare Pages.
 > Stack local orquestado por Docker + nginx + devtools (Python 3.14 + uv).
 
 ## Sitios
 
-| App | URL produccion | Subdominio local (puerto 9970) | Posicionamiento |
+| App | URL producción | Subdominio local (puerto 9970) | Posicionamiento |
 | --- | --- | --- | --- |
 | `apps/generic` | `the-full-stack.com` | `localhost` (apex) | Full Stack Senior — todas las skills |
 | `apps/hub` | `hub.the-full-stack.com` | `hub.localhost` | Selector multi-niche con cards |
@@ -14,7 +14,7 @@
 | `apps/architect` | `architect.the-full-stack.com` | `architect.localhost` | Frontend Architect + Microservicios |
 | `apps/leader` | `leader.the-full-stack.com` | `leader.localhost` | Tech Lead / Engineering Manager |
 | `apps/vibe` | `vibe.the-full-stack.com` | `vibe.localhost` | Vibe Coding / Claude Code / Dev tools |
-| — | — | `services.localhost` | Indice estatico de servicios locales |
+| — | — | `services.localhost` | Indice estático de servicios locales |
 
 ## Packages
 
@@ -45,7 +45,7 @@ NUNCA mezclar `npm` o `yarn` — solo `pnpm`.
 pnpm install              # instalar deps (allowBuilds: esbuild + sharp)
 pnpm run dev              # dev server en paralelo (todas las apps)
 pnpm run build            # build de todas las apps
-pnpm run preview          # preview del build estatico
+pnpm run preview          # preview del build estático
 pnpm run lint             # Biome check
 pnpm run lint:fix         # Biome con auto-fix
 pnpm run typecheck        # tsc + astro check (recursive)
@@ -67,7 +67,7 @@ on-demand). Container names: `portfolio-<servicio>-<env>`.
 pnpm run docker:up         # nginx + 6 apps (modo dev con HMR)
 pnpm run docker:ps         # listar containers
 pnpm run docker:logs       # tail -f de todos los servicios
-pnpm run docker:down       # bajar stack (preserva volumenes)
+pnpm run docker:down       # bajar stack (preserva volúmenes)
 
 pnpm run feature:up        # container Playwright (profile feature)
 pnpm run feature:run       # ejecutar specs E2E
@@ -94,7 +94,7 @@ http://services.localhost:9970   -> indice de servicios
 
 ## Comandos devtools (Python CLI)
 
-Entrypoint: `python devtools/run.py <script> [flags...]`. Bootstrap automatico
+Entrypoint: `python devtools/run.py <script> [flags...]`. Bootstrap automático
 via `uv sync` la primera vez. Ver `python devtools/run.py --help` para
 inventario completo.
 
@@ -124,7 +124,7 @@ python devtools/run.py docker format --module=<app> --env=local
 python devtools/run.py docker lint --module=devtools --env=local
 ```
 
-Modulos validos:
+Módulos válidos:
 
 - Frontend: `hub`, `generic`, `fintech`, `architect`, `leader`, `vibe`
 - Packages: `pkg-app-shared`, `pkg-content`, `pkg-cv-pdf`, `pkg-seo`, `pkg-ui`
@@ -156,16 +156,16 @@ python devtools/run.py verify --all-changed
 python devtools/run.py verify --staged --execute --json
 ```
 
-## Reglas criticas (siempre activas)
+## Reglas críticas (siempre activas)
 
 - SIEMPRE archivos temporales en `./tmp/` del proyecto, NUNCA `/tmp/` del sistema
 - SIEMPRE `rm -f` para eliminar (evita prompts interactivos)
 - SIEMPRE tokens del Design System via `var(--color-*)`, NUNCA hex inline
 - SIEMPRE fonts self-hosted via `@fontsource/*`, NUNCA Google Fonts CDN
 - SIEMPRE TypeScript strict, NUNCA `any` (usar `unknown` con narrow)
-- SIEMPRE Conventional Commits en espanol (subject + body)
+- SIEMPRE Conventional Commits en español (subject + body)
 - SIEMPRE Node 24 + pnpm 11.0.9 (declarado en `package.json` engines)
-- NUNCA atribucion de IA en commits, PRs, issues, ni comentarios
+- NUNCA atribución de IA en commits, PRs, issues, ni comentarios
 - NUNCA `find`, `grep -E/-r/-rn` en Bash (aliases rotos en WSL2): usar
   Glob / Grep / Read / Edit tools
 - NUNCA declarar trabajo "listo" sin ejecutar las verificaciones de
@@ -173,14 +173,14 @@ python devtools/run.py verify --staged --execute --json
 
 ## Git hooks (pre-commit + pre-push)
 
-Activacion automatica via `pnpm install` (script `prepare` setea
+Activación automática via `pnpm install` (script `prepare` setea
 `core.hooksPath`). Implementados en Python autocontenido (sin dependencia
 de devtools/.venv).
 
 ### Pre-commit (liviano, <10s)
 
 - `conformance` — Biome lint + format check sobre archivos staged
-- `frontend_purity` — prohibe `.js/.jsx/.mjs/.cjs` salvo configs en raiz
+- `frontend_purity` — prohibe `.js/.jsx/.mjs/.cjs` salvo configs en raíz
 
 ### Pre-push (estricto)
 
@@ -188,7 +188,7 @@ de devtools/.venv).
 - `frontend_purity`
 - `typecheck` — astro check (per-app) + tsc --noEmit recursivo
 - `unit_tests` — Vitest --coverage en packages modificados (>=80% per-file)
-- `build` — pnpm build estatico de todas las apps
+- `build` — pnpm build estático de todas las apps
 
 Skip por env: `SKIP_STEPS="build,unit_tests" git push ...`. Config en
 [.git-hooks/config.json](.git-hooks/config.json).
@@ -197,10 +197,10 @@ Skip por env: `SKIP_STEPS="build,unit_tests" git push ...`. Config en
 
 Dos jobs en [.github/workflows/ci.yml](.github/workflows/ci.yml):
 
-1. `quality-gates` (sin Docker): lint + typecheck + unit + build estatico
+1. `quality-gates` (sin Docker): lint + typecheck + unit + build estático
 2. `e2e-tests` (con Docker): levanta stack test + corre Playwright
 
-Trigger: PRs a `main`/`master`/`dev`. Limpieza automatica de atribucion
+Trigger: PRs a `main`/`master`/`dev`. Limpieza automática de atribución
 de IA en PRs via [.github/workflows/clean-pr-attribution.yml](.github/workflows/clean-pr-attribution.yml).
 
 ## Estructura del repo
@@ -223,7 +223,7 @@ de IA en PRs via [.github/workflows/clean-pr-attribution.yml](.github/workflows/
 ├── .git-hooks/           # pre-commit, pre-push, prepare-commit-msg
 ├── .github/workflows/    # ci.yml, deploy.yml, clean-pr-attribution.yml
 ├── .claude/              # rules, skills, agents, hooks de Claude Code
-├── docs/                 # documentacion del proyecto
+├── docs/                 # documentación del proyecto
 └── project.yml           # name: portfolio (single source of truth)
 ```
 
@@ -234,7 +234,7 @@ Antes de trabajar, identifica que contexto necesitas:
 | Tema | Archivo | Cuando leer |
 |------|---------|-------------|
 | Reglas generales | [.claude/rules/general.md](.claude/rules/general.md) | Indice de reglas + estructura del repo |
-| Astro + Biome + TS | [.claude/rules/astro-landing.md](.claude/rules/astro-landing.md) | Antes de crear componente / pagina / utility |
+| Astro + Biome + TS | [.claude/rules/astro-landing.md](.claude/rules/astro-landing.md) | Antes de crear componente / página / utility |
 | Design System | [.claude/rules/design-system.md](.claude/rules/design-system.md) | Tokens CSS, dark/light, tipografia, fonts |
 | Docstrings | [.claude/rules/docstring-standard.md](.claude/rules/docstring-standard.md) | Antes de documentar cualquier unidad de codigo |
 | Verify-before-done | [.claude/rules/verify-before-done.md](.claude/rules/verify-before-done.md) | Antes de reportar trabajo completado |
@@ -249,37 +249,37 @@ Antes de trabajar, identifica que contexto necesitas:
 | Docker stack | [docker/README.md](docker/README.md) | Levantar local, mapping subdominios, env files |
 | Tests E2E | [tests/feature/README.md](tests/feature/README.md) | Escribir specs Playwright |
 | CV (contenido) | [.claude/docs/cv/README.md](.claude/docs/cv/README.md) | Datos del CV (perfil, experiencia, proyectos) |
-| Estrategia portfolio 2026 | invocar skill `astro-portfolio` | Decisiones de SEO/GEO/ATS/AI literacy/diseno |
+| Estrategia portfolio 2026 | invocar skill `astro-portfolio` | Decisiones de SEO/GEO/ATS/AI literacy/diseño |
 
 ## Skills disponibles
 
-Invocables manualmente con `/<nombre>` o automaticamente segun keywords del
+Invocables manualmente con `/<nombre>` o automáticamente según keywords del
 prompt. Detalles del frontmatter: [.claude/rules/skills.md](.claude/rules/skills.md).
 
 | Skill | Uso |
 |-------|-----|
-| `astro-portfolio` | Referencia obligatoria para cualquier decision de estructura, SEO, GEO, ATS, diseno o stack del portfolio |
+| `astro-portfolio` | Referencia obligatoria para cualquier decisión de estructura, SEO, GEO, ATS, diseño o stack del portfolio |
 | `animations-css` | Animaciones CSS (scroll-driven, view transitions, micro-interactions) — NO usar libs como motion / gsap / aos |
 | `codebase-audit` | Auditoria de calidad: dead code, complexity, duplication, tech debt |
 | `dependency-upgrade` | Workflows de upgrade con pnpm (audit, outdated, CVE, majors) |
 | `fix-hooks` | Reparar errores de pre-commit / pre-push iterativamente |
 | `github-actions` | Workflows CI + testing local con `act` (nektos/act) |
 | `mermaid` | Crear / modificar diagramas `.mmd` en `docs/diagrams/` |
-| `research` | Deep research de tecnologias y librerias (skill con web habilitada) |
-| `spec-workflow` | Descomponer features en specs + tareas atomicas |
+| `research` | Deep research de tecnologías y librerías (skill con web habilitada) |
+| `spec-workflow` | Descomponer features en specs + tareas atómicas |
 | `tdd-workflow` | TDD obligatorio (Red-Green-Refactor) antes de implementar |
 
 ## Convenciones (resumen)
 
 - Componentes Astro: `PascalCase.astro` (ej. `ExperienceCard.astro`)
-- Paginas: kebab-case (`user-profile.astro`)
+- Páginas: kebab-case (`user-profile.astro`)
 - Utilities: kebab-case (`format-date.ts`)
 - Branches: `feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/` con `/` obligatorio
 - Tests: mirror de `src/` en `tests/unit/`, BDD-style en `it()` (`Given/When/Then`), asserts EXACTOS
-- Coverage minimo: 80% per-file en archivos modificados
-- Comunicacion: respuestas tecnicas directas, sin validacion emocional ni preambulos
+- Coverage mínimo: 80% per-file en archivos modificados
+- Comunicación: respuestas técnicas directas, sin validación emocional ni preámbulos
 
-## Documentacion (zonas)
+## Documentación (zonas)
 
 `docs/` tiene dos zonas separadas — NO mezclar:
 
@@ -294,13 +294,13 @@ y [.claude/rules/harness-protocol.md](.claude/rules/harness-protocol.md).
 ## Gotchas
 
 - WSL2: `find` esta aliasado a `fd`, `grep -E/-r/-rn` a `rg`. Cada uso
-  rompe la ejecucion — usar Glob / Grep / Read / Edit tools.
+  rompe la ejecución — usar Glob / Grep / Read / Edit tools.
 - Hooks en `.claude/hooks/` + `.git-hooks/` son enforcement real; CLAUDE.md
   no enforza por si solo. Ver [.claude/hooks/README.md](.claude/hooks/README.md).
-- `attribution.commit` y `attribution.pr` estan vacios en
+- `attribution.commit` y `attribution.pr` están vacíos en
   [.claude/settings.json](.claude/settings.json) — defensa en profundidad
-  contra atribucion de IA.
-- Branches `main`, `master`, `dev`, `release` estan protegidas: el hook
+  contra atribución de IA.
+- Branches `main`, `master`, `dev`, `release` están protegidas: el hook
   `protect-branch.sh` bloquea `git push` directo.
 - Subdominios `*.localhost` resuelven a 127.0.0.1 por RFC 6761 (no requiere
   editar `/etc/hosts` en el host). Dentro de containers Docker con

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portfolio multi-niche — Pablo Contreras (bypabloc)
 
-> Monorepo Astro 5+ con 6 sitios estaticos desplegados en Cloudflare Pages.
+> Monorepo Astro 5+ con 6 sitios estáticos desplegados en Cloudflare Pages.
 > Cada sitio cuenta la misma historia profesional con un acento diferente.
 
 ## Sitios

--- a/apps/generic/scripts/build-public-assets.mjs
+++ b/apps/generic/scripts/build-public-assets.mjs
@@ -1,8 +1,8 @@
 /**
  * @script build-public-assets
- * @description Pre-build step que genera assets dinamicos a /public:
+ * @description Pre-build step que genera assets dinámicos a /public:
  *   - cv.html, cv-es.html, cv-en.html (CV ATS-friendly)
- *   - llms.txt (lista de paginas para crawlers de IA)
+ *   - llms.txt (lista de páginas para crawlers de IA)
  *   - robots.txt (allow all + sitemap)
  *
  *   Se ejecuta antes de `astro build` (prebuild en package.json).

--- a/apps/hub/src/lib/niches.ts
+++ b/apps/hub/src/lib/niches.ts
@@ -1,6 +1,6 @@
 /**
  * @module niches
- * @description Definicion de las 5 cards del hub selector.
+ * @description Definición de las 5 cards del hub selector.
  */
 import type { Niche } from '@portfolio/content'
 

--- a/devtools/docker/README.md
+++ b/devtools/docker/README.md
@@ -10,12 +10,12 @@ python devtools/run.py docker <command> [--env=local] [flags...]
 
 ## Ambientes
 
-| Ambiente | Descripcion | Puerto (default) |
+| Ambiente | Descripción | Puerto (default) |
 | -------- | ----------- | ---------------- |
 | local | Desarrollo con hot reload (default) | 9979 |
 | dev | Desarrollo remoto (code baked) | 9978 |
 | test | Testing aislado | 9977 |
-| prod | Produccion con Gunicorn | 80 |
+| prod | Producción con Gunicorn | 80 |
 
 > El puerto se override via `PROXY_PORT` en `docker/env/.<env>`.
 
@@ -23,11 +23,11 @@ python devtools/run.py docker <command> [--env=local] [flags...]
 
 ### Lifecycle
 
-| Comando | Descripcion | Flags |
+| Comando | Descripción | Flags |
 | ------- | ----------- | ----- |
 | up | Levantar servicios | `--build`, `--detach` (default), `--service=NAME`, `--profile=NAME` |
 | down | Detener servicios | `--volumes` (eliminar datos) |
-| build | Construir imagenes | `--no-cache`, `--service=NAME`, `--profile=NAME` |
+| build | Construir imágenes | `--no-cache`, `--service=NAME`, `--profile=NAME` |
 | rebuild | Clean rebuild | `--service=NAME`, `--profile=NAME` |
 | logs | Ver logs | --tail=50, --follow / -w |
 | shell | Bash en server | |
@@ -38,7 +38,7 @@ python devtools/run.py docker <command> [--env=local] [flags...]
 
 #### Service-scoped operations
 
-`--service=NAME` limita la operacion a un solo container (mas rapido que rebuild completo). El profile se auto-resuelve si el servicio esta gated bajo uno (ej: `e2e` bajo `profiles: [e2e]`).
+`--service=NAME` limita la operación a un solo container (mas rápido que rebuild completo). El profile se auto-resuelve si el servicio esta gated bajo uno (ej: `e2e` bajo `profiles: [e2e]`).
 
 `--profile=NAME` se necesita SOLO para servicios on-demand (ej: levantar
 manualmente el servicio `e2e` requiere `--profile=e2e`).
@@ -61,7 +61,7 @@ python devtools/run.py docker up --env=local --profile=feature
 
 ### Django
 
-| Comando | Descripcion | Flags |
+| Comando | Descripción | Flags |
 | ------- | ----------- | ----- |
 | migrate | Ejecutar migraciones | |
 | makemigrations | Generar migraciones | |
@@ -75,7 +75,7 @@ python devtools/run.py docker up --env=local --profile=feature
 
 ### Calidad
 
-| Comando | Descripcion | Flags |
+| Comando | Descripción | Flags |
 | ------- | ----------- | ----- |
 | lint | Lint (Ruff/Biome) | `--module=server\|devtools\|dashboard\|landing` (default: `server`) |
 | lint-fix | Lint con auto-fix | `--module=server\|devtools\|dashboard\|landing` |
@@ -83,12 +83,12 @@ python devtools/run.py docker up --env=local --profile=feature
 
 > El subcomando `test` fue removido del CLI en 2026-05. Para ejecutar tests
 > usa el script unificado: `python devtools/run.py test_runner [flags]`.
-> Si invocas `docker test` veras un mensaje de migracion con las
+> Si invocas `docker test` veras un mensaje de migración con las
 > equivalencias para tus comandos.
 
 ### Base de datos
 
-| Comando | Descripcion | Flags |
+| Comando | Descripción | Flags |
 | ------- | ----------- | ----- |
 | db-shell | psql interactivo | |
 | db-tables | Listar tablas | `--output=text\|json` |
@@ -97,11 +97,11 @@ python devtools/run.py docker up --env=local --profile=feature
 | db-seed | Cargar fixtures | `--clear`, `--only=<app>`, `--dry-run` |
 | db-reset | Reset completo | `--no-seed`, `--no-superuser`, `--dry-run` |
 
-`--output=json` emite un documento parseable directo con `jq` o `json.load(sys.stdin)`. Disponible tambien en `ps` y `cache-status`.
+`--output=json` emite un documento parseable directo con `jq` o `json.load(sys.stdin)`. Disponible también en `ps` y `cache-status`.
 
 ### Setup
 
-| Comando | Descripcion | Flags |
+| Comando | Descripción | Flags |
 | ------- | ----------- | ----- |
 | setup | Setup inicial completo | --no-seed, --no-superuser |
 | clean | Eliminar todo (containers, images, volumes) | |
@@ -109,7 +109,7 @@ python devtools/run.py docker up --env=local --profile=feature
 
 ### Cache
 
-| Comando | Descripcion |
+| Comando | Descripción |
 | ------- | ----------- |
 | cache-clear-all | Limpiar __pycache__ |
 | cache-status | Estado de cache |
@@ -133,7 +133,7 @@ python devtools/run.py test_runner --module=server --type=integration
 python devtools/run.py docker db-seed --env=local --clear
 python devtools/run.py docker db-count
 
-# Produccion
+# Producción
 python devtools/run.py docker build --env=prod --no-cache
 python devtools/run.py docker up --env=prod
 ```

--- a/devtools/docker/_helpers.py
+++ b/devtools/docker/_helpers.py
@@ -78,7 +78,7 @@ def confirm_destructive(message: str) -> bool:
     short-circuits without doing damage.
     """
     print()
-    _warn(f'{_c(RED, "OPERACION DESTRUCTIVA")}')
+    _warn(f'{_c(RED, "OPERACIÓN DESTRUCTIVA")}')
     print(f'  {message}')
     print()
 
@@ -86,13 +86,13 @@ def confirm_destructive(message: str) -> bool:
         answer = input(
             f'{_c(YELLOW, "Confirmar?")} Escribe {_c(BOLD, "yes")} para continuar: '
         )
-    except (EOFError, KeyboardInterrupt):
+    except EOFError, KeyboardInterrupt:
         print()
-        _info('Operacion cancelada')
+        _info('Operación cancelada')
         return False
 
     if answer.strip().lower() != 'yes':
-        _info('Operacion cancelada')
+        _info('Operación cancelada')
         return False
 
     return True

--- a/devtools/docker/flags.py
+++ b/devtools/docker/flags.py
@@ -17,7 +17,7 @@ ENV_DESCRIPTIONS = {
     'local': 'Desarrollo local con hot reload',
     'dev': 'Desarrollo remoto (codigo en imagen)',
     'test': 'Ambiente de testing aislado',
-    'prod': 'Produccion con Gunicorn',
+    'prod': 'Producción con Gunicorn',
 }
 
 COMPOSE_FILES = {
@@ -133,7 +133,7 @@ JSON_OUTPUT_COMMANDS = frozenset(
 _COMMAND_SUMMARIES: dict[str, str] = {
     'up': 'Levantar servicios',
     'down': 'Detener servicios',
-    'build': 'Construir imagenes',
+    'build': 'Construir imágenes',
     'rebuild': 'Reconstruir desde cero (down + build --no-cache + up)',
     'logs': 'Ver logs de servicios',
     'shell': 'Bash interactivo en server',
@@ -283,7 +283,7 @@ def describe() -> ScriptDescribe:
                     'pkg-ui',
                 ],
                 'default': 'server',
-                'summary': 'Modulo a procesar',
+                'summary': 'Módulo a procesar',
             },
             'files': {
                 'type': 'string',
@@ -348,12 +348,12 @@ def _extract_command(flags_dict: dict) -> None:
     help`` (texto colorizado) o ``docker --help`` (README).
 
     Pasa todo lo que sigue a ``--`` (separador POSIX) directo a
-    ``subcommands``, asi ``docker exec --target=server -- echo hi`` y
+    ``subcommands``, así ``docker exec --target=server -- echo hi`` y
     ``docker manage migrate -- --plan --verbosity=2`` funcionan sin que
     el validador rechace los flags del subproceso.
     """
     # Argumentos posicionales: todo antes de '--' (separador POSIX) que no
-    # sea una flag. Despues de '--' viene en flags_dict['_passthrough'] via
+    # sea una flag. Después de '--' viene en flags_dict['_passthrough'] via
     # flags_to_dict, lo concatenamos al final de subcommands.
     raw_args = sys.argv[2:]
     pre_double_dash: list[str] = []
@@ -373,14 +373,14 @@ def _extract_command(flags_dict: dict) -> None:
             'Falta el comando. '
             'Ejecuta `docker help` (texto colorizado) o `docker --help` '
             '(README) para ver los comandos disponibles.\n'
-            f'Comandos validos: {", ".join(VALID_COMMANDS)}'
+            f'Comandos válidos: {", ".join(VALID_COMMANDS)}'
         )
 
     command = flags_dict['command']
     if command not in VALID_COMMANDS:
         raise ValueError(
             f"Comando desconocido: '{command}'\n"
-            f'Comandos validos: {", ".join(VALID_COMMANDS)}'
+            f'Comandos válidos: {", ".join(VALID_COMMANDS)}'
         )
 
 
@@ -402,8 +402,8 @@ _FRONTEND_MODULES = (
 def _validate_module(flags_dict: dict) -> None:
     """Validate --module flag for test/lint/format commands.
 
-    Portfolio: modulos validos son las 6 apps Astro (hub, generic, ...)
-    y los packages como `pkg-<name>`, ademas de server/devtools.
+    Portfolio: módulos válidos son las 6 apps Astro (hub, generic, ...)
+    y los packages como `pkg-<name>`, además de server/devtools.
     """
     command = flags_dict['command']
 
@@ -412,8 +412,8 @@ def _validate_module(flags_dict: dict) -> None:
         module = flags_dict.get('module', 'all')
         if module not in valid_modules:
             raise ValueError(
-                f"Modulo invalido: '{module}'\n"
-                f'Modulos validos para test: {", ".join(valid_modules)}'
+                f"Módulo inválido: '{module}'\n"
+                f'Módulos válidos para test: {", ".join(valid_modules)}'
             )
 
     if command in ('lint', 'lint-fix', 'format'):
@@ -423,8 +423,8 @@ def _validate_module(flags_dict: dict) -> None:
         module = flags_dict['module']
         if module not in valid_modules:
             raise ValueError(
-                f"Modulo invalido: '{module}'\n"
-                f'Modulos validos para {command}: {", ".join(valid_modules)}'
+                f"Módulo inválido: '{module}'\n"
+                f'Módulos válidos para {command}: {", ".join(valid_modules)}'
             )
 
     # output-format: solo para lint + server
@@ -433,8 +433,8 @@ def _validate_module(flags_dict: dict) -> None:
         valid_formats = ['console', 'json']
         if output_format not in valid_formats:
             raise ValueError(
-                f"Formato invalido: '{output_format}'\n"
-                f'Formatos validos: {", ".join(valid_formats)}'
+                f"Formato inválido: '{output_format}'\n"
+                f'Formatos válidos: {", ".join(valid_formats)}'
             )
         if command != 'lint':
             raise ValueError(
@@ -471,7 +471,7 @@ def flag(flags_dict: dict) -> dict:
         # Mensaje util cuando el usuario quiso pasar flags al subproceso (manage,
         # exec) y olvido el separador POSIX. Conservamos el error original como
         # contexto y agregamos la pista; otros comandos siguen viendo el error
-        # estandar de "Flags no permitidas: ...".
+        # estándar de "Flags no permitidas: ...".
         if flags_dict.get('command') in ('manage', 'exec'):
             cmd = flags_dict['command']
             example = (
@@ -490,7 +490,7 @@ def flag(flags_dict: dict) -> dict:
     env = flags_dict.get('env', 'local')
     if env not in VALID_ENVS:
         raise ValueError(
-            f"Ambiente invalido: '{env}'\nAmbientes validos: {', '.join(VALID_ENVS)}"
+            f"Ambiente inválido: '{env}'\nAmbientes válidos: {', '.join(VALID_ENVS)}"
         )
 
     flags_dict = set_default_values(

--- a/devtools/docker/help.py
+++ b/devtools/docker/help.py
@@ -31,7 +31,7 @@ def cmd_help(flags: dict[str, Any]) -> int:
             [
                 ('up', 'Iniciar servicios', '--detach --build --env=<env>'),
                 ('down', 'Detener servicios', '--volumes'),
-                ('build', 'Construir imagenes', '--no-cache'),
+                ('build', 'Construir imágenes', '--no-cache'),
                 (
                     'rebuild',
                     'Reconstruir desde cero',

--- a/devtools/docker/lifecycle.py
+++ b/devtools/docker/lifecycle.py
@@ -118,14 +118,14 @@ def cmd_build(flags: dict[str, Any]) -> int:
     if service:
         args.append(service)
 
-    _step('Construyendo imagenes...')
+    _step('Construyendo imágenes...')
     result = run_compose(env, args, timeout=600, profile=profile)
 
     if result.returncode != 0:
-        _err('Error construyendo imagenes')
+        _err('Error construyendo imágenes')
         return 1
 
-    _ok('Imagenes construidas')
+    _ok('Imágenes construidas')
     return 0
 
 
@@ -174,7 +174,7 @@ def cmd_shell(flags: dict[str, Any]) -> int:
 def cmd_exec(flags: dict[str, Any]) -> int:
     """Run an arbitrary command in a container.
 
-    Convencion: el comando del subproceso va despues del separador POSIX
+    Convencion: el comando del subproceso va después del separador POSIX
     ``--`` para que el validador del CLI no rechace los flags. Ej:
     ``docker exec --target=dashboard -- pnpm install`` o
     ``docker exec -- python manage.py shell``.
@@ -225,14 +225,14 @@ def cmd_ps(flags: dict[str, Any]) -> int:
             print('[]')
             return 0
         # docker compose ps emite NDJSON (un objeto por linea). Versiones mas
-        # nuevas reportan tambien array JSON; aceptamos ambos. Detectamos el
-        # caso array via el primer caracter no-whitespace para evitar el
+        # nuevas reportan también array JSON; aceptamos ambos. Detectamos el
+        # caso array via el primer carácter no-whitespace para evitar el
         # try/except/pass que Ruff S110 marca como anti-patron.
         if raw.lstrip().startswith('['):
             try:
                 parsed = json.loads(raw)
             except json.JSONDecodeError as exc:
-                _err(f'docker compose ps emitio JSON invalido: {exc}')
+                _err(f'docker compose ps emitio JSON inválido: {exc}')
                 return 1
             print(json.dumps(parsed, indent=2))
             return 0

--- a/devtools/docker/lifecycle_recovery.py
+++ b/devtools/docker/lifecycle_recovery.py
@@ -80,10 +80,10 @@ def cmd_rebuild(flags: dict[str, Any]) -> int:
         _err('Error deteniendo servicios')
         return 1
 
-    _step('Paso 2/3: Reconstruyendo imagenes (sin cache)...')
+    _step('Paso 2/3: Reconstruyendo imágenes (sin cache)...')
     result = run_compose(env, ['build', '--no-cache'], timeout=600)
     if result.returncode != 0:
-        _err('Error construyendo imagenes')
+        _err('Error construyendo imágenes')
         return 1
 
     _step('Paso 3/3: Iniciando servicios...')
@@ -194,6 +194,6 @@ def _print_refresh_plan(
         _step('2/3 Saltar limpieza de cache (--skip-cache)')
     _step('3/3 docker compose up -d --build')
     if not keep_volumes:
-        _info('Despues de healthy: manage.py migrate --noinput')
+        _info('Después de healthy: manage.py migrate --noinput')
     _info('Sin cambios aplicados (--dry-run)')
     return 0

--- a/devtools/docker/main.py
+++ b/devtools/docker/main.py
@@ -57,7 +57,7 @@ def cmd_test_removed(flags: dict[str, Any]) -> int:
     _err("'docker test' fue removido del CLI.")
     print()
     print(
-        f'{_c(YELLOW, "Migracion:")} usa '
+        f'{_c(YELLOW, "Migración:")} usa '
         f'{_c(CYAN, "python devtools/run.py test_runner")} '
         'para ejecutar tests.'
     )
@@ -77,7 +77,7 @@ def cmd_test_removed(flags: dict[str, Any]) -> int:
         '  docker test --module=landing ... ->  test_runner --module=landing ...'
     )
     print()
-    print('Documentacion: python devtools/run.py test_runner --help')
+    print('Documentación: python devtools/run.py test_runner --help')
     return 1
 
 
@@ -140,7 +140,7 @@ def main(flags: dict[str, Any]) -> int:
         _err('Docker no esta disponible')
         print(
             f'{YELLOW}  Docker Desktop debe estar corriendo '
-            f'con la integracion WSL2 activada.{NC}',
+            f'con la integración WSL2 activada.{NC}',
         )
         print(f'{CYAN}  1. Abrir Docker Desktop en Windows{NC}')
         print(
@@ -157,7 +157,7 @@ def main(flags: dict[str, Any]) -> int:
         return 1
     except KeyboardInterrupt:
         print()
-        _err('Operacion interrumpida por el usuario')
+        _err('Operación interrumpida por el usuario')
         return 130
     except (
         subprocess.SubprocessError,

--- a/devtools/docker/quality.py
+++ b/devtools/docker/quality.py
@@ -33,8 +33,8 @@ FRONTEND_MODULES = tuple(_PORTFOLIO_APPS) + tuple(
 )
 PYTHON_MODULES = ('server', 'devtools')
 
-# Modulos Python: cada uno tiene su ruff.toml autocontenido en su raiz.
-# Ruff autodetecta el config cuando el cwd es la raiz del modulo.
+# Módulos Python: cada uno tiene su ruff.toml autocontenido en su raíz.
+# Ruff autodetecta el config cuando el cwd es la raíz del módulo.
 _PYTHON_MODULE_META: dict[str, dict[str, str]] = {
     'server': {'workdir': '/app/server', 'strip_prefix': 'server/'},
     'devtools': {'workdir': '/app/devtools', 'strip_prefix': 'devtools/'},
@@ -72,8 +72,8 @@ def _biome_command(pkg_script: str) -> list[str]:
     """Convierte el nombre de script (lint, lint:fix, format) a cmd Biome real.
 
     Portfolio NO tiene scripts `lint`/`format` por app. Biome corre desde
-    el root del monorepo (la config `biome.json` esta en raiz). Por eso
-    invocamos directamente `npx @biomejs/biome` con el cwd del modulo.
+    el root del monorepo (la config `biome.json` esta en raíz). Por eso
+    invocamos directamente `npx @biomejs/biome` con el cwd del módulo.
     """
     if pkg_script == 'lint':
         return ['npx', '@biomejs/biome', 'check', '.']
@@ -149,7 +149,7 @@ def _run_ruff_on_host(
 ) -> int:
     """Run Ruff directly on host (uses devtools/.venv/bin/ruff).
 
-    Portfolio no tiene container Django; los modulos Python (devtools,
+    Portfolio no tiene container Django; los módulos Python (devtools,
     server stub) corren ruff localmente via el venv ya sincronizado.
     """
     from pathlib import Path

--- a/devtools/docker/setup.py
+++ b/devtools/docker/setup.py
@@ -60,10 +60,10 @@ def cmd_setup(flags: dict[str, Any]) -> int:
     step = 0
 
     step += 1
-    _step(f'Paso {step}/{total_steps}: Construyendo imagenes...')
+    _step(f'Paso {step}/{total_steps}: Construyendo imágenes...')
     result = run_compose(env, ['build'], timeout=600)
     if result.returncode != 0:
-        _err('Error construyendo imagenes')
+        _err('Error construyendo imágenes')
         return 1
 
     step += 1
@@ -200,7 +200,7 @@ def cmd_clean(flags: dict[str, Any]) -> int:
         return 0
 
     if not confirm_destructive(
-        f'Se eliminaran TODOS los containers, imagenes y volumes\n'
+        f'Se eliminaran TODOS los containers, imágenes y volumes\n'
         f'  con prefijo "{CONTAINER_PREFIX}" del ambiente {env}.\n'
         f'  Esto incluye la base de datos y datos de cache.'
     ):

--- a/devtools/docker/urls.py
+++ b/devtools/docker/urls.py
@@ -2,7 +2,7 @@
 
 Estos helpers introspectan los archivos compose y nginx del proyecto
 portfolio para construir el bloque "Servicios disponibles" que se imprime
-despues de ``docker up`` y ``docker setup``.
+después de ``docker up`` y ``docker setup``.
 """
 
 from __future__ import annotations
@@ -120,7 +120,7 @@ def parse_nginx_subdomains(env: str) -> list[tuple[str, str]]:
         architect.localhost  -> apps/architect
         leader.localhost     -> apps/leader
         vibe.localhost       -> apps/vibe
-        services.localhost   -> indice de servicios estatico
+        services.localhost   -> indice de servicios estático
     """
     nginx_file = DOCKER_DIR / 'nginx' / f'{env}.conf'
     if not nginx_file.exists():

--- a/devtools/harness_init/README.md
+++ b/devtools/harness_init/README.md
@@ -20,18 +20,18 @@ python devtools/run.py harness_init --quiet
 
 1. **Archivos base** — `docs/CHECKPOINTS.md`, `docs/progress/current.md`,
    `docs/progress/history.md`, `CLAUDE.md`, `.claude/settings.json`
-2. **`feature_list.json` por modulo** — recorre
-   `docs/<modulo>/feature_list.json` (landing, dashboard, server,
-   marketplace, cross). JSON valido y respeta `one_feature_at_a_time` por
-   modulo. Si un modulo no tiene archivo, no es error (solo aviso).
+2. **`feature_list.json` por módulo** — recorre
+   `docs/<módulo>/feature_list.json` (landing, dashboard, server,
+   marketplace, cross). JSON válido y respeta `one_feature_at_a_time` por
+   módulo. Si un módulo no tiene archivo, no es error (solo aviso).
 3. **Docker** — daemon corriendo y containers principales up
 4. **Branch** — la actual no debe ser protegida (master/dev/release)
 5. **`docs/progress/`** — limpio, sin temporales viejos de subagentes
 
 ## Cuando usarlo
 
-- Al iniciar una sesion de trabajo no trivial (Medium/Large)
-- Despues de un `git checkout` a una rama donde no recordas el estado
+- Al iniciar una sesión de trabajo no trivial (Medium/Large)
+- Después de un `git checkout` a una rama donde no recordas el estado
 - Antes de lanzar subagentes pesados (researcher, code-reviewer)
 - Como gate previo a invocar `/ship` o `/autopilot`
 
@@ -40,12 +40,12 @@ python devtools/run.py harness_init --quiet
 | Code | Significado |
 |------|-------------|
 | `0`  | Todo OK — puedes empezar a trabajar |
-| `1`  | Algo critico fallo — NO trabajar antes de resolver |
+| `1`  | Algo crítico fallo — NO trabajar antes de resolver |
 
 ## Relacion con otros componentes
 
-- Logica real en `.claude/hooks/harness-init.sh` (este archivo solo es
+- Lógica real en `.claude/hooks/harness-init.sh` (este archivo solo es
   wrapper para descubrimiento via `devtools/run.py`)
-- Documentacion del protocolo: `.claude/rules/harness-protocol.md`
+- Documentación del protocolo: `.claude/rules/harness-protocol.md`
 - Criterios de salud agregados: `docs/CHECKPOINTS.md`
-- feature_list por modulo: `docs/<modulo>/feature_list.json`
+- feature_list por módulo: `docs/<módulo>/feature_list.json`

--- a/devtools/harness_init/flags.py
+++ b/devtools/harness_init/flags.py
@@ -8,13 +8,13 @@ Wrapper sobre `.claude/hooks/harness-init.sh`. Verifica que el entorno del
 arnes (Harness Engineering) este listo para empezar a trabajar:
 
   1. Archivos base existen (docs/CHECKPOINTS.md, docs/progress/...)
-  2. Cualquier docs/<modulo>/feature_list.json existente es JSON valido y
-     respeta `one_feature_at_a_time` (por modulo)
+  2. Cualquier docs/<módulo>/feature_list.json existente es JSON válido y
+     respeta `one_feature_at_a_time` (por módulo)
   3. Docker daemon corriendo + containers principales up
   4. Branch actual no es protegida (master/dev/release)
   5. docs/progress/ esta limpio (sin temporales viejos)
 
-Exit code 0 si OK, 1 si hay errores criticos.
+Exit code 0 si OK, 1 si hay errores críticos.
 """
 
 from typing import Any
@@ -59,9 +59,9 @@ def describe() -> ScriptDescribe:
         'name': 'harness_init',
         'kind': 'monocommand',
         'summary': (
-            'Gate BLOQUEANTE de inicio de sesion (Harness Engineering): '
+            'Gate BLOQUEANTE de inicio de sesión (Harness Engineering): '
             'verifica archivos base (docs/CHECKPOINTS.md, docs/progress/), '
-            'feature_list.json por modulo, Docker, branch, docs/progress/ limpio'
+            'feature_list.json por módulo, Docker, branch, docs/progress/ limpio'
         ),
         'commands': [],
         'flags': {

--- a/devtools/harness_init/main.py
+++ b/devtools/harness_init/main.py
@@ -1,17 +1,17 @@
 """Wrapper Python sobre ``.claude/hooks/harness-init.sh``.
 
-Permite invocar el gate de inicio de sesion via la API unificada de devtools::
+Permite invocar el gate de inicio de sesión via la API unificada de devtools::
 
     python devtools/run.py harness_init
     python devtools/run.py harness_init --quiet
 
 Internamente delega al script bash en ``.claude/hooks/harness-init.sh`` (la
-fuente de verdad de la logica del gate). Este wrapper existe para que el gate
+fuente de verdad de la lógica del gate). Este wrapper existe para que el gate
 sea descubrible via ``python devtools/run.py --list-scripts`` y siga la misma
 convencion que ``test_runner``, ``scan``, ``verify``, ``upgrade_deps``.
 
 Salida del shell hook va a stderr (mensajes coloreados [OK]/[WARN]/[FAIL]).
-Exit code 0 si todo OK; 1 si hay errores criticos.
+Exit code 0 si todo OK; 1 si hay errores críticos.
 """
 
 import logging

--- a/devtools/hooks/main.py
+++ b/devtools/hooks/main.py
@@ -66,7 +66,7 @@ def _print_no_changes(hook_type: str) -> None:
     out('=' * 80)
     out(
         green(
-            f'  SIN CAMBIOS EN MODULOS RELEVANTES — {label.upper()} permitido'
+            f'  SIN CAMBIOS EN MÓDULOS RELEVANTES — {label.upper()} permitido'
         )
     )
     out(

--- a/devtools/mutation_testing/README.md
+++ b/devtools/mutation_testing/README.md
@@ -1,6 +1,6 @@
 # mutation_testing
 
-> Wrapper sobre `mutmut` con thresholds por criticidad. Politica:
+> Wrapper sobre `mutmut` con thresholds por criticidad. Política:
 > `.claude/rules/ai-testing-independence.md`.
 
 ## Concepto
@@ -15,9 +15,9 @@ verifica que los tests fallen. Si la mutacion **sobrevive**, el test es debil.
 |-----------|-----------|---------------|
 | **critical** | 85% | `apps/payments/services`, `apps/auth/services`, `common/security` |
 | **standard** | 70% | `apps/orders/services`, `apps/orders/selectors` |
-| **experimental** | 30% | (vacio; subir progresivo) |
+| **experimental** | 30% | (vacío; subir progresivo) |
 
-Config en [`config.py`](./config.py). Agregar nuevos modulos ahi.
+Config en [`config.py`](./config.py). Agregar nuevos módulos ahí.
 
 ## Uso
 
@@ -48,14 +48,14 @@ python devtools/run.py mutation_testing --all --dry-run
 
 - `0` — todos los paths >= threshold
 - `1` — al menos un path < threshold (o mutmut fallo en algun path)
-- `2` — error interno (config invalido, container no disponible)
+- `2` — error interno (config inválido, container no disponible)
 
-## Integracion con git hooks
+## Integración con git hooks
 
 El step `mutation_testing` del orquestador (`.git-hooks/_common.py`) puede
 correr en pre-push. **Default OFF** porque mutation testing es lento (5-15
 min en suite mediana). Activar via `.git-hooks/config.json` cuando la suite
-del modulo critico este estable. Ver `tmp/git-hooks-patch/README.md`.
+del módulo crítico este estable. Ver `tmp/git-hooks-patch/README.md`.
 
 ## Limitaciones / TODO
 

--- a/devtools/mutation_testing/config.py
+++ b/devtools/mutation_testing/config.py
@@ -1,12 +1,12 @@
 """Mutation testing config consumida por ``devtools/mutation_testing/main.py``.
 
-Define paths bajo ``server/`` con thresholds por criticidad. Politica completa:
+Define paths bajo ``server/`` con thresholds por criticidad. Política completa:
 ``.claude/rules/ai-testing-independence.md``.
 
-| Categoria | Threshold | Razon |
+| Categoria | Threshold | Razón |
 |-----------|-----------|-------|
 | critical  | 85%       | Bugs = perdida economica/legal (pagos, auth, PCI) |
-| standard  | 70%       | Logica de negocio core |
+| standard  | 70%       | Lógica de negocio core |
 | experimental | 30%    | Features nuevas; subir progresivo |
 
 Uso:
@@ -15,7 +15,7 @@ Uso:
     python devtools/run.py mutation_testing --category=critical
     python devtools/run.py mutation_testing --all
 
-NO es config nativa de mutmut — es un modulo Python propio del proyecto.
+NO es config nativa de mutmut — es un módulo Python propio del proyecto.
 ``main.py`` lo importa para clasificar paths y aplicar el threshold por
 categoria. mutmut se invoca via subprocess, no lee este archivo directamente.
 """
@@ -29,9 +29,9 @@ CRITICAL_THRESHOLD = 0.85
 STANDARD_THRESHOLD = 0.70
 EXPERIMENTAL_THRESHOLD = 0.30
 
-# Paths bajo server/ por categoria. Agregar nuevos modulos aqui cuando se
+# Paths bajo server/ por categoria. Agregar nuevos módulos aquí cuando se
 # creen apps. NO incluir tests/, migrations/, __init__.py — mutmut los
-# excluye automaticamente.
+# excluye automáticamente.
 CRITICAL_PATHS: tuple[str, ...] = (
     # Apps con dinero o credenciales — mutation score >= 85%
     'apps/payments/services',
@@ -40,7 +40,7 @@ CRITICAL_PATHS: tuple[str, ...] = (
 )
 
 STANDARD_PATHS: tuple[str, ...] = (
-    # Logica de negocio core — mutation score >= 70%
+    # Lógica de negocio core — mutation score >= 70%
     'apps/orders/services',
     'apps/orders/selectors',
 )
@@ -50,7 +50,7 @@ EXPERIMENTAL_PATHS: tuple[str, ...] = (
 )
 
 # Paths a excluir incluso si caen dentro de los anteriores (no aplica
-# mutation testing a archivos de configuracion/admin).
+# mutation testing a archivos de configuración/admin).
 EXCLUDED_FRAGMENTS: tuple[str, ...] = (
     '/admin/',
     '/migrations/',
@@ -64,7 +64,7 @@ EXCLUDED_FRAGMENTS: tuple[str, ...] = (
 
 
 def threshold_for_path(path: str) -> float:
-    """Retorna el threshold (0..1) que aplica a ``path`` segun su categoria."""
+    """Retorna el threshold (0..1) que aplica a ``path`` según su categoria."""
     if any(p in path for p in CRITICAL_PATHS):
         return CRITICAL_THRESHOLD
     if any(p in path for p in STANDARD_PATHS):
@@ -76,7 +76,7 @@ def threshold_for_path(path: str) -> float:
 
 
 def category_for_path(path: str) -> str:
-    """Retorna ``critical | standard | experimental`` segun la categoria del path."""
+    """Retorna ``critical | standard | experimental`` según la categoria del path."""
     if any(p in path for p in CRITICAL_PATHS):
         return 'critical'
     if any(p in path for p in EXPERIMENTAL_PATHS):
@@ -90,7 +90,7 @@ def is_excluded(path: str) -> bool:
 
 
 def all_categories() -> dict[str, tuple[str, ...]]:
-    """Mapping completo categoria -> paths para iteracion en el script."""
+    """Mapping completo categoria -> paths para iteración en el script."""
     return {
         'critical': CRITICAL_PATHS,
         'standard': STANDARD_PATHS,

--- a/devtools/mutation_testing/flags.py
+++ b/devtools/mutation_testing/flags.py
@@ -35,7 +35,7 @@ DEFAULTS: dict[str, Any] = {
 
 
 def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
-    """Procesa y valida las flags para el script mutation_testing.
+    """Procesa y válida las flags para el script mutation_testing.
 
     Args:
         flags_dict: Dict de flags ya procesado por ``run.py``.
@@ -44,7 +44,7 @@ def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
         Dict con flags validadas y defaults aplicados.
 
     Raises:
-        ValueError: si hay flags no permitidas o combinaciones invalidas.
+        ValueError: si hay flags no permitidas o combinaciones inválidas.
     """
     validate_allowed_flags(flags_dict, ALLOWED_FLAGS)
     flags_dict = set_default_values(flags_dict, DEFAULTS)
@@ -72,7 +72,7 @@ def _validate_category(flags_dict: dict[str, Any]) -> None:
         return
     if value not in VALID_CATEGORIES:
         msg = (
-            f'--category={value} invalido. '
+            f'--category={value} inválido. '
             f'Valores aceptados: {", ".join(VALID_CATEGORIES)}.'
         )
         raise ValueError(msg)

--- a/devtools/mutation_testing/main.py
+++ b/devtools/mutation_testing/main.py
@@ -4,7 +4,7 @@ Wrapper sobre ``mutmut`` con thresholds por criticidad. Lee la config en
 ``devtools/mutation_testing/config.py`` para clasificar paths y aplicar
 el threshold correspondiente.
 
-Politica completa: ``.claude/rules/ai-testing-independence.md``.
+Política completa: ``.claude/rules/ai-testing-independence.md``.
 
 Modos:
 - ``--paths=apps/payments,apps/auth`` -> mutar paths explicitos
@@ -12,14 +12,14 @@ Modos:
 - ``--all`` -> mutar todas las categorias
 - ``--dry-run`` -> imprimir plan sin ejecutar
 
-Ejecucion: el wrapper invoca ``mutmut run`` dentro del container del
+Ejecución: el wrapper invoca ``mutmut run`` dentro del container del
 server (Docker es el runtime obligatorio del proyecto). Si el container
-no esta arriba, falla con instruccion de levantarlo.
+no esta arriba, falla con instrucción de levantarlo.
 
 Exit codes:
     0 - todos los paths >= threshold
     1 - al menos un path < threshold (o mutmut fallo)
-    2 - error interno (config invalido, container no disponible)
+    2 - error interno (config inválido, container no disponible)
 """
 
 from __future__ import annotations
@@ -106,7 +106,7 @@ def _print_plan(
     targets: list[tuple[str, str, float]], config: ModuleType
 ) -> int:
     """Imprime que paths se mutarian con que threshold (--dry-run)."""
-    print('[mutation_testing] DRY RUN — plan de ejecucion:\n')
+    print('[mutation_testing] DRY RUN — plan de ejecución:\n')
     print(f'  {"path":50}  {"categoria":12}  threshold')
     print(f'  {"-" * 50}  {"-" * 12}  ---------')
     for path, category, threshold in targets:
@@ -293,7 +293,7 @@ def _parse_mutmut_score() -> float | None:
 
 
 if __name__ == '__main__':
-    # Permite ejecucion directa: python devtools/mutation_testing/main.py ...
+    # Permite ejecución directa: python devtools/mutation_testing/main.py ...
     sys.path.insert(0, str(_PROJECT_ROOT / 'devtools'))
     from mutation_testing.flags import flag
 

--- a/devtools/ruff.toml
+++ b/devtools/ruff.toml
@@ -7,7 +7,7 @@
 line-length = 80
 # Python real del proyecto: 3.14 (devtools/.venv via uv).
 # Ruff con target=py314 aplica PEP 758: ``except (A, B):`` sin ``as`` se
-# reformatea a ``except A, B:`` (mas conciso, valido en >= 3.14).
+# reformatea a ``except A, B:`` (mas conciso, válido en >= 3.14).
 #
 # Excepcion: archivos del bootstrap que corren ANTES del re-exec a Python
 # 3.14 (devtools/run.py y .git-hooks/*.py) tienen pin a py313 via
@@ -54,7 +54,7 @@ exclude = [
 
 [lint]
 select = [
-    # Estandares basicos
+    # Estándares básicos
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
 

--- a/devtools/run.py
+++ b/devtools/run.py
@@ -12,7 +12,7 @@ from types import ModuleType
 from utils.flags_to_dict import flags_to_dict
 
 
-# Anadir el directorio raiz del proyecto al path para que los imports absolutos funcionen
+# Anadir el directorio raíz del proyecto al path para que los imports absolutos funcionen
 project_root = Path(__file__).parent.parent
 if str(project_root) not in sys.path:
     sys.path.append(str(project_root))
@@ -125,10 +125,10 @@ _reexec_in_venv()
 
 
 def load_module_from_path(module_name: str, file_path: str) -> ModuleType:
-    """Carga un modulo desde una ruta especifica."""
+    """Carga un módulo desde una ruta especifica."""
     spec = importlib.util.spec_from_file_location(module_name, file_path)
     if spec is None:
-        msg = f'No se pudo cargar el modulo desde {file_path}'
+        msg = f'No se pudo cargar el módulo desde {file_path}'
         raise ImportError(msg)
 
     module = importlib.util.module_from_spec(spec)
@@ -137,7 +137,7 @@ def load_module_from_path(module_name: str, file_path: str) -> ModuleType:
 
 
 def discover_valid_scripts() -> list[str]:
-    """Descubre todos los scripts validos en el directorio devtools/."""
+    """Descubre todos los scripts válidos en el directorio devtools/."""
     scripts_dir = Path(__file__).parent
     valid_scripts = []
 
@@ -165,7 +165,7 @@ def show_global_help() -> None:
     valid_scripts = discover_valid_scripts()
 
     if not valid_scripts:
-        print('No se encontraron scripts validos.')
+        print('No se encontraron scripts válidos.')
         return
 
     print('Scripts disponibles:')
@@ -192,7 +192,7 @@ def _show_script_help(script_dir: Path, script_folder: str) -> None:
             print(content)
             return
 
-    print(f'Sin documentacion disponible para {script_folder}')
+    print(f'Sin documentación disponible para {script_folder}')
 
 
 def _resolve_script_paths(script_folder: str) -> tuple[Path, Path, Path]:
@@ -232,7 +232,7 @@ def _run_script(
     )
 
     if not hasattr(flags_module, 'flag'):
-        print(f"Error: No se encontro la funcion 'flag' en {flags_py_path}")
+        print(f"Error: No se encontro la función 'flag' en {flags_py_path}")
         sys.exit(1)
 
     # Modo silent: cuando el caller pide --only-list o --output=json,
@@ -250,7 +250,7 @@ def _run_script(
     try:
         parsed_flags = flags_module.flag(flags_dict)
     except ValueError as e:
-        print('\nError en la configuracion:', file=sys.stderr)
+        print('\nError en la configuración:', file=sys.stderr)
         print(f'   {e!s}', file=sys.stderr)
         print('\nPara ver la ayuda completa, usa:', file=sys.stderr)
         print(
@@ -263,7 +263,7 @@ def _run_script(
 
     if not hasattr(main_module, 'main'):
         print(
-            f"Error: No se encontro la funcion 'main' en {main_py_path}",
+            f"Error: No se encontro la función 'main' en {main_py_path}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -501,7 +501,7 @@ def _handle_introspection(flags_dict: dict, script_folder: str | None) -> bool:
     """Dispatch the introspection flags. Returns True if handled."""
     output = flags_dict.get('output', 'text')
     if output not in ('text', 'json'):
-        print(f"Output invalido: '{output}'. Validos: text, json")
+        print(f"Output inválido: '{output}'. Válidos: text, json")
         sys.exit(1)
 
     if flags_dict.get('list_scripts'):
@@ -547,7 +547,7 @@ def _emit_completion(argv: list[str]) -> None:
         print(_generate_bash_completion(), end='')
     else:
         print(
-            f"Shell invalido: '{shell}'. Validos: zsh, bash",
+            f"Shell inválido: '{shell}'. Válidos: zsh, bash",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -586,7 +586,7 @@ def main() -> None:
     )
 
     # Per-script introspection (--list-commands / --list-flags / --describe)
-    # corre antes de la validacion del script para que funcione incluso con
+    # corre antes de la validación del script para que funcione incluso con
     # scripts que no han migrado todas sus flags.
     introspection_requested = (
         flags_dict.get('list_commands')

--- a/devtools/scan/README.md
+++ b/devtools/scan/README.md
@@ -2,7 +2,7 @@
 
 Lista archivos del repo con filtros git-aware y, opcionalmente, su
 contenido. Es la pieza que usan los git-hooks (`.git-hooks/_common.py`)
-para clasificar archivos por modulo y purpose, y la que usa
+para clasificar archivos por módulo y purpose, y la que usa
 `test_runner --git-mode=...` para mapear cambios a tests.
 
 ## Uso
@@ -13,18 +13,18 @@ python devtools/run.py scan [flags]
 
 ## Flags principales
 
-| Flag | Descripcion | Default |
+| Flag | Descripción | Default |
 |------|-------------|---------|
 | `--git-mode=<mode>` | `changed`, `staged`, `unstaged`, `stash`, `unmerged`, `all` | none |
 | `--module=<name>` | Limita a `server`, `dashboard`, `landing`, `devtools` | none |
 | `--purpose=<name>` | `conformance` o `coverage` (aplica excludes especificos) | none |
-| `--only-extension=<ext>` | Filtra por extension (ej: `py`, `ts`) | [] |
-| `--excludes-extension=<ext>` | Excluye extensiones | [] |
+| `--only-extensión=<ext>` | Filtra por extensión (ej: `py`, `ts`) | [] |
+| `--excludes-extensión=<ext>` | Excluye extensiones | [] |
 | `--only-list` | Output `;`-separado (machine-readable, para pipe) | false |
-| `--only-folders-root` | Solo lista carpetas raiz | false |
+| `--only-folders-root` | Solo lista carpetas raíz | false |
 | `--include-ignored` | Incluye archivos en .gitignore | false |
 | `--include-deleted` | Incluye archivos eliminados (modo unmerged) | false |
-| `--exclude-empty` | Omite archivos vacios | false |
+| `--exclude-empty` | Omite archivos vacíos | false |
 | `--ignore-patterns=<glob>` | Patterns adicionales (separados por pipe) | [] |
 
 ## Ejemplos
@@ -40,10 +40,10 @@ python devtools/run.py scan --module=server --git-mode=all
 python devtools/run.py scan --module=server --purpose=coverage \
     --git-mode=changed --only-list
 
-# No mergeados vs rama base, solo Python (revision pre-PR)
-python devtools/run.py scan --git-mode=unmerged --only-extension=py
+# No mergeados vs rama base, solo Python (revisión pre-PR)
+python devtools/run.py scan --git-mode=unmerged --only-extensión=py
 
-# Carpetas raiz del proyecto (utilidad para descubrir modulos)
+# Carpetas raíz del proyecto (utilidad para descubrir módulos)
 python devtools/run.py scan --only-folders-root
 ```
 
@@ -62,7 +62,7 @@ Definidos en `devtools/scan/modules.py`:
 
 - **modules**: `server`, `dashboard`, `landing`, `devtools` — cada uno tiene
   extensions, exclude_patterns y opcionalmente `ruff_config`. Limita el
-  scan a archivos bajo el root del modulo.
+  scan a archivos bajo el root del módulo.
 - **purposes**: `conformance` (lint/format) y `coverage` (tests con
   coverage). Cada uno aplica excludes adicionales (ej: coverage excluye
   `__init__.py`, `migrations/`, etc.).
@@ -70,7 +70,7 @@ Definidos en `devtools/scan/modules.py`:
 ## Quien lo usa
 
 - `.git-hooks/_common.py` — clasifica staged files para correr lint/coverage
-  por modulo
+  por módulo
 - `devtools/test_runner` — mapea archivos cambiados a tests via
   path mirroring + per-file coverage
 - Manual / CI — para inspeccionar la estructura del proyecto
@@ -83,5 +83,5 @@ Definidos en `devtools/scan/modules.py`:
 - `files.py` — get_file_content + get_file_dates (filesystem)
 - `structure.py` — assembler que produce el dict final
 - `display.py` — `_display_list_mode` + `_display_detailed_mode`
-- `flags.py` — validacion de flags (incluye `describe()` para introspeccion)
-- `modules.py` — registry de modulos y purposes
+- `flags.py` — validación de flags (incluye `describe()` para introspeccion)
+- `modules.py` — registry de módulos y purposes

--- a/devtools/scan/display.py
+++ b/devtools/scan/display.py
@@ -58,7 +58,7 @@ def _display_detailed_mode(
 ) -> None:
     """Print the full human-readable view of the structure."""
     if flags.get('only_folders_root'):
-        print('Carpetas raiz del proyecto:')
+        print('Carpetas raíz del proyecto:')
         print('-' * 30)
         for folder in structure['folders']:
             print(f'  {folder}')

--- a/devtools/scan/flags.py
+++ b/devtools/scan/flags.py
@@ -44,12 +44,12 @@ DEFAULTS = {
 
 def get_valid_git_modes() -> list[str]:
     """
-    Obtiene lista de modos git validos.
+    Obtiene lista de modos git válidos.
 
     Returns
     -------
     list[str]
-        Lista de modos git validos como 'changed', 'staged', 'unstaged', etc.
+        Lista de modos git válidos como 'changed', 'staged', 'unstaged', etc.
     """
     return ['changed', 'staged', 'unstaged', 'stash', 'unmerged', 'all']
 
@@ -61,7 +61,7 @@ def _clean_extensions(extensions: str | list[str]) -> list[str]:
     Parameters
     ----------
     extensions : str | list[str]
-        Extension o lista de extensiones a limpiar.
+        Extensión o lista de extensiones a limpiar.
 
     Returns
     -------
@@ -74,7 +74,7 @@ def _clean_extensions(extensions: str | list[str]) -> list[str]:
 
 
 def _validate_git_mode(flags_dict: dict[str, Any]) -> None:
-    """Valida que git_mode sea uno de los valores permitidos."""
+    """Válida que git_mode sea uno de los valores permitidos."""
     git_mode = flags_dict.get('git_mode')
     if not git_mode:
         return
@@ -88,7 +88,7 @@ def _validate_git_mode(flags_dict: dict[str, Any]) -> None:
 
 
 def _validate_extensions(flags_dict: dict[str, Any]) -> None:
-    """Valida y normaliza excludes_extension y only_extension."""
+    """Válida y normaliza excludes_extension y only_extension."""
     if flags_dict.get('excludes_extension'):
         flags_dict['excludes_extension'] = _clean_extensions(
             flags_dict['excludes_extension'],
@@ -101,13 +101,13 @@ def _validate_extensions(flags_dict: dict[str, Any]) -> None:
 
         if flags_dict.get('excludes_extension'):
             raise ValueError(
-                'No se puede usar --only-extension junto con '
-                '--excludes-extension. Use una u otra.'
+                'No se puede usar --only-extensión junto con '
+                '--excludes-extensión. Use una u otra.'
             )
 
 
 def _validate_ignore_patterns(flags_dict: dict[str, Any]) -> None:
-    """Valida y normaliza ignore_patterns."""
+    """Válida y normaliza ignore_patterns."""
     if not flags_dict.get('ignore_patterns'):
         return
 
@@ -126,7 +126,7 @@ def _validate_ignore_patterns(flags_dict: dict[str, Any]) -> None:
 
 
 def _validate_module(flags_dict: dict[str, Any]) -> None:
-    """Valida --module y aplica config del module (extensions, exclude patterns)."""
+    """Válida --module y aplica config del module (extensions, exclude patterns)."""
     if not flags_dict.get('module'):
         return
 
@@ -138,7 +138,7 @@ def _validate_module(flags_dict: dict[str, Any]) -> None:
     except ValueError:
         valid_modules = ', '.join(get_module_names())
         raise ValueError(
-            f'Module invalido: {flags_dict["module"]}. Modules validos: {valid_modules}'
+            f'Module inválido: {flags_dict["module"]}. Modules válidos: {valid_modules}'
         ) from None
 
     # Module sobreescribe extensions y agrega exclude patterns
@@ -154,7 +154,7 @@ def _validate_module(flags_dict: dict[str, Any]) -> None:
 
 
 def _validate_purpose(flags_dict: dict[str, Any]) -> None:
-    """Valida --purpose y agrega sus exclude patterns."""
+    """Válida --purpose y agrega sus exclude patterns."""
     if not flags_dict.get('purpose'):
         return
 
@@ -162,8 +162,8 @@ def _validate_purpose(flags_dict: dict[str, Any]) -> None:
 
     if flags_dict['purpose'] not in VALID_PURPOSES:
         raise ValueError(
-            f'Purpose invalido: {flags_dict["purpose"]}. '
-            f'Validos: {", ".join(VALID_PURPOSES)}'
+            f'Purpose inválido: {flags_dict["purpose"]}. '
+            f'Válidos: {", ".join(VALID_PURPOSES)}'
         )
 
     if not flags_dict.get('module'):
@@ -204,7 +204,7 @@ def _print_processed_flags(flags_dict: dict[str, Any]) -> None:
 
 def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
     """
-    Procesa y valida las flags para el script scan.
+    Procesa y válida las flags para el script scan.
 
     Parameters
     ----------
@@ -219,7 +219,7 @@ def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
     Raises
     ------
     ValueError
-        Si se usan flags no permitidas o valores invalidos
+        Si se usan flags no permitidas o valores inválidos
     """
     validate_allowed_flags(flags_dict, ALLOWED_FLAGS)
     flags_dict = set_default_values(flags_dict, DEFAULTS)
@@ -250,7 +250,7 @@ def describe() -> ScriptDescribe:
             'module': {
                 'type': 'choice',
                 'choices': ['server', 'dashboard', 'landing', 'devtools'],
-                'summary': 'Limita a un modulo del proyecto',
+                'summary': 'Limita a un módulo del proyecto',
             },
             'purpose': {
                 'type': 'choice',
@@ -273,7 +273,7 @@ def describe() -> ScriptDescribe:
             'only_folders_root': {
                 'type': 'bool',
                 'default': False,
-                'summary': 'Solo lista carpetas raiz del proyecto',
+                'summary': 'Solo lista carpetas raíz del proyecto',
             },
             'only_list': {
                 'type': 'bool',
@@ -288,7 +288,7 @@ def describe() -> ScriptDescribe:
             'exclude_empty': {
                 'type': 'bool',
                 'default': False,
-                'summary': 'Omite archivos vacios',
+                'summary': 'Omite archivos vacíos',
             },
             'ignore_patterns': {
                 'type': 'list',

--- a/devtools/scan/git_query.py
+++ b/devtools/scan/git_query.py
@@ -38,7 +38,7 @@ def get_git_ignored_files() -> list[str]:
             )
         ]
     except git.InvalidGitRepositoryError:
-        print('Advertencia: No es un repositorio Git valido')
+        print('Advertencia: No es un repositorio Git válido')
         return []
     else:
         return unique_ignored_files

--- a/devtools/scan/ignore.py
+++ b/devtools/scan/ignore.py
@@ -85,7 +85,7 @@ def _matches_path_pattern(file_path: str, pattern: str) -> bool:
     Common shortcuts handled directly:
     - ``prefix/**``: any file under prefix/
     - ``**/segment/**``: segment appears anywhere as a directory
-    - ``**/*.ext``: files with extension at any depth
+    - ``**/*.ext``: files with extensión at any depth
     - ``**/__init__.py``: file at any depth
     Other patterns delegate to ``matches_ignore_pattern``.
     """

--- a/devtools/scan/modules.py
+++ b/devtools/scan/modules.py
@@ -1,7 +1,7 @@
 """Module definitions for project scanning.
 
 Each module is a logical region of the project with specific rules for
-file inclusion/exclusion. Modules are NOT necessarily 1:1 with directories —
+file inclusión/exclusión. Modules are NOT necessarily 1:1 with directories —
 they are code-defined profiles that map to scanning behavior.
 
 Purpose-specific excludes allow different tools (conformance, formatter,
@@ -82,7 +82,7 @@ def _package_module(pkg_name: str) -> dict[str, Any]:
 MODULES: dict[str, dict[str, Any]] = {
     # Server stub. NO existe backend en el portfolio; este module se mantiene
     # solo para que devtools/hooks/main.py (que verifica server/manage.py)
-    # no falle. La deteccion de archivos retorna vacio porque no hay .py
+    # no falle. La deteccion de archivos retorna vacío porque no hay .py
     # de production en server/.
     'server': {
         'description': 'Stub placeholder (no backend in portfolio)',
@@ -126,7 +126,7 @@ MODULES: dict[str, dict[str, Any]] = {
     },
 }
 
-# Inyectar dinamicamente las 6 apps Astro y los 5 packages.
+# Inyectar dinámicamente las 6 apps Astro y los 5 packages.
 for _app in PORTFOLIO_APPS:
     MODULES[_app] = _astro_app_module(_app)
 

--- a/devtools/shared/classification.py
+++ b/devtools/shared/classification.py
@@ -110,7 +110,7 @@ def classify_server_files(
             unit_pairs.append((source, f))
             seen_tests.add(f)
 
-    # `feature` reemplaza al historico `integration` (mayo 2026). Aceptamos
+    # `feature` reemplaza al histórico `integration` (mayo 2026). Aceptamos
     # ambas paths para evitar romper checkouts antiguos durante la transicion;
     # el `feature/` es la fuente nueva.
     integration_tests = [
@@ -176,7 +176,7 @@ def _resolve_test_to_source(
     """Reverse mirror: given a test path, find an existing source on disk.
 
     Dashboard tests end in `.test.ts`; landing tests end in `.ts`. We probe
-    each candidate source extension and return the first that exists.
+    each candidate source extensión and return the first that exists.
     """
     relative = test_path.removeprefix(layout['test_prefix'])
     test_ext = layout['test_extension']

--- a/devtools/shared/commands.py
+++ b/devtools/shared/commands.py
@@ -42,7 +42,7 @@ def build_pytest_integration_cmd(
 ) -> list[str]:
     """Build pytest command for feature tests (renombrado de integration).
 
-    Mantenemos el nombre de la funcion ``build_pytest_integration_cmd``
+    Mantenemos el nombre de la función ``build_pytest_integration_cmd``
     para no romper los hooks que la importan; el marker pytest cambia
     de ``integration`` a ``feature`` (mayo 2026) y el target default
     pasa de ``tests/`` a ``tests/feature/``.

--- a/devtools/shared/compose.py
+++ b/devtools/shared/compose.py
@@ -235,11 +235,11 @@ def ensure_running(env: str, auto_start: bool = True) -> bool:
         return True
 
     if not auto_start:
-        err(f'Los servicios no estan corriendo en ambiente {env}')
+        err(f'Los servicios no están corriendo en ambiente {env}')
         info(f'Iniciar con: python devtools/run.py docker up --env={env}')
         return False
 
-    warn('Los servicios no estan corriendo. Iniciando...')
+    warn('Los servicios no están corriendo. Iniciando...')
     result = run_compose(env, ['up', '-d'])
     if result.returncode != 0:
         err('No se pudo iniciar los servicios')
@@ -270,7 +270,7 @@ def wait_for_healthy(env: str, timeout: int = HEALTH_CHECK_TIMEOUT) -> bool:
                 break
 
         if all_healthy:
-            ok('Todos los servicios estan saludables')
+            ok('Todos los servicios están saludables')
             return True
 
         elapsed = int(time.time() - start)

--- a/devtools/shared/coverage.py
+++ b/devtools/shared/coverage.py
@@ -4,7 +4,7 @@ Returns structured results so callers (hooks, test_runner) can format output
 according to their own conventions.
 
 Exclusiones globales: archivos sin valor para coverage 80% (no contienen
-logica de negocio que requiera tests unitarios).
+lógica de negocio que requiera tests unitarios).
 """
 
 import json
@@ -15,12 +15,12 @@ COVERAGE_THRESHOLD = 80
 
 
 # Path patterns excluidos del enforcement de coverage 80% (server-side).
-# Estos archivos no contienen logica de negocio que requiera tests unitarios.
+# Estos archivos no contienen lógica de negocio que requiera tests unitarios.
 SERVER_COVERAGE_EXCLUDES: tuple[str, ...] = (
     '__init__.py',  # Re-exports
     '/enums/',  # TextChoices/IntegerChoices declarativas
     '/enums.py',
-    '/constants.py',  # UPPER_SNAKE_CASE constantes estaticas
+    '/constants.py',  # UPPER_SNAKE_CASE constantes estáticas
     '/migrations/',  # Auto-generadas por Django
     '/apps.py',  # AppConfig declarativa (1-2 lineas utiles)
     '/admin/',  # Admin classes (testeadas via integration)
@@ -32,12 +32,12 @@ SERVER_COVERAGE_EXCLUDES: tuple[str, ...] = (
     '/config/wsgi.py',
     '/config/asgi.py',
     'manage.py',
-    '/exceptions.py',  # Definicion de excepciones de dominio (sin logica)
+    '/exceptions.py',  # Definición de excepciones de dominio (sin lógica)
 )
 
 # Frontend (portfolio Astro 6 + packages): exclusiones equivalentes a server.
 # Pages, layouts, .astro y components son JSX-heavy / template-only y se
-# cubren via E2E (Playwright). La logica testeable real esta en src/lib/,
+# cubren via E2E (Playwright). La lógica testeable real esta en src/lib/,
 # packages/<X>/src/, validators y formatters.
 FRONTEND_COVERAGE_EXCLUDES: tuple[str, ...] = (
     '/types/',  # Solo type definitions
@@ -45,15 +45,15 @@ FRONTEND_COVERAGE_EXCLUDES: tuple[str, ...] = (
     '/config.ts',
     'env.d.ts',
     '.astro',  # Componentes Astro (template-only, testeados via E2E)
-    '/layouts/',  # Layouts/templates (estructura JSX, sin logica testeable)
+    '/layouts/',  # Layouts/templates (estructura JSX, sin lógica testeable)
     '/pages/',  # Pages Astro (file-based routing, testeadas via E2E)
-    '/public/',  # Assets estaticos
+    '/public/',  # Assets estáticos
     # Astro config files in apps/<APP> y packages/<PKG>
     '/astro.config.ts',
     '/vitest.config.ts',
     '/uno.config.ts',
     '/tailwind.config.ts',
-    # Scripts auxiliares (build-time, no logica testeable critica)
+    # Scripts auxiliares (build-time, no lógica testeable crítica)
     '/scripts/',
 )
 
@@ -62,7 +62,7 @@ def is_excluded_from_coverage(source: str) -> bool:
     """True si el source esta excluido del coverage 80% per-file.
 
     Aplica patrones SERVER_COVERAGE_EXCLUDES y FRONTEND_COVERAGE_EXCLUDES.
-    Centralizado aqui para que hooks, test_runner y CI usen el mismo criterio.
+    Centralizado aquí para que hooks, test_runner y CI usen el mismo criterio.
     """
     for pattern in SERVER_COVERAGE_EXCLUDES + FRONTEND_COVERAGE_EXCLUDES:
         if pattern in source:

--- a/devtools/shared/deletion_mirror.py
+++ b/devtools/shared/deletion_mirror.py
@@ -3,14 +3,14 @@
 Detecta dos clases de huerfanos cuando un changeset elimina archivos:
 
   - **Orphan test**: source eliminado pero su test mirror sigue en disco.
-    El usuario debe eliminar tambien el test mirror.
+    El usuario debe eliminar también el test mirror.
 
   - **Orphan source**: test eliminado pero su source sigue en disco.
-    El usuario debe restaurar el test (o eliminar tambien el source).
+    El usuario debe restaurar el test (o eliminar también el source).
 
 Se aplica solo al modo pre-push para no penalizar commits intermedios. Los
 renames (delete + add) NO reciben tratamiento especial: si el usuario hace
-``git mv source/foo.ts source/bar.ts`` debe mover tambien el test mirror,
+``git mv source/foo.ts source/bar.ts`` debe mover también el test mirror,
 o el hook lo bloqueara.
 
 Path mirroring (portfolio Astro monorepo):
@@ -80,7 +80,7 @@ def _frontend_source_candidates_from_mirror(
     """Reverse: candidate sources for a frontend mirror test path.
 
     Portfolio uses `.test.ts` mirrors. A test could correspond to a source
-    with extension .ts or .astro (apps) or .ts (packages). Returns all
+    with extensión .ts or .astro (apps) or .ts (packages). Returns all
     candidates and the caller probes which one exists on disk.
     """
     if module not in _FRONTEND_LAYOUT:
@@ -231,7 +231,7 @@ def collect_orphan_pairs(
     Args:
         deleted_by_module: dict con keys 'server', '<app>' (cada app Astro)
             y 'pkg-<package>' (cada package). Valor: lista de paths
-            eliminados en ese modulo.
+            eliminados en ese módulo.
         project_root: project root path (resolved).
 
     Returns:

--- a/devtools/shared/paths.py
+++ b/devtools/shared/paths.py
@@ -46,9 +46,9 @@ PORTFOLIO_PACKAGES: tuple[str, ...] = (
 # Test E2E shared (Playwright) — root-level, no por-app.
 FEATURE_TESTS_DIR: Path = PROJECT_ROOT / 'tests' / 'feature'
 
-# Aliases legacy: muchos modulos del fuente referencian DASHBOARD_DIR /
+# Aliases legacy: muchos módulos del fuente referencian DASHBOARD_DIR /
 # LANDING_DIR. Los mantenemos como punteros al primer app del portfolio
-# para que imports antiguos no exploten, pero NO se usan en logica nueva.
+# para que imports antiguos no exploten, pero NO se usan en lógica nueva.
 DASHBOARD_DIR: Path = APPS_DIR / 'generic'  # legacy alias
 LANDING_DIR: Path = APPS_DIR / 'generic'  # legacy alias
 E2E_DIR: Path = FEATURE_TESTS_DIR  # legacy alias

--- a/devtools/shared/purity.py
+++ b/devtools/shared/purity.py
@@ -27,7 +27,7 @@ _DEFAULT_EXCLUDED = ('node_modules/', '.astro/', 'dist/', 'coverage/')
 _PORTFOLIO_APPS = ('hub', 'generic', 'fintech', 'architect', 'leader', 'vibe')
 _PORTFOLIO_PACKAGES = ('app-shared', 'content', 'cv-pdf', 'seo', 'ui')
 
-# Mapeo modulo -> (path prefix, depth-of-module-root).
+# Mapeo módulo -> (path prefix, depth-of-module-root).
 # Depth-of-module-root es la cantidad de path parts ANTES del primer archivo.
 # Para apps/X/foo.ts: depth=2 -> 'apps','X','foo.ts' -> parts[0:2] = module root.
 # Para packages/X/foo.ts: depth=2 igual.

--- a/devtools/shared/scan_helper.py
+++ b/devtools/shared/scan_helper.py
@@ -18,7 +18,7 @@ Two modes:
 - ``files_for_module(module, git_mode, ...)`` — filtered by the module's
   ``root`` and ``extensions`` config. Use when you need files for a specific
   module (e.g., conformance for ``server/*.py``).
-- ``files_changed(git_mode)`` — every changed file, no module/extension
+- ``files_changed(git_mode)`` — every changed file, no module/extensión
   filter. Use when you need a transversal view (e.g., ``verify`` classifying
   any path).
 """
@@ -76,7 +76,7 @@ def files_for_module(
 
 
 def files_changed(*, git_mode: str = 'changed') -> list[str]:
-    """Every changed file for ``git_mode``, no module/extension filter.
+    """Every changed file for ``git_mode``, no module/extensión filter.
 
     Use this when you need to classify arbitrary paths (``verify`` checks
     server/dashboard/landing/devtools/.claude in one pass). Defaults to

--- a/devtools/shared/test_executors.py
+++ b/devtools/shared/test_executors.py
@@ -255,7 +255,7 @@ def run_frontend_tests(
     if not pkg_script:
         valid = ', '.join(sorted(frontend_test_types(module)))
         err(
-            f'Tipo de test invalido para {module}: {test_type}. Validos: {valid}',
+            f'Tipo de test inválido para {module}: {test_type}. Válidos: {valid}',
         )
         return 1
 

--- a/devtools/shared/weak_assertion.py
+++ b/devtools/shared/weak_assertion.py
@@ -4,20 +4,20 @@ Identifica asserts vagos via AST en archivos de test Python:
 
 - ``assert x > 0`` / ``assert x < N`` / ``assert x >= 0`` / ``assert x <= N``
 - ``assert result is not None`` / ``assert x is None``
-- ``assert isinstance(x, T)`` (cuando es la unica forma de verificar)
+- ``assert isinstance(x, T)`` (cuando es la única forma de verificar)
 - ``assert len(x) > 0`` / ``assert len(x) >= 1``
 - ``assert x``  (truthy check sin valor concreto)
 
 Estos patrones suelen indicar tests que pasan por casualidad (no demuestran
-el comportamiento esperado). Politica completa:
+el comportamiento esperado). Política completa:
 ``.claude/rules/ai-testing-independence.md``.
 
 Bypass:
-- Por linea: agregar ``# noqa: WEAK-ASSERT`` con razon en comentario.
+- Por linea: agregar ``# noqa: WEAK-ASSERT`` con razón en comentario.
 - Por archivo: agregar ``# weak-assert: skip-file`` en una linea.
 - Por step: ``SKIP_STEPS="weak_assertion" git commit ...``
 
-Esta logica se invoca desde:
+Esta lógica se invoca desde:
 - El step ``weak_assertion`` del orquestador de hooks (``.git-hooks/_common.py``).
 - El script ``devtools/run.py weak_assertion`` (CLI manual).
 """
@@ -53,7 +53,7 @@ def _is_compare_with_zero_or_int(node: ast.Compare) -> tuple[bool, str]:
     if not node.comparators or len(node.comparators) != 1:
         return False, ''
     comp = node.comparators[0]
-    # Solo flagear contra Constant numerico (no contra otra expresion)
+    # Solo flagear contra Constant numerico (no contra otra expresión)
     if not isinstance(comp, ast.Constant) or not isinstance(
         comp.value, int | float
     ):
@@ -64,7 +64,7 @@ def _is_compare_with_zero_or_int(node: ast.Compare) -> tuple[bool, str]:
         ast.Lt: '<',
         ast.LtE: '<=',
     }[type(op)]
-    return True, f'comparacion {op_str} {comp.value}'
+    return True, f'comparación {op_str} {comp.value}'
 
 
 def _is_isnone(node: ast.Compare) -> tuple[bool, str]:
@@ -109,11 +109,11 @@ def _classify_assert(test: ast.expr) -> tuple[str, str] | None:
 
     Retorna None si el assert no es weak.
     """
-    # 1) Truthy check standalone: assert x  (Name o Attribute, sin operacion)
+    # 1) Truthy check standalone: assert x  (Name o Attribute, sin operación)
     if isinstance(test, ast.Name | ast.Attribute):
         return (
             'truthy check sin valor concreto',
-            'usar comparacion exacta: assert x == <valor_esperado>',
+            'usar comparación exacta: assert x == <valor_esperado>',
         )
 
     # 2) Comparaciones vagas
@@ -121,7 +121,7 @@ def _classify_assert(test: ast.expr) -> tuple[str, str] | None:
         is_weak, label = _is_compare_with_zero_or_int(test)
         if is_weak:
             return (
-                f'comparacion vaga ({label})',
+                f'comparación vaga ({label})',
                 'usar igualdad exacta: assert x == <valor_esperado>',
             )
         is_weak, label = _is_isnone(test)
@@ -142,8 +142,8 @@ def _classify_assert(test: ast.expr) -> tuple[str, str] | None:
         is_weak, label = _is_isinstance_call(test)
         if is_weak:
             return (
-                f'verificacion de tipo ({label})',
-                'usar igualdad de valor + relegar tipo a typecheck estatico',
+                f'verificación de tipo ({label})',
+                'usar igualdad de valor + relegar tipo a typecheck estático',
             )
 
     return None
@@ -164,7 +164,7 @@ def _has_file_skip(source: str) -> bool:
     )
 
 
-# ── API publica ──────────────────────────────────────────────────────────
+# ── API pública ──────────────────────────────────────────────────────────
 
 
 def is_test_file(path: Path) -> bool:
@@ -232,8 +232,8 @@ def scan_files(
 ) -> list[WeakAssertFinding]:
     """Escanea una lista de paths (relativos o absolutos) y retorna findings.
 
-    Solo se procesan los que estan bajo un directorio ``tests/`` y existen en
-    disco. Paths sin extension ``.py`` se ignoran.
+    Solo se procesan los que están bajo un directorio ``tests/`` y existen en
+    disco. Paths sin extensión ``.py`` se ignoran.
     """
     findings: list[WeakAssertFinding] = []
     for f in files:
@@ -262,7 +262,7 @@ def format_findings(findings: list[WeakAssertFinding]) -> str:
     )
     lines.append(
         '\nBypass:\n'
-        '  - inline: agregar  # noqa: WEAK-ASSERT  con razon en comentario\n'
+        '  - inline: agregar  # noqa: WEAK-ASSERT  con razón en comentario\n'
         '  - archivo: agregar  # weak-assert: skip-file  en una linea\n'
         '  - emergencia: SKIP_STEPS="weak_assertion" git commit ...\n'
         '\nPolitica: .claude/rules/ai-testing-independence.md',

--- a/devtools/test_runner/README.md
+++ b/devtools/test_runner/README.md
@@ -1,6 +1,6 @@
 # test_runner
 
-Ejecuta tests para uno o todos los modulos del proyecto via Docker.
+Ejecuta tests para uno o todos los módulos del proyecto via Docker.
 
 ## Uso
 
@@ -10,28 +10,28 @@ python devtools/run.py test_runner [flags]
 
 ## Flags
 
-| Flag | Descripcion | Default |
+| Flag | Descripción | Default |
 | --- | --- | --- |
-| `--module=<name>` | Modulo a testear (`server`, `dashboard`, `landing`, `devtools`) | todos los modulos con tests |
+| `--module=<name>` | Módulo a testear (`server`, `dashboard`, `landing`, `devtools`) | todos los módulos con tests |
 | `--type=<type>` | Tipo de test (`unit`, `feature`, `integration`, `coverage`, `typecheck`, `all`) | `all` |
 | `--git-mode=<mode>` | Filtrar por estado git (`changed`, `staged`, `unstaged`, `unmerged`, `all`) | sin filtro |
 | `--env=<env>` | Docker environment (`local`, `dev`, `test`) | local |
 | `--verbose` | Informacion detallada | false |
 | `--quiet` | Suprimir output en exito | false |
 | `--screenshots` | Generar screenshots durante feature (solo `dashboard`/`landing`) | false |
-| `--ui-review` | Revisar screenshots con Gemini CLI tras ejecucion | false |
+| `--ui-review` | Revisar screenshots con Gemini CLI tras ejecución | false |
 | `--skip-empty` | Saltar si no hay archivos (con git-mode) | true |
 
-## Test types por modulo
+## Test types por módulo
 
-| Modulo | Tipos disponibles |
+| Módulo | Tipos disponibles |
 | --- | --- |
 | server | unit, feature, integration, coverage |
 | dashboard | unit, feature, coverage, typecheck |
 | landing | unit, feature, coverage, typecheck |
 | devtools | unit |
 
-> Mayo 2026: el modulo `e2e` y el tipo `--type=e2e` fueron eliminados.
+> Mayo 2026: el módulo `e2e` y el tipo `--type=e2e` fueron eliminados.
 > Cada producto (dashboard, landing, server) tiene su propio
 > `--type=feature` (BDD-style: Playwright para frontend, DRF APIClient +
 > seed_db para server).
@@ -39,7 +39,7 @@ python devtools/run.py test_runner [flags]
 ## Ejemplos
 
 ```bash
-# Suite completa (todos los modulos)
+# Suite completa (todos los módulos)
 python devtools/run.py test_runner
 
 # Server: coverage per-file >= 80%
@@ -67,7 +67,7 @@ python devtools/run.py test_runner --git-mode=staged
   (Chromium + WebKit). Timeout configurable via env var
   `FEATURE_READY_TIMEOUT` (default 600s).
 
-## Tambien disponible via test_runner
+## También disponible via test_runner
 
 ```bash
 python devtools/run.py test_runner --module=server --type=unit

--- a/devtools/test_runner/feature.py
+++ b/devtools/test_runner/feature.py
@@ -1,6 +1,6 @@
 """Feature execution helpers (Playwright para dashboard/landing, pytest para server).
 
-Mayo 2026: reemplaza al historico ``e2e.py``. Cada modulo tiene su
+Mayo 2026: reemplaza al histórico ``e2e.py``. Cada módulo tiene su
 propio ``--type=feature``:
 
   - ``--module=dashboard --type=feature`` -> servicio dashboard-feature (Playwright)
@@ -38,14 +38,14 @@ _FEATURE_READY_PROGRESS_INTERVAL = 30
 def _feature_service_for(module: str) -> str:
     """Map module to its compose service name.
 
-    Portfolio: el servicio Playwright es unico (``feature``) y testea
+    Portfolio: el servicio Playwright es único (``feature``) y testea
     todas las apps Astro a traves de nginx. No hay containers feature
     por-app como en el template fuente.
     """
     if module == 'feature':
         return 'feature'
     raise ValueError(
-        f'Modulo {module!r} no tiene servicio Playwright asociado. '
+        f'Módulo {module!r} no tiene servicio Playwright asociado. '
         'Solo --module=feature soporta Playwright en portfolio.',
     )
 

--- a/devtools/test_runner/flags.py
+++ b/devtools/test_runner/flags.py
@@ -4,8 +4,8 @@ Validates and normalizes flags for the unified test runner that
 orchestrates tests across all project modules (server, dashboard, landing,
 devtools).
 
-Mayo 2026: el modulo `e2e` y el tipo `--type=e2e` fueron eliminados.
-Ahora cada modulo expone su propio `--type=feature` (BDD-style):
+Mayo 2026: el módulo `e2e` y el tipo `--type=e2e` fueron eliminados.
+Ahora cada módulo expone su propio `--type=feature` (BDD-style):
   - server: pytest -m feature contra tests/feature/ (DRF APIClient + DB seed)
   - dashboard: Playwright contra dashboard/tests/feature/
   - landing:   Playwright contra landing/tests/feature/
@@ -43,7 +43,7 @@ _PORTFOLIO_PACKAGES = ('app-shared', 'content', 'cv-pdf', 'seo', 'ui')
 
 # Registry of valid test types per module.
 # Portfolio: apps Astro tienen unit+coverage+typecheck; tests E2E son
-# globales (tests/feature/) sin modulo asignado por app.
+# globales (tests/feature/) sin módulo asignado por app.
 MODULE_TEST_TYPES: dict[str, list[str]] = {
     'server': ['unit'],
     'devtools': ['unit'],
@@ -99,18 +99,18 @@ def _validate_module(flags_dict: dict[str, Any]) -> None:
     """Validate --module flag against known modules with tests.
 
     Mayo 2026: rechaza explicitamente ``--module=e2e`` y ``--module=tests``
-    con mensaje de migracion (ya no son modulos validos; cada feature
-    test vive bajo el modulo de su producto: dashboard, landing, server).
+    con mensaje de migración (ya no son módulos válidos; cada feature
+    test vive bajo el módulo de su producto: dashboard, landing, server).
     """
     module = flags_dict.get('module')
     if module is None:
         return
 
-    # Atajos historicos eliminados: dar mensaje claro de migracion.
+    # Atajos históricos eliminados: dar mensaje claro de migración.
     if module in {'e2e', 'tests'}:
         raise ValueError(
             f'--module={module} fue eliminado en mayo 2026.\n'
-            'Usa el modulo del producto y --type=feature:\n'
+            'Usa el módulo del producto y --type=feature:\n'
             '  python devtools/run.py test_runner --module=dashboard --type=feature\n'
             '  python devtools/run.py test_runner --module=landing --type=feature\n'
             '  python devtools/run.py test_runner --module=server --type=feature',
@@ -119,8 +119,8 @@ def _validate_module(flags_dict: dict[str, Any]) -> None:
     valid_modules = [m for m, types in MODULE_TEST_TYPES.items() if types]
     if module not in valid_modules:
         raise ValueError(
-            f"Modulo invalido: '{module}'. "
-            f'Modulos con tests: {", ".join(sorted(valid_modules))}',
+            f"Módulo inválido: '{module}'. "
+            f'Módulos con tests: {", ".join(sorted(valid_modules))}',
         )
 
 
@@ -131,8 +131,8 @@ def _validate_type(flags_dict: dict[str, Any]) -> None:
     If --module is set, validates against that module's types.
     If not, validates that at least one module supports the type.
 
-    Mayo 2026: rechaza ``--type=e2e`` con mensaje de migracion. Antes el
-    tipo `e2e` solo aplicaba al modulo `e2e`; ahora cada producto tiene
+    Mayo 2026: rechaza ``--type=e2e`` con mensaje de migración. Antes el
+    tipo `e2e` solo aplicaba al módulo `e2e`; ahora cada producto tiene
     su `--type=feature` (BDD-style).
     """
     test_type = flags_dict.get('type', 'all')
@@ -142,7 +142,7 @@ def _validate_type(flags_dict: dict[str, Any]) -> None:
     if test_type == 'e2e':
         raise ValueError(
             '--type=e2e fue eliminado en mayo 2026. '
-            'Usa --type=feature por modulo:\n'
+            'Usa --type=feature por módulo:\n'
             '  python devtools/run.py test_runner --module=dashboard --type=feature\n'
             '  python devtools/run.py test_runner --module=landing --type=feature\n'
             '  python devtools/run.py test_runner --module=server --type=feature',
@@ -155,7 +155,7 @@ def _validate_type(flags_dict: dict[str, Any]) -> None:
         if test_type not in valid_types:
             raise ValueError(
                 f"Tipo '{test_type}' no disponible para '{module}'. "
-                f'Tipos validos: all, {", ".join(valid_types)}',
+                f'Tipos válidos: all, {", ".join(valid_types)}',
             )
         return
 
@@ -168,8 +168,8 @@ def _validate_type(flags_dict: dict[str, Any]) -> None:
             {t for types in MODULE_TEST_TYPES.values() for t in types},
         )
         raise ValueError(
-            f"Tipo '{test_type}' no disponible en ningun modulo. "
-            f'Tipos validos: all, {", ".join(all_types)}',
+            f"Tipo '{test_type}' no disponible en ningun módulo. "
+            f'Tipos válidos: all, {", ".join(all_types)}',
         )
 
 
@@ -193,8 +193,8 @@ def _validate_env(flags_dict: dict[str, Any]) -> None:
     env = flags_dict.get('env', 'local')
     if env not in VALID_ENVS:
         raise ValueError(
-            f"Ambiente invalido: '{env}'. "
-            f'Ambientes validos para tests: {", ".join(VALID_ENVS)}',
+            f"Ambiente inválido: '{env}'. "
+            f'Ambientes válidos para tests: {", ".join(VALID_ENVS)}',
         )
 
 
@@ -244,10 +244,10 @@ def _validate_playwright_only_flag(
     key: str,
     present: bool,
 ) -> None:
-    """Valida que un flag de Playwright (sharding/projects) no se use con
+    """Válida que un flag de Playwright (sharding/projects) no se use con
     server o con --type distinto de feature.
 
-    Sharding y projects son features de Playwright, asi que requieren
+    Sharding y projects son features de Playwright, así que requieren
     --module=dashboard|landing y --type=feature.
     """
     if not present:
@@ -263,7 +263,7 @@ def _validate_playwright_only_flag(
 
 
 def _validate_sharding_flags(flags_dict: dict[str, Any]) -> None:
-    """Valida --project, --shard, --shard-total, --fail-on-flaky.
+    """Válida --project, --shard, --shard-total, --fail-on-flaky.
 
     Reglas:
     - Las 4 flags requieren --module=dashboard|landing y --type=feature
@@ -359,7 +359,7 @@ def describe() -> ScriptDescribe:
             'module': {
                 'type': 'choice',
                 'choices': sorted(m for m, t in MODULE_TEST_TYPES.items() if t),
-                'summary': 'Modulo a testear (default: todos los con tests)',
+                'summary': 'Módulo a testear (default: todos los con tests)',
             },
             'type': {
                 'type': 'choice',

--- a/devtools/test_runner/full_suites.py
+++ b/devtools/test_runner/full_suites.py
@@ -6,7 +6,7 @@ delegates to ``shared.test_executors`` (server, dashboard, landing) or the local
 ``feature`` helper (Playwright) — y para ``devtools`` se invoca pytest en
 el host Python 3.14, fuera de Docker.
 
-Mayo 2026: el modulo top-level ``e2e`` fue eliminado. Ahora cada producto
+Mayo 2026: el módulo top-level ``e2e`` fue eliminado. Ahora cada producto
 (dashboard, landing) tiene su ``--type=feature`` mapeado a Playwright via
 ``test_runner.feature.run_feature``. Server tiene ``--type=feature``
 mapeado a pytest -m feature dentro de ``shared.test_executors``.
@@ -116,7 +116,7 @@ def execute_full_suites(
                 results[key] = run_server_tests(env, t, verbose, quiet=quiet)
             elif module in _all_frontend:
                 # Apps Astro o packages: usar el path generico de frontend tests
-                # (vitest run + coverage en cwd del modulo dentro del container).
+                # (vitest run + coverage en cwd del módulo dentro del container).
                 results[key] = _run_portfolio_frontend_tests(
                     env=env,
                     module=module,

--- a/devtools/test_runner/main.py
+++ b/devtools/test_runner/main.py
@@ -50,14 +50,14 @@ def main(flags: dict[str, Any]) -> int:
     if not modules:
         from shared.console import _warn
 
-        _warn('No hay modulos que soporten ese tipo de test')
+        _warn('No hay módulos que soporten ese tipo de test')
         return 0 if skip_empty else 1
 
     mode_label = f'git-mode={git_mode}' if git_mode else 'full'
     _header(f'test_runner [{test_type}] [{env}] [{mode_label}]')
 
     if verbose:
-        print(f'  Modulos: {", ".join(modules)}')
+        print(f'  Módulos: {", ".join(modules)}')
 
     # Docker es necesario para server, dashboard, landing. Devtools corre en
     # el host (Python 3.14 via uv) y NO depende de Docker — saltar el

--- a/devtools/test_runner/summary.py
+++ b/devtools/test_runner/summary.py
@@ -26,7 +26,7 @@ def print_summary(results: dict[str, int]) -> None:
     print(f'{CYAN}{"=" * 60}{NC}')
     print(f'{CYAN} Resumen{NC}')
     print(f'{CYAN}{"=" * 60}{NC}')
-    print(f'  {"Modulo":<30} {"Estado":>10}')
+    print(f'  {"Módulo":<30} {"Estado":>10}')
     print(f'  {"-" * 30} {"-" * 10}')
 
     for module, exit_code in results.items():
@@ -62,7 +62,7 @@ def evaluate_results(
     all_skipped = all(code == -1 for code in results.values())
     if all_skipped:
         if skip_empty:
-            _warn('Todos los modulos saltados (sin archivos cambiados)')
+            _warn('Todos los módulos saltados (sin archivos cambiados)')
             return 0
         _err('No se ejecutaron tests (sin archivos cambiados)')
         return 1

--- a/devtools/test_runner/ui_review.py
+++ b/devtools/test_runner/ui_review.py
@@ -24,14 +24,14 @@ UI_REVIEW_PROMPT = """\
 Eres un auditor senior de UI/UX. Analiza las siguientes capturas de pantalla \
 y detecta inconsistencias, errores visuales y problemas de calidad.
 
-IMAGENES:
+IMÁGENES:
 {image_lines}
 
-EVALUACION REQUERIDA:
+EVALUACIÓN REQUERIDA:
 1. Espaciado: margenes y paddings consistentes entre elementos. Detectar gaps \
 irregulares, espacios desiguales entre campos, secciones o componentes.
 2. Tipografia: consistencia de font-size, font-weight, line-height y \
-font-family entre elementos del mismo tipo. Detectar jerarquias rotas.
+font-family entre elementos del mismo tipo. Detectar jerarquías rotas.
 3. Layout y alineacion: elementos desalineados, centrado incorrecto, anchos \
 inconsistentes, overflow de contenido.
 4. Colores y contraste: uso consistente de la paleta de colores. Contraste \
@@ -42,7 +42,7 @@ consistentes entre todas las capturas. Detectar variaciones no intencionales.
 filled), evaluar si son claros, distinguibles y consistentes.
 7. Responsividad: si hay capturas de diferentes viewports, evaluar que el \
 layout se adapte correctamente sin romper alineacion ni legibilidad.
-8. Accesibilidad visual: touch targets minimo 44x44px en mobile, indicadores \
+8. Accesibilidad visual: touch targets mínimo 44x44px en mobile, indicadores \
 de campos requeridos, visibilidad de mensajes de error.
 9. Artefactos: elementos de debug, overlays de desarrollo, tooltips residuales \
 o cualquier elemento que no deberia estar visible en la UI final.
@@ -52,41 +52,41 @@ contenedor, scrollbars inesperados.
 FORMATO DE SALIDA (por cada hallazgo):
 
 ---
-### [SEVERIDAD] Titulo descriptivo del problema
+### [SEVERIDAD] Título descriptivo del problema
 - **Archivos afectados**: lista completa de paths origen
 - **Elemento**: componente o elemento HTML afectado
-- **Problema**: descripcion tecnica precisa de la inconsistencia detectada
+- **Problema**: descripción técnica precisa de la inconsistencia detectada
 - **Impacto UX**: como afecta al usuario final
-- **Cambio tecnico esperado**:
+- **Cambio técnico esperado**:
   - CSS: propiedad y valor exacto a aplicar o corregir
   - Componente: nombre generico del componente a modificar
-  - Logica: cambio de logica si aplica
-- **Criterio WCAG**: numero y nombre si aplica, o N/A
+  - Lógica: cambio de lógica si aplica
+- **Criterio WCAG**: número y nombre si aplica, o N/A
 ---
 
 SEVERIDADES:
-- CRITICA: bloquea release o rompe funcionalidad/accesibilidad
+- CRÍTICA: bloquea release o rompe funcionalidad/accesibilidad
 - MAYOR: afecta experiencia de usuario significativamente
 - MENOR: inconsistencia visual notable
-- COSMETICA: detalle de polish
+- COSMÉTICA: detalle de polish
 
 FALSOS POSITIVOS CONOCIDOS (NO reportar):
 - Estado de foco (focus ring/border) visible en inputs dentro de screenshots: \
 las capturas son generadas por Playwright que interactua programaticamente con \
-los campos. El ultimo campo editado retiene el foco porque no hay blur \
-explicito. Esto NO es un bug de la aplicacion, es un artefacto del test runner.
+los campos. El último campo editado retiene el foco porque no hay blur \
+explicito. Esto NO es un bug de la aplicación, es un artefacto del test runner.
 - Espaciado responsive diferente entre viewports (ej. gap-4 en mobile vs gap-6 \
 en desktop): variaciones intencionales de spacing entre breakpoints son \
-decisiones de diseno validas, no inconsistencias. Solo reportar si el spacing \
+decisiones de diseño válidas, no inconsistencias. Solo reportar si el spacing \
 rompe la alineacion o legibilidad dentro de un mismo viewport.
 - Campos de formulario sin icono junto a campos con icono: la presencia de \
-iconos decorativos en inputs es opcional por campo segun su contexto semantico. \
+iconos decorativos en inputs es opcional por campo según su contexto semántico. \
 No todos los campos requieren icono. Solo reportar si la ausencia de icono \
-rompe la alineacion horizontal o el tamano del input respecto a los demas.
+rompe la alineacion horizontal o el tamaño del input respecto a los demas.
 
 REGLAS:
-- Responder SOLO en ESPANOL
-- NO incluir introduccion, conclusion ni texto fuera del formato
+- Responder SOLO en ESPAÑOL
+- NO incluir introducción, conclusion ni texto fuera del formato
 - Cada hallazgo debe ser accionable: un desarrollador frontend debe poder \
 implementar el fix sin preguntas
 - Si no hay problemas, responder: Sin hallazgos.

--- a/devtools/tests/unit/src/docker/flags.py
+++ b/devtools/tests/unit/src/docker/flags.py
@@ -2,7 +2,7 @@
 
 Path mirroring: devtools/docker/flags.py -> this file.
 
-Validacion clave: comando posicional requerido (Fase 3 cambio el default
+Validación clave: comando posicional requerido (Fase 3 cambio el default
 de 'help' a error explicito), removido 'docker test' (Fase 3 dejo shim),
 ``describe()`` retorna inventario completo (Fase 4).
 """
@@ -47,7 +47,7 @@ class TestCommandExtraction:
 
     def test_test_command_still_in_registry(self, monkeypatch):
         # Fase 3: 'docker test' fue removido como funcionalidad pero queda
-        # en VALID_COMMANDS para que el shim de migracion (cmd_test_removed)
+        # en VALID_COMMANDS para que el shim de migración (cmd_test_removed)
         # tenga oportunidad de imprimir el mensaje en lugar de un 'comando
         # desconocido'.
         monkeypatch.setattr('sys.argv', ['run.py', 'docker', 'test'])
@@ -76,7 +76,7 @@ class TestEnvFlag:
         )
         from docker.flags import flag
 
-        with pytest.raises(ValueError, match='Ambiente invalido'):
+        with pytest.raises(ValueError, match='Ambiente inválido'):
             flag({'env': 'staging'})
 
 

--- a/devtools/tests/unit/src/mutation_testing/config.py
+++ b/devtools/tests/unit/src/mutation_testing/config.py
@@ -2,7 +2,7 @@
 
 Path mirroring: ``devtools/mutation_testing/config.py`` -> this file.
 
-Politica AI-testing independence: ``.claude/rules/ai-testing-independence.md``.
+Política AI-testing independence: ``.claude/rules/ai-testing-independence.md``.
 """
 
 import pytest
@@ -30,13 +30,13 @@ class TestThresholdConstants:
         """
         Given critical paths cubren codigo con dinero o credenciales,
         When se consulta CRITICAL_THRESHOLD,
-        Then es exactamente 0.85 (85% mutation score minimo).
+        Then es exactamente 0.85 (85% mutation score mínimo).
         """
         assert CRITICAL_THRESHOLD == 0.85
 
     def test_standard_threshold_is_70_percent(self) -> None:
         """
-        Given standard paths cubren logica de negocio core,
+        Given standard paths cubren lógica de negocio core,
         When se consulta STANDARD_THRESHOLD,
         Then es exactamente 0.70.
         """
@@ -136,7 +136,7 @@ class TestIsExcluded:
     )
     def test_infrastructure_paths_are_excluded(self, path: str) -> None:
         """
-        Given paths de infraestructura sin logica de negocio (admin,
+        Given paths de infraestructura sin lógica de negocio (admin,
         migrations, management, __init__, apps, urls, constants, enums),
         When se consulta is_excluded,
         Then retorna True (mutation testing los ignora).
@@ -145,7 +145,7 @@ class TestIsExcluded:
 
     def test_service_path_is_not_excluded(self) -> None:
         """
-        Given un path con logica de negocio (services/),
+        Given un path con lógica de negocio (services/),
         When se consulta is_excluded,
         Then retorna False (mutation testing aplica).
         """
@@ -175,11 +175,11 @@ class TestAllCategories:
 
 
 class TestCriticalPathsCoverage:
-    """Verifica que los paths criticos esperados esten registrados."""
+    """Verifica que los paths críticos esperados esten registrados."""
 
     def test_payments_services_in_critical(self) -> None:
         """
-        Given la politica que apps/payments/services es codigo critico,
+        Given la política que apps/payments/services es codigo crítico,
         When se inspecciona CRITICAL_PATHS,
         Then contiene 'apps/payments/services'.
         """
@@ -187,7 +187,7 @@ class TestCriticalPathsCoverage:
 
     def test_auth_services_in_critical(self) -> None:
         """
-        Given la politica que apps/auth/services es codigo critico,
+        Given la política que apps/auth/services es codigo crítico,
         When se inspecciona CRITICAL_PATHS,
         Then contiene 'apps/auth/services'.
         """
@@ -195,7 +195,7 @@ class TestCriticalPathsCoverage:
 
     def test_security_in_critical(self) -> None:
         """
-        Given la politica que common/security es codigo critico (PCI),
+        Given la política que common/security es codigo crítico (PCI),
         When se inspecciona CRITICAL_PATHS,
         Then contiene 'common/security'.
         """
@@ -205,7 +205,7 @@ class TestCriticalPathsCoverage:
 class TestExcludedFragments:
     def test_admin_fragment_is_excluded(self) -> None:
         """
-        Given que el admin Django no contiene logica testeable por mutmut,
+        Given que el admin Django no contiene lógica testeable por mutmut,
         When se inspecciona EXCLUDED_FRAGMENTS,
         Then '/admin/' esta presente.
         """

--- a/devtools/tests/unit/src/run.py
+++ b/devtools/tests/unit/src/run.py
@@ -97,7 +97,7 @@ class TestDescribeFlag:
         assert payload['summary'].strip()
 
     def test_describe_does_not_execute_script(self):
-        # Si --describe se procesa antes de la validacion del script,
+        # Si --describe se procesa antes de la validación del script,
         # un script con flags requeridas (hooks --type) no debe explotar.
         payload = _run_cli(['hooks', '--describe', '--output=json'])
         assert payload['name'] == 'hooks'
@@ -126,7 +126,7 @@ class TestListFlags:
         # No top-level metadata, solo flags.
         assert 'name' not in payload
         assert 'commands' not in payload
-        # Contenido tipico de scan flags.
+        # Contenido típico de scan flags.
         assert 'git_mode' in payload
         assert 'module' in payload
 

--- a/devtools/tests/unit/src/shared/classification.py
+++ b/devtools/tests/unit/src/shared/classification.py
@@ -53,8 +53,8 @@ class TestClassifyFrontendFilesDashboard:
     def test_shadcn_ui_source_is_excluded(self, tmp_path):
         """`components/ui/` (shadcn copy-paste) excluido del coverage 80%.
 
-        Razon: shadcn/ui son componentes copy-paste verbatim del registry,
-        no se modifican con logica de negocio. Logica testeable vive en
+        Razón: shadcn/ui son componentes copy-paste verbatim del registry,
+        no se modifican con lógica de negocio. Lógica testeable vive en
         components/features/ y modules/.
         """
         from shared.classification import classify_frontend_files
@@ -104,7 +104,7 @@ class TestClassifyFrontendFilesDashboard:
         ) in result['unit_pairs']
 
     def test_lib_root_is_supported(self, tmp_path):
-        """Sources en dashboard/lib/ tambien tienen mirror obligatorio."""
+        """Sources en dashboard/lib/ también tienen mirror obligatorio."""
         from shared.classification import classify_frontend_files
 
         (tmp_path / 'dashboard' / 'lib' / 'validators').mkdir(parents=True)
@@ -145,8 +145,8 @@ class TestClassifyFrontendFilesDashboard:
     def test_tsx_source_pairs_with_test_ts(self, tmp_path):
         """`.tsx` source mapea a `.test.ts` en mirror (siempre).
 
-        Usa `dashboard/modules/items/schemas/` (logica testeable Zod, NO
-        excluido) en lugar de actions/api/store que estan excluidos por
+        Usa `dashboard/modules/items/schemas/` (lógica testeable Zod, NO
+        excluido) en lugar de actions/api/store que están excluidos por
         ser wrappers thin testeados via E2E.
         """
         from shared.classification import classify_frontend_files
@@ -349,7 +349,7 @@ class TestClassifyFrontendFilesLanding:
     def test_astro_source_excluded_from_coverage(self, tmp_path):
         """`.astro` files (Astro components/pages) excluidos del coverage 80%.
 
-        Razon: Astro es template-only, no business logic. /pages/ es
+        Razón: Astro es template-only, no business logic. /pages/ es
         file-based routing testeado via E2E specs.
         """
         from shared.classification import classify_frontend_files

--- a/devtools/tests/unit/src/shared/console.py
+++ b/devtools/tests/unit/src/shared/console.py
@@ -3,7 +3,7 @@
 Path mirroring: devtools/shared/console.py -> this file.
 
 Verifica que header/info/ok/warn/err/step van a STDERR, no stdout. Esto
-mantiene stdout limpio para JSON / data output, asi callers pueden hacer
+mantiene stdout limpio para JSON / data output, así callers pueden hacer
 ``cmd --output=json | jq ...`` sin que los banners contaminen el parse.
 """
 
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.unit
 def captured(
     capsys: pytest.CaptureFixture[str],
 ) -> Callable[..., pytest.CaptureResult[str]]:
-    """Devuelve un closure que ejecuta una funcion y devuelve (out, err)."""
+    """Devuelve un closure que ejecuta una función y devuelve (out, err)."""
 
     def _run(
         fn: Callable[..., Any],
@@ -40,9 +40,9 @@ class TestConsoleGoesToStderr:
     def test_header_to_stderr(self, captured):
         from shared.console import header
 
-        result = captured(header, 'titulo')
+        result = captured(header, 'título')
         assert result.out == ''
-        assert 'titulo' in result.err
+        assert 'título' in result.err
 
     def test_info_to_stderr(self, captured):
         from shared.console import info
@@ -106,7 +106,7 @@ class TestConsoleGoesToStderr:
 
 
 class TestColourReturnsString:
-    """colour() es funcion pura: devuelve string, no escribe a ningun stream."""
+    """colour() es función pura: devuelve string, no escribe a ningun stream."""
 
     def test_colour_returns_string_with_codes(self, capsys):
         from shared.console import CYAN

--- a/devtools/tests/unit/src/shared/deletion_mirror.py
+++ b/devtools/tests/unit/src/shared/deletion_mirror.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.unit
 
 
 class TestClassifyDeletedFiles:
-    """Clasifica una lista plana de paths eliminados por modulo."""
+    """Clasifica una lista plana de paths eliminados por módulo."""
 
     def test_classifies_server_python_files(self):
         from shared.deletion_mirror import classify_deleted_files
@@ -178,7 +178,7 @@ class TestCollectOrphanPairsServer:
         from shared.deletion_mirror import collect_orphan_pairs
 
         # Eliminamos un __init__.py (excluido). No debe haber orphan ni siquiera
-        # si su mirror existiera (lo cual es absurdo, pero verificamos exclusion).
+        # si su mirror existiera (lo cual es absurdo, pero verificamos exclusión).
         self._make_file(tmp_path, 'server/tests/unit/src/apps/foo/__init__.py')
 
         result = collect_orphan_pairs(
@@ -200,7 +200,7 @@ class TestCollectOrphanPairsServer:
 
 
 class TestCollectOrphanPairsApp:
-    """Detecta huerfanos en el modulo dashboard."""
+    """Detecta huerfanos en el módulo dashboard."""
 
     def _make_file(self, root: Path, path: str) -> None:
         target = root / path
@@ -252,7 +252,7 @@ class TestCollectOrphanPairsApp:
         ]
 
     def test_vue_source_excluded_from_deletion_check(self, tmp_path):
-        """Componentes .vue estan excluidos de coverage, no deben triggerear orphan."""
+        """Componentes .vue están excluidos de coverage, no deben triggerear orphan."""
         from shared.deletion_mirror import collect_orphan_pairs
 
         # Aunque borremos el .vue, no debe contar como orphan
@@ -279,7 +279,7 @@ class TestCollectOrphanPairsApp:
 
 
 class TestCollectOrphanPairsLanding:
-    """Detecta huerfanos en el modulo landing."""
+    """Detecta huerfanos en el módulo landing."""
 
     def _make_file(self, root: Path, path: str) -> None:
         target = root / path
@@ -356,7 +356,7 @@ class TestCollectOrphanPairsLanding:
 
 
 class TestCollectOrphanPairsMixed:
-    """Casos combinados: empty inputs, multiples modulos, etc."""
+    """Casos combinados: empty inputs, multiples módulos, etc."""
 
     def test_empty_input_returns_empty_result(self, tmp_path):
         from shared.deletion_mirror import collect_orphan_pairs

--- a/devtools/tests/unit/src/shared/scan_helper.py
+++ b/devtools/tests/unit/src/shared/scan_helper.py
@@ -66,9 +66,9 @@ class TestFilesChanged:
         self,
         fake_structure: dict[str, Any],
     ) -> None:
-        """``files_changed`` no debe limitar por modulo ni extensiones.
+        """``files_changed`` no debe limitar por módulo ni extensiones.
 
-        Asi captura archivos de .claude/, docs/, root: todo lo cambiado.
+        Así captura archivos de .claude/, docs/, root: todo lo cambiado.
         """
         fake_structure['return_value'] = {'files': {}}
 
@@ -100,7 +100,7 @@ class TestFilesChanged:
         self,
         fake_structure: dict[str, Any],
     ) -> None:
-        """Estructura vacia o ``None`` -> lista vacia, sin excepciones."""
+        """Estructura vacía o ``None`` -> lista vacía, sin excepciones."""
         fake_structure['return_value'] = {}
 
         assert files_changed(git_mode='staged') == []
@@ -129,7 +129,7 @@ class TestFilesChanged:
 
 
 class TestFilesForModule:
-    """``files_for_module`` filtra por root + extensiones del modulo."""
+    """``files_for_module`` filtra por root + extensiones del módulo."""
 
     @pytest.fixture
     def fake_structure(
@@ -170,7 +170,7 @@ class TestFilesForModule:
         self,
         fake_structure: dict[str, Any],
     ) -> None:
-        """Solo archivos con extensiones validas del modulo deben volver."""
+        """Solo archivos con extensiones válidas del módulo deben volver."""
         fake_structure['return_value'] = {
             'files': {
                 'server/x.py': {},
@@ -199,5 +199,5 @@ class TestFilesForModule:
 
         flags = fake_structure['calls'][0]
         # ignore_patterns debe contener al menos los exclude_patterns base
-        # del modulo + los purpose_excludes (e.g. '**/__init__.py').
+        # del módulo + los purpose_excludes (e.g. '**/__init__.py').
         assert any('__init__.py' in p for p in flags['ignore_patterns'])

--- a/devtools/tests/unit/src/test_runner/flags.py
+++ b/devtools/tests/unit/src/test_runner/flags.py
@@ -4,8 +4,8 @@ Path mirroring: devtools/test_runner/flags.py -> this file.
 
 Cubre las flags de Playwright (--project, --shard, --shard-total,
 --fail-on-flaky) que requieren --module=dashboard|landing y --type=feature
-(mayo 2026: el modulo top-level `e2e` fue eliminado y cada producto
-tiene su `--type=feature`). La validacion existente de module/type/env
+(mayo 2026: el módulo top-level `e2e` fue eliminado y cada producto
+tiene su `--type=feature`). La validación existente de module/type/env
 ya esta probada implicitamente al usarse en cada invocacion.
 """
 
@@ -194,7 +194,7 @@ class TestDockerEnvDefault:
     """El flag --env honra la env var DOCKER_ENV cuando esta seteada."""
 
     def test_uses_docker_env_var_as_default(self, monkeypatch):
-        # Forzar reload del modulo flags para que recompute _DEFAULT_ENV
+        # Forzar reload del módulo flags para que recompute _DEFAULT_ENV
         import importlib
 
         monkeypatch.setenv('DOCKER_ENV', 'test')

--- a/devtools/tests/unit/src/utils/describe.py
+++ b/devtools/tests/unit/src/utils/describe.py
@@ -2,7 +2,7 @@
 
 Path mirroring: devtools/utils/describe.py -> this file.
 
-Cubre el contrato basico que cada flags.py debe respetar:
+Cubre el contrato básico que cada flags.py debe respetar:
 - describe() retorna dict con name/kind/summary/commands/flags
 - kind es 'subcommand' o 'monocommand'
 - En subcommand-kind, cada command tiene name/summary/flags/destructive/deprecated
@@ -84,7 +84,7 @@ class TestDescribeContract:
         if describe_fn is None:
             pytest.skip(f'{script_name} no implementa describe()')
         d = describe_fn()
-        assert d['summary'].strip(), f'{script_name}: summary esta vacio'
+        assert d['summary'].strip(), f'{script_name}: summary esta vacío'
 
     @pytest.mark.parametrize('script_name', SCRIPTS)
     def test_subcommand_scripts_have_commands(self, script_name):

--- a/devtools/tests/unit/src/utils/flags_to_dict.py
+++ b/devtools/tests/unit/src/utils/flags_to_dict.py
@@ -3,7 +3,7 @@
 Path mirroring: devtools/utils/flags_to_dict.py -> this file.
 
 Cubre el cambio de comportamiento de Fase 6: el split por ``|`` ahora es
-opt-in via el parametro ``list_flags``. Antes cualquier valor con ``|``
+opt-in via el parámetro ``list_flags``. Antes cualquier valor con ``|``
 se convertia silenciosamente en lista, lo cual sorprendia cuando el
 flag esperaba un string.
 """
@@ -195,7 +195,7 @@ class TestDoubleDashPassthrough:
         }
 
     def test_flags_after_double_dash_kept_verbatim(self):
-        # Esto es el caso clave: '--list' despues del '--' NO se parsea
+        # Esto es el caso clave: '--list' después del '--' NO se parsea
         # como flag CLI; va al subproceso tal cual.
         from utils.flags_to_dict import flags_to_dict
 

--- a/devtools/tests/unit/src/verify/flags.py
+++ b/devtools/tests/unit/src/verify/flags.py
@@ -30,7 +30,7 @@ class TestFlagDefaults:
 
 
 class TestFlagValidation:
-    """Validacion de combinaciones de flags."""
+    """Validación de combinaciones de flags."""
 
     def test_staged_only(self) -> None:
         result = flag({'staged': True})
@@ -47,7 +47,7 @@ class TestFlagValidation:
         assert result['all_changed'] is True
 
     def test_two_sources_raises(self) -> None:
-        """Combinar dos fuentes es invalido."""
+        """Combinar dos fuentes es inválido."""
         with pytest.raises(ValueError, match='Solo se permite UNA fuente'):
             flag({'staged': True, 'modified': True})
 

--- a/devtools/tests/unit/src/verify/main.py
+++ b/devtools/tests/unit/src/verify/main.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.unit
 
 
 class TestClassifyFile:
-    """Clasificacion correcta de archivos por path."""
+    """Clasificación correcta de archivos por path."""
 
     @pytest.mark.parametrize(
         'path,expected',
@@ -66,7 +66,7 @@ class TestClassifyFile:
 
 
 class TestVerificationsFor:
-    """Reglas de verificacion por clasificacion."""
+    """Reglas de verificación por clasificación."""
 
     def test_server_model_includes_makemigrations(self) -> None:
         verifs = verifications_for('server_model')
@@ -117,12 +117,12 @@ class TestVerificationsFor:
         self,
         classification: str,
     ) -> None:
-        """Clasificaciones de skip retornan lista vacia."""
+        """Clasificaciones de skip retornan lista vacía."""
         assert verifications_for(classification) == []
 
 
 class TestBuildReports:
-    """Construccion de reportes a partir de lista de archivos."""
+    """Construcción de reportes a partir de lista de archivos."""
 
     def test_builds_one_report_per_file(self) -> None:
         files = [
@@ -165,7 +165,7 @@ class TestDeduplicateCommands:
         reports = build_reports(files)
         unique = deduplicate_commands(reports)
         # Server model: 3 cmds. App TS: 2 cmds. Lint server compartido entre los models.
-        # Total unicos esperado: makemigrations + lint server + unit tests + typecheck dashboard + lint dashboard = 5.
+        # Total únicos esperado: makemigrations + lint server + unit tests + typecheck dashboard + lint dashboard = 5.
         assert len(unique) == 5
 
     def test_empty_reports_returns_empty(self) -> None:
@@ -177,7 +177,7 @@ class TestCollectChangedFilesUsesScan:
 
     Estos tests aseguran el contrato del refactor: verify ya no invoca git
     directo, sino que pasa por scan (la fuente canonica). El mapeo flag ->
-    git_mode es la unica logica que vive en verify.
+    git_mode es la única lógica que vive en verify.
     """
 
     @pytest.fixture
@@ -190,7 +190,7 @@ class TestCollectChangedFilesUsesScan:
             return captured.get('return_value', [])
 
         # Importamos dentro del fixture para asegurar que el monkeypatch
-        # afecta al modulo correcto cuando ``verify.main`` lo importa lazy.
+        # afecta al módulo correcto cuando ``verify.main`` lo importa lazy.
         import verify.main as verify_main
 
         monkeypatch.setattr(
@@ -244,7 +244,7 @@ class TestCollectChangedFilesUsesScan:
         self,
         fake_scan: dict[str, Any],
     ) -> None:
-        """``--all-changed`` explicito tambien mapea a ``changed``."""
+        """``--all-changed`` explicito también mapea a ``changed``."""
         fake_scan['return_value'] = []
 
         result = collect_changed_files({'all_changed': True})
@@ -256,7 +256,7 @@ class TestCollectChangedFilesUsesScan:
         self,
         fake_scan: dict[str, Any],
     ) -> None:
-        """Si scan no detecta nada, verify retorna lista vacia (sin error)."""
+        """Si scan no detecta nada, verify retorna lista vacía (sin error)."""
         fake_scan['return_value'] = []
 
         result = collect_changed_files({'staged': True})
@@ -267,9 +267,9 @@ class TestCollectChangedFilesUsesScan:
         self,
         fake_scan: dict[str, Any],
     ) -> None:
-        """Archivos fuera de modulos de scan (.claude/, root) deben aparecer.
+        """Archivos fuera de módulos de scan (.claude/, root) deben aparecer.
 
-        Como ``files_changed`` no filtra por modulo, archivos en ``.claude/``,
+        Como ``files_changed`` no filtra por módulo, archivos en ``.claude/``,
         ``docs/`` o root del proyecto pasan. verify los clasifica luego.
         """
         fake_scan['return_value'] = [

--- a/devtools/upgrade_deps/README.md
+++ b/devtools/upgrade_deps/README.md
@@ -1,6 +1,6 @@
 # upgrade_deps
 
-> Bumpea las dependencias de los manifestos del proyecto a la ultima version
+> Bumpea las dependencias de los manifestos del proyecto a la última version
 > estable disponible en PyPI / npm registry.
 
 ## Uso
@@ -54,8 +54,8 @@ python devtools/run.py upgrade_deps
 
 ## Concurrencia
 
-Hasta 10 requests simultaneos por registry. PyPI y npm tienen rate limits
-generosos para manifestos pequenos (<100 paquetes), no deberia haber
+Hasta 10 requests simultáneos por registry. PyPI y npm tienen rate limits
+generosos para manifestos pequeños (<100 paquetes), no deberia haber
 problemas.
 
 ## Lo que NO hace
@@ -65,7 +65,7 @@ problemas.
 - **NO rebuildea** containers Docker.
 - **NO ejecuta tests** post-upgrade.
 
-Despues de correr el script, vos decides:
+Después de correr el script, vos decides:
 
 ```bash
 # Reinstalar deps en containers

--- a/devtools/upgrade_deps/main.py
+++ b/devtools/upgrade_deps/main.py
@@ -57,7 +57,7 @@ NPM_MANIFESTS = (
     PROJECT_ROOT / 'landing' / 'package.json',
 )
 
-# Concurrencia: limita a N requests simultaneos al mismo registry para no
+# Concurrencia: limita a N requests simultáneos al mismo registry para no
 # saturar PyPI/npm si un manifest es grande.
 _CONCURRENCY = 10
 
@@ -185,7 +185,7 @@ def _write_pyproject_toml(path: Path, results: list[dict]) -> int:
     parser no encontro la linea (`line_no == 0`), se omite — escenario raro
     (e.g. spec en multiples lineas) que no soportamos para no corromper formato.
 
-    Retorna numero de cambios escritos.
+    Retorna número de cambios escritos.
     """
     upgrades = [r for r in results if r['action'] == ACTION_UP]
     if not upgrades:

--- a/devtools/upgrade_deps/registry.py
+++ b/devtools/upgrade_deps/registry.py
@@ -1,7 +1,7 @@
-"""Clientes asincronos para PyPI y npm registry.
+"""Clientes asíncronos para PyPI y npm registry.
 
-Cada funcion recibe un ``httpx.AsyncClient`` ya creado y devuelve la lista de
-versiones publicadas. Errores HTTP (404, timeout) retornan lista vacia para
+Cada función recibe un ``httpx.AsyncClient`` ya creado y devuelve la lista de
+versiones publicadas. Errores HTTP (404, timeout) retornan lista vacía para
 que el caller pueda continuar con otros paquetes sin abortar el batch.
 """
 
@@ -25,7 +25,7 @@ async def fetch_pypi_versions(
 
     Returns:
         Lista de versiones que tienen al menos un archivo publicado y no
-        fueron yanked. Lista vacia si 404 o respuesta sin ``releases``.
+        fueron yanked. Lista vacía si 404 o respuesta sin ``releases``.
     """
     url = f'{PYPI_BASE}/{name}/json'
     response = await client.get(url, timeout=DEFAULT_TIMEOUT)

--- a/devtools/upgrade_deps/reporter.py
+++ b/devtools/upgrade_deps/reporter.py
@@ -1,6 +1,6 @@
 """Reporte tabular de resultados del upgrade."""
 
-# Colores ANSI minimos (mismos codes que .git-hooks/_common.py)
+# Colores ANSI mínimos (mismos codes que .git-hooks/_common.py)
 _GREEN = '\033[0;32m'
 _YELLOW = '\033[1;33m'
 _CYAN = '\033[0;36m'

--- a/devtools/upgrade_deps/versions.py
+++ b/devtools/upgrade_deps/versions.py
@@ -1,4 +1,4 @@
-"""Comparacion de versiones (PEP 440 / SemVer).
+"""Comparación de versiones (PEP 440 / SemVer).
 
 Usa ``packaging.version`` (incluido en stdlib via setuptools en Python >=3.13;
 fallback a regex propia si no esta disponible). Maneja pre-releases
@@ -32,7 +32,7 @@ def is_prerelease(version: str) -> bool:
 
 
 def _parse_version_tuple(version: str) -> tuple[int, ...]:
-    """Convierte ``1.10.3`` -> (1, 10, 3) para comparacion numerica.
+    """Convierte ``1.10.3`` -> (1, 10, 3) para comparación numerica.
 
     Strips pre-release suffixes y build metadata. Numbers no parseables se
     truncan en el primer componente no-numerico.
@@ -42,7 +42,7 @@ def _parse_version_tuple(version: str) -> tuple[int, ...]:
     # Remove pre-release suffixes (-alpha, .dev0, a1, b2, rc1, etc.)
     base = _PRERELEASE_RE.split(base)[0]
     # Remove trailing .post (treated as same release for ordering purposes —
-    # post-releases siguen al stable, asi que son equivalentes para "es mas
+    # post-releases siguen al stable, así que son equivalentes para "es mas
     # nuevo que").
     base = re.sub(r'\.post\d+$', '', base)
 
@@ -76,5 +76,5 @@ def pick_latest_stable(versions: list[str]) -> str | None:
 
 
 def format_with_prefix(*, prefix: str, version: str) -> str:
-    """Concatena prefijo + version preservando la semantica del manifest."""
+    """Concatena prefijo + version preservando la semántica del manifest."""
     return f'{prefix}{version}'

--- a/devtools/utils/flags_to_dict.py
+++ b/devtools/utils/flags_to_dict.py
@@ -5,7 +5,7 @@ con strings, ints inferidos por el caller, y bools (`--foo` sin valor).
 
 Comportamiento de listas: por defecto, valores con `|` se devuelven COMO
 STRING. Para que un flag se trate como lista (y se haga split por `|`), el
-caller debe declararlo en ``list_flags``. Esta opcion explicita reemplaza
+caller debe declararlo en ``list_flags``. Esta opción explicita reemplaza
 el viejo comportamiento de splittear cualquier valor con ``|`` — que era
 magia silenciosa: si pasabas ``--name="alice|bob"`` esperando un string
 recibias una lista sin saberlo.
@@ -22,7 +22,7 @@ el parser produce ``{'target': 'server', '_passthrough': ['python', '-c',
 'print(1)']}``, y el comando docker concatena ``_passthrough`` a sus
 ``subcommands`` antes de ejecutar.
 
-Migracion: scripts que dependen de listas (scan: ``excludes_extension``,
+Migración: scripts que dependen de listas (scan: ``excludes_extension``,
 ``only_extension``, ``ignore_patterns``) ahora normalizan via su propio
 validador (ej. ``_clean_extensions``) que ya aceptaba ``str | list[str]``.
 """

--- a/devtools/verify/README.md
+++ b/devtools/verify/README.md
@@ -2,7 +2,7 @@
 
 Dada una lista de archivos modificados/staged en git, retorna las
 verificaciones que deberian correrse antes de declarar la feature como
-"lista" segun `.claude/rules/verify-before-done.md`.
+"lista" según `.claude/rules/verify-before-done.md`.
 
 API unificada para que agentes (feature-implementer, hook-fixer) sepan que
 correr sin re-parsear las reglas.
@@ -26,10 +26,10 @@ python devtools/run.py verify --staged
 python devtools/run.py verify --staged --execute
 
 # Output JSON estructurado (util para agentes). El JSON va a stdout
-# limpio; banners y bootstrap a stderr, asi puedes pipear:
+# limpio; banners y bootstrap a stderr, así puedes pipear:
 python devtools/run.py verify --staged --json | jq '.files'
 
-# Combinacion comun: staged + execute + JSON.
+# Combinación comun: staged + execute + JSON.
 python devtools/run.py verify --staged --execute --json
 ```
 
@@ -40,14 +40,14 @@ python devtools/run.py verify --staged --execute --json
 | `--staged` | false | Solo archivos en git index (`git diff --cached`) |
 | `--modified` | false | Solo archivos modificados (`git diff`) sin staged |
 | `--all-changed` | true (si ningun otro) | Staged + modified + untracked |
-| `--execute` | false | Correr cada verificacion y capturar exit + output |
+| `--execute` | false | Correr cada verificación y capturar exit + output |
 | `--json` | false | Output como JSON estructurado |
 
 Solo una de `--staged`, `--modified`, `--all-changed` puede usarse.
 
-## Clasificacion de archivos
+## Clasificación de archivos
 
-| Clasificacion | Verificaciones |
+| Clasificación | Verificaciones |
 |---------------|----------------|
 | server_model | makemigrations --dry-run + lint + unit tests |
 | server_admin | manage.py check + lint |
@@ -88,7 +88,7 @@ Ventajas vs invocar `git` directo:
 ## Exit codes
 
 - 0: todas las verificaciones pasaron (o sin --execute)
-- 1: alguna verificacion fallo (solo con --execute)
+- 1: alguna verificación fallo (solo con --execute)
 - 2: error de invocacion
 
 ## Casos de uso
@@ -112,6 +112,6 @@ Si exit != 0, el agente lee el JSON, identifica que falla y aplica fix.
 
 ### En slash command /ship
 
-El comando `/ship` invoca `verify --staged --execute` despues de TDD y
+El comando `/ship` invoca `verify --staged --execute` después de TDD y
 antes de invocar `hook-fixer` para que las verificaciones especificas del
 tipo de cambio se corran primero.

--- a/devtools/verify/__init__.py
+++ b/devtools/verify/__init__.py
@@ -1,6 +1,6 @@
 """verify: dada una lista de archivos modificados/staged, retorna las
 verificaciones que deberian correrse antes de declarar la feature como
-"lista" (segun .claude/rules/verify-before-done.md).
+"lista" (según .claude/rules/verify-before-done.md).
 
 Permite invocar con --execute para correr cada comando y reportar exit
 codes en JSON.

--- a/devtools/verify/flags.py
+++ b/devtools/verify/flags.py
@@ -50,7 +50,7 @@ def _validate_source_flags(flags_dict: dict[str, Any]) -> None:
 
 def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
     """
-    Procesa y valida las flags para verify.
+    Procesa y válida las flags para verify.
 
     Parameters
     ----------
@@ -65,7 +65,7 @@ def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
     Raises
     ------
     ValueError
-        Si se usan flags no permitidas o combinaciones invalidas.
+        Si se usan flags no permitidas o combinaciones inválidas.
     """
     validate_allowed_flags(flags_dict, ALLOWED_FLAGS)
     flags_dict = set_default_values(flags_dict, DEFAULTS)
@@ -78,7 +78,7 @@ def describe() -> ScriptDescribe:
     return {
         'name': 'verify',
         'kind': 'monocommand',
-        'summary': 'Sugerir/ejecutar verificaciones segun archivos cambiados',
+        'summary': 'Sugerir/ejecutar verificaciones según archivos cambiados',
         'commands': [],
         'flags': {
             'staged': {

--- a/devtools/verify/main.py
+++ b/devtools/verify/main.py
@@ -1,14 +1,14 @@
 """verify main.
 
 Dada una lista de archivos cambiados (staged/modified/all_changed):
-1. Clasifica cada archivo por modulo y tipo (model, admin, service, view, etc.).
-2. Determina las verificaciones aplicables segun .claude/rules/verify-before-done.md.
-3. Si --execute: corre cada verificacion, captura exit + output truncado.
+1. Clasifica cada archivo por módulo y tipo (model, admin, service, view, etc.).
+2. Determina las verificaciones aplicables según .claude/rules/verify-before-done.md.
+3. Si --execute: corre cada verificación, captura exit + output truncado.
 4. Reporta resultado humano (texto) o JSON estructurado (--json).
 
 Exit codes:
 - 0: todas las verificaciones pasaron (o sin --execute).
-- 1: alguna verificacion fallo (solo con --execute).
+- 1: alguna verificación fallo (solo con --execute).
 - 2: error de invocacion (sin archivos cambiados, etc).
 """
 
@@ -33,7 +33,7 @@ logger = logging.getLogger('verify')
 
 @dataclass
 class Verification:
-    """Una verificacion sugerida para un archivo."""
+    """Una verificación sugerida para un archivo."""
 
     reason: str
     cmd: str
@@ -70,7 +70,7 @@ def collect_changed_files(flags: dict[str, Any]) -> list[str]:
 
     Delegates to ``shared.scan_helper.files_changed``: la deteccion de
     archivos por estado git vive en ``devtools/scan/`` (fuente canonica).
-    Asi heredamos el filtrado de archivos eliminados, respeto a
+    Así heredamos el filtrado de archivos eliminados, respeto a
     ``.gitignore``, y soporte para todos los modos git de scan.
     """
     git_mode = _resolve_git_mode(flags)
@@ -347,7 +347,7 @@ def execute_verifications(verifications: list[Verification]) -> int:
             )
         except subprocess.TimeoutExpired:
             v.exit_code = -1
-            v.output = '<TIMEOUT despues de 120s>'
+            v.output = '<TIMEOUT después de 120s>'
         except OSError as e:
             v.exit_code = -2
             v.output = f'<ERROR ejecutando: {e}>'
@@ -402,11 +402,11 @@ def render_text(
 
     if not verifications:
         logger.info('')
-        logger.info('verify: ninguna verificacion aplica para estos archivos.')
+        logger.info('verify: ninguna verificación aplica para estos archivos.')
         return
 
     logger.info('')
-    logger.info('Verificaciones sugeridas (%d unicas):', len(verifications))
+    logger.info('Verificaciones sugeridas (%d únicas):', len(verifications))
     for v in verifications:
         marker = _verification_marker(v, executed=executed)
         logger.info('  - %s%s', v.reason, marker)

--- a/devtools/weak_assertion/README.md
+++ b/devtools/weak_assertion/README.md
@@ -1,21 +1,21 @@
 # weak_assertion
 
-> Detector AST de asserts vagos en archivos de test Python (politica
+> Detector AST de asserts vagos en archivos de test Python (política
 > `.claude/rules/ai-testing-independence.md`).
 
 ## Patrones detectados
 
 | Patron | Ejemplo rechazado | Fix sugerido |
 |--------|-------------------|--------------|
-| Comparacion vaga | `assert x > 0` / `assert x < 100` | `assert x == 42` |
+| Comparación vaga | `assert x > 0` / `assert x < 100` | `assert x == 42` |
 | Check de None | `assert result is not None` | `assert result == {'status': 'ok'}` |
-| Verificacion de tipo | `assert isinstance(x, dict)` | `assert x == {'a': 1}` (typecheck estatico se encarga) |
+| Verificación de tipo | `assert isinstance(x, dict)` | `assert x == {'a': 1}` (typecheck estático se encarga) |
 | len comparado | `assert len(items) > 0` | `assert items == [item_a, item_b]` |
 | Truthy check | `assert flag` | `assert flag is True` o `assert flag == 'ok'` |
 
 ## Bypass
 
-- **Inline**: `# noqa: WEAK-ASSERT` en la misma linea, con razon en comentario
+- **Inline**: `# noqa: WEAK-ASSERT` en la misma linea, con razón en comentario
 - **Por archivo**: `# weak-assert: skip-file` en cualquier linea del archivo
 - **Step entero**: `SKIP_STEPS="weak_assertion" git commit ...`
 
@@ -40,7 +40,7 @@ python devtools/run.py weak_assertion --git-mode=staged --quiet
 - `0` - sin findings (o sin archivos relevantes)
 - `1` - al menos un weak assertion detectado
 
-## Integracion con git hooks
+## Integración con git hooks
 
 El step `weak_assertion` del orquestador (`.git-hooks/_common.py`) invoca
 este script en pre-commit. Para activar:
@@ -55,8 +55,8 @@ este script en pre-commit. Para activar:
    ```
 2. Agregar el handler en `.git-hooks/_common.py` (ver `tmp/git-hooks-patch/`).
 
-## Lista logica
+## Lista lógica
 
-La logica AST vive en `devtools/shared/weak_assertion.py` para que sea
+La lógica AST vive en `devtools/shared/weak_assertion.py` para que sea
 testeable y reutilizable. Este script (`devtools/weak_assertion/`) es solo
-el wrapper CLI + integracion git-mode.
+el wrapper CLI + integración git-mode.

--- a/devtools/weak_assertion/__init__.py
+++ b/devtools/weak_assertion/__init__.py
@@ -1,5 +1,5 @@
 """Weak assertion detector script (devtools).
 
 CLI manual + handler reusable para el step ``weak_assertion`` de los hooks.
-La logica AST vive en ``devtools/shared/weak_assertion.py``.
+La lógica AST vive en ``devtools/shared/weak_assertion.py``.
 """

--- a/devtools/weak_assertion/flags.py
+++ b/devtools/weak_assertion/flags.py
@@ -33,7 +33,7 @@ VALID_GIT_MODES = ('staged', 'unmerged', 'modified', 'changed')
 
 
 def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
-    """Procesa y valida las flags para el script weak_assertion.
+    """Procesa y válida las flags para el script weak_assertion.
 
     Args:
         flags_dict: Dict de flags ya procesado por ``run.py`` (parser hace
@@ -43,7 +43,7 @@ def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
         Dict con flags validadas y defaults aplicados.
 
     Raises:
-        ValueError: si hay flags no permitidas o valores invalidos.
+        ValueError: si hay flags no permitidas o valores inválidos.
     """
     validate_allowed_flags(flags_dict, ALLOWED_FLAGS)
     flags_dict = set_default_values(flags_dict, DEFAULTS)
@@ -70,7 +70,7 @@ def _validate_git_mode(flags_dict: dict[str, Any]) -> None:
         return
     if value not in VALID_GIT_MODES:
         msg = (
-            f'--git-mode={value} invalido. '
+            f'--git-mode={value} inválido. '
             f'Valores aceptados: {", ".join(VALID_GIT_MODES)}.'
         )
         raise ValueError(msg)
@@ -82,7 +82,7 @@ def describe() -> ScriptDescribe:
         'name': 'weak_assertion',
         'kind': 'monocommand',
         'summary': (
-            'Detecta asserts vagos en archivos de test Python (politica '
+            'Detecta asserts vagos en archivos de test Python (política '
             'AI-testing independence). Falla con exit 1 si encuentra '
             'asserts vagos en archivos staged/unmerged.'
         ),
@@ -92,7 +92,7 @@ def describe() -> ScriptDescribe:
                 'type': 'list',
                 'summary': (
                     'Paths separados por coma. Solo se procesan los que '
-                    'estan bajo un directorio tests/ y existen en disco.'
+                    'están bajo un directorio tests/ y existen en disco.'
                 ),
             },
             'git_mode': {

--- a/devtools/weak_assertion/main.py
+++ b/devtools/weak_assertion/main.py
@@ -1,6 +1,6 @@
 """``weak_assertion`` script entry point.
 
-Detecta asserts vagos en archivos de test Python via AST. Politica:
+Detecta asserts vagos en archivos de test Python via AST. Política:
 ``.claude/rules/ai-testing-independence.md``.
 
 Modos:
@@ -70,7 +70,7 @@ def _resolve_files(flags: dict[str, Any]) -> list[str]:
 
 
 if __name__ == '__main__':
-    # Permite ejecucion directa: python devtools/weak_assertion/main.py ...
+    # Permite ejecución directa: python devtools/weak_assertion/main.py ...
     sys.path.insert(0, str(_PROJECT_ROOT / 'devtools'))
     from weak_assertion.flags import get_flags
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Docker - Portfolio
 
-> Orquestacion multi-ambiente para las 6 apps Astro del portfolio + nginx.
+> Orquestación multi-ambiente para las 6 apps Astro del portfolio + nginx.
 
 ## Ambientes
 
@@ -9,11 +9,11 @@
 | local    | 9970         | `pnpm dev` (HMR) | Desarrollo con hot reload |
 | dev      | 9971         | `pnpm dev` (HMR, code baked) | Desarrollo remoto |
 | test     | 9972         | `pnpm build` + `preview` | E2E tests aislados |
-| prod     | 9973         | `pnpm build` + `preview` | Build de produccion |
+| prod     | 9973         | `pnpm build` + `preview` | Build de producción |
 
 ## Mapping de subdominios (todos los ambientes)
 
-| Subdominio          | App         | Equivalente en produccion       |
+| Subdominio          | App         | Equivalente en producción       |
 | ------------------- | ----------- | ------------------------------- |
 | `localhost`         | apps/generic   | the-full-stack.com           |
 | `hub.localhost`     | apps/hub       | hub.the-full-stack.com       |
@@ -31,14 +31,14 @@ docker/
 ├── dockerfiles/{env}/feature/Dockerfile # Playwright shared (solo local/test)
 ├── docker-compose/{env}.yml             # Compose por ambiente
 ├── nginx/{env}.conf                     # Nginx config por ambiente
-├── nginx/error-pages/                   # Paginas de error HTML
-├── nginx/services-page/                 # Indice estatico de servicios.localhost
+├── nginx/error-pages/                   # Páginas de error HTML
+├── nginx/services-page/                 # Indice estático de servicios.localhost
 ├── env/.example                         # Template de variables
 ├── env/.{env}                           # Variables por ambiente (gitignored)
 └── scripts/                             # Entrypoint scripts
 ```
 
-## Inicio rapido
+## Inicio rápido
 
 ```bash
 # 1. Copiar env template (opcional, valores por default funcionan)
@@ -68,7 +68,7 @@ docker compose -p portfolio -f docker/docker-compose/local.yml down
 
 ## Servicios
 
-| Servicio   | Imagen        | Descripcion |
+| Servicio   | Imagen        | Descripción |
 | ---------- | ------------- | ----------- |
 | nginx      | nginx:alpine  | Reverse proxy + subdominios |
 | generic    | node:24-alpine | Astro 6 dev/preview server |
@@ -96,7 +96,7 @@ docker compose -p portfolio -f docker/docker-compose/local.yml \
 ## Notas
 
 - Node 24 (Alpine) + pnpm 11.0.9 (via corepack) en todos los containers
-- Las 6 apps exponen puerto 4321 internamente. Solo nginx publica al host
+- Las 6 apps exponen puerto 4321 internamente. Solo nginx pública al host
 - En **local** y **dev**: bind mount del codigo fuente -> HMR funciona
 - En **test** y **prod**: `pnpm build` + `pnpm preview` (sin bind mount, sin HMR)
 - `/etc/hosts` no requiere entradas: `*.localhost` resuelve a 127.0.0.1 por RFC

--- a/docker/env/.example
+++ b/docker/env/.example
@@ -1,20 +1,20 @@
 # Portfolio - Variables de ambiente para Docker Compose.
 #
-# Copiar este archivo a .local, .dev, .test o .prod segun corresponda.
-# Los archivos .{env} estan en .gitignore — no committear.
+# Copiar este archivo a .local, .dev, .test o .prod según corresponda.
+# Los archivos .{env} están en .gitignore — no committear.
 #
-# Puerto Nginx (puerto unico publicado al host).
+# Puerto Nginx (puerto único publicado al host).
 # Defaults:
 #   local: 9970, dev: 9971, test: 9972, prod: 9973
 PROXY_PORT=9970
 
 # UID/GID del usuario host (evita root-owned files en bind mounts).
-# Estos vienen seteados automaticamente por devtools, pero pueden
-# overridearse aqui si es necesario.
+# Estos vienen seteados automáticamente por devtools, pero pueden
+# overridearse aquí si es necesario.
 # UID=1000
 # GID=1000
 
-# URLs publicas por app (usadas por Astro al generar canonicals, sitemap).
+# URLs públicas por app (usadas por Astro al generar canonicals, sitemap).
 # Apuntan a localhost:PROXY_PORT en dev/local; en prod son los dominios reales.
 SITE_URL_GENERIC=http://localhost
 SITE_URL_HUB=http://hub.localhost

--- a/docker/nginx/dev.conf
+++ b/docker/nginx/dev.conf
@@ -7,9 +7,9 @@
 #   architect.localhost  -> apps/architect
 #   leader.localhost     -> apps/leader
 #   vibe.localhost       -> apps/vibe
-#   services.localhost   -> servicio estatico de indice
+#   services.localhost   -> servicio estático de indice
 #
-# Todas las apps Astro exponen :4321 internamente. nginx publica solo en
+# Todas las apps Astro exponen :4321 internamente. nginx pública solo en
 # el puerto :9970 (ver docker/env/.local PROXY_PORT).
 
 upstream generic_app    { server generic:4321; }
@@ -20,7 +20,7 @@ upstream leader_app     { server leader:4321; }
 upstream vibe_app       { server vibe:4321; }
 
 # Defaults aplicados a todos los server blocks via include.
-# error_pages reutiliza los HTML estaticos del volume.
+# error_pages reutiliza los HTML estáticos del volume.
 
 # === localhost -> apps/generic (the-full-stack.com en prod) ===
 server {
@@ -208,7 +208,7 @@ server {
     }
 }
 
-# === services.localhost -> indice estatico ===
+# === services.localhost -> indice estático ===
 # Hub HTML montado en /usr/share/nginx/services-page con la lista de
 # subdominios del stack local. JS hace health check con fetch.
 server {

--- a/docker/nginx/error-pages/loading.html
+++ b/docker/nginx/error-pages/loading.html
@@ -29,7 +29,7 @@
   <div class="box">
     <div class="spinner"></div>
     <h1>Servidor calentando...</h1>
-    <p>El upstream esta arrancando. Esta pagina se recarga sola en 3 segundos.</p>
+    <p>El upstream esta arrancando. Esta página se recarga sola en 3 segundos.</p>
   </div>
 </body>
 </html>

--- a/docker/nginx/local.conf
+++ b/docker/nginx/local.conf
@@ -7,9 +7,9 @@
 #   architect.localhost  -> apps/architect
 #   leader.localhost     -> apps/leader
 #   vibe.localhost       -> apps/vibe
-#   services.localhost   -> servicio estatico de indice
+#   services.localhost   -> servicio estático de indice
 #
-# Todas las apps Astro exponen :4321 internamente. nginx publica solo en
+# Todas las apps Astro exponen :4321 internamente. nginx pública solo en
 # el puerto :9970 (ver docker/env/.local PROXY_PORT).
 
 upstream generic_app    { server generic:4321; }
@@ -20,7 +20,7 @@ upstream leader_app     { server leader:4321; }
 upstream vibe_app       { server vibe:4321; }
 
 # Defaults aplicados a todos los server blocks via include.
-# error_pages reutiliza los HTML estaticos del volume.
+# error_pages reutiliza los HTML estáticos del volume.
 
 # === localhost -> apps/generic (the-full-stack.com en prod) ===
 server {
@@ -208,7 +208,7 @@ server {
     }
 }
 
-# === services.localhost -> indice estatico ===
+# === services.localhost -> indice estático ===
 # Hub HTML montado en /usr/share/nginx/services-page con la lista de
 # subdominios del stack local. JS hace health check con fetch.
 server {

--- a/docker/nginx/prod.conf
+++ b/docker/nginx/prod.conf
@@ -7,9 +7,9 @@
 #   architect.localhost  -> apps/architect
 #   leader.localhost     -> apps/leader
 #   vibe.localhost       -> apps/vibe
-#   services.localhost   -> servicio estatico de indice
+#   services.localhost   -> servicio estático de indice
 #
-# Todas las apps Astro exponen :4321 internamente. nginx publica solo en
+# Todas las apps Astro exponen :4321 internamente. nginx pública solo en
 # el puerto :9970 (ver docker/env/.local PROXY_PORT).
 
 upstream generic_app    { server generic:4321; }
@@ -20,7 +20,7 @@ upstream leader_app     { server leader:4321; }
 upstream vibe_app       { server vibe:4321; }
 
 # Defaults aplicados a todos los server blocks via include.
-# error_pages reutiliza los HTML estaticos del volume.
+# error_pages reutiliza los HTML estáticos del volume.
 
 # === localhost -> apps/generic (the-full-stack.com en prod) ===
 server {
@@ -208,7 +208,7 @@ server {
     }
 }
 
-# === services.localhost -> indice estatico ===
+# === services.localhost -> indice estático ===
 # Hub HTML montado en /usr/share/nginx/services-page con la lista de
 # subdominios del stack local. JS hace health check con fetch.
 server {

--- a/docker/nginx/services-page/index.html
+++ b/docker/nginx/services-page/index.html
@@ -114,7 +114,7 @@
 
     <footer>
       Page servida por nginx desde <code>/usr/share/nginx/services-page/</code>.
-      <br>El puerto del proxy se infiere del location.host automaticamente.
+      <br>El puerto del proxy se infiere del location.host automáticamente.
     </footer>
   </div>
 

--- a/docker/nginx/test.conf
+++ b/docker/nginx/test.conf
@@ -7,9 +7,9 @@
 #   architect.localhost  -> apps/architect
 #   leader.localhost     -> apps/leader
 #   vibe.localhost       -> apps/vibe
-#   services.localhost   -> servicio estatico de indice
+#   services.localhost   -> servicio estático de indice
 #
-# Todas las apps Astro exponen :4321 internamente. nginx publica solo en
+# Todas las apps Astro exponen :4321 internamente. nginx pública solo en
 # el puerto :9970 (ver docker/env/.local PROXY_PORT).
 
 upstream generic_app    { server generic:4321; }
@@ -20,7 +20,7 @@ upstream leader_app     { server leader:4321; }
 upstream vibe_app       { server vibe:4321; }
 
 # Defaults aplicados a todos los server blocks via include.
-# error_pages reutiliza los HTML estaticos del volume.
+# error_pages reutiliza los HTML estáticos del volume.
 
 # === localhost -> apps/generic (the-full-stack.com en prod) ===
 server {
@@ -208,7 +208,7 @@ server {
     }
 }
 
-# === services.localhost -> indice estatico ===
+# === services.localhost -> indice estático ===
 # Hub HTML montado en /usr/share/nginx/services-page con la lista de
 # subdominios del stack local. JS hace health check con fetch.
 server {

--- a/docker/scripts/app-dev-entrypoint.sh
+++ b/docker/scripts/app-dev-entrypoint.sh
@@ -23,11 +23,11 @@ GID_RUN="${GID:-1000}"
 
 # Fix permisos del bind mount y named volumes.
 # /app                -> bind mount del repo (puede ser root-owned en CI)
-# /app/node_modules   -> named volume vacio (root-owned al primer mount)
+# /app/node_modules   -> named volume vacío (root-owned al primer mount)
 #
 # IMPORTANTE: chown solo de /app (depth 0) y /app/node_modules. NO recursivo
 # en el bind mount porque (a) es caro y (b) lo del host se ve afectado en
-# desarrollo local. pnpm escribe sus _tmp_<n>_<hash> en la raiz del workdir
+# desarrollo local. pnpm escribe sus _tmp_<n>_<hash> en la raíz del workdir
 # (/app/), por eso necesita /app con write para uid app.
 if [ "$(id -u)" = "0" ]; then
   echo "[entrypoint] Ajustando permisos como root..."

--- a/docker/scripts/app-preview-entrypoint.sh
+++ b/docker/scripts/app-preview-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Entrypoint para apps Astro en modo preview (build estatico + serve).
+# Entrypoint para apps Astro en modo preview (build estático + serve).
 #
 # CORRE COMO ROOT al inicio para fixear permisos, luego cae a user app.
 

--- a/docker/scripts/feature-entrypoint.sh
+++ b/docker/scripts/feature-entrypoint.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-# Anadir resolucion de subdominios *.localhost (api, generic, hub, fintech, ...)
+# Anadir resolución de subdominios *.localhost (api, generic, hub, fintech, ...)
 if ! grep -q 'hub.localhost' /etc/hosts 2>/dev/null; then
   echo "Adding *.localhost subdomain entries to /etc/hosts..."
   printf '\n127.0.0.1\thub.localhost\n' >> /etc/hosts
@@ -21,8 +21,8 @@ fi
 cd /app/tests/feature
 
 echo "Installing feature test dependencies..."
-# --ignore-workspace evita que pnpm escale al monorepo raiz y haga un
-# install vacio. tests/feature/ tiene su propio package.json aislado.
+# --ignore-workspace evita que pnpm escale al monorepo raíz y haga un
+# install vacío. tests/feature/ tiene su propio package.json aislado.
 pnpm install --ignore-workspace --frozen-lockfile 2>/dev/null \
   || pnpm install --ignore-workspace
 

--- a/packages/seo/src/lib/build-llms-txt.ts
+++ b/packages/seo/src/lib/build-llms-txt.ts
@@ -4,7 +4,7 @@
  *   Formato: spec llms.txt (https://llmstxt.org). En INGLES (audiencia: crawlers
  *   de IA en cualquier idioma).
  *
- *   Cubre AC-3: cada subdominio sirve llms.txt con paginas y resumenes.
+ *   Cubre AC-3: cada subdominio sirve llms.txt con páginas y resumenes.
  */
 import type { Niche, Profile } from '@portfolio/content'
 

--- a/packages/seo/src/lib/build-person-schema.ts
+++ b/packages/seo/src/lib/build-person-schema.ts
@@ -3,7 +3,7 @@
  * @description Construye un schema.org Person para JSON-LD. Toma el Profile
  *   compartido y ajusta jobTitle/knowsAbout/description al nicho.
  *
- *   Cubre AC-2: cada subdominio tiene JSON-LD Person valido con campos
+ *   Cubre AC-2: cada subdominio tiene JSON-LD Person válido con campos
  *   especificos del nicho.
  *
  * @param input - profile, niche, locale, canonicalUrl, knowsAbout (skills filtradas)

--- a/packages/ui/src/components/ContactLinks.astro
+++ b/packages/ui/src/components/ContactLinks.astro
@@ -2,7 +2,7 @@
 /**
  * @component ContactLinks
  * @description Lista de links de contacto. El email se decodifica solo en
- *   cliente (anti-scraping basico).
+ *   cliente (anti-scraping básico).
  *
  * @props {string} email - Email a obfuscar (b64 en data-attr)
  * @props {string} linkedin

--- a/packages/ui/src/components/Hero.astro
+++ b/packages/ui/src/components/Hero.astro
@@ -4,7 +4,7 @@
  * @description Hero principal con eyebrow + headline + summary + CTAs.
  *   Usa stagger animation via custom property --i.
  *
- * @props {string} eyebrow - Texto pequeno arriba del headline (badge del niche)
+ * @props {string} eyebrow - Texto pequeño arriba del headline (badge del niche)
  * @props {string} headline - H1 principal
  * @props {string} summary - Parrafo descriptivo (1-3 lineas)
  * @props {Array<{href, label, variant?}>} [ctas] - Hasta 2 CTAs

--- a/packages/ui/src/components/Nav.astro
+++ b/packages/ui/src/components/Nav.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * @component Nav
- * @description Barra de navegacion principal. Recibe links y nombre del sitio.
+ * @description Barra de navegación principal. Recibe links y nombre del sitio.
  *
  * @props {Array<{href: string, label: string}>} items - Items del menu
  * @props {string} brand - Texto del logotipo

--- a/packages/ui/src/components/SectionHeader.astro
+++ b/packages/ui/src/components/SectionHeader.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * @component SectionHeader
- * @description Encabezado de seccion con eyebrow + titulo + subtitulo opcional.
+ * @description Encabezado de seccion con eyebrow + título + subtitulo opcional.
  */
 interface Props {
   eyebrow?: string

--- a/packages/ui/src/lib/obfuscate-email.ts
+++ b/packages/ui/src/lib/obfuscate-email.ts
@@ -1,6 +1,6 @@
 /**
  * @function obfuscateEmail
- * @description Codifica un email a base64 url-safe para anti-scraping basico.
+ * @description Codifica un email a base64 url-safe para anti-scraping básico.
  *   El script inline del componente lo decodifica solo en cliente.
  *
  *   Usa btoa/atob (disponibles en browser y Node 22+). El stack del portfolio

--- a/packages/ui/src/lib/reveal-on-scroll.ts
+++ b/packages/ui/src/lib/reveal-on-scroll.ts
@@ -6,7 +6,7 @@
  *   Si prefers-reduced-motion: reduce esta activo, marca todos visibles
  *   inmediatamente y retorna noop.
  *
- * @returns funcion disconnect para limpiar el observer (opcional)
+ * @returns función disconnect para limpiar el observer (opcional)
  *
  * @example
  *   // En BaseLayout.astro <script>:

--- a/packages/ui/src/lib/theme-toggle.ts
+++ b/packages/ui/src/lib/theme-toggle.ts
@@ -1,6 +1,6 @@
 /**
  * @module theme-toggle
- * @description Logica pura del theme toggle. Cicla system -> dark -> light.
+ * @description Lógica pura del theme toggle. Cicla system -> dark -> light.
  *   Persiste preferencia en localStorage. El BaseLayout debe correr applyTheme()
  *   ANTES de pintar para evitar FOUC.
  *

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -1,6 +1,6 @@
 /**
  * @config tokens.css
- * @description API publica del DS: CSS vars consumidas por TODOS los componentes.
+ * @description API pública del DS: CSS vars consumidas por TODOS los componentes.
  *   Cambiar un token = cambiar 1 linea, sin recompilar.
  *
  *   Modo base = system (respeta prefers-color-scheme). Toggle aplica clase

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,8 +1,8 @@
 /**
  * @config vitest
  * @description Vitest config para @portfolio/ui. Cubre lib/ vanilla TS.
- *   Componentes .astro NO se testean aqui (no se renderean en JSDOM); su
- *   verificacion es astro check + E2E.
+ *   Componentes .astro NO se testean aquí (no se renderean en JSDOM); su
+ *   verificación es astro check + E2E.
  */
 import { defineConfig } from 'vitest/config'
 

--- a/server/README.md
+++ b/server/README.md
@@ -3,14 +3,14 @@
 > Directorio placeholder requerido por la arquitectura de `devtools/`.
 > Este portfolio NO tiene backend Django. `server/manage.py` es solo
 > un stub que existe para que `devtools/hooks/main.py` no aborte al
-> verificar la presencia del modulo server.
+> verificar la presencia del módulo server.
 
 ## Por que existe
 
 El orquestador de hooks (`devtools/hooks/main.py`) hereda de
-`mvp-template-full-stack`, donde existe un Django server. La logica
-de deteccion de archivos (`shared/scan_helper.py`) y de clasificacion
-asume que `server/` es un workspace valido.
+`mvp-template-full-stack`, donde existe un Django server. La lógica
+de deteccion de archivos (`shared/scan_helper.py`) y de clasificación
+asume que `server/` es un workspace válido.
 
 Para mantener paridad 100% con esa arquitectura sin tener Django:
 
@@ -25,6 +25,6 @@ Para mantener paridad 100% con esa arquitectura sin tener Django:
 1. Reemplazar `manage.py` por el real de Django
 2. Agregar las apps Django bajo `server/<app>/`
 3. Crear `server/ruff.toml` con la config de linting
-4. Los hooks empezaran a detectar archivos `.py` automaticamente
+4. Los hooks empezaran a detectar archivos `.py` automáticamente
 
-Por ahora, este directorio queda intencionalmente vacio.
+Por ahora, este directorio queda intencionalmente vacío.

--- a/tests/feature/README.md
+++ b/tests/feature/README.md
@@ -18,7 +18,7 @@ tests/feature/
 ├── helpers/
 │   ├── screenshot.ts        # Capture + adjuntar al report
 │   └── inspect-overlay.ts   # Debug overlay (gated by DEBUG_INSPECT=1)
-└── <feature>/<feature>.spec.ts  # Tus specs van aqui
+└── <feature>/<feature>.spec.ts  # Tus specs van aquí
 ```
 
 ## Convencion para escribir tests

--- a/tests/feature/fixtures/api/api-client.ts
+++ b/tests/feature/fixtures/api/api-client.ts
@@ -3,8 +3,8 @@ import type { APIRequestContext } from '@playwright/test'
 /**
  * @class ApiClient
  * @description Cliente HTTP reusable para llamadas al backend desde tests E2E.
- *   Stub minimo: el portfolio actual no tiene backend. Cuando se agregue
- *   (form de contacto, analytics, etc.), agregar metodos aqui.
+ *   Stub mínimo: el portfolio actual no tiene backend. Cuando se agregue
+ *   (form de contacto, analytics, etc.), agregar métodos aquí.
  */
 export class ApiClient {
   private readonly request: APIRequestContext

--- a/tests/feature/fixtures/index.ts
+++ b/tests/feature/fixtures/index.ts
@@ -11,7 +11,7 @@ import { ApiClient } from './api/api-client.js'
  * expone para verificaciones contra el backend desde tests.
  *
  * Helpers para URLs por subdominio: `subdomainUrl('hub')` retorna
- * `http://hub.localhost:<PROXY_PORT>` segun la baseURL del config.
+ * `http://hub.localhost:<PROXY_PORT>` según la baseURL del config.
  */
 export interface TestFixtures {
   apiClient: ApiClient

--- a/tests/feature/helpers/inspect-overlay.ts
+++ b/tests/feature/helpers/inspect-overlay.ts
@@ -2,8 +2,8 @@ import type { Page } from '@playwright/test'
 
 /**
  * @function inspectOverlay
- * @description Pausa la ejecucion del test e inyecta un overlay
- *   informativo (URL, viewport, browser) sobre la pagina para debugging
+ * @description Pausa la ejecución del test e inyecta un overlay
+ *   informativo (URL, viewport, browser) sobre la página para debugging
  *   manual con `--headed`. Solo activo si DEBUG_INSPECT=1.
  *
  * @example

--- a/tests/feature/smoke/smoke.spec.ts
+++ b/tests/feature/smoke/smoke.spec.ts
@@ -2,7 +2,7 @@
  * @feature Smoke tests - portfolio multi-subdominio
  * @description Verifica que cada uno de los 6 subdominios del stack
  *   local responde HTTP 200 y renderiza al menos el body. Es el smoke
- *   minimo que prueba: nginx + cada app Astro + reverse-proxy.
+ *   mínimo que prueba: nginx + cada app Astro + reverse-proxy.
  */
 import { expect, subdomainUrl, test } from '../fixtures/index.js'
 
@@ -32,7 +32,7 @@ test.describe('Feature: Smoke - 6 apps Astro responden', () => {
       expect(response, `no response from ${url}`).not.toBeNull()
       expect(response?.status(), `status del primer load`).toBeLessThan(400)
 
-      // Assert: el body renderizo (no es pagina de error)
+      // Assert: el body renderizo (no es página de error)
       const body = page.locator('body')
       await expect(body).toBeVisible()
     })


### PR DESCRIPTION
## Problema

Mucho del texto en español del repo (CLAUDE.md, docstrings, README, hooks, mensajes
de output, scripts de Docker, etc.) no tenía las tildes correspondientes. Esto pasa
porque la migración inicial de devtools/docker venía de un template fuente con la
misma convención sin acentos.

El español de calidad requiere tildes en palabras como `función`, `ejecución`,
`módulo`, `página`, `validación`, `también`, `están`, `después`, etc.

## Solución

Spell-fix masivo a 109 archivos del repo (511 cambios, balanceados como
inserciones y eliminaciones).

Approach técnico:
1. Mapping curado de ~280 palabras `sin_tilde -> con_tilde`
2. Regex word-boundary case-insensitive que preserva mayúsculas
3. Exclusiones agresivas: identificadores de código (camelCase/snake_case/kebab-case),
   paths, URLs, código inline, bloques fenced
4. Validación post-fix de JSON/YAML/Bash/Python + functional tests de devtools

Alcance positivo:
- CLAUDE.md, README.md
- .git-hooks/ (Python + JSON)
- .github/ (workflows, PR template)
- .claude/rules/verify-before-done.md (sección sobre feature tests)
- docker/ (README, env files, nginx configs, error pages, services-page, scripts)
- tests/feature/ (fixtures, helpers, README, smoke spec)
- devtools/ (docstrings en archivos modificados)
- apps/ y packages/ (JSDoc en componentes y libs)
- server/README.md

Exclusiones intencionales:
- `.claude/skills/mermaid/` y `.claude/docs/mermaid/` (el parser de Mermaid falla
  con tildes en labels — convención documentada en `mermaid/03-best-practices.md`)
- node_modules, dist, .astro, coverage, .venv, .git-store (binarios y caches)
- Identificadores de código y paths (preservados por regex word-boundary)

Falsos positivos revertidos manualmente:
- `VS Code Extension API` (nombre propio inglés) en cv-*.html y projects.ts
- `extension` dentro de strings `en: '...'` y archivos `cv-en.html` (texto inglés)

## Como probar

```bash
# 1. Verificar que devtools sigue funcional
python3 devtools/run.py docker ps --env=local
python3 devtools/run.py test_runner --module=pkg-content --type=unit
python3 devtools/run.py test_runner --module=generic --type=typecheck

# 2. Verificar que JSON / YAML / Bash siguen siendo válidos
python3 -m json.tool .git-hooks/config.json
python3 -m json.tool package.json
for f in docker/docker-compose/*.yml .github/workflows/*.yml; do
  python3 -c "import yaml; yaml.safe_load(open('$f'))" && echo "OK $f"
done
for f in docker/scripts/*.sh .git-hooks/prepare-commit-msg; do
  bash -n "$f" && echo "OK $f"
done

# 3. Spot check de archivos: verificar tildes presentes en español, ausentes en mermaid
grep -c "ción" CLAUDE.md  # debe ser >0
grep -c "ción" .claude/skills/mermaid/SKILL.md  # debe ser 0 (mermaid sin tildes)

# 4. Verificar que mermaid skill sigue limpia
grep "convencion" .claude/skills/mermaid/SKILL.md  # debe encontrar "convencion" sin tilde
```

## TODO

- Sin pendientes. Es un cleanup ortográfico — listo para merge.