### PR TITLE
chore(claude): importa contenido Python-related desde mvp-template-full-stack

### DIFF
--- a/.claude/docs/django-6/01-api-reference.md
+++ b/.claude/docs/django-6/01-api-reference.md
@@ -1,0 +1,305 @@
+[Volver al indice](README.md) | [Siguiente: Background Tasks](02-background-tasks.md)
+
+# Django 6 - API Reference
+
+> Referencia completa de Django 6.0: instalacion, settings, nuevas features y guia de migracion.
+
+## Identificacion
+
+| Campo | Valor |
+|-------|-------|
+| Nombre | Django |
+| Version | 6.0.3 (ultima estable) |
+| Release | 3 diciembre 2025 |
+| Soporte activo | Hasta agosto 2026 |
+| Soporte seguridad | Hasta abril 2027 |
+| Python minimo | 3.12 |
+| LTS | No (5.2 es LTS hasta abril 2028) |
+| Documentacion | docs.djangoproject.com |
+
+## Instalacion
+
+```bash
+# Con pip
+pip install Django==6.0.3
+
+# Con uv (recomendado)
+uv add Django==6.0.3
+
+# Verificar version
+python -c "import django; print(django.VERSION)"
+```
+
+### Dependencias recomendadas para PostgreSQL
+
+```txt
+# requirements.txt
+Django==6.0.3
+psycopg[binary]==3.2.6    # psycopg3, NO psycopg2
+```
+
+## Settings criticos
+
+### DEFAULT_AUTO_FIELD
+
+Django 6 cambia el default de `AutoField` (int32) a `BigAutoField` (int64):
+
+```python
+# settings.py - ya es el default, pero explicitar para claridad
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+```
+
+**Migracion**: Si tienes proyectos con `AutoField`, agrega esto en `AppConfig`:
+
+```python
+class MyAppConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"  # mantener legacy
+```
+
+### DATABASES con psycopg3
+
+```python
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.getenv("DB_NAME", "mydb"),
+        "USER": os.getenv("DB_USER", "postgres"),
+        "PASSWORD": os.getenv("DB_PASSWORD", ""),
+        "HOST": os.getenv("DB_HOST", "localhost"),
+        "PORT": os.getenv("DB_PORT", "5432"),
+        "OPTIONS": {
+            "pool": True,  # connection pooling nativo de psycopg3
+        },
+    }
+}
+```
+
+psycopg3 es auto-detectado por Django 6 si esta instalado. No requiere `ENGINE` especial.
+
+## CSP Middleware (Content Security Policy)
+
+Soporte nativo contra XSS. Reemplaza el paquete `django-csp`.
+
+### Configuracion
+
+```python
+# settings.py
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.security.ContentSecurityPolicyMiddleware",  # nuevo
+    # ...
+]
+
+SECURE_CSP = {
+    "default-src": ["'self'"],
+    "script-src": ["'self'", "https://cdn.example.com"],
+    "style-src": ["'self'", "'unsafe-inline'"],
+    "img-src": ["'self'", "data:", "https:"],
+    "font-src": ["'self'", "https://fonts.gstatic.com"],
+    "connect-src": ["'self'"],
+}
+
+# Para modo report-only (no bloquea, solo reporta)
+SECURE_CSP_REPORT_ONLY = {
+    "default-src": ["'self'"],
+    "report-uri": "/csp-report/",
+}
+```
+
+### Nonces automaticos
+
+```python
+# En templates
+<script nonce="{{ request.csp_nonce }}">
+    // JavaScript seguro
+</script>
+```
+
+### Decoradores per-view
+
+```python
+from django.views.decorators.csp import csp_override
+
+@csp_override({"script-src": ["'self'", "'unsafe-eval'"]})
+def admin_view(request):
+    # Vista con CSP custom
+    pass
+```
+
+## Template Partials
+
+Definir y reutilizar fragmentos de template sin crear archivos separados:
+
+```html
+<!-- base_page.html -->
+{% partialdef sidebar %}
+  <nav class="sidebar">
+    <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/about/">About</a></li>
+    </ul>
+  </nav>
+{% endpartialdef %}
+
+<!-- Usar en el mismo template -->
+<div class="layout">
+  {% partial sidebar %}
+  <main>{{ content }}</main>
+</div>
+
+<!-- O incluir desde otro template -->
+{% partial "base_page.html:sidebar" %}
+```
+
+Util para componentes HTMX que necesitan re-renderizar solo una parte.
+
+## Email API modernizada
+
+Django 6 migra a `email.message.EmailMessage` de Python 3.6+:
+
+```python
+from django.core.mail import EmailMessage
+
+# API sin cambios para uso basico
+email = EmailMessage(
+    subject="Bienvenido",
+    body="Contenido del email",
+    from_email="noreply@example.com",
+    to=["user@example.com"],
+)
+email.send()
+```
+
+**Deprecados**: `SafeMIMEText`, `SafeMIMEMultipart`. Los argumentos opcionales de `send_mail()` ahora son keyword-only.
+
+## AsyncPaginator
+
+Paginacion nativa para vistas async:
+
+```python
+from django.core.paginator import AsyncPaginator
+
+async def product_list(request):
+    queryset = Product.objects.all()
+    paginator = AsyncPaginator(queryset, per_page=25)
+    page = await paginator.aget_page(request.GET.get("page", 1))
+    return render(request, "products/list.html", {"page": page})
+```
+
+## Lexeme y Full-Text Search
+
+Nuevo tipo `Lexeme` para full-text search en PostgreSQL:
+
+```python
+from django.contrib.postgres.search import SearchVector, SearchQuery, Lexeme
+
+# Busqueda con lexemes personalizados
+query = SearchQuery(Lexeme("python", weight="A") & Lexeme("django", weight="B"))
+results = Article.objects.annotate(
+    search=SearchVector("title", "body"),
+).filter(search=query)
+```
+
+## GeneratedField auto-refresh
+
+`GeneratedField` y `db_default` ahora se refrescan automaticamente despues de `save()`:
+
+```python
+from django.db import models
+
+class Product(models.Model):
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+    tax_rate = models.DecimalField(max_digits=4, decimal_places=2, default=0.19)
+    total = models.GeneratedField(
+        expression=models.F("price") * (1 + models.F("tax_rate")),
+        output_field=models.DecimalField(max_digits=12, decimal_places=2),
+        db_persist=True,
+    )
+
+# Despues de save(), product.total tiene el valor calculado (sin refresh_from_db)
+product = Product(price=100, tax_rate=0.19)
+product.save()
+print(product.total)  # 119.00 -- auto-refreshed
+```
+
+Funciona en PostgreSQL, SQLite y Oracle.
+
+## ORM: Nuevas funcionalidades
+
+### StringAgg cross-database
+
+```python
+from django.db.models.functions import StringAgg
+
+# Funciona en PostgreSQL, SQLite, MySQL
+tags = Article.objects.values("author").annotate(
+    all_tags=StringAgg("tags__name", delimiter=", ")
+)
+```
+
+### AnyValue aggregate
+
+```python
+from django.db.models import AnyValue
+
+# Obtener un valor arbitrario de un grupo (util con GROUP BY)
+results = Order.objects.values("customer_id").annotate(
+    sample_product=AnyValue("product__name")
+)
+```
+
+### Model.NotUpdated exception
+
+```python
+try:
+    updated = Product.objects.filter(id=1, version=5).update(
+        name="New Name", version=6
+    )
+    if updated == 0:
+        raise Product.NotUpdated("Concurrent modification detected")
+except Product.NotUpdated:
+    # Manejar conflicto de concurrencia
+    pass
+```
+
+## Deprecaciones y removals
+
+### Removido en Django 6.0
+
+| Eliminado | Reemplazo |
+|-----------|-----------|
+| `force_text()` | `force_str()` |
+| `smart_text()` | `smart_str()` |
+| `SafeMIMEText` | `email.message.EmailMessage` |
+| Python 3.10/3.11 | Python 3.12+ |
+| MariaDB 10.5 | MariaDB 10.6+ |
+| `as_sql()` retornando listas | Debe retornar tuplas |
+
+### Deprecado (removido en Django 7)
+
+| Deprecado | Reemplazo |
+|-----------|-----------|
+| `SafeMIMEMultipart` | `email.message.EmailMessage` |
+| Argumentos posicionales en `send_mail()` | Usar keyword arguments |
+
+## Compatibilidad
+
+| Componente | Versiones soportadas |
+|------------|---------------------|
+| Python | 3.12, 3.13 |
+| PostgreSQL | 14, 15, 16, 17, 18 |
+| MySQL | 8.0, 8.4, 9.0 |
+| MariaDB | 10.6, 10.11, 11.x |
+| SQLite | 3.39+ |
+
+## Django 6.1 (en desarrollo)
+
+Features anticipadas para agosto 2026:
+
+- **Field Fetch Modes**: `FETCH_PEERS` elimina N+1 queries automaticamente, `FETCH_RAISE` previene acceso lazy
+- **Database-level delete**: `DB_CASCADE`, `DB_SET_NULL`, `DB_SET_DEFAULT`
+- PostgreSQL 15+ minimo, MySQL 8.4+ minimo
+
+---
+
+[Volver al indice](README.md) | [Siguiente: Background Tasks](02-background-tasks.md)

--- a/.claude/docs/django-6/02-background-tasks.md
+++ b/.claude/docs/django-6/02-background-tasks.md
@@ -1,0 +1,218 @@
+[Anterior: API Reference](01-api-reference.md) | [Volver al indice](README.md)
+
+# Django 6 - Background Tasks Framework
+
+> Sistema built-in para ejecutar codigo fuera del ciclo request-response con `@task` decorator y `.enqueue()`.
+
+## Concepto
+
+Django 6 incluye un framework nativo de tareas en background. Permite mover operaciones costosas (envio de emails, procesamiento de imagenes, llamadas a APIs) fuera del request-response sin necesidad de Celery o Redis para casos simples.
+
+**Flujo basico**:
+
+1. Decorar funcion con `@task`
+2. Llamar `.enqueue()` en el request
+3. Django ejecuta la tarea en background segun el backend configurado
+
+## Configuracion
+
+```python
+# settings.py
+
+# Backend para desarrollo (ejecuta inmediatamente, sincrono)
+TASKS_BACKEND = "django.tasks.backends.ImmediateBackend"
+
+# Backend dummy (no ejecuta, util para tests)
+# TASKS_BACKEND = "django.tasks.backends.DummyBackend"
+
+# Backend de produccion (requiere paquete de terceros)
+# TASKS_BACKEND = "django_tasks_database.DatabaseBackend"
+```
+
+### Backends de produccion (terceros)
+
+Django solo incluye backends de desarrollo. Para produccion:
+
+| Backend | Paquete | Broker |
+|---------|---------|--------|
+| Database | `django-tasks-database` | PostgreSQL/MySQL |
+| Redis | `django-tasks-redis` | Redis |
+
+```bash
+# Instalar backend de base de datos
+uv add django-tasks-database
+```
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    "django_tasks_database",
+]
+TASKS_BACKEND = "django_tasks_database.DatabaseBackend"
+```
+
+```bash
+# Crear tabla de tareas
+python manage.py migrate
+
+# Ejecutar worker de tareas
+python manage.py run_tasks
+```
+
+## @task decorator
+
+```python
+from django.tasks import task
+
+@task()
+def send_welcome_email(user_id: int) -> None:
+    """Envia email de bienvenida al usuario."""
+    user = User.objects.get(id=user_id)
+    user.email_user(
+        subject="Bienvenido",
+        message=f"Hola {user.first_name}",
+    )
+
+@task(priority=10)
+def process_payment(payment_id: int) -> dict:
+    """Procesa un pago con prioridad alta."""
+    payment = Payment.objects.get(id=payment_id)
+    result = gateway.charge(payment)
+    return {"status": result.status, "transaction_id": result.id}
+```
+
+### Parametros del decorator
+
+| Parametro | Tipo | Default | Descripcion |
+|-----------|------|---------|-------------|
+| `priority` | int | 0 | Prioridad (mayor = primero) |
+| `queue` | str | "default" | Cola de ejecucion |
+| `unique` | bool | False | Evitar duplicados |
+
+## Enqueue
+
+```python
+# En una vista
+from myapp.tasks import send_welcome_email, process_payment
+
+def register_user(request):
+    user = User.objects.create_user(...)
+
+    # Encolar tarea - NO ejecuta inmediatamente
+    result = send_welcome_email.enqueue(user.id)
+
+    # result es un TaskResult con metodos utiles
+    print(result.id)        # UUID de la tarea
+    print(result.status)    # "pending", "running", "completed", "failed"
+
+    return redirect("dashboard")
+```
+
+### Encolar con opciones
+
+```python
+from datetime import timedelta
+
+# Ejecutar con delay
+send_welcome_email.enqueue(user.id, run_after=timedelta(minutes=5))
+
+# Ejecutar en cola especifica
+process_payment.enqueue(payment.id, queue="high_priority")
+```
+
+## Retry y error handling
+
+```python
+from django.tasks import task
+import logging
+
+logger = logging.getLogger(__name__)
+
+@task()
+def call_external_api(endpoint: str, payload: dict) -> dict:
+    """Llama a API externa con manejo de errores."""
+    try:
+        response = requests.post(endpoint, json=payload, timeout=30)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as e:
+        logger.error(f"API call failed: {e}")
+        raise  # Re-raise para que el backend maneje el retry
+```
+
+El mecanismo de retry depende del backend:
+
+```python
+# django-tasks-database soporta retry nativo
+TASKS_BACKEND = "django_tasks_database.DatabaseBackend"
+TASKS_DATABASE_BACKEND = {
+    "MAX_RETRIES": 3,
+    "RETRY_DELAY": 60,  # segundos
+}
+```
+
+## Integracion con rezebra
+
+Ejemplo de uso para procesamiento en lote:
+
+```python
+from django.tasks import task
+from myapp.services import process_item, upload_to_s3
+
+@task(queue="processing")
+def process_and_upload(item_id: int, s3_key: str) -> str:
+    """Procesa un item y sube resultado a S3."""
+    result_bytes = process_item(item_id)
+    url = upload_to_s3(result_bytes, s3_key)
+    return url
+
+# En la vista o script
+for i, item_id in enumerate(item_ids):
+    process_and_upload.enqueue(
+        item_id=item_id,
+        s3_key=f"results/batch_{batch_id}/{i}.pdf",
+    )
+```
+
+## Celery vs Background Tasks
+
+| Aspecto | Django Background Tasks | Celery |
+|---------|------------------------|--------|
+| Setup | Minimo (built-in) | Requiere broker (Redis/RabbitMQ) |
+| Dependencias | Solo Django | celery + broker + result backend |
+| Tareas periodicas | No soportado (usar django-tasks-scheduler) | Beat scheduler built-in |
+| Workflows | No soportado | Chains, groups, chords |
+| Monitoring | Basico (admin) | Flower, eventos, metricas |
+| Distribuido | Limitado | Multi-worker, multi-nodo |
+| Retry | Via backend de terceros | Built-in con backoff |
+| Caso de uso | Tareas simples, emails, webhooks | Workflows complejos, distribuido |
+| Performance | Adecuado para volumen bajo-medio | Alto volumen, baja latencia |
+
+### Cuando usar Background Tasks
+
+- Envio de emails/notificaciones
+- Llamadas a APIs externas (webhooks, procesamiento)
+- Procesamiento de archivos pequenos
+- Proyectos que no justifican un broker dedicado
+
+### Cuando usar Celery
+
+- Tareas periodicas (cron-like)
+- Workflows complejos (chains, groups)
+- Alto volumen de tareas (>1000/min)
+- Arquitectura distribuida multi-nodo
+- Requiere monitoring avanzado
+
+## Limitaciones
+
+1. **Sin tareas periodicas** nativas (necesita `django-tasks-scheduler` u otro)
+2. **Sin workflows** (chains, groups, chords como Celery)
+3. **Backends de produccion son terceros** (Django solo incluye desarrollo)
+4. **Sin dashboard de monitoring** built-in (depende del backend)
+5. **Retry limitado** al backend elegido
+6. **Sin soporte multi-nodo** real (limitado a un worker por defecto)
+
+---
+
+[Anterior: API Reference](01-api-reference.md) | [Volver al indice](README.md)

--- a/.claude/docs/django-6/README.md
+++ b/.claude/docs/django-6/README.md
@@ -1,0 +1,24 @@
+# Django 6 - Referencia Tecnica
+
+> Framework web Python 3.12+ con Background Tasks nativo, CSP middleware, Template Partials y AsyncPaginator.
+
+## Contenido
+
+| Tema | Archivo | Cuando leer |
+|------|---------|-------------|
+| API, settings y features | [01-api-reference.md](01-api-reference.md) | Configurar proyecto, CSP, Template Partials, Email, AsyncPaginator, Lexeme |
+| Background Tasks | [02-background-tasks.md](02-background-tasks.md) | @task decorator, enqueue, retry, comparacion con Celery |
+
+## Reglas criticas
+
+- SIEMPRE usar Python 3.12+ (minimo obligatorio en Django 6)
+- SIEMPRE usar `DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"` (default en Django 6)
+- SIEMPRE usar psycopg3 (`psycopg[binary]`) en lugar de psycopg2
+- SIEMPRE usar `@task` decorator para tareas simples en background
+- NUNCA usar `django.utils.encoding.force_text` (removido en Django 6)
+- NUNCA usar `SafeMIMEText`/`SafeMIMEMultipart` (deprecados, usar `email.message.EmailMessage`)
+- PREFERIR `AsyncPaginator` para paginacion en vistas async
+
+## Navegacion
+
+Contexto padre: [CLAUDE.md](../../../CLAUDE.md)

--- a/.claude/docs/django-admin/01-dynamic-admin.md
+++ b/.claude/docs/django-admin/01-dynamic-admin.md
@@ -1,0 +1,323 @@
+[Anterior: README](README.md) | [Siguiente: 02-typescript-moderno](02-typescript-moderno.md)
+
+# 01. Dynamic Admin Configuration
+
+> Configuracion dinamica de ModelAdmin: fieldsets, list_display, readonly_fields, inlines y actions que cambian segun el contexto (usuario, permisos, estado del objeto).
+
+## Metodos `get_*` del ModelAdmin
+
+Django 6 ModelAdmin expone metodos `get_*()` que permiten retornar valores diferentes segun request/obj:
+
+```python
+class MyAdmin(admin.ModelAdmin):
+    # Metodos dinamicos principales:
+    # get_list_display(request) -> list[str]
+    # get_list_filter(request) -> list
+    # get_search_fields(request) -> list[str]
+    # get_fieldsets(request, obj=None) -> list[tuple]
+    # get_readonly_fields(request, obj=None) -> tuple[str, ...]
+    # get_inline_instances(request, obj=None) -> list[InlineModelAdmin]
+    # get_form(request, obj=None, **kwargs) -> type[ModelForm]
+    # get_queryset(request) -> QuerySet
+    # get_changeform_initial_data(request) -> dict
+    # get_actions(request) -> dict
+    # get_list_display_links(request, list_display) -> list | None
+    # get_exclude(request, obj=None) -> list[str] | None
+    # get_ordering(request) -> list[str]
+    # get_paginator(request, queryset, per_page, ...) -> Paginator
+    pass
+```
+
+## Dynamic `list_display` por permisos
+
+```python
+@admin.register(CostRecord)
+class CostRecordAdmin(admin.ModelAdmin):
+    def get_list_display(self, request):
+        base = ['user', 'provider', 'amount', 'currency', 'billed_date']
+        if request.user.has_perm('billing.view_cost_details'):
+            base.insert(3, 'cost_tier')
+            base.append('internal_notes')
+        return base
+```
+
+## Conditional fieldsets por estado del objeto
+
+Patron: mostrar fieldsets diferentes en add vs change, o segun el status del objeto.
+
+```python
+@admin.register(Product)
+class ProductAdmin(admin.ModelAdmin):
+    def get_fieldsets(self, request, obj=None):
+        # Add view: solo campos basicos
+        if obj is None:
+            return [
+                ('Product', {'fields': ['name', 'slug', 'visibility']}),
+                ('Details', {'fields': self._detail_fields()}),
+                ('Pricing', {'fields': ['price', 'currency']}),
+            ]
+
+        # Change view: campos completos + estado
+        fieldsets = [
+            ('Product', {
+                'fields': ['created_by_display', 'name', 'slug',
+                           'status', 'visibility'],
+            }),
+            ('Details', {'fields': self._detail_fields()}),
+            ('Pricing', {'fields': ['price', 'currency']}),
+        ]
+
+        # Agregar seccion de imagenes solo si tiene imagen
+        if obj.image_url:
+            fieldsets.append(
+                ('Images', {
+                    'fields': ['image_preview', 'description_preview'],
+                }),
+            )
+
+        return fieldsets
+```
+
+## Dynamic `readonly_fields`
+
+Patron: campos editables en add, readonly en change (o segun status).
+
+```python
+_EDITABLE_ON_CHANGE = frozenset({'name', 'slug', 'visibility'})
+
+_READONLY_ADD = ('created_by_display', 'image_preview')
+_READONLY_CHANGE = (
+    'created_by_display', 'status', 'sku',
+    'image_preview',
+)
+
+def get_readonly_fields(self, request, obj=None):
+    if obj is None:
+        return self._READONLY_ADD
+    return self._READONLY_CHANGE
+```
+
+Patron avanzado — readonly por status:
+
+```python
+def get_readonly_fields(self, request, obj=None):
+    readonly = list(self._READONLY_BASE)
+    if obj and obj.status in ('completed', 'archived'):
+        # Bloquear TODOS los campos si esta completado/archivado
+        readonly.extend(
+            f.name for f in obj._meta.get_fields()
+            if hasattr(f, 'name') and f.name not in readonly
+        )
+    return tuple(readonly)
+```
+
+## Conditional inlines
+
+```python
+def get_inline_instances(self, request, obj=None):
+    """Solo mostrar inlines en change view, no en add."""
+    if obj is None:
+        return []
+    return super().get_inline_instances(request, obj)
+```
+
+Patron avanzado — inlines por tipo de objeto:
+
+```python
+def get_inlines(self, request, obj=None):
+    """Diferentes inlines segun schedule_type."""
+    inlines = [RecentExecutionsInline]
+    if obj and obj.schedule_type == 'crontab':
+        inlines.append(CrontabDetailInline)
+    elif obj and obj.schedule_type == 'interval':
+        inlines.append(IntervalDetailInline)
+    return inlines
+```
+
+## Dynamic actions
+
+```python
+def get_actions(self, request):
+    actions = super().get_actions(request)
+    # Remover delete para usuarios sin permiso especial
+    if not request.user.has_perm('products.bulk_delete_product'):
+        actions.pop('delete_selected', None)
+    # Agregar acciones segun grupo
+    if request.user.groups.filter(name='Content Managers').exists():
+        actions['action_bulk_activate'] = (
+            self.action_bulk_activate,
+            'action_bulk_activate',
+            'Activate selected',
+        )
+    return actions
+```
+
+## Dynamic `list_filter`
+
+```python
+def get_list_filter(self, request):
+    filters = ['status', 'visibility']
+    if request.user.is_superuser:
+        filters.extend(['created_by', 'preferred_provider'])
+    return filters
+```
+
+## `get_changeform_initial_data` para defaults inteligentes
+
+```python
+def get_changeform_initial_data(self, request):
+    """Pre-fill con defaults del usuario o sistema."""
+    initial = super().get_changeform_initial_data(request)
+    if 'category' not in initial:
+        from apps.catalog.models.category import Category
+        default = Category.get_default()
+        if default:
+            initial['category'] = default.pk
+    # Pre-fill created_by con usuario actual
+    initial.setdefault('created_by', request.user.pk)
+    return initial
+```
+
+## Dynamic `get_form` con inyeccion de request
+
+Patron para pasar el request al form:
+
+```python
+def get_form(self, request, obj=None, **kwargs):
+    form_class = super().get_form(request, obj, **kwargs)
+
+    class FormWithRequest(form_class):
+        def __init__(self_form, *args, **kw):
+            super().__init__(*args, **kw)
+            self_form.request = request
+
+    return FormWithRequest
+```
+
+## `save_model` con auto-assign de usuario
+
+```python
+def save_model(self, request, obj, form, change):
+    if not change:
+        obj.created_by = request.user
+    super().save_model(request, obj, form, change)
+```
+
+## `response_add` / `response_change` para custom redirects
+
+```python
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+
+def response_add(self, request, obj, post_url_continue=None):
+    """Redirect a pagina de procesamiento despues de crear producto."""
+    if '_process' in request.POST:
+        url = reverse('admin:products_product_process_progress')
+        return HttpResponseRedirect(f'{url}?ids={obj.pk}')
+    return super().response_add(request, obj, post_url_continue)
+```
+
+## `changeform_view` para inyectar extra context
+
+```python
+def changeform_view(self, request, object_id=None,
+                    form_url='', extra_context=None):
+    extra_context = extra_context or {}
+    if object_id:
+        extra_context['related_groups'] = self._get_related_groups(object_id)
+        extra_context['can_process'] = request.user.has_perm(
+            'products.process_product',
+        )
+    return super().changeform_view(
+        request, object_id, form_url, extra_context,
+    )
+```
+
+## Patron completo: Admin con multiples niveles de dinamismo
+
+```python
+@admin.register(Order)
+class OrderAdmin(admin.ModelAdmin):
+    def get_list_display(self, request):
+        cols = ['title', 'status_badge', 'category', 'scheduled_at']
+        if request.user.is_superuser:
+            cols.insert(1, 'author')
+        return cols
+
+    def get_fieldsets(self, request, obj=None):
+        base = [('Content', {'fields': ['title', 'body', 'product']})]
+        if obj is None:
+            base.append(('Category', {'fields': ['category']}))
+        else:
+            base.append(('Category', {
+                'fields': ['category', 'status', 'completed_at'],
+            }))
+            if obj.status == 'draft':
+                base.append(('Schedule', {
+                    'fields': ['scheduled_at'],
+                    'classes': ('collapse',),
+                }))
+        return base
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj is None:
+            return ()
+        readonly = ['status', 'completed_at']
+        if obj.status != 'draft':
+            readonly.extend(['title', 'body', 'category'])
+        return tuple(readonly)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.select_related('product', 'category', 'product__created_by')
+        if not request.user.is_superuser:
+            qs = qs.filter(product__created_by=request.user)
+        return qs
+```
+
+## Breaking change Django 6: `lookup_allowed`
+
+Django 6 agrego el parametro `request` a `lookup_allowed()`. Si override este metodo, actualizar la firma:
+
+```python
+# Django 5 (legacy)
+def lookup_allowed(self, lookup, value):
+    return super().lookup_allowed(lookup, value)
+
+# Django 6 (obligatorio)
+def lookup_allowed(self, lookup, value, request):
+    if lookup in ('created_by__email',):
+        return True
+    return super().lookup_allowed(lookup, value, request)
+```
+
+## Mejores practicas
+
+1. **Centralizar constantes de readonly** como `ClassVar` o `frozenset` (no recalcular en cada request)
+2. **Separar logica compleja** en metodos privados `_get_scenario_groups()`, no inline en `get_fieldsets()`
+3. **Type hints** en todos los metodos override: `def get_fieldsets(self, request: HttpRequest, obj: Product | None = None) -> list[...]`
+4. **Usar `@admin.display`** decorator en vez de asignar atributos: `short_description`, `ordering`, `boolean`
+5. **NUNCA** acceder a `request.user` para logica de negocio — solo para presentacion/permisos
+6. **Testar admins** verificando que la pagina carga (HTTP 200) y los campos esperados aparecen
+
+## Anti-patrones
+
+```python
+# MAL: logica de negocio en save_model
+def save_model(self, request, obj, form, change):
+    obj.calculate_price()        # Esto va en un service
+    obj.notify_subscribers()     # Esto va en un service
+    obj.update_inventory()       # Esto va en un service
+    super().save_model(request, obj, form, change)
+
+# BIEN: delegar a service
+def save_model(self, request, obj, form, change):
+    if not change:
+        obj.created_by = request.user
+    super().save_model(request, obj, form, change)
+    if not change:
+        from apps.orders.services.creation import on_order_created
+        on_order_created(order=obj)
+```
+
+[Anterior: README](README.md) | [Siguiente: 02-typescript-moderno](02-typescript-moderno.md)

--- a/.claude/docs/django-admin/02-typescript-moderno.md
+++ b/.claude/docs/django-admin/02-typescript-moderno.md
@@ -1,0 +1,838 @@
+[Anterior: 01-dynamic-admin](01-dynamic-admin.md) | [Siguiente: 03-custom-views-templates](03-custom-views-templates.md)
+
+# 02. TypeScript Moderno en Django Admin
+
+> TypeScript strict, esbuild, HTMX, Alpine.js, ES modules, Fetch API tipado, y patrones para interactividad en el admin de Django 6. NUNCA depender de jQuery. Typing obligatorio en todas las funciones.
+
+## Build pipeline: esbuild + tsc
+
+esbuild transpila TypeScript a JavaScript. `tsc --noEmit` verifica tipos sin emitir. Ambos corren por separado.
+
+### Estructura de directorios
+
+```
+server/apps/<app>/
+├── static-src/<app>/           # Source TypeScript
+│   ├── package.json
+│   ├── tsconfig.json
+│   ├── build.ts
+│   └── src/
+│       ├── types/
+│       │   ├── django-admin.d.ts   # Tipos Django admin DOM
+│       │   ├── htmx.d.ts           # Declaraciones HTMX
+│       │   └── globals.d.ts        # Window extensions (Alpine, etc.)
+│       ├── utils/
+│       │   ├── dom.ts              # Helpers DOM tipados
+│       │   └── api.ts              # Fetch wrapper tipado
+│       ├── schedule_toggle.ts
+│       └── chart-dashboard.ts
+└── static/<app>/
+    ├── js/
+    │   └── schedule_toggle.js      # Output IIFE (para Media.js)
+    └── admin/
+        └── chart-dashboard.mjs     # Output ESM (para script type=module)
+```
+
+### tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@utils/*": ["src/utils/*"],
+      "@types/*": ["src/types/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+```
+
+Notas:
+- `noEmit: true` — esbuild emite, `tsc` solo verifica tipos
+- `isolatedModules: true` — compatible con esbuild (transpila archivos aislados)
+- `moduleResolution: "bundler"` — recomendado para proyectos con bundler (2025+)
+- `noUncheckedIndexedAccess: true` — agrega `| undefined` a accesos de array
+
+### package.json
+
+```json
+{
+  "scripts": {
+    "build": "node build.js",
+    "watch": "node build.js --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0",
+    "typescript": "^5.8.0"
+  }
+}
+```
+
+### build.js (esbuild config)
+
+```javascript
+const esbuild = require('esbuild')
+const isWatch = process.argv.includes('--watch')
+
+const iifeConfig = {
+  entryPoints: ['src/schedule_toggle.ts', 'src/image_selector.ts'],
+  outdir: '../static/<app>/js',
+  bundle: false,
+  platform: 'browser',
+  target: 'es2022',
+  format: 'iife',
+  minify: !isWatch,
+  sourcemap: isWatch ? 'inline' : false,
+}
+
+const esmConfig = {
+  entryPoints: ['src/chart-dashboard.ts'],
+  outdir: '../static/<app>/admin',
+  bundle: true,
+  platform: 'browser',
+  target: 'es2022',
+  format: 'esm',
+  outExtension: { '.js': '.mjs' },
+  minify: !isWatch,
+}
+
+if (isWatch) {
+  Promise.all([
+    esbuild.context(iifeConfig).then(ctx => ctx.watch()),
+    esbuild.context(esmConfig).then(ctx => ctx.watch()),
+  ])
+} else {
+  Promise.all([
+    esbuild.build(iifeConfig),
+    esbuild.build(esmConfig),
+  ])
+}
+```
+
+## Como cargar JS compilado en el admin
+
+### Via `Media` class (recomendado)
+
+```python
+@admin.register(ScheduledApiCall)
+class ScheduledApiCallAdmin(admin.ModelAdmin):
+    class Media:
+        js = ('scheduler/js/schedule_toggle.js',)  # Output de esbuild
+        css = {
+            'all': ('scheduler/css/admin_custom.css',),
+        }
+```
+
+Ubicacion del output: `server/apps/<app>/static/<app>/js/<filename>.js`
+
+### Via widget `Media`
+
+```python
+class ImageCheckboxSelect(forms.CheckboxSelectMultiple):
+    class Media:
+        js = ('publications/js/image_selector.js',)
+```
+
+### Via template override (para ES modules)
+
+```html
+<!-- server/templates/admin/base_site.html -->
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block extrahead %}
+{{ block.super }}
+<script type="module" src="{% static 'myapp/admin/chart-dashboard.mjs' %}"></script>
+{% endblock %}
+```
+
+## Helpers DOM tipados
+
+Helpers reutilizables para evitar repetir `instanceof` checks en cada archivo:
+
+```typescript
+// utils/dom.ts
+
+export function getInput(id: string): HTMLInputElement | null {
+  const el = document.getElementById(id)
+  return el instanceof HTMLInputElement ? el : null
+}
+
+export function getSelect(id: string): HTMLSelectElement | null {
+  const el = document.getElementById(id)
+  return el instanceof HTMLSelectElement ? el : null
+}
+
+export function getTextarea(id: string): HTMLTextAreaElement | null {
+  const el = document.getElementById(id)
+  return el instanceof HTMLTextAreaElement ? el : null
+}
+
+export function queryDiv(
+  selector: string,
+  parent: ParentNode = document,
+): HTMLDivElement | null {
+  return parent.querySelector<HTMLDivElement>(selector)
+}
+
+export function getTypedElement<T extends HTMLElement>(
+  id: string,
+  ctor: abstract new (...args: never[]) => T,
+): T | null {
+  const el = document.getElementById(id)
+  return el instanceof ctor ? el : null
+}
+```
+
+### Tabla de tipos por selector Django admin
+
+| Selector | Tipo TypeScript |
+|----------|----------------|
+| `#id_<campo>` texto/numero | `HTMLInputElement` |
+| `#id_<campo>` select/choice | `HTMLSelectElement` |
+| `#id_<campo>` textarea | `HTMLTextAreaElement` |
+| `.form-row.field-<nombre>` | `HTMLDivElement` |
+| `#<model>_form` | `HTMLFormElement` |
+| `input[name="csrfmiddlewaretoken"]` | `HTMLInputElement` |
+| `fieldset.module h2` | `HTMLHeadingElement` |
+| `.inline-group` | `HTMLDivElement` |
+| `.add-row a` | `HTMLAnchorElement` |
+| `.submit-row` | `HTMLDivElement` |
+
+## Patron IIFE tipado
+
+Patron obligatorio del proyecto para scripts cargados via `Media.js`:
+
+```typescript
+;(function (): void {
+  'use strict'
+
+  function init(): void {
+    const element = document.getElementById('id_some_field')
+    if (!element) return  // Guard: salir si no estamos en la pagina correcta
+    // ...
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+})()
+```
+
+Nota: `;` inicial previene bugs de ASI al concatenar archivos.
+
+## Toggle de campos condicional
+
+Patron con tipos estrictos:
+
+```typescript
+;(function (): void {
+  'use strict'
+
+  function setRowVisibility(fieldNames: readonly string[], visible: boolean): void {
+    for (const name of fieldNames) {
+      const row = document.querySelector<HTMLDivElement>(`.form-row.field-${name}`)
+      if (row) row.style.display = visible ? '' : 'none'
+    }
+  }
+
+  function toggleScheduleFields(): void {
+    const scheduleType = document.getElementById('id_schedule_type')
+    if (!(scheduleType instanceof HTMLSelectElement)) return
+
+    const INTERVAL_FIELDS = ['interval_every', 'interval_period'] as const
+    const CRONTAB_FIELDS = [
+      'cron_minute', 'cron_hour', 'cron_day_of_month',
+      'cron_month_of_year', 'cron_day_of_week', 'cron_timezone',
+    ] as const
+
+    function update(): void {
+      const val: string = scheduleType.value
+      setRowVisibility(INTERVAL_FIELDS, val === 'interval')
+      setRowVisibility(CRONTAB_FIELDS, val === 'crontab')
+    }
+
+    scheduleType.addEventListener('change', update)
+    update()
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', toggleScheduleFields)
+  } else {
+    toggleScheduleFields()
+  }
+})()
+```
+
+Selectores clave del DOM admin de Django:
+
+| Selector | Que selecciona |
+|----------|---------------|
+| `#id_<fieldname>` | Input/select de un campo |
+| `.form-row.field-<fieldname>` | Row completa (label + input + help text) |
+| `fieldset.module h2` | Header de un fieldset |
+| `.inline-group` | Container de un inline |
+| `.add-row a` | Link "Add another" en inlines |
+| `#<model>_form` | El form principal |
+| `.submit-row` | Barra de botones submit |
+
+## Inyectar botones en fieldset headers
+
+```typescript
+function injectButton(headerText: string, buttonText: string, handler: () => void): void {
+  const headers = document.querySelectorAll<HTMLHeadingElement>('fieldset.module h2')
+
+  for (const h2 of headers) {
+    if (!h2.textContent?.includes(headerText)) continue
+
+    const btn = document.createElement('button')
+    btn.type = 'button'
+    btn.textContent = buttonText
+    btn.style.cssText = [
+      'margin-left:12px',
+      'cursor:pointer',
+      'font-size:.8rem',
+      'padding:2px 10px',
+      'border:1px solid rgba(255,255,255,0.4)',
+      'border-radius:4px',
+      'background:rgba(255,255,255,0.15)',
+      'color:inherit',
+    ].join(';')
+    btn.addEventListener('click', handler)
+    h2.appendChild(btn)
+    break
+  }
+}
+```
+
+## Event delegation para contenido dinamico
+
+```typescript
+// MAL: event listeners directos (no funciona con inlines dinamicos)
+document.querySelectorAll<HTMLInputElement>('.inline-row input').forEach((input) => {
+  input.addEventListener('change', handler)  // Se pierde al agregar rows
+})
+
+// BIEN: event delegation en el container
+const container = document.getElementById('id_selected_images')
+if (container) {
+  container.addEventListener('change', (e: Event) => {
+    const target = e.target
+    if (target instanceof HTMLInputElement && target.type === 'checkbox') {
+      enforceLimit()
+    }
+  })
+}
+```
+
+## Fetch API tipado
+
+### Wrapper con discriminated union
+
+```typescript
+// utils/api.ts
+
+type ApiSuccess<T> = { ok: true; data: T }
+type ApiError = { ok: false; status: number; message: string }
+type ApiResult<T> = ApiSuccess<T> | ApiError
+
+function getCsrfToken(): string {
+  const input = document.querySelector<HTMLInputElement>(
+    'input[name="csrfmiddlewaretoken"]',
+  )
+  if (input?.value) return input.value
+
+  const match = document.cookie.match(/csrftoken=([^;]+)/)
+  return match?.[1] ?? ''
+}
+
+async function adminFetch<T>(
+  url: string,
+  options: RequestInit = {},
+): Promise<ApiResult<T>> {
+  try {
+    const response = await fetch(url, {
+      ...options,
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      return { ok: false, status: response.status, message: response.statusText }
+    }
+
+    const data = (await response.json()) as T
+    return { ok: true, data }
+  } catch (error) {
+    return { ok: false, status: 0, message: String(error) }
+  }
+}
+
+export { adminFetch, getCsrfToken }
+export type { ApiResult }
+```
+
+### Uso con tipos inferidos
+
+```typescript
+interface JobStatusResponse {
+  jobs: Record<string, 'pending' | 'running' | 'done' | 'failed'>
+  all_done: boolean
+}
+
+const result = await adminFetch<JobStatusResponse>(
+  `/admin/scheduler/job-status/?ids=${ids}`,
+)
+
+if (!result.ok) {
+  console.error(`HTTP ${result.status}: ${result.message}`)
+  return
+}
+
+// result.data tipado como JobStatusResponse sin cast
+updateUI(result.data.jobs)
+```
+
+## Polling de status tipado
+
+```typescript
+interface PollConfig<T> {
+  url: string
+  interval: number
+  onData: (data: T) => boolean  // Retorna true para continuar polling
+  onError?: (status: number) => void
+  maxRetries?: number
+}
+
+async function pollStatus<T>(config: PollConfig<T>): Promise<void> {
+  const { url, interval, onData, onError, maxRetries = 10 } = config
+  let retries = 0
+
+  async function poll(): Promise<void> {
+    const result = await adminFetch<T>(url)
+
+    if (!result.ok) {
+      retries++
+      onError?.(result.status)
+      if (retries < maxRetries) {
+        setTimeout(poll, interval * 2)  // Backoff on error
+      }
+      return
+    }
+
+    retries = 0
+    const shouldContinue = onData(result.data)
+    if (shouldContinue) {
+      setTimeout(poll, interval)
+    }
+  }
+
+  await poll()
+}
+
+// Uso
+pollStatus<JobStatusResponse>({
+  url: `/admin/products/product/job-status/?job_ids=${jobIds.join(',')}`,
+  interval: 2000,
+  onData: (data) => {
+    updateProgressUI(data.jobs)
+    return !data.all_done
+  },
+})
+```
+
+## `json_script` template tag para pasar datos tipados
+
+En el template:
+
+```html
+{{ timing_stats_json|json_script:"timing-stats-data" }}
+{{ product_list|json_script:"product-data" }}
+```
+
+En TypeScript:
+
+```typescript
+function getJsonData<T>(elementId: string): T | null {
+  const el = document.getElementById(elementId)
+  if (!el?.textContent) return null
+
+  try {
+    return JSON.parse(el.textContent) as T
+  } catch {
+    return null
+  }
+}
+
+interface TimingStats {
+  avg_ms: number
+  p99_ms: number
+  total_calls: number
+}
+
+const timingStats = getJsonData<TimingStats>('timing-stats-data')
+if (timingStats) {
+  console.log(`Avg: ${timingStats.avg_ms}ms`)  // Tipado
+}
+```
+
+## `data-` attributes para datos simples
+
+```python
+# En el widget
+def build_attrs(self, base_attrs, extra_attrs=None):
+    attrs = super().build_attrs(base_attrs, extra_attrs)
+    attrs['data-max-images'] = str(self._max_images)
+    attrs['data-category-id'] = str(self._category_id)
+    return attrs
+```
+
+```typescript
+function getDataAttr(el: HTMLElement, name: string, fallback: number): number {
+  const raw = el.dataset[name]
+  if (raw === undefined) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isNaN(parsed) ? fallback : parsed
+}
+
+const maxImages = getDataAttr(container, 'maxImages', 2)
+const categoryId = container.dataset.categoryId ?? ''
+```
+
+## Event typing — Django admin events
+
+### Declaraciones de tipos
+
+```typescript
+// types/django-admin.d.ts
+
+interface FormsetEventDetail {
+  formsetName: string
+}
+
+declare global {
+  interface DocumentEventMap {
+    'formset:added': CustomEvent<FormsetEventDetail>
+    'formset:removed': CustomEvent<FormsetEventDetail>
+  }
+}
+
+export {}
+```
+
+### Uso con tipos inferidos
+
+```typescript
+document.addEventListener('formset:added', (event) => {
+  // TypeScript infiere: event es CustomEvent<FormsetEventDetail>
+  const newRow = event.target
+  const formsetName: string = event.detail.formsetName
+
+  if (!(newRow instanceof HTMLElement)) return
+  if (formsetName !== 'author_set') return
+  initializeRow(newRow)
+})
+
+document.addEventListener('formset:removed', (_event) => {
+  // Cleanup si es necesario
+})
+```
+
+### Custom events propios
+
+```typescript
+interface StatusChangedDetail {
+  objectId: string
+  newStatus: 'pending' | 'running' | 'done' | 'failed'
+}
+
+declare global {
+  interface DocumentEventMap {
+    'admin:status-changed': CustomEvent<StatusChangedDetail>
+  }
+}
+
+function dispatchStatusChanged(detail: StatusChangedDetail): void {
+  document.dispatchEvent(
+    new CustomEvent<StatusChangedDetail>('admin:status-changed', {
+      bubbles: true,
+      detail,
+    }),
+  )
+}
+```
+
+## HTMX en Django Admin
+
+### Declaraciones de tipos
+
+```typescript
+// types/htmx.d.ts
+
+declare namespace Htmx {
+  function process(element: Element): void
+  function trigger(element: Element | string, event: string, detail?: unknown): void
+  function ajax(
+    verb: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    path: string,
+    context: Element | string | {
+      target?: Element | string
+      swap?: string
+      values?: Record<string, string>
+    },
+  ): Promise<void>
+  const config: {
+    defaultSwapStyle: string
+    defaultSettleDelay: number
+    historyCacheSize: number
+    [key: string]: unknown
+  }
+}
+
+declare const htmx: typeof Htmx
+```
+
+### Setup
+
+```python
+class Media:
+    js = ('admin/js/vendor/htmx.min.js',)
+```
+
+### Procesar nuevos elementos HTMX
+
+```typescript
+document.addEventListener('formset:added', (event) => {
+  const target = event.target
+  if (target instanceof Element) {
+    htmx.process(target)  // Tipado correctamente
+  }
+})
+```
+
+### Templates HTMX (sin cambios — HTML puro)
+
+```html
+<!-- Inline partial updates -->
+<div id="status-panel"
+     hx-get="{% url 'admin:myapp_model_status' object.pk %}"
+     hx-trigger="every 5s"
+     hx-swap="innerHTML">
+  {% include "admin/myapp/model/_status_partial.html" %}
+</div>
+
+<!-- Form submission parcial -->
+<button type="button"
+        hx-post="{% url 'admin:products_product_process_enqueue' %}?ids={{ object.pk }}"
+        hx-target="#process-result"
+        hx-swap="innerHTML"
+        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+  Process Now
+</button>
+<div id="process-result"></div>
+```
+
+### View para HTMX partial (Python — sin cambios)
+
+```python
+def get_urls(self):
+    custom = [
+        path(
+            '<uuid:pk>/status/',
+            self.admin_site.admin_view(self.status_partial_view),
+            name='myapp_model_status',
+        ),
+    ]
+    return custom + super().get_urls()
+
+def status_partial_view(self, request, pk):
+    obj = self.get_object(request, pk)
+    return TemplateResponse(
+        request,
+        'admin/myapp/model/_status_partial.html',
+        {'object': obj},
+    )
+```
+
+## Alpine.js para reactividad ligera
+
+### Declaraciones de tipos
+
+```typescript
+// types/globals.d.ts
+
+interface Window {
+  Alpine: {
+    data(name: string, component: (...args: unknown[]) => object): void
+    store(name: string, data: object): void
+    start(): void
+  }
+}
+```
+
+### Componente Alpine tipado
+
+```typescript
+interface ScheduleTypeData {
+  scheduleType: string
+  isInterval(): boolean
+  isCrontab(): boolean
+}
+
+function scheduleTypeComponent(initialValue: string): ScheduleTypeData {
+  return {
+    scheduleType: initialValue,
+    isInterval(): boolean {
+      return this.scheduleType === 'interval'
+    },
+    isCrontab(): boolean {
+      return this.scheduleType === 'crontab'
+    },
+  }
+}
+
+document.addEventListener('alpine:init', () => {
+  window.Alpine.data('scheduleType', (initial: unknown) =>
+    scheduleTypeComponent(String(initial ?? 'interval')),
+  )
+})
+```
+
+### Templates Alpine (HTML puro — sin cambios)
+
+```html
+<div x-data="{ tab: 'basic' }">
+  <div style="display:flex;gap:8px;margin-bottom:16px">
+    <button type="button" @click="tab = 'basic'"
+            :style="tab === 'basic' ? 'font-weight:bold' : ''">
+      Basic Info
+    </button>
+    <button type="button" @click="tab = 'advanced'"
+            :style="tab === 'advanced' ? 'font-weight:bold' : ''">
+      Advanced
+    </button>
+  </div>
+
+  <div x-show="tab === 'basic'">{{ basic_fieldset }}</div>
+  <div x-show="tab === 'advanced'">{{ advanced_fieldset }}</div>
+</div>
+```
+
+## ES Modules con TypeScript
+
+esbuild emite `.mjs` con `format: 'esm'`. Django los carga via `<script type="module">`:
+
+```html
+{% block extrahead %}
+{{ block.super }}
+<script type="module" src="{% static 'myapp/admin/chart-dashboard.mjs' %}"></script>
+{% endblock %}
+```
+
+```typescript
+// chart-dashboard.ts — esbuild emite chart-dashboard.mjs
+import { Chart } from '/static/admin/js/vendor/chart.esm.js'
+
+interface ChartData {
+  labels: string[]
+  datasets: Array<{
+    label: string
+    data: number[]
+  }>
+}
+
+const ctx = document.getElementById('stats-chart')
+if (ctx instanceof HTMLCanvasElement) {
+  const data = getJsonData<ChartData>('chart-data')
+  if (data) {
+    new Chart(ctx, { type: 'line', data })
+  }
+}
+```
+
+Nota: archivos `.js` cargados via `Media.js` usan `<script>` normal (IIFE). Para ES modules, usar template override con `type="module"`.
+
+## Inline formset tipado
+
+```typescript
+;(function (): void {
+  'use strict'
+
+  function initializeRow(row: HTMLElement): void {
+    const selects = row.querySelectorAll<HTMLSelectElement>('select')
+    for (const select of selects) {
+      select.addEventListener('change', handleSelectChange)
+    }
+  }
+
+  function handleSelectChange(e: Event): void {
+    const target = e.target
+    if (!(target instanceof HTMLSelectElement)) return
+    // Logica del cambio
+  }
+
+  // Django admin dispara estos eventos al agregar/remover inline rows
+  document.addEventListener('formset:added', (event) => {
+    const newRow = event.target
+    if (newRow instanceof HTMLElement) {
+      initializeRow(newRow)
+    }
+  })
+
+  document.addEventListener('formset:removed', (_event) => {
+    // Cleanup si es necesario
+  })
+})()
+```
+
+## Mejores practicas TypeScript en admin
+
+1. **Tipos explicitos en todas las funciones** — parametros y retorno, sin excepciones
+2. **SIEMPRE IIFE** — nunca variables globales en scripts `Media.js`
+3. **Guard clause con `instanceof`** — `if (!(el instanceof HTMLSelectElement)) return`
+4. **`as const` en arrays constantes** — para inferir tipos literales
+5. **`readonly` en parametros que no mutan** — `readonly string[]` en vez de `string[]`
+6. **Discriminated unions para API responses** — `{ ok: true; data: T } | { ok: false; ... }`
+7. **Helpers DOM tipados** — reutilizar `getInput()`, `getSelect()`, etc.
+8. **Event delegation** sobre listeners directos para contenido dinamico
+9. **`json_script` con generico** — `getJsonData<T>(id)` para datos del template
+10. **Fetch API tipado** — nunca `XMLHttpRequest`, siempre `adminFetch<T>()`
+11. **CSRF token** en cada POST (cookie `csrftoken` o input hidden)
+12. **`defer`** o DOMContentLoaded — nunca scripts bloqueantes
+13. **No jQuery** — vanilla TS es suficiente para todo lo que necesita admin
+14. **Progressive enhancement** — el admin debe funcionar sin JS (JS mejora la UX)
+15. **No `any`** — usar `unknown` + narrowing cuando el tipo no es conocido
+
+## Cuando usar cada herramienta
+
+| Necesidad | Herramienta | Razon |
+|-----------|-------------|-------|
+| Show/hide campos | Vanilla TS (IIFE) | Simple, sin dependencias, tipado |
+| Form validation client-side | Vanilla TS | Complementa server-side validation |
+| AJAX calls / polling | `adminFetch<T>()` | Tipado, discriminated union, CSRF |
+| Partial page updates | HTMX + tipos `.d.ts` | Declarativo, sin TS custom |
+| Estado reactivo en form | Alpine.js + tipos | Ligero (17KB), declarativo |
+| Charts / visualizaciones | ES module + libreria | Chart.js, D3.js via `.mjs` |
+| Inline row management | `formset:added` event | Django built-in, tipado via `DocumentEventMap` |
+| Drag-and-drop sorting | Sortable.js + `@types` | Libreria especializada |
+
+[Anterior: 01-dynamic-admin](01-dynamic-admin.md) | [Siguiente: 03-custom-views-templates](03-custom-views-templates.md)

--- a/.claude/docs/django-admin/03-custom-views-templates.md
+++ b/.claude/docs/django-admin/03-custom-views-templates.md
@@ -1,0 +1,480 @@
+[Anterior: 02-typescript-moderno](02-typescript-moderno.md) | [Siguiente: 04-reusable-patterns](04-reusable-patterns.md)
+
+# 03. Custom Views y Templates
+
+> Como agregar vistas custom al admin (dashboards, wizards, progress pages), override de templates, y el sistema de bloques de Django admin.
+
+## `get_urls()` para registrar vistas custom
+
+Patron fundamental para agregar endpoints al admin:
+
+```python
+from django.urls import path
+
+@admin.register(Product)
+class ProductAdmin(admin.ModelAdmin):
+    def get_urls(self):
+        custom = [
+            path(
+                'process-progress/',
+                self.admin_site.admin_view(self.process_progress_view),
+                name='products_product_process_progress',
+            ),
+            path(
+                'process-enqueue/',
+                self.admin_site.admin_view(self.process_enqueue_view),
+                name='products_product_process_enqueue',
+            ),
+            path(
+                '<uuid:pk>/dashboard/',
+                self.admin_site.admin_view(self.dashboard_view),
+                name='products_product_dashboard',
+            ),
+        ]
+        # CRITICO: custom ANTES de super() — evita que Django capture la URL
+        return custom + super().get_urls()
+```
+
+Reglas:
+- SIEMPRE wrappear con `self.admin_site.admin_view()` — asegura autenticacion + permisos
+- URLs custom VAN ANTES de `super().get_urls()` — Django matchea `<path>` antes
+- Naming convention: `<app>_<model>_<action>` para consistencia con admin URL names
+
+## Vista HTML (TemplateResponse)
+
+```python
+from django.template.response import TemplateResponse
+
+def process_progress_view(self, request):
+    raw_ids = request.GET.get('ids', '')
+    id_list = [i.strip() for i in raw_ids.split(',') if i.strip()]
+    products = Product.objects.filter(pk__in=id_list).select_related(
+        'preferred_provider',
+    )
+
+    context = {
+        **self.admin_site.each_context(request),  # Sidebar, site_header, etc.
+        'title': 'Generating base images',
+        'products': products,
+        'opts': self.model._meta,  # Para breadcrumbs
+        'changelist_url': reverse('admin:products_product_changelist'),
+    }
+    return TemplateResponse(
+        request,
+        'admin/products/product/process_progress.html',
+        context,
+    )
+```
+
+`self.admin_site.each_context(request)` inyecta:
+- `site_header`, `site_title`, `site_url`
+- `has_permission` (boolean)
+- `available_apps` (para el sidebar)
+- `is_popup`, `is_nav_sidebar_enabled`
+
+## Vista JSON (API endpoints)
+
+```python
+from django.http import JsonResponse
+
+def process_enqueue_view(self, request):
+    """POST endpoint para encolar generacion."""
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Method not allowed'}, status=405)
+
+    raw_ids = request.GET.get('ids', '')
+    id_list = [i.strip() for i in raw_ids.split(',') if i.strip()]
+
+    jobs = []
+    for product in Product.objects.filter(pk__in=id_list):
+        job = create_generation_job(product=product)
+        process_task.delay(str(job.pk))
+        jobs.append({
+            'job_id': str(job.pk),
+            'product_name': product.name,
+        })
+
+    return JsonResponse({'jobs': jobs})
+```
+
+## Vistas standalone (fuera del ModelAdmin)
+
+Para vistas que no pertenecen a un modelo especifico:
+
+```python
+# server/apps/products/admin/category_views.py
+
+from django.template.response import TemplateResponse
+
+def category_picker_view(request, admin_site, opts):
+    """Vista standalone registrada en ProductAdmin.get_urls()."""
+    raw_ids = request.GET.get('ids', '')
+    # ...
+    context = {
+        **admin_site.each_context(request),
+        'title': 'Select categories',
+        'opts': opts,
+        'products': products,
+        'categories': categories,
+    }
+    return TemplateResponse(
+        request,
+        'admin/products/product/category_picker.html',
+        context,
+    )
+```
+
+Registrar en `get_urls()`:
+
+```python
+def get_urls(self):
+    from apps.products.admin.category_views import category_picker_view
+
+    custom = [
+        path(
+            'category-picker/',
+            self.admin_site.admin_view(
+                lambda r: category_picker_view(
+                    r, self.admin_site, self.model._meta,
+                ),
+            ),
+            name='products_product_category_picker',
+        ),
+    ]
+    return custom + super().get_urls()
+```
+
+## Admin actions con paginas intermedias
+
+Patron: action redirige a vista custom en vez de ejecutar directamente.
+
+```python
+@admin.action(description='Process selected')
+def action_process(self, request, queryset):
+    """Redirige a pagina de progreso."""
+    ids = ','.join(str(pk) for pk in queryset.values_list('pk', flat=True))
+    url = reverse('admin:products_product_process_progress') + f'?ids={ids}'
+    return HttpResponseRedirect(url)
+```
+
+Para confirmacion:
+
+```python
+@admin.action(description='Delete with confirmation')
+def action_delete_with_confirm(self, request, queryset):
+    if request.POST.get('confirmed'):
+        count = queryset.count()
+        queryset.delete()
+        self.message_user(request, f'{count} objects deleted.')
+        return None
+
+    context = {
+        **self.admin_site.each_context(request),
+        'title': 'Confirm deletion',
+        'queryset': queryset,
+        'opts': self.model._meta,
+        'action_checkbox_name': admin.helpers.ACTION_CHECKBOX_NAME,
+    }
+    return TemplateResponse(
+        request,
+        'admin/myapp/confirm_action.html',
+        context,
+    )
+```
+
+Template de confirmacion:
+
+```html
+{% extends "admin/base_site.html" %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <p>Are you sure you want to delete {{ queryset.count }} items?</p>
+  <ul>
+    {% for obj in queryset %}
+    <li>{{ obj }}
+      <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk }}">
+    </li>
+    {% endfor %}
+  </ul>
+  <input type="hidden" name="action" value="action_delete_with_confirm">
+  <input type="hidden" name="confirmed" value="1">
+  <input type="submit" value="Confirm Delete" class="default">
+  <a href="{% url opts|admin_urlname:'changelist' %}">Cancel</a>
+</form>
+{% endblock %}
+```
+
+## Sistema de templates del admin
+
+### Jerarquia de busqueda de templates
+
+Django admin busca templates en este orden:
+1. `templates/admin/<app>/<model>/<template>.html` — mas especifico
+2. `templates/admin/<app>/<template>.html` — nivel app
+3. `templates/admin/<template>.html` — global admin
+4. Django built-in `django/contrib/admin/templates/admin/<template>.html`
+
+### Templates principales que se pueden overridear
+
+| Template | Uso |
+|----------|-----|
+| `change_form.html` | Formulario de add/change individual |
+| `change_list.html` | Lista de objetos |
+| `delete_confirmation.html` | Confirmacion de borrado |
+| `object_history.html` | Historial de cambios |
+| `base_site.html` | Base del sitio admin (branding) |
+| `index.html` | Dashboard principal del admin |
+| `app_index.html` | Indice de una app |
+| `login.html` | Pagina de login |
+
+### Bloques de `change_form.html`
+
+```html
+{% extends "admin/change_form.html" %}
+{% load static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {# CSS y JS adicional #}
+{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <style>/* CSS inline */</style>
+{% endblock %}
+
+{% block content_title %}
+  {# Titulo customizado #}
+  <h1>{{ title }} - Custom</h1>
+{% endblock %}
+
+{% block content %}
+  {{ block.super }}
+  {# Contenido adicional DESPUES del form #}
+{% endblock %}
+
+{% block after_field_sets %}
+  {# Insertar contenido entre fieldsets y botones #}
+  <div class="custom-section">
+    {% include "admin/myapp/_preview_panel.html" %}
+  </div>
+{% endblock %}
+
+{% block after_related_objects %}
+  {# Insertar despues de inlines #}
+{% endblock %}
+
+{% block submit_buttons_bottom %}
+  {{ block.super }}
+  {# Botones adicionales junto a Save #}
+  <input type="submit" name="_process" value="Save & Process">
+{% endblock %}
+```
+
+### Bloques de `change_list.html`
+
+```html
+{% extends "admin/change_list.html" %}
+
+{% block content_title %}
+  {{ block.super }}
+  <a href="{% url 'admin:myapp_model_export' %}" class="button">
+    Export CSV
+  </a>
+{% endblock %}
+
+{% block result_list %}
+  {{ block.super }}
+  {# Contenido adicional debajo de la tabla #}
+{% endblock %}
+
+{% block pagination %}
+  {{ block.super }}
+{% endblock %}
+```
+
+## Patron: `change_form_template` para override por modelo
+
+```python
+@admin.register(Product)
+class ProductAdmin(admin.ModelAdmin):
+    change_form_template = 'admin/products/product/change_form.html'
+```
+
+Template location: `server/apps/products/templates/admin/products/product/change_form.html`
+
+Ejemplo real del proyecto — inyectar seccion de related items:
+
+```html
+{% extends "admin/change_form.html" %}
+{% load i18n static %}
+
+{% block after_field_sets %}
+  {{ block.super }}
+
+  {% if related_groups %}
+  <fieldset class="module">
+    <h2>{% trans "Related Items" %}</h2>
+    <div style="padding:16px">
+      {% for group in related_groups %}
+      <div style="margin-bottom:24px">
+        <h3>{{ group.name }}
+          <small style="color:#666">({{ group.provider }})</small>
+        </h3>
+        <div style="display:flex;gap:12px;flex-wrap:wrap">
+          {% for img in group.images %}
+          <div style="text-align:center">
+            <img src="{{ img.url }}"
+                 style="max-width:180px;max-height:250px;
+                        object-fit:contain;border-radius:4px;
+                        border:1px solid #ddd">
+            <div style="font-size:12px;color:#666;margin-top:4px">
+              Item {{ img.index }}
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+        <div style="font-size:12px;color:#888;margin-top:8px">
+          {{ group.success_count }} OK / {{ group.fail_count }} Failed
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </fieldset>
+  {% endif %}
+{% endblock %}
+```
+
+## Dashboard custom en admin
+
+```python
+# admin.py o admin_site.py
+from django.contrib.admin import AdminSite
+
+class CustomAdminSite(AdminSite):
+    site_header = 'Rezebra Admin'
+    site_title = 'Rezebra'
+    index_title = 'Dashboard'
+    index_template = 'admin/custom_index.html'
+
+    def index(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context.update({
+            'total_products': Product.objects.count(),
+            'pending_orders': Order.objects.filter(
+                status='pending',
+            ).count(),
+            'recent_orders': Order.objects.order_by(
+                '-created_at',
+            )[:5],
+        })
+        return super().index(request, extra_context)
+
+admin_site = CustomAdminSite(name='custom_admin')
+```
+
+Template `admin/custom_index.html`:
+
+```html
+{% extends "admin/index.html" %}
+
+{% block content %}
+<div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;
+            margin-bottom:24px">
+  <div class="module" style="padding:16px;text-align:center">
+    <h3>{{ total_products }}</h3>
+    <p>Total Products</p>
+  </div>
+  <div class="module" style="padding:16px;text-align:center">
+    <h3>{{ pending_orders }}</h3>
+    <p>Pending Orders</p>
+  </div>
+</div>
+
+{{ block.super }}
+{% endblock %}
+```
+
+## Wizard multi-step en admin
+
+```python
+def get_urls(self):
+    return [
+        path('wizard/step1/', self.admin_site.admin_view(self.wizard_step1),
+             name='myapp_model_wizard_step1'),
+        path('wizard/step2/', self.admin_site.admin_view(self.wizard_step2),
+             name='myapp_model_wizard_step2'),
+        path('wizard/step3/', self.admin_site.admin_view(self.wizard_step3),
+             name='myapp_model_wizard_step3'),
+    ] + super().get_urls()
+
+def wizard_step1(self, request):
+    if request.method == 'POST':
+        form = Step1Form(request.POST)
+        if form.is_valid():
+            request.session['wizard_step1'] = form.cleaned_data
+            return HttpResponseRedirect(
+                reverse('admin:myapp_model_wizard_step2'),
+            )
+    else:
+        form = Step1Form()
+
+    context = {
+        **self.admin_site.each_context(request),
+        'title': 'Step 1: Select Options',
+        'form': form,
+        'opts': self.model._meta,
+        'current_step': 1,
+        'total_steps': 3,
+    }
+    return TemplateResponse(
+        request,
+        'admin/myapp/model/wizard_step.html',
+        context,
+    )
+```
+
+## Partial templates (reutilizables)
+
+Convencion de naming: prefijo `_` para partials.
+
+```
+templates/admin/products/product/
+├── change_form.html        # Override principal
+├── process_progress.html  # Vista custom full-page
+├── category_picker.html    # Vista custom full-page
+├── _status_badge.html      # Partial: badge de status
+├── _image_grid.html        # Partial: grid de imagenes
+└── _progress_bar.html      # Partial: barra de progreso
+```
+
+```html
+{# _image_grid.html #}
+<div class="image-grid" style="display:flex;gap:12px;flex-wrap:wrap">
+  {% for img in images %}
+  <div class="image-card" style="text-align:center;max-width:200px">
+    <img src="{{ img.url }}"
+         style="max-width:200px;max-height:280px;object-fit:contain;
+                border:1px solid #ddd;border-radius:4px">
+    <span style="font-size:.8rem;color:#555">{{ img.label }}</span>
+  </div>
+  {% empty %}
+  <em style="color:#999">No items yet</em>
+  {% endfor %}
+</div>
+```
+
+Incluir: `{% include "admin/products/product/_image_grid.html" with images=base_images %}`
+
+## Mejores practicas
+
+1. **`each_context(request)`** obligatorio en vistas custom — asegura sidebar y branding
+2. **`opts` en context** — necesario para breadcrumbs y URL generation en templates
+3. **`TemplateResponse`** sobre `render()` — permite middleware de template alterar la respuesta
+4. **Partials con prefijo `_`** — distinguir de templates full-page
+5. **NUNCA lanzar 500** en vistas custom — catch exceptions y mostrar mensajes amigables
+6. **`admin_view()` wrapper** — SIEMPRE para autenticacion y permisos
+7. **URLs custom ANTES de `super().get_urls()`** — Django matchea en orden
+
+[Anterior: 02-typescript-moderno](02-typescript-moderno.md) | [Siguiente: 04-reusable-patterns](04-reusable-patterns.md)

--- a/.claude/docs/django-admin/04-reusable-patterns.md
+++ b/.claude/docs/django-admin/04-reusable-patterns.md
@@ -1,0 +1,528 @@
+[Anterior: 03-custom-views-templates](03-custom-views-templates.md) | [Siguiente: 05-performance-security](05-performance-security.md)
+
+# 04. Reusable Patterns y Mixins
+
+> Mixins reutilizables, base classes, patrones de composicion, AdminSite custom, y estrategias para admin escalables y consistentes.
+
+## Base ModelAdmin del proyecto
+
+Patron para establecer defaults de proyecto:
+
+```python
+# server/common/admin/base.py
+from django.contrib import admin
+
+
+class BaseModelAdmin(admin.ModelAdmin):
+    """Base admin con defaults del proyecto rezebra."""
+
+    # Prevenir N+1 en list view
+    show_full_result_count = False  # Evita COUNT(*) en tablas grandes
+
+    # Timestamps siempre readonly
+    readonly_fields = ('created_at', 'updated_at')
+
+    # Paginacion por defecto
+    list_per_page = 25
+    list_max_show_all = 200
+
+    def get_queryset(self, request):
+        """Override para que subclases puedan agregar select_related."""
+        return super().get_queryset(request)
+
+    def save_model(self, request, obj, form, change):
+        """Hook para auto-assign de created_by si existe."""
+        if not change and hasattr(obj, 'created_by') and not obj.created_by_id:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
+```
+
+Uso:
+
+```python
+from common.admin.base import BaseModelAdmin
+
+@admin.register(Order)
+class OrderAdmin(BaseModelAdmin):
+    list_display = ('title', 'status', 'category')
+    # Hereda show_full_result_count=False, readonly timestamps, etc.
+```
+
+## Mixin: Export CSV
+
+```python
+# server/common/admin/mixins/export_csv.py
+import csv
+from django.http import HttpResponse
+
+
+class ExportCSVMixin:
+    """Agrega action para exportar a CSV."""
+
+    def get_csv_fields(self):
+        """Override para definir campos a exportar."""
+        return [f.name for f in self.model._meta.get_fields()
+                if hasattr(f, 'column')]
+
+    def get_csv_filename(self):
+        return f'{self.model._meta.model_name}_export.csv'
+
+    @admin.action(description='Export selected to CSV')
+    def export_as_csv(self, request, queryset):
+        fields = self.get_csv_fields()
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = (
+            f'attachment; filename="{self.get_csv_filename()}"'
+        )
+
+        writer = csv.writer(response)
+        writer.writerow(fields)
+
+        for obj in queryset.only(*fields):
+            row = []
+            for field in fields:
+                value = getattr(obj, field, '')
+                if callable(value):
+                    value = value()
+                row.append(str(value))
+            writer.writerow(row)
+
+        return response
+```
+
+Uso:
+
+```python
+@admin.register(CostRecord)
+class CostRecordAdmin(ExportCSVMixin, BaseModelAdmin):
+    actions = ['export_as_csv']
+
+    def get_csv_fields(self):
+        return ['user', 'provider', 'amount', 'currency', 'billed_date']
+```
+
+## Mixin: Audit Log
+
+```python
+# server/common/admin/mixins/audit_log.py
+import logging
+
+logger = logging.getLogger('admin.audit')
+
+
+class AuditLogMixin:
+    """Logea cambios en admin para auditoria."""
+
+    def save_model(self, request, obj, form, change):
+        action = 'changed' if change else 'added'
+        logger.info(
+            'Admin %s %s %s (pk=%s)',
+            request.user.username,
+            action,
+            obj._meta.model_name,
+            obj.pk,
+            extra={
+                'user_id': str(request.user.pk),
+                'model': f'{obj._meta.app_label}.{obj._meta.model_name}',
+                'object_id': str(obj.pk),
+                'action': action,
+                'changed_fields': list(form.changed_data) if change else [],
+            },
+        )
+        super().save_model(request, obj, form, change)
+
+    def delete_model(self, request, obj):
+        logger.info(
+            'Admin %s deleted %s (pk=%s)',
+            request.user.username,
+            obj._meta.model_name,
+            obj.pk,
+            extra={
+                'user_id': str(request.user.pk),
+                'model': f'{obj._meta.app_label}.{obj._meta.model_name}',
+                'object_id': str(obj.pk),
+                'action': 'deleted',
+            },
+        )
+        super().delete_model(request, obj)
+```
+
+## Mixin: Read-Only Admin
+
+```python
+# server/common/admin/mixins/readonly.py
+
+class ReadOnlyAdminMixin:
+    """Admin completamente read-only (para logs, audit trail, etc.)."""
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        actions.pop('delete_selected', None)
+        return actions
+```
+
+Uso:
+
+```python
+@admin.register(AuditLog)
+class AuditLogAdmin(ReadOnlyAdminMixin, BaseModelAdmin):
+    list_display = ('user', 'action', 'target_type', 'created_at')
+    list_filter = ('action', 'target_type')
+    date_hierarchy = 'created_at'
+```
+
+## Mixin: Soft Delete
+
+```python
+# server/common/admin/mixins/soft_delete.py
+
+class SoftDeleteAdminMixin:
+    """Admin para modelos con soft delete (is_active flag)."""
+
+    def get_queryset(self, request):
+        """Mostrar todos, incluidos soft-deleted."""
+        return self.model._default_manager.all()
+
+    def delete_model(self, request, obj):
+        """Soft delete en vez de hard delete."""
+        obj.is_active = False
+        obj.save(update_fields=['is_active', 'updated_at'])
+
+    def delete_queryset(self, request, queryset):
+        """Bulk soft delete."""
+        queryset.update(is_active=False)
+
+    @admin.action(description='Restore selected (undelete)')
+    def action_restore(self, request, queryset):
+        count = queryset.update(is_active=True)
+        self.message_user(request, f'{count} item(s) restored.')
+```
+
+## Mixin: Status Badge Display
+
+```python
+# server/common/admin/mixins/status_badge.py
+from django.utils.html import format_html
+
+
+class StatusBadgeMixin:
+    """Mixin para mostrar status con badge coloreado."""
+
+    # Override en subclase
+    STATUS_COLORS: dict[str, tuple[str, str]] = {
+        # 'status_value': ('background', 'foreground')
+    }
+
+    def status_badge_html(self, status: str, label: str = '') -> str:
+        bg, fg = self.STATUS_COLORS.get(status, ('#6c757d', '#fff'))
+        return format_html(
+            '<span style="'
+            'background:{};color:{};padding:2px 8px;'
+            'border-radius:4px;font-size:11px;'
+            'font-weight:600;text-transform:uppercase;'
+            'letter-spacing:.5px'
+            '">{}</span>',
+            bg, fg, label or status,
+        )
+```
+
+Uso:
+
+```python
+@admin.register(Order)
+class OrderAdmin(StatusBadgeMixin, BaseModelAdmin):
+    STATUS_COLORS = {
+        'queued': ('#6c757d', '#fff'),
+        'processing': ('#0d6efd', '#fff'),
+        'completed': ('#198754', '#fff'),
+        'failed': ('#dc3545', '#fff'),
+    }
+
+    @admin.display(description='Status', ordering='status')
+    def status_display(self, obj):
+        return self.status_badge_html(obj.status, obj.get_status_display())
+```
+
+## Mixin: Thumbnail Display
+
+```python
+# server/common/admin/mixins/thumbnail.py
+from django.utils.html import format_html
+
+
+class ThumbnailMixin:
+    """Mixin para mostrar thumbnails de imagenes en list_display."""
+
+    THUMBNAIL_SIZE = (48, 48)
+
+    def thumbnail_html(
+        self,
+        url: str | None,
+        alt: str = '',
+        size: tuple[int, int] | None = None,
+    ) -> str:
+        if not url:
+            return format_html(
+                '<span style="color:#999">{}</span>', '\u2014',
+            )
+
+        w, h = size or self.THUMBNAIL_SIZE
+        return format_html(
+            '<img src="{}" alt="{}" width="{}" height="{}"'
+            ' style="object-fit:cover;border-radius:4px;'
+            'border:1px solid #ddd;vertical-align:middle">',
+            url, alt, w, h,
+        )
+```
+
+## Mixin: Background Task Trigger
+
+```python
+# server/common/admin/mixins/task_trigger.py
+
+class TaskTriggerMixin:
+    """Mixin para encolar background tasks desde admin actions."""
+
+    def enqueue_task(self, request, queryset, task_func, description):
+        """Helper generico para encolar tasks por cada objeto."""
+        count = 0
+        for obj in queryset:
+            task_func.delay(str(obj.pk))
+            count += 1
+
+        self.message_user(
+            request,
+            f'{count} task(s) enqueued: {description}',
+        )
+```
+
+Uso:
+
+```python
+@admin.register(ScheduledApiCall)
+class ScheduledApiCallAdmin(TaskTriggerMixin, BaseModelAdmin):
+    @admin.action(description='Execute now (immediate)')
+    def execute_now(self, request, queryset):
+        from apps.scheduler.tasks import execute_scheduled_api_call
+        self.enqueue_task(
+            request,
+            queryset.filter(is_active=True),
+            execute_scheduled_api_call,
+            'scheduled API call execution',
+        )
+```
+
+## Composicion de mixins
+
+Orden de herencia (MRO): mixins ANTES de la base class.
+
+```python
+@admin.register(Product)
+class ProductAdmin(
+    AuditLogMixin,
+    StatusBadgeMixin,
+    ThumbnailMixin,
+    ExportCSVMixin,
+    BaseModelAdmin,
+):
+    actions = ['export_as_csv', 'action_process']
+    # ...
+```
+
+## Custom AdminSite
+
+Para branding y personalizacion del sitio admin completo:
+
+```python
+# server/config/admin_site.py
+from django.contrib.admin import AdminSite
+
+
+class RezebraAdminSite(AdminSite):
+    site_header = 'Rezebra Administration'
+    site_title = 'Rezebra'
+    index_title = 'Dashboard'
+
+    def get_app_list(self, request, app_label=None):
+        """Reorder apps in sidebar."""
+        app_list = super().get_app_list(request, app_label)
+        # Custom ordering
+        priority = {
+            'products': 0,
+            'orders': 1,
+            'categories': 2,
+            'accounts': 3,
+            'scheduler': 4,
+        }
+        app_list.sort(key=lambda x: priority.get(x['app_label'], 99))
+        return app_list
+```
+
+Registrar:
+
+```python
+# server/config/urls.py
+from config.admin_site import RezebraAdminSite
+
+admin_site = RezebraAdminSite(name='admin')
+
+# Registrar todos los modelos en admin_site en vez de admin.site
+# O usar: admin.site = admin_site (reemplazo global)
+```
+
+## Custom filters reutilizables
+
+```python
+# server/common/admin/filters.py
+from django.contrib.admin import SimpleListFilter
+from django.utils import timezone
+
+
+class CreatedRecentlyFilter(SimpleListFilter):
+    """Filtrar por items creados recientemente."""
+    title = 'Created'
+    parameter_name = 'created_recently'
+
+    def lookups(self, request, model_admin):
+        return [
+            ('today', 'Today'),
+            ('week', 'Last 7 days'),
+            ('month', 'Last 30 days'),
+        ]
+
+    def queryset(self, request, queryset):
+        now = timezone.now()
+        match self.value():
+            case 'today':
+                return queryset.filter(created_at__date=now.date())
+            case 'week':
+                return queryset.filter(
+                    created_at__gte=now - timezone.timedelta(days=7),
+                )
+            case 'month':
+                return queryset.filter(
+                    created_at__gte=now - timezone.timedelta(days=30),
+                )
+        return queryset
+
+
+class IsActiveFilter(SimpleListFilter):
+    """Filtro booleano mejorado con labels descriptivos."""
+    title = 'Active'
+    parameter_name = 'is_active'
+
+    def lookups(self, request, model_admin):
+        return [('1', 'Active'), ('0', 'Inactive')]
+
+    def queryset(self, request, queryset):
+        if self.value() == '1':
+            return queryset.filter(is_active=True)
+        if self.value() == '0':
+            return queryset.filter(is_active=False)
+        return queryset
+
+
+class HasRelatedFilter(SimpleListFilter):
+    """Filtro generico para "tiene relacion" / "no tiene relacion"."""
+    title = ''  # Override
+    parameter_name = ''  # Override
+    related_field = ''  # Override: nombre del campo FK/M2M
+
+    def lookups(self, request, model_admin):
+        return [('yes', 'Has'), ('no', 'Missing')]
+
+    def queryset(self, request, queryset):
+        lookup = f'{self.related_field}__isnull'
+        if self.value() == 'yes':
+            return queryset.filter(**{lookup: False})
+        if self.value() == 'no':
+            return queryset.filter(**{lookup: True})
+        return queryset
+```
+
+Uso:
+
+```python
+class HasImageFilter(HasRelatedFilter):
+    title = 'Image'
+    parameter_name = 'has_image'
+    related_field = 'image_url'
+
+    def queryset(self, request, queryset):
+        if self.value() == 'yes':
+            return queryset.exclude(image_url='')
+        if self.value() == 'no':
+            return queryset.filter(image_url='')
+        return queryset
+```
+
+## `@admin.display` decorator (Django 5+)
+
+Reemplazo limpio de los atributos `short_description`, `admin_order_field`, `boolean`:
+
+```python
+# ANTES (legacy)
+def status_badge(self, obj):
+    return format_html('...')
+status_badge.short_description = 'Status'
+status_badge.admin_order_field = 'status'
+
+# AHORA (Django 5+/6)
+@admin.display(description='Status', ordering='status')
+def status_badge(self, obj):
+    return format_html('...')
+
+# Para booleanos
+@admin.display(description='Active', boolean=True)
+def is_active_display(self, obj):
+    return obj.is_active
+
+# Con empty_value para None
+@admin.display(description='Last run', empty_value='-', ordering='last_executed_at')
+def last_run_display(self, obj):
+    return obj.last_executed_at
+```
+
+## Patron: Admin modular con archivos separados
+
+Para admin complejos, dividir en archivos:
+
+```
+server/apps/products/admin/
+├── __init__.py              # Re-exports
+├── product.py               # ProductAdmin principal
+├── product_variant.py       # ProductVariantInline
+├── product_image.py         # ProductImageInline
+├── forms.py                 # ProductAdminForm
+└── category_views.py        # Vistas standalone de categories
+```
+
+`__init__.py`:
+
+```python
+from apps.products.admin.product import ProductAdmin
+from apps.products.admin.product_variant import ProductVariantAdmin
+
+__all__ = ['ProductAdmin', 'ProductVariantAdmin']
+```
+
+## Mejores practicas
+
+1. **Mixins para comportamiento transversal** — no duplicar logica entre admins
+2. **Base class para defaults de proyecto** — `show_full_result_count`, readonly timestamps, etc.
+3. **Un archivo por admin class** cuando supera ~100 lineas
+4. **Filters reutilizables** en `common/admin/filters.py`
+5. **`@admin.display`** siempre sobre atributos legacy
+6. **Composicion sobre herencia profunda** — max 3-4 niveles de herencia
+7. **AdminSite custom** para branding, ordering de apps, dashboard
+
+[Anterior: 03-custom-views-templates](03-custom-views-templates.md) | [Siguiente: 05-performance-security](05-performance-security.md)

--- a/.claude/docs/django-admin/05-performance-security.md
+++ b/.claude/docs/django-admin/05-performance-security.md
@@ -1,0 +1,350 @@
+[Anterior: 04-reusable-patterns](04-reusable-patterns.md) | [Siguiente: 06-widgets-inlines-forms](06-widgets-inlines-forms.md)
+
+# 05. Performance y Security
+
+> Optimizacion de queries, prevencion de N+1, permisos granulares, field-level permissions, y seguridad en Django admin.
+
+## Prevencion de N+1 en list view
+
+### `list_select_related`
+
+```python
+@admin.register(CostRecord)
+class CostRecordAdmin(admin.ModelAdmin):
+    list_display = ('user', 'provider', 'amount', 'billed_date')
+
+    # Opcion 1: boolean — Django auto-detecta FK en list_display
+    list_select_related = True
+
+    # Opcion 2: tuple explicita — mas eficiente, solo lo necesario
+    list_select_related = ('user', 'provider', 'job')
+```
+
+### `get_queryset()` con prefetch
+
+```python
+def get_queryset(self, request):
+    return (
+        super()
+        .get_queryset(request)
+        .select_related('created_by', 'preferred_provider')
+        .prefetch_related('images', 'shares__user')
+    )
+```
+
+### `.only()` para modelos con muchos campos
+
+```python
+def get_queryset(self, request):
+    qs = super().get_queryset(request)
+    if self.model._meta.model_name == 'order':
+        # Solo cargar campos usados en list_display
+        qs = qs.only(
+            'id', 'title', 'status', 'platform_id',
+            'scheduled_at', 'created_at',
+        )
+    return qs
+```
+
+## `show_full_result_count`
+
+```python
+class BaseModelAdmin(admin.ModelAdmin):
+    show_full_result_count = False  # Evita COUNT(*) en tablas con >10K rows
+```
+
+Sin esto, Django ejecuta `SELECT COUNT(*) FROM tabla` en cada page load del changelist.
+
+## `autocomplete_fields` vs `raw_id_fields`
+
+| Feature | `autocomplete_fields` | `raw_id_fields` |
+|---------|----------------------|-----------------|
+| UI | Dropdown con search (Select2) | Input texto + icono lookup |
+| Query | AJAX search on type | Solo al abrir popup |
+| Requisito | `search_fields` en el admin del FK target | Ninguno |
+| UX | Mejor para usuarios finales | OK para admins tecnicos |
+
+```python
+@admin.register(CostRecord)
+class CostRecordAdmin(admin.ModelAdmin):
+    # Requiere que UserAdmin tenga search_fields definido
+    autocomplete_fields = ('user', 'provider', 'job')
+
+    # Alternativa sin requisito de search_fields
+    # raw_id_fields = ('user', 'provider', 'job')
+```
+
+Requisito del modelo target:
+
+```python
+@admin.register(User)
+class UserAdmin(admin.ModelAdmin):
+    search_fields = ('username', 'email', 'first_name')  # REQUERIDO para autocomplete
+```
+
+## Paginacion eficiente
+
+```python
+class BaseModelAdmin(admin.ModelAdmin):
+    list_per_page = 25           # Items por pagina (default: 100 es mucho)
+    list_max_show_all = 200      # Max items en "Show all"
+
+    # Para tablas enormes (>100K rows)
+    show_full_result_count = False
+```
+
+## `search_fields` eficientes
+
+```python
+# MAL: search con __icontains en campos no indexados
+search_fields = ('description__icontains', 'body__icontains')
+
+# BIEN: search en campos indexados
+search_fields = ('name', 'codename', 'created_by__username')
+# Django aplica __icontains automaticamente
+
+# Para busqueda exacta (mas rapida):
+search_fields = ('=email', '=username')  # = prefix = exact match
+
+# Para busqueda por prefijo (usa index B-tree):
+search_fields = ('^name', '^codename')  # ^ prefix = startswith
+```
+
+## `date_hierarchy` eficiente
+
+```python
+@admin.register(APICallLog)
+class APICallLogAdmin(admin.ModelAdmin):
+    date_hierarchy = 'created_at'  # Requiere index en created_at
+    # TimestampedModel ya incluye index en created_at
+```
+
+Para tablas grandes, `date_hierarchy` puede ser lento. Alternativa con filtro:
+
+```python
+list_filter = (
+    ('created_at', admin.DateFieldListFilter),
+)
+```
+
+## Permisos: hooks del ModelAdmin
+
+### Permisos por accion
+
+```python
+def has_add_permission(self, request):
+    """Controla quien puede agregar objetos."""
+    return request.user.has_perm('myapp.add_model')
+
+def has_change_permission(self, request, obj=None):
+    """Controla quien puede editar. obj=None para changelist."""
+    if obj and hasattr(obj, 'created_by'):
+        # Solo el creador o superuser puede editar
+        return obj.created_by == request.user or request.user.is_superuser
+    return super().has_change_permission(request, obj)
+
+def has_delete_permission(self, request, obj=None):
+    """Controla quien puede borrar."""
+    if obj and obj.status == 'published':
+        return False  # No borrar publicados
+    return super().has_delete_permission(request, obj)
+
+def has_view_permission(self, request, obj=None):
+    """Controla quien puede ver (read-only access)."""
+    return True  # Todos pueden ver
+
+def has_module_permission(self, request):
+    """Controla si la app aparece en el index del admin."""
+    return request.user.is_staff
+```
+
+### Read-only para ciertos usuarios
+
+```python
+def get_readonly_fields(self, request, obj=None):
+    readonly = list(super().get_readonly_fields(request, obj))
+    if not request.user.is_superuser:
+        # Usuarios normales no pueden cambiar status ni provider
+        readonly.extend(['status', 'preferred_provider'])
+    return tuple(readonly)
+```
+
+### Filtrar queryset por usuario
+
+```python
+def get_queryset(self, request):
+    qs = super().get_queryset(request)
+    if not request.user.is_superuser:
+        # Usuarios normales solo ven sus propios objetos
+        qs = qs.filter(created_by=request.user)
+    return qs
+```
+
+## Field-level permissions
+
+Patron para controlar visibilidad de campos por grupo/permiso:
+
+```python
+# Campos sensibles que requieren permiso especial
+_SENSITIVE_FIELDS = ('api_key', 'credentials', 'internal_notes')
+_SENSITIVE_PERMISSION = 'billing.view_sensitive_data'
+
+def get_fieldsets(self, request, obj=None):
+    fieldsets = list(super().get_fieldsets(request, obj))
+    if not request.user.has_perm(self._SENSITIVE_PERMISSION):
+        # Remover campos sensibles de todos los fieldsets
+        fieldsets = [
+            (name, {
+                **options,
+                'fields': [
+                    f for f in options['fields']
+                    if f not in self._SENSITIVE_FIELDS
+                ],
+            })
+            for name, options in fieldsets
+        ]
+    return fieldsets
+
+def get_list_display(self, request):
+    cols = list(super().get_list_display(request))
+    if not request.user.has_perm(self._SENSITIVE_PERMISSION):
+        cols = [c for c in cols if c not in self._SENSITIVE_FIELDS]
+    return cols
+```
+
+## Inline permissions
+
+```python
+class RecentExecutionsInline(admin.TabularInline):
+    model = ApiCallExecution
+    extra = 0
+    max_num = 10
+    readonly_fields = fields
+    can_delete = False
+
+    def has_add_permission(self, request, obj=None):
+        return False  # Solo lectura
+
+    def has_change_permission(self, request, obj=None):
+        return False  # Solo lectura
+```
+
+## `format_html` seguro vs `mark_safe` inseguro
+
+```python
+# SEGURO: format_html escapa automaticamente los argumentos
+@admin.display(description='Status')
+def status_badge(self, obj):
+    return format_html(
+        '<span style="color:{}">{}</span>',
+        self.STATUS_COLORS.get(obj.status, '#666'),
+        obj.get_status_display(),  # Escapado automaticamente
+    )
+
+# INSEGURO: mark_safe NO escapa nada
+from django.utils.safestring import mark_safe
+def bad_status(self, obj):
+    return mark_safe(f'<span>{obj.user_input}</span>')  # XSS vulnerability!
+
+# Si NECESITAS mark_safe (HTML construido en loop), escapar manualmente:
+from django.utils.html import escape, format_html
+cards = ''
+for item in items:
+    cards += format_html('<div>{}</div>', item.name)
+return mark_safe(cards)  # noqa: S308 — cada parte ya esta escapada via format_html
+```
+
+## Prevencion de CSRF en vistas custom
+
+```python
+def generate_enqueue_view(self, request):
+    """Custom POST view — CSRF protegido automaticamente por admin_view()."""
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Method not allowed'}, status=405)
+    # self.admin_site.admin_view() ya aplica CSRF + auth check
+    # Solo necesitas CSRF token en el request
+    # ...
+```
+
+En JavaScript:
+
+```javascript
+// Incluir CSRF token en cada POST
+fetch(url, {
+  method: 'POST',
+  headers: {
+    'X-CSRFToken': document.querySelector(
+      'input[name="csrfmiddlewaretoken"]',
+    ).value,
+  },
+  credentials: 'same-origin',
+})
+```
+
+## Rate limiting en admin actions
+
+```python
+from django.core.cache import cache
+
+@admin.action(description='Generate images (rate limited)')
+def action_generate(self, request, queryset):
+    cache_key = f'admin_generate_{request.user.pk}'
+    last_run = cache.get(cache_key)
+
+    if last_run:
+        self.message_user(
+            request,
+            'Please wait 60 seconds between operations.',
+            messages.WARNING,
+        )
+        return
+
+    cache.set(cache_key, True, timeout=60)
+    # ... enqueue tasks
+```
+
+## Admin LogEntry (audit trail built-in)
+
+Django ya registra cambios en `LogEntry`. Acceder:
+
+```python
+from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
+
+# Ver historial de un objeto
+entries = LogEntry.objects.filter(
+    content_type__app_label='products',
+    content_type__model='product',
+    object_id=str(product.pk),
+).select_related('user', 'content_type')
+
+for entry in entries:
+    print(f'{entry.action_time}: {entry.user} {entry.get_action_flag_display()}')
+    if entry.change_message:
+        print(f'  Changes: {entry.get_change_message()}')
+```
+
+## Checklist de performance
+
+| Check | Accion |
+|-------|--------|
+| N+1 en list view | `list_select_related` o `get_queryset()` con `select_related` |
+| COUNT(*) lento | `show_full_result_count = False` |
+| Search lento | Usar `^` (startswith) o `=` (exact) en `search_fields` |
+| FK con muchas opciones | `autocomplete_fields` (no dropdown completo) |
+| Tabla >100K rows | `list_per_page = 25`, no `date_hierarchy` |
+| Inline con muchos items | `max_num` + `extra = 0` + `readonly_fields` |
+| Campos no usados cargados | `.only()` o `.defer()` en `get_queryset()` |
+
+## Checklist de seguridad
+
+| Check | Accion |
+|-------|--------|
+| Custom views sin auth | SIEMPRE `admin_site.admin_view()` wrapper |
+| HTML con datos de usuario | SIEMPRE `format_html()`, NUNCA `mark_safe(f-string)` |
+| CSRF en POST custom | Header `X-CSRFToken` en Fetch, `credentials: 'same-origin'` |
+| Datos sensibles en list | `get_list_display()` condicional por permiso |
+| Objetos de otros usuarios | `get_queryset()` filtrado por `created_by=request.user` |
+| Actions destructivas | `has_delete_permission()` + confirmacion intermedia |
+| Credentials en forms | `PasswordInput(render_value=False)` + encriptar en `save()` |
+
+[Anterior: 04-reusable-patterns](04-reusable-patterns.md) | [Siguiente: 06-widgets-inlines-forms](06-widgets-inlines-forms.md)

--- a/.claude/docs/django-admin/06-widgets-inlines-forms.md
+++ b/.claude/docs/django-admin/06-widgets-inlines-forms.md
@@ -1,0 +1,501 @@
+[Anterior: 05-performance-security](05-performance-security.md) | [Siguiente: 07-third-party-libraries](07-third-party-libraries.md)
+
+# 06. Widgets, Inlines y Forms Avanzados
+
+> Custom widgets con thumbnails, inline avanzados, formsets, sortable inlines, nested inlines, y forms custom para el admin.
+
+## Custom Widget con thumbnails
+
+Patron real del proyecto — checkbox con preview de imagenes:
+
+```python
+# server/apps/products/admin/widgets.py
+
+class ImageCheckboxSelect(forms.CheckboxSelectMultiple):
+    """Checkbox widget con thumbnail previews y data attributes."""
+
+    def __init__(self, image_data=None, max_images=2, **kwargs):
+        super().__init__(**kwargs)
+        # image_data: list of (image_id, label, category_id, url)
+        self._image_data = {
+            row[0]: (row[2], row[3]) for row in (image_data or [])
+        }
+        self._max_images = max_images
+
+    def create_option(self, name, value, label, selected, index, **kwargs):
+        option = super().create_option(
+            name, value, label, selected, index, **kwargs,
+        )
+
+        image_id = str(value) if value else ''
+        data = self._image_data.get(image_id)
+        if data:
+            category_id, url = data
+            # Inyectar data attributes para JS
+            option['attrs']['data-category-id'] = category_id
+            if url:
+                thumb = format_html(
+                    '<img src="{}" style="width:80px;height:120px;'
+                    'object-fit:cover;border-radius:4px;'
+                    'margin-left:8px;vertical-align:middle" />',
+                    url,
+                )
+                option['label'] = mark_safe(f'{label}{thumb}')
+
+        return option
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs['data-max-images'] = str(self._max_images)
+        return attrs
+
+    class Media:
+        js = ('products/js/image_selector.js',)
+```
+
+## JSON Editor Widget (OBLIGATORIO para JSONField)
+
+SIEMPRE usar `JSONEditorWidget` de `django-json-widget` para campos `JSONField` en admin. NUNCA usar `forms.Textarea` plano.
+
+Libreria: `django-json-widget>=2.1.1` (declarada en `server/pyproject.toml`, registrada en `INSTALLED_APPS` como `'django_json_widget'`).
+
+Ofrece: syntax highlighting, validacion JSON en tiempo real, modos `code` (editor) y `tree` (visual), dark mode nativo.
+
+```python
+from django.db import models
+from django_json_widget.widgets import JSONEditorWidget
+
+@admin.register(MyModel)
+class MyModelAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        models.JSONField: {
+            'widget': JSONEditorWidget(
+                options={
+                    'mode': 'code',
+                    'modes': ['code', 'tree'],
+                },
+            ),
+        },
+    }
+```
+
+Para customizar altura por campo especifico (override individual en el form):
+
+```python
+class MyForm(forms.ModelForm):
+    class Meta:
+        model = MyModel
+        fields = '__all__'
+        widgets = {
+            'config': JSONEditorWidget(
+                options={'mode': 'tree', 'modes': ['tree', 'code']},
+                attrs={'style': 'height:300px;width:90%'},
+            ),
+        }
+```
+
+## Custom Widget: Color Picker
+
+```python
+class ColorWidget(forms.TextInput):
+    input_type = 'color'
+    template_name = 'admin/widgets/color_input.html'
+
+    def __init__(self, attrs=None):
+        defaults = {'style': 'width:60px;height:32px;padding:2px;cursor:pointer'}
+        if attrs:
+            defaults.update(attrs)
+        super().__init__(attrs=defaults)
+```
+
+## Custom ModelForm para admin
+
+Patron real del proyecto — form con campos inline para schedule:
+
+```python
+class ScheduledApiCallForm(forms.ModelForm):
+    """Form con campos adicionales no-modelo."""
+
+    # Campos que NO existen en el modelo
+    credentials_plain = forms.CharField(
+        required=False,
+        widget=forms.PasswordInput(render_value=False),
+        help_text='Bearer token o API key. Dejar vacio para mantener actual.',
+        label='Credentials',
+    )
+
+    interval_every = forms.IntegerField(
+        required=False, min_value=1, initial=5, label='Every',
+    )
+    interval_period = forms.ChoiceField(
+        required=False,
+        choices=[('minutes', 'Minutes'), ('hours', 'Hours'), ('days', 'Days')],
+        label='Period',
+    )
+
+    class Meta:
+        model = ScheduledApiCall
+        fields = ('name', 'url', 'http_method', 'schedule_type', 'is_active')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._populate_from_instance()
+
+    def _populate_from_instance(self):
+        """Llenar campos inline desde FK existentes."""
+        obj = self.instance
+        if not obj or not obj.pk:
+            return
+        if obj.interval:
+            self.fields['interval_every'].initial = obj.interval.every
+            self.fields['interval_period'].initial = obj.interval.period
+
+    def clean(self):
+        cleaned = super().clean()
+        schedule_type = cleaned.get('schedule_type')
+        if schedule_type == 'interval':
+            if not cleaned.get('interval_every'):
+                self.add_error('interval_every', 'Required for interval schedule.')
+        return cleaned
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+
+        # Encriptar credentials si se proporcionaron
+        plain = self.cleaned_data.get('credentials_plain', '')
+        if plain:
+            instance.set_credentials(plain)
+
+        # Crear/actualizar schedule FK
+        if self.cleaned_data['schedule_type'] == 'interval':
+            from django_tasks_database.models import IntervalSchedule
+            schedule, _ = IntervalSchedule.objects.get_or_create(
+                every=self.cleaned_data['interval_every'],
+                period=self.cleaned_data['interval_period'],
+            )
+            instance.interval = schedule
+
+        if commit:
+            instance.save()
+        return instance
+```
+
+Registrar:
+
+```python
+@admin.register(ScheduledApiCall)
+class ScheduledApiCallAdmin(admin.ModelAdmin):
+    form = ScheduledApiCallForm
+```
+
+## TabularInline vs StackedInline
+
+| Feature | TabularInline | StackedInline |
+|---------|--------------|---------------|
+| Layout | Tabla (compacta) | Formulario vertical (amplia) |
+| Mejor para | Pocos campos, muchos items | Muchos campos, pocos items |
+| Espacio | Ahorra espacio vertical | Consume mas espacio |
+
+```python
+class ProductVariantInline(admin.TabularInline):
+    model = ProductVariant
+    extra = 1
+    autocomplete_fields = ('user',)
+    fields = ('user', 'permission')
+
+class ProductImageInline(admin.StackedInline):
+    model = ProductImage
+    extra = 0
+    fields = (
+        'platform', 'username', 'encrypted_password',
+        'auth_token', 'is_active',
+    )
+```
+
+## Inline avanzado: Read-only con link al objeto
+
+```python
+class RecentExecutionsInline(admin.TabularInline):
+    model = ApiCallExecution
+    extra = 0
+    max_num = 10
+    fields = ('status', 'response_status', 'latency_ms', 'executed_at')
+    readonly_fields = fields
+    ordering = ['-executed_at']
+    can_delete = False
+    show_change_link = True  # Link al change view del objeto inline
+
+    def has_add_permission(self, request, obj=None):
+        return False
+```
+
+## Dynamic `get_extra()` en inlines
+
+```python
+class ProductVariantInline(admin.TabularInline):
+    model = ProductVariant
+
+    def get_extra(self, request, obj=None, **kwargs):
+        """No extra forms si ya hay shares, 1 si no hay."""
+        if obj and obj.shares.exists():
+            return 0
+        return 1
+```
+
+## Inline con form custom
+
+```python
+class ProductVariantForm(forms.ModelForm):
+    class Meta:
+        model = ProductVariant
+        fields = ('user', 'permission')
+        widgets = {
+            'permission': forms.RadioSelect,
+        }
+
+    def clean_user(self):
+        user = self.cleaned_data['user']
+        product = self.instance.product if self.instance.pk else None
+        if product and product.created_by == user:
+            raise forms.ValidationError("Can't share with the owner.")
+        return user
+
+class ProductVariantInline(admin.TabularInline):
+    model = ProductVariant
+    form = ProductVariantForm
+```
+
+## Sortable Inlines (drag-and-drop)
+
+Sin libreria — patron basico con campo `order`:
+
+```python
+class OrderItemInline(admin.TabularInline):
+    model = OrderItem
+    extra = 0
+    fields = ('order', 'name', 'description')
+    ordering = ['order']
+
+    class Media:
+        js = ('admin/js/sortable_inline.js',)
+```
+
+```javascript
+// sortable_inline.js — usando Sortable.js
+(function () {
+  'use strict'
+
+  function init() {
+    var tbody = document.querySelector('.inline-group tbody')
+    if (!tbody) return
+
+    // Requiere Sortable.js cargado
+    if (typeof Sortable === 'undefined') return
+
+    Sortable.create(tbody, {
+      handle: '.drag-handle',
+      animation: 150,
+      onEnd: function () {
+        // Actualizar campo order en cada row
+        var rows = tbody.querySelectorAll('tr.dynamic-orderitem_set')
+        rows.forEach(function (row, index) {
+          var orderInput = row.querySelector('input[name$="-order"]')
+          if (orderInput) orderInput.value = index
+        })
+      },
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+})()
+```
+
+Con django-admin-sortable2 (recomendado):
+
+```python
+# pip install django-admin-sortable2
+from adminsortable2.admin import SortableInlineAdminMixin
+
+class OrderItemInline(SortableInlineAdminMixin, admin.TabularInline):
+    model = OrderItem
+    extra = 0
+    # El campo de orden se detecta automaticamente (position_field)
+```
+
+## Formset customization
+
+```python
+class ProductVariantInline(admin.TabularInline):
+    model = ProductVariant
+    extra = 1
+    min_num = 0
+    max_num = 10
+    validate_min = False
+    validate_max = True
+
+    def get_formset(self, request, obj=None, **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
+        # Customizar el formset class
+        formset.validate_min = self.validate_min
+        formset.validate_max = self.validate_max
+        return formset
+```
+
+## Inline condicional en fieldsets
+
+Mostrar inlines solo en ciertas condiciones:
+
+```python
+def get_inline_instances(self, request, obj=None):
+    """Solo mostrar inlines en change view."""
+    if obj is None:
+        return []
+
+    inlines = []
+    for inline_class in self.get_inlines(request, obj):
+        inline = inline_class(self.model, self.admin_site)
+        if self._should_show_inline(inline, obj):
+            inlines.append(inline)
+    return inlines
+
+def _should_show_inline(self, inline, obj):
+    """Logica para decidir si mostrar un inline."""
+    if isinstance(inline, ProductImageInline):
+        return obj.status == 'active'
+    return True
+```
+
+## Custom formfield overrides
+
+Cambiar widgets globalmente por tipo de campo:
+
+```python
+from django_json_widget.widgets import JSONEditorWidget
+
+@admin.register(ScheduledApiCall)
+class ScheduledApiCallAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        models.JSONField: {
+            'widget': JSONEditorWidget(
+                options={'mode': 'code', 'modes': ['code', 'tree']},
+            ),
+        },
+        models.TextField: {
+            'widget': forms.Textarea(attrs={
+                'rows': 4,
+                'style': 'width:100%',
+            }),
+        },
+        models.URLField: {
+            'widget': forms.URLInput(attrs={
+                'style': 'width:100%',
+                'placeholder': 'https://',
+            }),
+        },
+    }
+```
+
+**REGLA**: Todo `formfield_overrides` que incluya `models.JSONField` DEBE usar `JSONEditorWidget`. Usar `forms.Textarea` para JSONField esta prohibido.
+
+## Prepopulated fields
+
+```python
+@admin.register(Product)
+class ProductAdmin(admin.ModelAdmin):
+    prepopulated_fields = {
+        'codename': ('name',),  # Auto-genera slug desde name
+    }
+```
+
+Para logica mas compleja, usar JS via Media:
+
+```javascript
+// codename_autofill.js
+(function () {
+  'use strict'
+
+  function init() {
+    var nameField = document.getElementById('id_name')
+    var codenameField = document.getElementById('id_codename')
+    if (!nameField || !codenameField) return
+    if (codenameField.value) return // No sobreescribir si ya tiene valor
+
+    nameField.addEventListener('input', function () {
+      codenameField.value = nameField.value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_|_$/g, '')
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+})()
+```
+
+## Fieldset classes
+
+Django admin soporta CSS classes en fieldsets:
+
+```python
+fieldsets = (
+    ('Basic', {
+        'fields': ('name', 'codename'),
+    }),
+    ('Advanced', {
+        'fields': ('preferred_provider', 'visibility'),
+        'classes': ('collapse',),  # Colapsado por defecto
+    }),
+    ('Debug', {
+        'fields': ('created_at', 'updated_at'),
+        'classes': ('collapse', 'wide'),
+        'description': 'Timestamps automaticos del modelo.',
+    }),
+)
+```
+
+Classes disponibles:
+- `collapse` — fieldset colapsado, toggle con click
+- `wide` — inputs mas anchos
+- Custom classes via CSS en `Media.css`
+
+## Patron: Fields dinamicos con HTMX
+
+```html
+<!-- change_form.html override -->
+{% block after_field_sets %}
+{{ block.super }}
+
+<fieldset class="module" id="dynamic-preview">
+  <h2>Live Preview</h2>
+  <div hx-get="{% url 'admin:products_product_preview' object_id %}"
+       hx-trigger="change from:#id_name, change from:#id_codename delay:500ms"
+       hx-swap="innerHTML"
+       hx-include="#product_form">
+    {% include "admin/products/product/_preview.html" %}
+  </div>
+</fieldset>
+{% endblock %}
+```
+
+## Mejores practicas
+
+1. **Widgets via `formfield_overrides`** para cambios globales por tipo de campo
+2. **`create_option()` override** para inyectar `data-` attributes y thumbnails
+3. **`Media` class** en widgets para JS/CSS autoincluidos
+4. **`extra = 0`** en inlines de solo lectura — no mostrar forms vacios
+5. **`show_change_link = True`** en inlines readonly — permite navegar al objeto
+6. **`autocomplete_fields`** sobre dropdowns para FK con >50 opciones
+7. **`max_num` en inlines** — previene abuse y mejora UX
+8. **Formset validation** via `clean()` en form custom del inline
+9. **JS en archivos separados** via `Media` — nunca inline en Python
+10. **JSONField SIEMPRE con `JSONEditorWidget`** de `django-json-widget` — NUNCA `forms.Textarea` plano
+
+[Anterior: 05-performance-security](05-performance-security.md) | [Siguiente: 07-third-party-libraries](07-third-party-libraries.md)

--- a/.claude/docs/django-admin/07-third-party-libraries.md
+++ b/.claude/docs/django-admin/07-third-party-libraries.md
@@ -1,0 +1,313 @@
+[Anterior: 06-widgets-inlines-forms](06-widgets-inlines-forms.md) | [Volver: README](README.md)
+
+# 07. Third-party Libraries 2025
+
+> Librerias de terceros para mejorar el admin de Django: UI moderna, import/export, sorting, nested inlines, y mas.
+
+## django-unfold (UI moderna)
+
+La opcion mas popular en 2025 para modernizar la UI del admin sin cambiar la logica.
+
+```
+pip install django-unfold
+```
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    'unfold',
+    'unfold.contrib.filters',
+    'unfold.contrib.forms',
+    'unfold.contrib.import_export',  # Si usas django-import-export
+    'django.contrib.admin',
+    # ...
+]
+```
+
+Caracteristicas:
+- UI moderna con Tailwind CSS (dark mode incluido)
+- Sidebar responsive y customizable
+- Dashboard con widgets y charts
+- Compatible con todos los features nativos de Django admin
+- Tabs en fieldsets
+- Formularios mejorados (Select2, date pickers, toggles)
+- No requiere cambiar ModelAdmin — funciona con lo existente
+
+```python
+from unfold.admin import ModelAdmin
+
+@admin.register(Product)
+class ProductAdmin(ModelAdmin):
+    # Misma API que django.contrib.admin.ModelAdmin
+    list_display = ('name', 'status', 'created_at')
+
+    # Feature de unfold: tabs en fieldsets
+    fieldsets_tabs = True
+```
+
+Evaluacion:
+- Pro: drop-in replacement, UX profesional, mantenido activamente
+- Contra: agrega dependencia de Tailwind, puede conflictuar con CSS custom
+- Ideal para: proyectos que necesitan admin presentable para stakeholders
+- Evitar si: el admin es solo para devs y funciona bien con el default
+
+## django-import-export
+
+Import/export CSV, Excel, JSON desde el admin.
+
+```
+pip install django-import-export
+```
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    # ...
+    'import_export',
+]
+
+# admin.py
+from import_export.admin import ImportExportModelAdmin
+from import_export import resources
+
+class CostRecordResource(resources.ModelResource):
+    class Meta:
+        model = CostRecord
+        fields = ('id', 'user__username', 'provider__name',
+                  'amount', 'currency', 'billed_date')
+        export_order = fields
+
+@admin.register(CostRecord)
+class CostRecordAdmin(ImportExportModelAdmin):
+    resource_classes = [CostRecordResource]
+    list_display = ('user', 'provider', 'amount', 'billed_date')
+```
+
+Caracteristicas:
+- Export a CSV, XLSX, JSON, YAML, TSV, HTML
+- Import con preview y validacion antes de confirmar
+- Dry run para validar sin guardar
+- Hook `before_import_row()`, `after_import_row()` para transformaciones
+- Soporte para FK (resolucion por natural key o PK)
+
+```python
+class CostRecordResource(resources.ModelResource):
+    class Meta:
+        model = CostRecord
+        import_id_fields = ('id',)  # Campo para identificar updates vs creates
+        skip_unchanged = True
+        report_skipped = True
+
+    def before_import_row(self, row, **kwargs):
+        """Transformar datos antes de importar."""
+        if 'amount' in row:
+            row['amount'] = str(row['amount']).replace(',', '.')
+```
+
+Evaluacion:
+- Pro: robusto, flexible, bien mantenido, formatos multiples
+- Contra: import de archivos grandes puede ser lento (no async)
+- Ideal para: migrar datos, exports para reportes, bulk updates
+
+## django-admin-sortable2
+
+Drag-and-drop reordering en list view e inlines.
+
+```
+pip install django-admin-sortable2
+```
+
+```python
+from adminsortable2.admin import SortableAdminMixin, SortableInlineAdminMixin
+
+@admin.register(Category)
+class CategoryAdmin(SortableAdminMixin, admin.ModelAdmin):
+    list_display = ('name', 'scope', 'is_active')
+    # Requiere campo de orden en el modelo (e.g., 'order' o 'position')
+
+class OrderItemInline(SortableInlineAdminMixin, admin.TabularInline):
+    model = OrderItem
+    extra = 0
+```
+
+Modelo requiere campo de orden:
+
+```python
+class Category(TimestampedModel):
+    name = models.CharField(max_length=100)
+    order = models.PositiveIntegerField(default=0, db_index=True)
+
+    class Meta:
+        ordering = ['order']
+```
+
+Evaluacion:
+- Pro: drag-and-drop nativo, funciona en list view e inlines
+- Contra: requiere campo de orden en modelo, JS incluido puede conflictuar
+- Ideal para: categories, items, cualquier cosa con orden manual
+
+## django-nested-admin
+
+Inlines dentro de inlines (multi-nivel).
+
+```
+pip install django-nested-admin
+```
+
+```python
+import nested_admin
+
+class OrderItemInline(nested_admin.NestedTabularInline):
+    model = OrderItem
+    extra = 0
+
+class OrderInline(nested_admin.NestedStackedInline):
+    model = Order
+    inlines = [OrderItemInline]  # Inline DENTRO de inline
+    extra = 0
+
+@admin.register(Collection)
+class CollectionAdmin(nested_admin.NestedModelAdmin):
+    inlines = [OrderInline]
+```
+
+Evaluacion:
+- Pro: resuelve limitacion nativa de Django (no nested inlines)
+- Contra: complejidad de JS, puede ser lento con muchos niveles
+- Ideal para: relaciones jerarquicas (Collection > Order > OrderItem)
+- Evitar si: puedes resolver con `autocomplete_fields` o views separadas
+
+## django-admin-interface
+
+Customizacion visual del admin via DB (sin codigo).
+
+```
+pip install django-admin-interface
+```
+
+Permite desde el admin:
+- Cambiar colores, logo, favicon
+- Custom CSS via textarea en el admin
+- Temas guardados en DB (switchable)
+- Responsive sidebar
+
+Evaluacion:
+- Pro: no-code customization, ideal para clientes no-tecnicos
+- Contra: overhead de queries para cargar tema en cada request
+- Ideal para: admin que sera usado por no-tecnicos que quieren branding
+
+## django-jazzmin
+
+Tema Bootstrap 4 para el admin con sidebar moderna.
+
+```
+pip install django-jazzmin
+```
+
+```python
+INSTALLED_APPS = [
+    'jazzmin',
+    'django.contrib.admin',
+    # ...
+]
+
+JAZZMIN_SETTINGS = {
+    'site_title': 'Rezebra',
+    'site_header': 'Rezebra Admin',
+    'site_brand': 'Rezebra',
+    'welcome_sign': 'Welcome to Rezebra',
+    'show_sidebar': True,
+    'navigation_expanded': False,
+    'icons': {
+        'products.Product': 'fas fa-box',
+        'orders.Order': 'fas fa-shopping-cart',
+    },
+}
+```
+
+Evaluacion:
+- Pro: facil setup, iconos Font Awesome, sidebar moderna
+- Contra: Bootstrap 4 (no 5), menos activo que unfold en 2025
+- Ideal para: upgrade rapido de look & feel sin mucho effort
+- Alternativa moderna: django-unfold (Tailwind, mas activo)
+
+## django-debug-toolbar
+
+No es un tema, pero esencial para development del admin:
+
+```
+pip install django-debug-toolbar
+```
+
+```python
+# settings/local.py
+INSTALLED_APPS += ['debug_toolbar']
+MIDDLEWARE.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+INTERNAL_IPS = ['127.0.0.1']
+```
+
+Muestra:
+- SQL queries ejecutadas (N+1 detection)
+- Template rendering time
+- Cache hits/misses
+- Request/response headers
+
+## django-extensions
+
+Utilidades para desarrollo:
+
+```
+pip install django-extensions
+```
+
+Comandos utiles para admin:
+- `show_urls` — lista todas las URLs (incluyendo admin custom)
+- `graph_models` — genera diagrama ER de los modelos
+- `shell_plus` — shell con auto-import de modelos
+- `admin_generator` — genera codigo admin basico para todos los modelos
+
+```bash
+# Generar admin boilerplate automatico
+python manage.py admin_generator products
+```
+
+## Comparacion rapida
+
+| Libreria | Proposito | Mantenimiento 2025 | Complejidad |
+|----------|-----------|--------------------|-------------|
+| django-unfold | UI moderna (Tailwind) | Activo | Baja (drop-in) |
+| django-import-export | CSV/Excel import/export | Activo | Media |
+| django-admin-sortable2 | Drag-and-drop ordering | Activo | Baja |
+| django-nested-admin | Nested inlines | Activo | Alta |
+| django-admin-interface | No-code customization | Activo | Baja |
+| django-jazzmin | Tema Bootstrap | Moderado | Baja |
+| django-debug-toolbar | Debug/profiling | Activo | Baja |
+| django-extensions | Dev utilities | Activo | Baja |
+
+## Recomendaciones para rezebra
+
+Para el proyecto rezebra, las librerias mas relevantes serian:
+
+1. **django-import-export** — export de CostRecords, AuditLogs, Orders a CSV para analisis
+2. **django-admin-sortable2** — ordering de Categories, items con orden manual
+3. **django-debug-toolbar** — detectar N+1 queries en development
+4. **django-unfold** — si se necesita admin presentable (evaluar si vale la dependencia)
+
+No recomendadas actualmente:
+- django-nested-admin — el proyecto usa admin views custom en vez de nested inlines
+- django-jazzmin — django-unfold es la opcion mas moderna
+- django-admin-interface — el branding se controla via templates
+
+## Instalar sin romper
+
+Antes de agregar cualquier libreria:
+
+1. Verificar compatibilidad con Django 6 y Python 3.14
+2. Agregar a `server/pyproject.toml` (`[project.dependencies]` con version pinned `==X.Y.Z`)
+3. Regenerar lockfile: `uv lock --project server`
+4. Rebuild container: `python devtools/run.py docker rebuild --service=server`
+5. Agregar a `INSTALLED_APPS` en el orden correcto (antes o despues de `django.contrib.admin` segun docs)
+6. Ejecutar tests: `python devtools/run.py test_runner --module=server --type=coverage`
+7. Verificar que admin existente no se rompe (HTTP 200 en changelist y add views)
+
+[Anterior: 06-widgets-inlines-forms](06-widgets-inlines-forms.md) | [Volver: README](README.md)

--- a/.claude/docs/django-admin/README.md
+++ b/.claude/docs/django-admin/README.md
@@ -1,0 +1,47 @@
+# Django Admin Avanzado
+
+> Guia completa para crear admin custom dinamicos, escalables y reutilizables con Django 6 y JavaScript moderno.
+
+## Contenido
+
+| Capitulo | Archivo | Cuando leer |
+|----------|---------|-------------|
+| 01. Dynamic Admin Configuration | [01-dynamic-admin.md](01-dynamic-admin.md) | Cuando necesites fieldsets condicionales, list_display dinamico, readonly fields por estado, o inlines condicionales |
+| 02. TypeScript Moderno en Admin | [02-typescript-moderno.md](02-typescript-moderno.md) | Cuando necesites interactividad: toggle de campos, AJAX tipado, HTMX, Alpine.js, ES modules, o widgets con TypeScript strict |
+| 03. Custom Views y Templates | [03-custom-views-templates.md](03-custom-views-templates.md) | Cuando necesites dashboards, paginas wizard, vistas custom con `get_urls()`, o override de templates |
+| 04. Reusable Patterns y Mixins | [04-reusable-patterns.md](04-reusable-patterns.md) | Cuando necesites mixins reutilizables, base classes, export CSV, audit log, soft delete, o admin site custom |
+| 05. Performance y Security | [05-performance-security.md](05-performance-security.md) | Cuando necesites optimizar queries, prevenir N+1, permisos granulares, o field-level permissions |
+| 06. Widgets, Inlines y Forms | [06-widgets-inlines-forms.md](06-widgets-inlines-forms.md) | Cuando necesites widgets custom, inlines dinamicos, formsets, sortable inlines, o nested inlines |
+| 07. Third-party Libraries 2025 | [07-third-party-libraries.md](07-third-party-libraries.md) | Cuando quieras evaluar django-unfold, jazzmin, import-export, admin-sortable2, u otras librerias |
+
+## Reglas criticas
+
+- SIEMPRE TypeScript strict — compilar a JS via esbuild, NUNCA depender de jQuery
+- SIEMPRE `format_html()` — NUNCA `mark_safe()` con datos de usuario
+- SIEMPRE `self.admin_site.admin_view()` para wrappear custom views — previene acceso no autenticado
+- SIEMPRE `select_related`/`prefetch_related` en `get_queryset()` — previene N+1
+- NUNCA logica de negocio en el admin — delegar a services/selectors
+- NUNCA inline JS en `format_html()` para logica compleja — usar archivos `.ts` compilados via `Media` class
+- TS source en `static-src/<app>/src/`, JS output en `static/<app>/js/` siguiendo patron del proyecto
+- Typing obligatorio en todas las funciones: parametros y retorno explicitos
+
+## Patrones del proyecto rezebra
+
+El proyecto ya usa admin avanzados. Referencia:
+
+| Archivo | Patron |
+|---------|--------|
+| `server/apps/products/admin/product.py` | `get_urls()`, custom views, `get_fieldsets()` condicional, `get_readonly_fields()`, `Media` JS, `format_html` badges, `changeform_view` con extra context |
+| `server/apps/products/admin/forms.py` | Custom `ModelForm` con validacion, `clean()` override |
+| `server/apps/products/admin/category_views.py` | Vistas admin standalone con templates custom |
+| `server/apps/scheduler/admin/scheduled_api_call.py` | Form con campos inline (interval/crontab), `save()` override, JS toggle, actions custom |
+| `server/apps/products/admin/widgets.py` | Custom widgets (`ImageCheckboxSelect`), `create_option()` override, `data-` attributes |
+| `server/apps/products/static/products/js/image_selector.js` | Vanilla JS: filter, enforce limits, event delegation, dynamic counter |
+| `server/apps/scheduler/static/scheduler/js/schedule_toggle.js` | Vanilla JS: show/hide fields condicionalmente |
+| `server/apps/products/static/products/admin/randomize_fields.js` | Vanilla JS: randomize form fields, inject button in fieldset header |
+
+## Navegacion
+
+- Proyecto: [CLAUDE.md](../../../CLAUDE.md)
+- Django 6: [django-6/README.md](../django-6/README.md)
+- Django rules: [rules/django.md](../../rules/django.md)

--- a/.claude/docs/docker-django/01-dockerfile.md
+++ b/.claude/docs/docker-django/01-dockerfile.md
@@ -1,0 +1,316 @@
+[Volver al indice](README.md) | [Siguiente: Docker Compose](02-docker-compose.md)
+
+# Docker para Django - Dockerfile
+
+> Patrones de Dockerfile para Django 6 con multi-stage builds, uv y seguridad.
+
+## Base image
+
+```dockerfile
+# Recomendado: slim-bookworm (~41MB)
+FROM python:3.12-slim-bookworm
+
+# Alternativa: bookworm completo (~350MB) - solo si necesitas compiladores
+FROM python:3.12-bookworm
+
+# NO recomendado: alpine (~17MB) - musl libc rompe psycopg2, Pillow, numpy
+FROM python:3.12-alpine  # EVITAR
+```
+
+| Image | Size | Pros | Contras |
+|-------|------|------|---------|
+| `slim-bookworm` | ~41MB | Balance tamano/compatibilidad | Falta compiladores |
+| `bookworm` | ~350MB | Todo incluido | Grande |
+| `alpine` | ~17MB | Minima | musl rompe wheels binarios |
+
+**Recomendacion**: `python:3.12-slim-bookworm` para todos los proyectos Django.
+
+## Multi-stage build
+
+Reduce imagen de ~1.2GB a ~150MB separando build de runtime:
+
+```dockerfile
+# ============================================
+# Stage 1: Builder - instala dependencias
+# ============================================
+FROM python:3.12-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# ============================================
+# Stage 2: Runtime - solo lo necesario
+# ============================================
+FROM python:3.12-slim-bookworm AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user
+RUN useradd --create-home --shell /bin/bash appuser
+
+# Copiar dependencias del builder
+COPY --from=builder /install /usr/local
+
+WORKDIR /app
+COPY --chown=appuser:appuser . .
+
+# Collectstatic
+RUN python manage.py collectstatic --noinput
+
+USER appuser
+
+EXPOSE 8000
+CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3"]
+```
+
+## Instalacion con uv
+
+10-15x mas rapido que pip. Recomendado para 2025+:
+
+```dockerfile
+# ============================================
+# Stage 1: Builder con uv
+# ============================================
+FROM python:3.12-slim-bookworm AS builder
+
+# Instalar uv desde imagen oficial
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copiar archivos de dependencias primero (cache de layers)
+COPY pyproject.toml uv.lock ./
+
+# Instalar dependencias con uv
+ENV UV_LINK_MODE=copy
+RUN uv sync --frozen --no-dev --no-install-project
+
+# ============================================
+# Stage 2: Runtime
+# ============================================
+FROM python:3.12-slim-bookworm AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash appuser
+
+WORKDIR /app
+
+# Copiar virtualenv del builder
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+COPY --chown=appuser:appuser . .
+RUN python manage.py collectstatic --noinput
+
+USER appuser
+EXPOSE 8000
+CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3"]
+```
+
+**Nota**: `UV_LINK_MODE=copy` evita symlinks rotos al copiar entre stages.
+
+## Instalacion con pip
+
+Alternativa tradicional con cache mount:
+
+```dockerfile
+FROM python:3.12-slim-bookworm AS builder
+
+WORKDIR /app
+COPY requirements.txt .
+
+# Cache mount acelera rebuilds
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir --prefix=/install -r requirements.txt
+```
+
+## Non-root user
+
+Seguridad obligatoria en produccion:
+
+```dockerfile
+# Crear usuario sin privilegios
+RUN useradd --create-home --shell /bin/bash --uid 1000 appuser
+
+# Dar ownership del directorio de trabajo
+COPY --chown=appuser:appuser . /app
+
+# Cambiar a non-root ANTES de CMD
+USER appuser
+```
+
+**Nunca** ejecutar `gunicorn` o `manage.py` como root.
+
+## ENTRYPOINT vs CMD
+
+```dockerfile
+# Patron recomendado: entrypoint.sh + CMD
+COPY --chown=appuser:appuser entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000"]
+```
+
+```bash
+#!/bin/bash
+# entrypoint.sh
+set -e
+
+# Esperar a que PostgreSQL este listo
+echo "Waiting for PostgreSQL..."
+while ! python -c "import psycopg; psycopg.connect('$DATABASE_URL')" 2>/dev/null; do
+    sleep 1
+done
+echo "PostgreSQL ready"
+
+# Ejecutar migraciones
+python manage.py migrate --noinput
+
+# Ejecutar comando pasado como argumento
+exec "$@"
+```
+
+## Health checks
+
+```dockerfile
+# Health check en Dockerfile
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/')" || exit 1
+```
+
+```python
+# urls.py - endpoint de health check
+from django.http import JsonResponse
+
+def health_check(request):
+    return JsonResponse({"status": "ok"})
+
+urlpatterns = [
+    path("health/", health_check),
+]
+```
+
+## .dockerignore
+
+```text
+# .dockerignore
+.git
+.gitignore
+.env
+.env.*
+*.pyc
+__pycache__
+*.pyo
+.pytest_cache
+.mypy_cache
+.ruff_cache
+htmlcov
+.coverage
+*.egg-info
+dist
+build
+node_modules
+tmp/
+.claude/
+*.md
+!requirements*.txt
+docker-compose*.yml
+Dockerfile*
+.dockerignore
+.venv
+.vscode
+```
+
+## Optimizacion de cache de layers
+
+Orden de instrucciones para maximizar cache:
+
+```dockerfile
+# 1. Base image (cambia raramente)
+FROM python:3.12-slim-bookworm
+
+# 2. System packages (cambia raramente)
+RUN apt-get update && apt-get install -y ...
+
+# 3. Dependencias Python (cambia ocasionalmente)
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# 4. Codigo fuente (cambia frecuentemente)
+COPY . .
+
+# 5. Build steps (collectstatic, etc.)
+RUN python manage.py collectstatic --noinput
+```
+
+Copiar `requirements.txt` ANTES del codigo fuente permite reusar la cache de pip cuando solo cambia el codigo.
+
+> Nota: el server de rezebra usa la imagen oficial `ghcr.io/astral-sh/uv:python3.14-bookworm-slim` con `uv sync --frozen --no-install-project`, que aplica el mismo principio (lockfile copiado primero, luego codigo) pero con uv en lugar de pip. Ver `docker/dockerfiles/{prod,dev,local,test}/server` y la guia de migracion en este repo.
+
+## Ejemplo completo production-ready
+
+```dockerfile
+# Dockerfile
+FROM python:3.12-slim-bookworm AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+ENV UV_LINK_MODE=copy
+RUN uv sync --frozen --no-dev --no-install-project
+
+FROM python:3.12-slim-bookworm AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash --uid 1000 appuser
+
+WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY --chown=appuser:appuser . .
+RUN python manage.py collectstatic --noinput
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8000/health/ || exit 1
+
+USER appuser
+EXPOSE 8000
+CMD ["gunicorn", "config.wsgi:application", \
+     "--bind", "0.0.0.0:8000", \
+     "--workers", "3", \
+     "--timeout", "120", \
+     "--access-logfile", "-"]
+```
+
+---
+
+[Volver al indice](README.md) | [Siguiente: Docker Compose](02-docker-compose.md)

--- a/.claude/docs/docker-django/02-docker-compose.md
+++ b/.claude/docs/docker-django/02-docker-compose.md
@@ -1,0 +1,398 @@
+[Anterior: Dockerfile](01-dockerfile.md) | [Volver al indice](README.md)
+
+# Docker para Django - Docker Compose
+
+> Configuracion de compose.yml para Django 6 + PostgreSQL 18 con health checks, volumes y secrets.
+
+## compose.yml basico
+
+```yaml
+# compose.yml (sin campo "version:" - deprecado)
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgres://postgres:secret@db:5432/mydb
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:18-bookworm
+    environment:
+      POSTGRES_DB: mydb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+```
+
+## PostgreSQL 18 PGDATA (breaking change)
+
+La imagen Docker oficial de PostgreSQL 18 cambia la ruta de datos:
+
+| Version | PGDATA por defecto |
+|---------|-------------------|
+| PG 14-17 | `/var/lib/postgresql/data` |
+| PG 18 | `/var/lib/postgresql/18/docker` |
+
+### Opcion 1: Usar nueva ruta (recomendado para proyectos nuevos)
+
+```yaml
+services:
+  db:
+    image: postgres:18-bookworm
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker
+```
+
+### Opcion 2: Override PGDATA (compatibilidad con volumenes existentes)
+
+```yaml
+services:
+  db:
+    image: postgres:18-bookworm
+    environment:
+      PGDATA: /var/lib/postgresql/data
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+```
+
+### Opcion 3: Migrar datos existentes
+
+```bash
+# 1. Backup con pg_dumpall
+docker compose exec db pg_dumpall -U postgres > backup.sql
+
+# 2. Eliminar volumen antiguo
+docker compose down -v
+
+# 3. Actualizar compose.yml con nueva ruta
+# 4. Recrear y restaurar
+docker compose up -d db
+docker compose exec -T db psql -U postgres < backup.sql
+```
+
+## Health checks
+
+### PostgreSQL
+
+```yaml
+services:
+  db:
+    image: postgres:18-bookworm
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d mydb"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+```
+
+### Django
+
+```yaml
+services:
+  web:
+    build: .
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    depends_on:
+      db:
+        condition: service_healthy
+```
+
+### depends_on con condiciones
+
+```yaml
+services:
+  web:
+    depends_on:
+      db:
+        condition: service_healthy     # espera health check
+      redis:
+        condition: service_started     # solo espera que inicie
+      migrations:
+        condition: service_completed_successfully  # espera que termine OK
+```
+
+## Volumes
+
+### Named volumes (datos persistentes)
+
+```yaml
+volumes:
+  pgdata:
+    driver: local
+
+services:
+  db:
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker
+```
+
+### Bind mounts (desarrollo)
+
+```yaml
+services:
+  web:
+    volumes:
+      - .:/app                    # Codigo fuente (hot reload)
+      - /app/.venv                # Excluir .venv del bind mount
+      - static_data:/app/static   # Static files persistentes
+```
+
+## Entorno de desarrollo
+
+```yaml
+# compose.yml (desarrollo)
+services:
+  web:
+    build:
+      context: .
+      target: builder    # usar stage de builder (tiene dev dependencies)
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/app
+      - /app/.venv
+    ports:
+      - "8000:8000"
+    environment:
+      - DEBUG=1
+      - DATABASE_URL=postgres://postgres:secret@db:5432/mydb
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:18-bookworm
+    environment:
+      POSTGRES_DB: mydb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5432:5432"    # Exponer para acceso local con pgAdmin/DBeaver
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+```
+
+### Docker Compose Watch (hot reload automatico)
+
+```yaml
+services:
+  web:
+    build: .
+    develop:
+      watch:
+        - action: sync
+          path: ./src
+          target: /app/src
+        - action: rebuild
+          path: requirements.txt
+```
+
+```bash
+docker compose watch  # Inicia con file watching
+```
+
+## Entorno de produccion
+
+```yaml
+# compose.prod.yml
+services:
+  web:
+    build:
+      context: .
+      target: runtime
+    restart: always
+    environment:
+      - DJANGO_SETTINGS_MODULE=config.settings.production
+      - DATABASE_URL=postgres://appuser:${DB_PASSWORD}@db:5432/mydb
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
+      - SECRET_KEY=${SECRET_KEY}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  db:
+    image: postgres:18-bookworm
+    restart: always
+    environment:
+      POSTGRES_DB: mydb
+      POSTGRES_USER: appuser
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U appuser -d mydb"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - static_data:/var/www/static:ro
+    depends_on:
+      web:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+  static_data:
+```
+
+```bash
+# Ejecutar con compose de produccion
+docker compose -f compose.yml -f compose.prod.yml up -d
+```
+
+## Docker secrets
+
+Manejo seguro de credenciales (no usar env vars para produccion):
+
+```yaml
+services:
+  db:
+    image: postgres:18-bookworm
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
+
+  web:
+    build: .
+    secrets:
+      - db_password
+      - django_secret_key
+
+secrets:
+  db_password:
+    file: ./secrets/db_password.txt    # archivo local
+  django_secret_key:
+    file: ./secrets/django_secret.txt
+```
+
+```python
+# settings.py - leer secrets desde archivo
+from pathlib import Path
+
+def read_secret(name: str, default: str = "") -> str:
+    secret_path = Path(f"/run/secrets/{name}")
+    if secret_path.exists():
+        return secret_path.read_text().strip()
+    return os.getenv(name.upper(), default)
+
+SECRET_KEY = read_secret("django_secret_key")
+DB_PASSWORD = read_secret("db_password")
+```
+
+## Migraciones en Docker
+
+### Opcion 1: En entrypoint (simple)
+
+```bash
+# entrypoint.sh
+python manage.py migrate --noinput
+exec "$@"
+```
+
+### Opcion 2: Service separado (produccion)
+
+```yaml
+services:
+  migrations:
+    build: .
+    command: python manage.py migrate --noinput
+    environment:
+      - DATABASE_URL=postgres://postgres:secret@db:5432/mydb
+    depends_on:
+      db:
+        condition: service_healthy
+
+  web:
+    build: .
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
+```
+
+### Init scripts de PostgreSQL
+
+```yaml
+services:
+  db:
+    image: postgres:18-bookworm
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker
+      - ./init-scripts:/docker-entrypoint-initdb.d  # Se ejecutan al crear DB
+```
+
+```sql
+-- init-scripts/01-extensions.sql
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
+## Comandos utiles
+
+```bash
+# Levantar servicios
+docker compose up -d
+
+# Ver logs
+docker compose logs -f web
+docker compose logs -f db
+
+# Ejecutar comando en container
+docker compose exec web python manage.py createsuperuser
+docker compose exec db psql -U postgres -d mydb
+
+# Shell Django
+docker compose exec web python manage.py shell
+
+# Rebuild sin cache
+docker compose build --no-cache web
+
+# Parar y eliminar volumenes
+docker compose down -v
+
+# Ver estado de health checks
+docker compose ps
+```
+
+---
+
+[Anterior: Dockerfile](01-dockerfile.md) | [Volver al indice](README.md)

--- a/.claude/docs/docker-django/README.md
+++ b/.claude/docs/docker-django/README.md
@@ -1,0 +1,25 @@
+# Docker para Django + PostgreSQL - Referencia Tecnica
+
+> Containerizacion de aplicaciones Django 6 con PostgreSQL 18 usando Docker Compose, multi-stage builds y uv.
+
+## Contenido
+
+| Tema | Archivo | Cuando leer |
+|------|---------|-------------|
+| Dockerfile y build | [01-dockerfile.md](01-dockerfile.md) | Multi-stage build, uv, non-root, health checks, .dockerignore |
+| Docker Compose | [02-docker-compose.md](02-docker-compose.md) | compose.yml, PostgreSQL 18 PGDATA, volumes, secrets, migraciones |
+
+## Reglas criticas
+
+- SIEMPRE usar `python:3.12-slim-bookworm` como imagen base (~41MB)
+- SIEMPRE usar multi-stage builds (builder + runtime)
+- SIEMPRE ejecutar como non-root user en produccion
+- SIEMPRE incluir health checks en `compose.yml`
+- NUNCA incluir `.env` en la imagen Docker (usar Docker secrets o env vars)
+- NUNCA usar el campo `version:` en `compose.yml` (deprecado)
+- PREFERIR `uv` sobre `pip` para instalacion de dependencias (10-15x mas rapido)
+- SIEMPRE usar `.dockerignore` para excluir `.env`, `.git`, `tmp/`, `__pycache__`
+
+## Navegacion
+
+Contexto padre: [CLAUDE.md](../../../CLAUDE.md)

--- a/.claude/docs/postgresql-18/01-api-reference.md
+++ b/.claude/docs/postgresql-18/01-api-reference.md
@@ -1,0 +1,273 @@
+[Volver al indice](README.md) | [Siguiente: Django Integration](02-django-integration.md)
+
+# PostgreSQL 18 - API Reference
+
+> Referencia de features, configuracion y cambios breaking de PostgreSQL 18.
+
+## Identificacion
+
+| Campo | Valor |
+|-------|-------|
+| Version | 18.3 (ultima estable) |
+| Release | 25 septiembre 2025 |
+| Soporte | Hasta noviembre 2030 |
+| Docker image | `postgres:18-bookworm` / `postgres:18-alpine` |
+| Driver Python | psycopg3 (`psycopg[binary]>=3.2`) |
+
+### Politica de soporte
+
+| Version | EOL |
+|---------|-----|
+| PostgreSQL 18 | Nov 2030 |
+| PostgreSQL 17 | Nov 2029 |
+| PostgreSQL 16 | Nov 2028 |
+| PostgreSQL 15 | Nov 2027 |
+| PostgreSQL 14 | Nov 2026 |
+| PostgreSQL 13 | EOL (nov 2025) |
+
+## Asynchronous I/O (AIO)
+
+Feature estrella de PostgreSQL 18. Hasta **3x mejora en lecturas** al usar I/O asincrono para operaciones de disco.
+
+### Configuracion
+
+```ini
+# postgresql.conf
+io_method = worker          # default: usa threads para I/O
+# io_method = io_uring      # Linux 5.11+, mejor performance
+```
+
+| Metodo | Requisito | Performance |
+|--------|-----------|-------------|
+| `worker` | Cualquier OS | Buena (default) |
+| `io_uring` | Linux 5.11+ | Mejor (hasta 3x en reads) |
+
+**Nota**: `io_uring` requiere kernel Linux 5.11+ y `liburing`. En Docker con kernel del host, verificar version del host.
+
+### Beneficios
+
+- Read-ahead automatico para sequential scans
+- Parallel I/O para queries complejas
+- Reduce latencia en workloads I/O-bound
+- Transparente para la aplicacion (no requiere cambios en queries)
+
+## Virtual Generated Columns
+
+Columnas calculadas que NO se almacenan en disco (se calculan al leer):
+
+```sql
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    price NUMERIC(10, 2),
+    tax_rate NUMERIC(4, 2) DEFAULT 0.19,
+    -- Virtual: se calcula al leer, no ocupa espacio
+    total NUMERIC(12, 2) GENERATED ALWAYS AS (price * (1 + tax_rate)) VIRTUAL
+);
+
+-- Stored: se almacena en disco (ya existia en PG 12+)
+ALTER TABLE products ADD COLUMN
+    search_text TEXT GENERATED ALWAYS AS (name || ' ' || description) STORED;
+```
+
+| Tipo | Almacenamiento | Indexable | Uso |
+|------|---------------|-----------|-----|
+| VIRTUAL | No (calcula al leer) | No | Campos derivados simples |
+| STORED | Si (calcula al escribir) | Si | Campos que necesitan indice |
+
+**Default en PostgreSQL 18**: Si se omite `VIRTUAL`/`STORED`, se usa `VIRTUAL`.
+
+## uuidv7()
+
+Funcion nativa para generar UUIDs v7 (time-ordered):
+
+```sql
+-- UUID v7: incluye timestamp, ordenable temporalmente
+SELECT uuidv7();
+-- Resultado: 019526a0-7b3c-7def-8123-456789abcdef
+
+-- Como primary key
+CREATE TABLE events (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Extraer timestamp del UUID v7
+SELECT uuid_extract_timestamp('019526a0-7b3c-7def-8123-456789abcdef');
+```
+
+### uuidv7 vs uuid v4
+
+| Aspecto | uuid v4 | uuidv7 |
+|---------|---------|--------|
+| Orden | Aleatorio | Temporal (cronologico) |
+| Indice B-tree | Fragmentacion alta | Insert secuencial, mejor performance |
+| Timestamp | No incluye | Incluye (extraible) |
+| Colisiones | Improbable (122 bits) | Improbable (similar) |
+| Uso recomendado | Legacy | Nuevos proyectos |
+
+## Skip Scan
+
+Optimizacion de B-tree index que permite "saltar" valores en el indice:
+
+```sql
+-- Indice compuesto
+CREATE INDEX idx_orders_status_date ON orders (status, created_at);
+
+-- Antes (PG 17): Full index scan si no filtras por 'status'
+-- Ahora (PG 18): Skip scan salta valores unicos de 'status'
+SELECT * FROM orders WHERE created_at > '2025-01-01';
+-- Usa idx_orders_status_date eficientemente aunque no filtre por status
+```
+
+Util cuando la primera columna del indice tiene **baja cardinalidad** (pocos valores unicos).
+
+## RETURNING OLD/NEW
+
+Acceder a valores anteriores y nuevos en operaciones DML:
+
+```sql
+-- UPDATE con acceso a valores old y new
+UPDATE products SET price = price * 1.10
+WHERE category = 'electronics'
+RETURNING
+    id,
+    OLD.price AS precio_anterior,
+    NEW.price AS precio_nuevo;
+
+-- DELETE con valores eliminados
+DELETE FROM expired_sessions
+WHERE expires_at < now()
+RETURNING OLD.*;
+
+-- Util para auditing
+INSERT INTO audit_log (table_name, old_data, new_data)
+SELECT 'products', row_to_json(OLD.*), row_to_json(NEW.*)
+FROM (
+    UPDATE products SET price = price * 1.10
+    WHERE id = 1
+    RETURNING OLD.*, NEW.*
+) changes;
+```
+
+## OAuth 2.0 nativo
+
+Autenticacion con providers OAuth sin extensiones externas:
+
+```ini
+# pg_hba.conf
+# Autenticacion con OAuth 2.0 provider
+host all all 0.0.0.0/0 oauth issuer="https://accounts.google.com" scope="openid email"
+```
+
+```ini
+# postgresql.conf
+oauth_providers = 'google'
+oauth_provider_google_issuer = 'https://accounts.google.com'
+oauth_provider_google_client_id = 'your-client-id'
+oauth_provider_google_client_secret = 'your-client-secret'
+```
+
+## Breaking changes
+
+### PGDATA en Docker
+
+**Cambio critico**: La ruta de datos cambia en la imagen Docker oficial.
+
+| Version | PGDATA |
+|---------|--------|
+| PG 17 y anterior | `/var/lib/postgresql/data` |
+| PG 18 | `/var/lib/postgresql/18/docker` |
+
+**Impacto**: Volumenes existentes con `postgres:17` no funcionan directamente con `postgres:18`.
+
+```yaml
+# docker-compose.yml - CORRECTO para PG 18
+services:
+  db:
+    image: postgres:18-bookworm
+    volumes:
+      - pgdata:/var/lib/postgresql/18/docker  # nueva ruta
+    environment:
+      POSTGRES_PASSWORD: secret
+
+# Alternativa: forzar ruta antigua
+services:
+  db:
+    image: postgres:18-bookworm
+    environment:
+      PGDATA: /var/lib/postgresql/data  # override manual
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+```
+
+### Otras deprecaciones
+
+- `md5` authentication deprecado (usar `scram-sha-256`)
+- Data checksums habilitados por defecto
+- `password_encryption` default cambia a `scram-sha-256`
+
+## Configuracion recomendada (desarrollo)
+
+```ini
+# postgresql.conf - desarrollo local
+listen_addresses = '*'
+max_connections = 100
+shared_buffers = 256MB
+effective_cache_size = 768MB
+work_mem = 16MB
+maintenance_work_mem = 128MB
+
+# AIO
+io_method = worker
+
+# Logging
+log_statement = 'all'
+log_duration = on
+log_min_duration_statement = 100  # ms
+
+# Autenticacion
+password_encryption = 'scram-sha-256'
+```
+
+## psycopg3 connection
+
+```python
+import psycopg
+from psycopg.rows import dict_row
+
+# Conexion sincrona
+conn = psycopg.connect(
+    "host=localhost dbname=mydb user=postgres password=secret",
+    row_factory=dict_row,
+)
+
+# Conexion asincrona
+import asyncio
+
+async def query():
+    aconn = await psycopg.AsyncConnection.connect(
+        "host=localhost dbname=mydb user=postgres password=secret",
+        row_factory=dict_row,
+    )
+    async with aconn.cursor() as cur:
+        await cur.execute("SELECT * FROM products WHERE id = %s", [1])
+        row = await cur.fetchone()
+        return row
+
+# Connection pool
+from psycopg_pool import ConnectionPool
+
+pool = ConnectionPool(
+    "host=localhost dbname=mydb user=postgres password=secret",
+    min_size=4,
+    max_size=10,
+)
+with pool.connection() as conn:
+    conn.execute("SELECT 1")
+```
+
+---
+
+[Volver al indice](README.md) | [Siguiente: Django Integration](02-django-integration.md)

--- a/.claude/docs/postgresql-18/02-django-integration.md
+++ b/.claude/docs/postgresql-18/02-django-integration.md
@@ -1,0 +1,304 @@
+[Anterior: API Reference](01-api-reference.md) | [Volver al indice](README.md)
+
+# PostgreSQL 18 - Integracion con Django
+
+> Configuracion de Django 6 con PostgreSQL 18: psycopg3, UUIDv7, GeneratedField, full-text search y performance.
+
+## DATABASES config con psycopg3
+
+```python
+# settings.py
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.getenv("DB_NAME", "mydb"),
+        "USER": os.getenv("DB_USER", "postgres"),
+        "PASSWORD": os.getenv("DB_PASSWORD", ""),
+        "HOST": os.getenv("DB_HOST", "localhost"),
+        "PORT": os.getenv("DB_PORT", "5432"),
+        "OPTIONS": {
+            "pool": True,           # connection pooling nativo
+            "pool_min_size": 4,     # conexiones minimas en pool
+            "pool_max_size": 10,    # conexiones maximas en pool
+        },
+    }
+}
+```
+
+Django 6 auto-detecta psycopg3 si esta instalado. No requiere cambiar `ENGINE`.
+
+## psycopg3 vs psycopg2
+
+| Aspecto | psycopg2 | psycopg3 |
+|---------|----------|----------|
+| Paquete | `psycopg2-binary` | `psycopg[binary]` |
+| Python | 3.7+ | 3.8+ |
+| Async | No nativo | Nativo (`AsyncConnection`) |
+| Connection pool | Externo (pgbouncer) | Built-in |
+| COPY | `copy_expert()` | `copy()` con streaming |
+| Pipeline mode | No | Si (batch queries) |
+| Prepared statements | Limitado | Automatico |
+| Mantenimiento | Legacy (solo security fixes) | Activo |
+| Django support | Django 3.2+ | Django 4.2+ |
+| Recomendacion | Proyectos legacy | **Proyectos nuevos** |
+
+### Migracion psycopg2 a psycopg3
+
+```bash
+# 1. Cambiar dependencia
+uv remove psycopg2-binary
+uv add "psycopg[binary]>=3.2"
+
+# 2. No se necesitan cambios en settings.py (auto-detectado)
+# 3. Ejecutar tests para verificar
+pytest tests/ -v
+```
+
+## UUIDv7 como Primary Key
+
+### Custom field para Django
+
+```python
+# myapp/fields.py
+import uuid
+from django.db import models
+
+
+class UUIDv7Field(models.UUIDField):
+    """UUID v7 field que usa la funcion nativa de PostgreSQL 18."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("default", uuid.uuid7)  # Python 3.14+
+        kwargs.setdefault("editable", False)
+        kwargs.setdefault("unique", True)
+        super().__init__(*args, **kwargs)
+
+    def db_type(self, connection):
+        return "uuid"
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if value is None:
+            return None
+        return str(value)
+```
+
+### Alternativa con db_default (PostgreSQL nativo)
+
+```python
+from django.db import models
+from django.db.models.functions import Random
+
+class Event(models.Model):
+    # Usa uuidv7() de PostgreSQL 18 directamente
+    id = models.UUIDField(
+        primary_key=True,
+        db_default=models.Func(function="uuidv7"),
+    )
+    name = models.CharField(max_length=255)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["id"]  # uuidv7 es cronologico, ordering por id = ordering por tiempo
+```
+
+### Modelo base reutilizable
+
+```python
+# myapp/models/base.py
+from django.db import models
+
+
+class UUIDv7Model(models.Model):
+    """Modelo base con UUIDv7 como primary key."""
+
+    id = models.UUIDField(
+        primary_key=True,
+        db_default=models.Func(function="uuidv7"),
+        editable=False,
+    )
+
+    class Meta:
+        abstract = True
+
+
+# Uso
+class Product(UUIDv7Model):
+    name = models.CharField(max_length=255)
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+```
+
+## GeneratedField + Virtual Columns
+
+Django `GeneratedField` con PostgreSQL 18 virtual generated columns:
+
+```python
+from django.db import models
+
+class Invoice(models.Model):
+    subtotal = models.DecimalField(max_digits=10, decimal_places=2)
+    tax_rate = models.DecimalField(max_digits=4, decimal_places=2, default=0.19)
+
+    # Virtual: calculado al leer, no almacenado en disco
+    total = models.GeneratedField(
+        expression=models.F("subtotal") * (1 + models.F("tax_rate")),
+        output_field=models.DecimalField(max_digits=12, decimal_places=2),
+        db_persist=False,  # False = virtual (PG 18+), True = stored
+    )
+
+    # Stored: calculado al escribir, almacenado, indexable
+    search_text = models.GeneratedField(
+        expression=models.functions.Concat(
+            "customer_name", models.Value(" "), "invoice_number"
+        ),
+        output_field=models.CharField(max_length=500),
+        db_persist=True,  # stored = permite crear indice
+    )
+```
+
+| `db_persist` | Tipo | Almacenamiento | Indexable | PG minimo |
+|-------------|------|---------------|-----------|-----------|
+| `False` | Virtual | No | No | 18 |
+| `True` | Stored | Si | Si | 12 |
+
+**Auto-refresh en Django 6**: Despues de `save()`, los `GeneratedField` se refrescan automaticamente (sin necesidad de `refresh_from_db()`).
+
+## Full-Text Search con Lexeme
+
+```python
+from django.contrib.postgres.search import (
+    SearchVector,
+    SearchQuery,
+    SearchRank,
+    Lexeme,
+)
+
+# Busqueda basica
+results = Article.objects.annotate(
+    search=SearchVector("title", "body", config="spanish"),
+).filter(
+    search=SearchQuery("django postgresql", config="spanish"),
+)
+
+# Con ranking
+results = Article.objects.annotate(
+    search=SearchVector("title", weight="A") + SearchVector("body", weight="B"),
+    rank=SearchRank(
+        SearchVector("title", weight="A") + SearchVector("body", weight="B"),
+        SearchQuery("django"),
+    ),
+).filter(rank__gte=0.1).order_by("-rank")
+
+# Con Lexeme (nuevo en Django 6)
+query = SearchQuery(
+    Lexeme("python", weight="A", prefix=True)
+    & Lexeme("django", weight="B")
+)
+results = Article.objects.annotate(
+    search=SearchVector("title", "body"),
+).filter(search=query)
+```
+
+### Indice GIN para full-text search
+
+```python
+from django.contrib.postgres.indexes import GinIndex
+
+class Article(models.Model):
+    title = models.CharField(max_length=255)
+    body = models.TextField()
+
+    class Meta:
+        indexes = [
+            GinIndex(
+                SearchVector("title", "body", config="spanish"),
+                name="article_search_idx",
+            ),
+        ]
+```
+
+## Indices y Skip Scan
+
+```python
+from django.db import models
+
+class Order(models.Model):
+    status = models.CharField(max_length=20, db_index=True)  # baja cardinalidad
+    created_at = models.DateTimeField(auto_now_add=True)
+    total = models.DecimalField(max_digits=10, decimal_places=2)
+
+    class Meta:
+        indexes = [
+            # PG 18 skip scan optimiza queries que no filtran por 'status'
+            models.Index(fields=["status", "created_at"], name="idx_order_status_date"),
+
+            # BRIN para tablas grandes con datos cronologicos
+            # BrinIndex no existe en Django, usar raw SQL o RunSQL
+        ]
+```
+
+## Extensiones utiles
+
+```python
+# settings.py
+INSTALLED_APPS = [
+    "django.contrib.postgres",  # Requerido para features PG
+    # ...
+]
+```
+
+### Habilitar extensiones via migracion
+
+```python
+from django.contrib.postgres.operations import (
+    CreateExtension,
+    BloomExtension,
+    BtreeGinExtension,
+    TrigramExtension,
+)
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    operations = [
+        CreateExtension("pgcrypto"),       # Encriptacion
+        TrigramExtension(),                # pg_trgm para busqueda fuzzy
+        BtreeGinExtension(),               # btree_gin para indices compuestos
+        CreateExtension("hstore"),         # Key-value pairs
+    ]
+```
+
+| Extension | Uso | Django support |
+|-----------|-----|---------------|
+| `pgcrypto` | UUIDs, encriptacion | `CryptoExtension` |
+| `pg_trgm` | Busqueda fuzzy, similarity | `TrigramExtension` |
+| `btree_gin` | Indices GIN en columnas btree | `BtreeGinExtension` |
+| `hstore` | Key-value store | `HStoreExtension` |
+| `PostGIS` | Datos geograficos | `django.contrib.gis` |
+
+## Performance tips
+
+```python
+# 1. select_related para FK (JOIN)
+orders = Order.objects.select_related("customer", "product").all()
+
+# 2. prefetch_related para M2M (query separada)
+articles = Article.objects.prefetch_related("tags", "comments").all()
+
+# 3. only/defer para campos grandes
+products = Product.objects.only("id", "name", "price").all()
+
+# 4. iterator para datasets grandes
+for order in Order.objects.all().iterator(chunk_size=1000):
+    process(order)
+
+# 5. bulk operations
+Product.objects.bulk_create(products, batch_size=500)
+Product.objects.bulk_update(products, ["price", "stock"], batch_size=500)
+
+# 6. explain() para analizar queries
+qs = Product.objects.filter(price__gt=100)
+print(qs.explain(analyze=True, verbose=True))
+```
+
+---
+
+[Anterior: API Reference](01-api-reference.md) | [Volver al indice](README.md)

--- a/.claude/docs/postgresql-18/README.md
+++ b/.claude/docs/postgresql-18/README.md
@@ -1,0 +1,23 @@
+# PostgreSQL 18 - Referencia Tecnica
+
+> Motor de base de datos relacional con Asynchronous I/O, virtual generated columns, uuidv7() y OAuth 2.0 nativo.
+
+## Contenido
+
+| Tema | Archivo | Cuando leer |
+|------|---------|-------------|
+| Features y configuracion | [01-api-reference.md](01-api-reference.md) | AIO, uuidv7, virtual columns, skip scan, RETURNING OLD/NEW, config |
+| Integracion con Django | [02-django-integration.md](02-django-integration.md) | psycopg3, UUIDv7Field, GeneratedField, full-text search, performance |
+
+## Reglas criticas
+
+- SIEMPRE usar psycopg3 (`psycopg[binary]`) para proyectos nuevos con Django
+- SIEMPRE verificar ruta `PGDATA` en Docker (cambio breaking en PostgreSQL 18)
+- SIEMPRE usar `uuidv7()` en lugar de `uuid_generate_v4()` para PKs (ordenables temporalmente)
+- SIEMPRE usar `scram-sha-256` para autenticacion (md5 deprecado)
+- NUNCA usar `PGDATA=/var/lib/postgresql/data` sin subpath en Docker (conflicto con mount)
+- PREFERIR virtual generated columns sobre triggers para campos calculados
+
+## Navegacion
+
+Contexto padre: [CLAUDE.md](../../../CLAUDE.md)

--- a/.claude/docs/skills/django-6.md
+++ b/.claude/docs/skills/django-6.md
@@ -1,0 +1,36 @@
+# django-6 - keywords extendidos
+
+Lista exhaustiva de keywords (EN+ES) que activan esta skill.
+La descripcion principal en `SKILL.md` solo lista los mas comunes
+para mantenerla bajo 500 chars. Esta es la lista completa.
+
+## Keywords en ingles
+
+- `@task decorator`
+- `AsyncPaginator`
+- `CSP middleware`
+- `GeneratedField`
+- `Lexeme`
+- `background tasks django`
+- `django`
+- `django 6`
+- `django async`
+- `django docs`
+- `django email`
+- `django project`
+- `django settings`
+- `django setup`
+- `django task`
+- `django6`
+- `full-text search django`
+- `template partials`
+
+## Keywords en espanol
+
+- `como configurar django`
+- `documentacion django`
+- `referencia django`
+
+## Como usar este archivo
+
+Si Claude Code no esta invocando esta skill cuando deberia, verificar que el termino del usuario aparezca aqui. Si falta, agregarlo y opcionalmente promoverlo a la lista de SKILL.md (respetando el limite de 500 chars).

--- a/.claude/docs/skills/django-admin.md
+++ b/.claude/docs/skills/django-admin.md
@@ -1,0 +1,42 @@
+# django-admin - keywords extendidos
+
+Lista exhaustiva de keywords (EN+ES) que activan esta skill.
+La descripcion principal en `SKILL.md` solo lista los mas comunes
+para mantenerla bajo 500 chars. Esta es la lista completa.
+
+## Keywords en ingles
+
+- `admin action`
+- `admin custom`
+- `admin fieldset`
+- `admin filter`
+- `admin form`
+- `admin inline`
+- `admin javascript`
+- `admin js`
+- `admin mixin`
+- `admin performance`
+- `admin permissions`
+- `admin reusable`
+- `admin security`
+- `admin template`
+- `admin view`
+- `admin widget`
+- `advanced admin`
+- `custom admin`
+- `django admin`
+- `dynamic admin`
+- `improve admin`
+- `scalable admin`
+
+## Keywords en espanol
+
+- `admin avanzado`
+- `admin dinamico`
+- `admin escalable`
+- `admin reusable`
+- `mejorar admin`
+
+## Como usar este archivo
+
+Si Claude Code no esta invocando esta skill cuando deberia, verificar que el termino del usuario aparezca aqui. Si falta, agregarlo y opcionalmente promoverlo a la lista de SKILL.md (respetando el limite de 500 chars).

--- a/.claude/docs/skills/django-performance.md
+++ b/.claude/docs/skills/django-performance.md
@@ -1,0 +1,42 @@
+# django-performance - keywords extendidos
+
+Lista exhaustiva de keywords (EN+ES) que activan esta skill.
+La descripcion principal en `SKILL.md` solo lista los mas comunes
+para mantenerla bajo 500 chars. Esta es la lista completa.
+
+## Keywords en ingles
+
+- `EXPLAIN`
+- `N+1`
+- `cache`
+- `database performance`
+- `index`
+- `n plus one`
+- `optimize`
+- `performance`
+- `prefetch_related`
+- `profiling`
+- `query count`
+- `query optimization`
+- `select_related`
+- `slow`
+- `slow query`
+- `too many queries`
+
+## Keywords en espanol
+
+- `como optimizo`
+- `documentame select_related`
+- `explicame N+1`
+- `indice`
+- `lento`
+- `muchas queries`
+- `optimizacion de queries`
+- `optimizar`
+- `que patron uso para`
+- `query lenta`
+- `rendimiento`
+
+## Como usar este archivo
+
+Si Claude Code no esta invocando esta skill cuando deberia, verificar que el termino del usuario aparezca aqui. Si falta, agregarlo y opcionalmente promoverlo a la lista de SKILL.md (respetando el limite de 500 chars).

--- a/.claude/docs/skills/docker-django.md
+++ b/.claude/docs/skills/docker-django.md
@@ -1,0 +1,38 @@
+# docker-django - keywords extendidos
+
+Lista exhaustiva de keywords (EN+ES) que activan esta skill.
+La descripcion principal en `SKILL.md` solo lista los mas comunes
+para mantenerla bajo 500 chars. Esta es la lista completa.
+
+## Keywords en ingles
+
+- `compose`
+- `compose.yml`
+- `container`
+- `containerize`
+- `docker`
+- `docker compose`
+- `docker dev`
+- `docker django`
+- `docker health check`
+- `docker image`
+- `docker postgres`
+- `docker production`
+- `docker secrets`
+- `docker setup`
+- `docker volume`
+- `dockerfile`
+- `multi-stage build`
+
+## Keywords en espanol
+
+- `como dockerizar`
+- `containerizar`
+- `contenedor`
+- `dockerizar django`
+- `documentacion docker`
+- `referencia docker`
+
+## Como usar este archivo
+
+Si Claude Code no esta invocando esta skill cuando deberia, verificar que el termino del usuario aparezca aqui. Si falta, agregarlo y opcionalmente promoverlo a la lista de SKILL.md (respetando el limite de 500 chars).

--- a/.claude/docs/skills/next-django-integration.md
+++ b/.claude/docs/skills/next-django-integration.md
@@ -1,0 +1,32 @@
+# next-django-integration - keywords extendidos
+
+Lista exhaustiva de keywords (EN+ES) que activan esta skill.
+La descripcion principal en `SKILL.md` solo lista los mas comunes
+para mantenerla bajo 500 chars. Esta es la lista completa.
+
+## Keywords en ingles
+
+- `api client`
+- `auth cookie`
+- `backend api`
+- `cors next django`
+- `django integration`
+- `drf token`
+- `fetch django`
+- `httpOnly`
+- `lib/api-client`
+- `next-django`
+- `proxy.ts`
+
+## Keywords en espanol
+
+- `cliente api`
+- `cookie autenticacion`
+- `integracion django`
+- `next con django`
+- `proxy auth`
+- `token drf`
+
+## Como usar este archivo
+
+Si Claude Code no esta invocando esta skill cuando deberia, verificar que el termino del usuario aparezca aqui. Si falta, agregarlo y opcionalmente promoverlo a la lista de SKILL.md (respetando el limite de 500 chars).

--- a/.claude/docs/skills/postgresql-18.md
+++ b/.claude/docs/skills/postgresql-18.md
@@ -1,0 +1,37 @@
+# postgresql-18 - keywords extendidos
+
+Lista exhaustiva de keywords (EN+ES) que activan esta skill.
+La descripcion principal en `SKILL.md` solo lista los mas comunes
+para mantenerla bajo 500 chars. Esta es la lista completa.
+
+## Keywords en ingles
+
+- `AIO`
+- `RETURNING OLD NEW`
+- `async io postgres`
+- `database`
+- `django postgres`
+- `django postgresql`
+- `pg config`
+- `pg18`
+- `postgres`
+- `postgres 18`
+- `postgresql`
+- `postgresql 18`
+- `postgresql config`
+- `psycopg`
+- `psycopg3`
+- `skip scan`
+- `uuidv7`
+- `virtual generated columns`
+
+## Keywords en espanol
+
+- `base de datos`
+- `como configurar postgres`
+- `documentacion postgres`
+- `referencia postgres`
+
+## Como usar este archivo
+
+Si Claude Code no esta invocando esta skill cuando deberia, verificar que el termino del usuario aparezca aqui. Si falta, agregarlo y opcionalmente promoverlo a la lista de SKILL.md (respetando el limite de 500 chars).

--- a/.claude/docs/templates/server-architecture-from-mvp-template/README.md
+++ b/.claude/docs/templates/server-architecture-from-mvp-template/README.md
@@ -1,0 +1,46 @@
+---
+name: server-architecture
+description: >
+  Complete reference for Django 6 server architecture (config, settings, apps,
+  models, providers, workflows, tasks, storage). ALWAYS invoke when user needs
+  server structure or model fields before implementing features. Triggers:
+  "server", "arquitectura", "modelos", "apps", "django apps", "contexto del
+  server", "que apps hay", "model relationships", "fields", "modulos del
+  proyecto". More keywords: .claude/docs/skills/server-architecture.md
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "seccion: overview | config | all"
+metadata:
+  version: "1.0"
+---
+
+# Server Architecture - Referencia Completa
+
+## Navegacion por argumento
+
+El usuario puede invocar `/server-architecture <seccion>` para cargar contexto especifico.
+
+### Si el argumento es "overview" o no hay argumento:
+
+LEE el indice general:
+- [.claude/docs/server-architecture/README.md](.claude/docs/server-architecture/README.md)
+
+Presenta el resumen del server, las apps, conteo de modelos, y relaciones entre apps.
+
+### Si el argumento es "config" o "common" o "settings" o "enums":
+
+LEE la configuracion y modelos base:
+- [.claude/docs/server-architecture/01-config-common.md](.claude/docs/server-architecture/01-config-common.md)
+
+Cubre: settings (base/dev/prod/test), URLs, WSGI/ASGI, UUIDv7Model, TimestampedModel, enums, seed_db command.
+
+### Si el argumento es "all":
+
+LEE TODOS los archivos en orden:
+1. [.claude/docs/server-architecture/README.md](.claude/docs/server-architecture/README.md)
+2. [.claude/docs/server-architecture/01-config-common.md](.claude/docs/server-architecture/01-config-common.md)
+
+## Respuesta
+
+Despues de leer los docs relevantes, responde la pregunta del usuario con informacion precisa basada en la documentacion.
+Si necesitas verificar el estado actual del codigo (campos exactos, nuevos archivos), usa Glob/Grep/Read directamente en `server/`.

--- a/.claude/docs/templates/server-architecture-from-mvp-template/docs/01-config-common.md
+++ b/.claude/docs/templates/server-architecture-from-mvp-template/docs/01-config-common.md
@@ -1,0 +1,116 @@
+# Config y Common - Settings, modelos base, enums
+
+[Volver al indice](README.md)
+
+> Configuracion Django y modelos base compartidos.
+
+## Settings (config/settings/)
+
+| Archivo | Proposito |
+|---------|-----------|
+| `base.py` | Settings comunes: INSTALLED_APPS, MIDDLEWARE, AUTH_USER_MODEL, DATABASES, REST_FRAMEWORK |
+| `dev.py` | Override para desarrollo: DEBUG=True, CORS abierto, logging verbose |
+| `prod.py` | Override para produccion: SECURE_SSL_REDIRECT, HSTS, cookies seguras |
+| `test.py` | Override para pytest: SQLite in-memory, password hashers rapidos |
+
+### Settings clave
+
+```python
+# base.py
+INSTALLED_APPS = [
+    # Django core
+    'django.contrib.admin', ..., 'django.contrib.staticfiles',
+    # Third party
+    'rest_framework',
+    'rest_framework.authtoken',
+    'corsheaders',
+    'django_json_widget',
+    # Project
+    'common',           # Necesario para management commands
+    'apps.accounts',    # User custom
+    'apps.items',       # Recurso ejemplo
+    'apps.api',         # Router central
+]
+
+AUTH_USER_MODEL = 'accounts.User'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.TokenAuthentication'],
+    'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
+}
+```
+
+### URLs (config/urls.py)
+
+- `/admin/` — Django admin
+- `/api/v1/` — Router DRF (incluye apps con namespace)
+
+## Modelos base (common/models.py)
+
+### TimestampedModel
+
+```python
+class TimestampedModel(models.Model):
+    """Abstract base model with UUIDv7 PK and timestamps."""
+
+    id = models.UUIDField(
+        primary_key=True,
+        default=uuid.uuid4,
+        editable=False,
+        db_default=models.Func(function='uuidv7'),  # PG18 nativo
+    )
+    created_at = models.DateTimeField(db_default=Now())
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+        ordering = ['-created_at']
+```
+
+**TODOS los modelos del proyecto heredan de TimestampedModel**, no de `models.Model` directamente.
+
+## Excepciones base (common/exceptions.py)
+
+```python
+class ApplicationError(Exception):
+    def __init__(self, message: str = '', extra: dict | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.extra = extra or {}
+```
+
+Cada app define excepciones propias heredando: `class ProductNotFoundError(ApplicationError): ...`
+
+## Enums compartidos (common/enums.py)
+
+Enums que aplican a multiples apps van aqui. Ejemplo: estados globales, roles de usuario.
+
+## Management commands (common/management/commands/)
+
+### seed_db
+
+Carga fixtures con merge por ambiente.
+
+```bash
+# Carga fixtures default + overrides del ambiente
+python devtools/run.py docker exec python manage.py seed_db --env=local
+python devtools/run.py docker exec python manage.py seed_db --env=local --clear  # reset primero
+```
+
+Estructura de fixtures:
+- `fixtures/default/*.json` — datos iniciales (14 archivos con prefijo numerico)
+- `fixtures/local/*.json` — overrides para ambiente local
+- `fixtures/test/*.json` — overrides para tests
+
+Resolucion: por natural keys (e.g., User por email, Item por nombre).
+
+## Reglas criticas
+
+1. SIEMPRE heredar de `TimestampedModel`, nunca de `models.Model` directo
+2. ForeignKey a User: SIEMPRE via `settings.AUTH_USER_MODEL`
+3. Django 6: `CheckConstraint(condition=...)` (NO `check=` que fue removido)
+4. `db_default=Func(function='uuidv7')` para UUIDv7 nativo PG18
+5. Excepciones de dominio heredan de `common.exceptions.ApplicationError`
+6. Settings sensibles SIEMPRE desde env vars (`os.environ.get(...)`)
+
+[Volver al indice](README.md)

--- a/.claude/docs/templates/server-architecture-from-mvp-template/docs/README.md
+++ b/.claude/docs/templates/server-architecture-from-mvp-template/docs/README.md
@@ -1,0 +1,61 @@
+# Server Architecture - Indice
+
+> Referencia completa del Django 6 server en `server/`. Apps, modelos, providers, workflows y storage.
+
+## Cuando leer cada capitulo
+
+| Capitulo | Cuando leer |
+|----------|-------------|
+| [01-config-common.md](01-config-common.md) | Buscar settings, modelos base, enums compartidos, seed_db, paths |
+
+## Arquitectura del server (overview)
+
+```
+server/
+├── config/                   # Settings (base, dev, prod, test), URLs, WSGI/ASGI
+├── common/                   # Modelos base, enums, utilities, management commands
+│   ├── models.py             # TimestampedModel (UUIDv7 PK + timestamps)
+│   ├── enums.py              # Enums compartidos
+│   ├── exceptions.py         # ApplicationError base
+│   └── management/commands/  # seed_db
+├── apps/                     # Apps Django del dominio
+│   ├── accounts/             # User model (custom AbstractUser + email login)
+│   ├── items/                # Item model con Status/Category enums
+│   └── api/                  # Router central /api/v1/
+└── tests/                    # pytest infrastructure (unit + integration)
+```
+
+## Apps registradas
+
+| App | Modelos principales | Descripcion |
+|-----|---------------------|-------------|
+| `accounts` | `User` (extends AbstractUser + TimestampedModel) | Autenticacion por email |
+| `items` | `Item` (status: DRAFT/ACTIVE/ARCHIVED; category: GENERAL/TECHNOLOGY/BUSINESS/DESIGN) | Recurso de ejemplo del template |
+| `api` | (sin modelos) | Router DRF central, expone `/api/v1/<app>/` |
+| `common` | (abstract: TimestampedModel) | Modelos base, management commands |
+
+## Patron de cada app
+
+```
+apps/<nombre>/
+├── models/         # Un modelo por archivo
+├── services/       # Logica de escritura (keyword-only args con *)
+├── selectors/      # Logica de lectura (retornan QuerySet)
+├── admin/          # Un admin class por archivo
+├── serializers/    # input.py (validacion) y output.py (respuesta)
+├── views/          # Thin views: delegan a services/selectors
+├── exceptions.py   # Custom exceptions heredando de ApplicationError
+└── urls.py         # URL patterns de la app
+```
+
+## Reglas criticas
+
+- TODOS los modelos heredan de `common.models.TimestampedModel` (UUIDv7 PK)
+- Services usan keyword-only args: `def create_x(*, user, name, ...)`
+- Selectors NUNCA escriben — solo retornan QuerySet
+- ForeignKey a User SIEMPRE via `settings.AUTH_USER_MODEL`
+- Django 6: CheckConstraint usa `condition=` (NO `check=`)
+
+## Navegacion
+
+- [01-config-common.md](01-config-common.md) — Settings, modelos base, enums, seed_db

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,0 +1,127 @@
+---
+description: "Estandares de base de datos PostgreSQL 18 con Django 6: modelos, constraints, indexes, migrations, QuerySets y prevencion de N+1"
+globs: "server/apps/*/models/**/*.py,server/apps/*/migrations/*.py"
+---
+
+# Database Standards - Rezebra
+
+> Reglas para PostgreSQL 18 con Django 6 ORM.
+
+## Modelos base
+
+- SIEMPRE heredar de `TimestampedModel` (UUIDv7 PK + created_at + updated_at)
+- PK via `db_default=Func(function='uuidv7')` (PostgreSQL 18 nativo)
+- NUNCA usar UUID4 manual ni IDs secuenciales
+- ForeignKey a User: usar `settings.AUTH_USER_MODEL`
+- `db_default` para defaults a nivel de base de datos (mejor integridad)
+
+## Constraints (CRITICO)
+
+- Django 6: `CheckConstraint` usa `condition=` (NO `check=`)
+- UniqueConstraint con `name` descriptivo: `uq_<modelo>_<campos>`
+- CheckConstraint con `name`: `ck_<modelo>_<logica>`
+- Preferir constraints a nivel de DB sobre validacion solo en Python
+
+```python
+# Ejemplo: Appointment sin solapamiento para mismo staff
+constraints = [
+    models.UniqueConstraint(
+        fields=['business', 'staff', 'start'],
+        name='uq_appointment_business_staff_start',
+    ),
+    models.CheckConstraint(
+        condition=Q(price_amount_cents__gte=0),
+        name='ck_appointment_non_negative_price',
+    ),
+]
+```
+
+## Indexes
+
+- Index en campos usados frecuentemente en WHERE/ORDER BY
+- Partial indexes con `condition=` para filtros comunes
+- GIN indexes para JSONField y full-text search
+- Index en `created_at` viene automatico de TimestampedModel
+
+```python
+indexes = [
+    # Citas activas por negocio + fecha: patron de consulta mas frecuente
+    models.Index(fields=['business', 'start', 'status']),
+    models.Index(
+        fields=['business', 'staff', 'start'],
+        condition=Q(status__in=['CONFIRMED', 'PENDING']),
+        name='ix_appointment_active_by_staff',
+    ),
+]
+```
+
+## QuerySets custom
+
+- Definir QuerySet custom para filtros reutilizables
+- Usar `as_manager()` para registrar como manager
+
+```python
+class AppointmentQuerySet(models.QuerySet):
+    def active(self):
+        return self.exclude(status=AppointmentStatus.CANCELLED)
+
+    def for_business(self, business):
+        return self.filter(business=business)
+
+class Appointment(TimestampedModel):
+    objects = AppointmentQuerySet.as_manager()
+```
+
+## SELECT FOR UPDATE SKIP LOCKED (reserva atomica de slots)
+
+Para crear citas sin race conditions, usar `select_for_update(skip_locked=True)`
+dentro de `@transaction.atomic`:
+
+```python
+@transaction.atomic
+def reserve_slot(*, business, staff, start, end):
+    conflict = (
+        Appointment.objects
+        .select_for_update(skip_locked=True)
+        .filter(
+            business=business,
+            staff=staff,
+            status__in=['CONFIRMED', 'PENDING'],
+            start__lt=end,
+            end__gt=start,
+        )
+        .exists()
+    )
+    if conflict:
+        raise SlotTakenError("El slot ya fue reservado", extra={'start': str(start)})
+```
+
+## Prevencion de N+1 (CRITICO)
+
+- `select_related()` para FK y OneToOne (JOIN en SQL)
+- `prefetch_related()` para M2M y reverse FK (query separada)
+- Aplicar en selectors, NUNCA en views
+- `.exists()` en vez de `.count() > 0`
+- `.only()`/`.defer()` para modelos con muchos campos
+- `F()` expressions para updates atomicos
+- `bulk_create()`/`bulk_update()` con `batch_size` para operaciones masivas
+
+## Natural keys (fixtures)
+
+- Implementar `natural_key()` en modelos que se cargan via fixtures
+- Retornar tupla con campo(s) unico(s): `return (self.name,)`
+- Fixture resolution: FK fields resueltos por nombre natural
+
+## Migrations
+
+- Auto-generadas via `makemigrations` — NUNCA editar SQL manualmente
+- Seeds via `RunPython` en migrations numeradas (0002_seed_*)
+- Seeds SIEMPRE reversibles (reverse function que borra lo insertado)
+- Usar `apps.get_model()` en migrations, no imports directos
+- Despues de crear/modificar: `python devtools/run.py docker migrate`
+
+## GeneratedField (PG18)
+
+- `GeneratedField(db_persist=False)` para columnas virtuales
+- Ideal para campos derivados que no necesitan almacenamiento
+- Evita inconsistencias entre campo calculado y datos base

--- a/.claude/rules/devtools.md
+++ b/.claude/rules/devtools.md
@@ -1,0 +1,78 @@
+---
+description: "Estandares para scripts de desarrollo en devtools/: estructura de scripts, flags pattern, ruff config separado, sin Django"
+globs: "devtools/**/*.py"
+---
+
+# Devtools Development Standards
+
+> Reglas para scripts de desarrollo en devtools/.
+
+## Estructura
+
+- Entry point unico: `devtools/run.py` (plugin loader dinamico)
+- Cada script es un paquete: `devtools/<nombre>/`
+- Archivos obligatorios por script: `main.py` (logica) + `flags.py` (validacion) + `README.md`
+- Utilidades compartidas en `devtools/shared/` y `devtools/utils/`
+- Scripts disponibles: `scan`, `docker`, `test_runner`, `verify`, `hooks`,
+  `e2e`, `init`, `upgrade_deps`
+- Modulos por script max 300 lineas — partir por dominio cuando crece
+  (ver `docker/`, `scan/`, `test_runner/` como ejemplo)
+
+## API: posicional vs flags
+
+Convencion fija para que el CLI sea predecible:
+
+- **Scripts con multiples comandos discretos** (`docker` y futuros similares)
+  toman comando posicional: `docker up`, `docker shell`. El comando NO se
+  pasa como `--command=...`.
+- **Scripts mono-comando con parametrizacion** (`scan`, `test_runner`,
+  `verify`, `upgrade_deps`, `init`, `hooks`, `e2e`) usan SOLO flags. No
+  exponen subcomandos: el script es la unidad. Ej: `test_runner
+  --module=server --type=unit`.
+
+## Comando unico para tests
+
+Tests se corren via `python devtools/run.py test_runner [flags]`. El viejo
+`docker test` fue removido en 2026-05 (Fase 3 del refactor CLI). Si alguien
+lo invoca, `docker test` imprime un mensaje de migracion con equivalencias
+y exit 1. NUNCA se vuelve a anadir como atajo: una sola fuente de verdad.
+
+## Convenciones de codigo
+
+- Python 3.14 (se ejecuta en local via `devtools/.venv`, NO en Docker)
+- NUNCA importar Django — devtools es independiente del server
+- Ruff config propio: `devtools/ruff.toml` (autocontenido, sin extends, autodetectado cuando cwd=`/app/devtools/`)
+- Dependencias propias en `devtools/pyproject.toml` + `devtools/uv.lock` (gestionado por uv)
+- Bootstrap automatico: `devtools/run.py` ejecuta `uv sync --frozen --project devtools` la primera vez (o cuando el lockfile cambia) y se re-exec en `devtools/.venv/bin/python`
+- Type hints obligatorios en funciones publicas
+
+## Ruff config (devtools-specific)
+
+`devtools/ruff.toml` es un archivo autocontenido (sin `extend`). Contiene
+todas las reglas comunes mas estas particularidades de devtools:
+
+- `src = ["."]` (cwd es la raiz del modulo)
+- `per-file-target-version`: `devtools/run.py` y `.git-hooks/**/*.py` pinneados a `py313` (corren en Python del shell ANTES del re-exec a Python 3.14 del `.venv`)
+- Ignorados globales adicionales: `TRY003` (CLI tools usan mensajes descriptivos en excepciones — son la interfaz de usuario)
+- Per-file ignores: `**/*.py` ignora `T20` (`print()` es la interfaz de CLI) y `F401` (imports para re-export en `__init__.py` es comun)
+- Tests: `devtools/tests/**/*.py` ignora `S101`, `ANN001`/`201`/`202`, `PLR2004` (magic values en asserts), `INP001` (tests no necesitan `__init__.py`)
+- isort known-first-party: `scan`, `docker`, `test_runner`
+- isort known-third-party: `git` (GitPython)
+
+## Patron flags.py
+
+- Cada script define sus flags en `flags.py` con validacion
+- Retorna un dict tipado con los flags parseados
+- Validacion de combinaciones invalidas antes de ejecutar
+
+## Patron main.py
+
+- Funcion `main(flags: dict)` como entry point
+- Logging con modulo `logging`, nunca `print()` (excepto en CLI output donde `T20` esta ignorado)
+- Exit codes: 0 (ok), 1 (error de usuario), 2 (error interno)
+
+## Testing
+
+- Tests en `devtools/tests/` (si aplican)
+- Testear logica pura: parsing de flags, validaciones, transformaciones
+- Coverage y formatter obligatorios

--- a/.claude/rules/django.md
+++ b/.claude/rules/django.md
@@ -1,0 +1,289 @@
+---
+description: "Estandares Django 6 para server/: estructura de app, modelos thin, admin, providers, testing y seguridad"
+globs: "server/**/*.py"
+---
+
+# Django Development Standards - Rezebra
+
+> Reglas para el proyecto Django 6 en server/.
+
+## Estructura de app (OBLIGATORIO)
+
+> Reglas genericas de estructura de archivos y `__init__.py`: ver `python.md`. Aqui solo Django app structure.
+
+- Django project en `server/`, config en `server/config/`
+- Apps en `server/apps/<nombre>/`
+- Modelos base en `server/common/models.py` (UUIDv7Model, TimestampedModel)
+- Excepciones base en `server/common/exceptions.py` (ApplicationError)
+- Enums compartidos en `server/common/enums.py`
+- Archivos monoliticos (`models.py`, `admin.py`, `enums.py`, `services.py`) PROHIBIDOS — usar carpetas (`models/`, `admin/`, `enums/`, `services/`, `selectors/`, `tasks/`) con `__init__.py` que solo re-exporta
+
+### Estructura completa de una app
+
+```
+server/apps/<nombre>/
+├── models/                    # Un modelo por archivo
+│   ├── __init__.py            # Re-exports
+│   └── <model_name>.py       # Model + QuerySet + Manager
+├── services/                  # Logica de escritura (create, update, delete)
+│   ├── __init__.py
+│   └── <dominio>.py           # Funciones con keyword-only args (*)
+├── selectors/                 # Logica de lectura (get, list, filter)
+│   ├── __init__.py
+│   └── <dominio>_queries.py   # Retornan QuerySet, nunca escriben
+├── admin/                     # Un admin class por archivo
+│   ├── __init__.py
+│   └── <model_name>.py       # @admin.register(Model)
+├── serializers/               # DRF serializers
+│   ├── __init__.py
+│   ├── input.py               # Serializer puro para validacion
+│   └── output.py              # ModelSerializer read-only para respuesta
+├── views/                     # Thin views (delegan a services/selectors)
+│   ├── __init__.py
+│   └── <dominio>.py
+├── tasks/                     # Background tasks (thin wrappers de services)
+│   ├── __init__.py
+│   └── <dominio>.py
+├── enums/                     # TextChoices/IntegerChoices
+│   ├── __init__.py
+│   └── <nombre>.py
+├── migrations/
+├── urls.py
+├── apps.py
+├── constants.py               # Constantes de la app (UPPER_SNAKE_CASE)
+└── exceptions.py              # Excepciones custom heredando de ApplicationError
+```
+
+## Modelos (thin models)
+
+- SIEMPRE heredar de `TimestampedModel` (UUIDv7 PK + created_at/updated_at)
+- PKs son UUIDv7 nativo de PostgreSQL 18 via `db_default=Func(function="uuidv7")`
+- ForeignKey a User: usar `settings.AUTH_USER_MODEL`, no `User` directo
+- ForeignKey y M2M: SIEMPRE definir `related_name` explicito (ver abajo)
+- `db_default` para defaults a nivel de base de datos (mejor integridad)
+- Django 6: `CheckConstraint` usa `condition=` (no `check=` que fue removido)
+- JSONField para datos semi-estructurados
+- GeneratedField(db_persist=False) para columnas virtuales PG18
+
+### related_name (obligatorio en FK y M2M)
+
+Definir `related_name` explicito permite consultas reversas legibles desde el
+modelo padre. Si no se necesita relacion reversa, usar `related_name='+'` para
+que Django no la cree (ahorra memoria y evita ambiguedad).
+
+```python
+# Correcto
+class Appointment(TimestampedModel):
+    consumer = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='appointments',
+    )
+
+# Uso de la relacion reversa
+user.appointments.all()
+user.appointments.filter(status=AppointmentStatus.CONFIRMED)
+
+# Si no se necesita reversa
+class AuditLog(TimestampedModel):
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name='+',
+    )
+```
+
+### Que va en el modelo
+
+- Definicion de campos y `Meta` (constraints, indexes, ordering)
+- `__str__()` obligatorio
+- `clean()` para validacion a nivel de instancia
+- Propiedades simples calculadas (sin queries a DB)
+- Custom QuerySet y Manager
+
+### Que NO va en el modelo (va en services)
+
+- Logica de negocio compleja
+- Llamadas a APIs externas
+- Validaciones que involucran multiples modelos
+- Logica de notificaciones
+- Verificaciones de permisos
+
+### Custom QuerySet pattern
+
+```python
+from django.db import models
+
+class AppointmentQuerySet(models.QuerySet):
+    def active(self) -> AppointmentQuerySet:
+        return self.exclude(status=AppointmentStatus.CANCELLED)
+
+    def for_business(self, business: Business) -> AppointmentQuerySet:
+        return self.filter(business=business)
+
+    def with_related(self) -> AppointmentQuerySet:
+        return self.select_related('consumer', 'service', 'staff')
+
+class Appointment(TimestampedModel):
+    objects = AppointmentQuerySet.as_manager()
+```
+
+## QuerySet optimization (CRITICO)
+
+```python
+# SIEMPRE select_related para FK/OneToOne
+queryset.select_related('author', 'category')
+
+# SIEMPRE prefetch_related para M2M/reverse FK
+queryset.prefetch_related('tags', 'comments')
+
+# .exists() en vez de .count() > 0
+if queryset.exists(): ...
+
+# .only()/.defer() para modelos grandes
+queryset.only('id', 'title', 'created_at')
+
+# F() expressions para updates atomicos
+from django.db.models import F
+Model.objects.filter(pk=1).update(count=F('count') + 1)
+
+# bulk operations con batch_size
+Model.objects.bulk_create(objects, batch_size=1000)
+Model.objects.bulk_update(objects, ['field1'], batch_size=1000)
+```
+
+## Admin
+
+- `@admin.register(Model)` decorator en vez de `admin.site.register()`
+- SIEMPRE definir `list_display`, `list_filter`, `search_fields`
+- `readonly_fields` para campos computados/generados
+- `autocomplete_fields` para FK con muchas opciones
+- `list_select_related` para prevenir N+1 en lista
+- `fieldsets` para agrupacion organizada
+- Inlines para relaciones M2M through
+- **JSONField en admin SIEMPRE con `JSONEditorWidget`** de `django-json-widget` (NUNCA Textarea plano):
+
+```python
+from django.db import models
+from django_json_widget.widgets import JSONEditorWidget
+
+formfield_overrides = {
+    models.JSONField: {
+        'widget': JSONEditorWidget(
+            options={'mode': 'code', 'modes': ['code', 'tree']},
+        ),
+    },
+}
+```
+
+## Enums
+
+- Preferir `TextChoices` sobre `IntegerChoices` (legible en DB, auto-documentado)
+- `IntegerChoices` solo para columnas con millones de filas donde el rendimiento importa
+- Archivo unico `enums.py` si son 3 o menos enums simples
+- Carpeta `enums/` si son mas de 3 o tienen metodos custom
+
+## Background Tasks
+
+- Import de service functions DENTRO del body (evitar circular imports)
+- Tasks son wrappers thin de services, no logica directa
+- Retornar resultados serializables (dict, no model instances)
+
+## Signals
+
+- EVITAR signals cuando sea posible — preferir llamadas directas en services
+- Usar solo para: comunicacion cross-app sin circular deps, audit logging, cache invalidation
+- NUNCA para logica de negocio
+
+## Constants
+
+- Constantes de app en `constants.py` (no en models ni settings)
+- Constantes de proyecto en `common/constants.py`
+- Valores dependientes del entorno en settings (no en constants)
+
+## Migrations
+
+- `0001_initial` auto-generadas via `makemigrations`
+- Seeds via `RunPython` en migrations numeradas (0002_seed_*)
+- Seeds siempre reversibles (reverse function que borra lo insertado)
+- Usar `apps.get_model()` en migrations, no imports directos
+- **OBLIGATORIO**: Despues de crear/modificar migration, ejecutar `python devtools/run.py docker migrate --env=local`
+
+## Providers (Factory Pattern)
+
+- Base: `generation/providers/base.py` (BaseProvider ABC)
+- Adapters: archivos por proveedor (wrappean APIs externas)
+- Registry: `get_provider(name)` retorna el adapter correcto
+- NO instanciar clients directamente, siempre via factory
+- Dependency injection en services para testability
+
+## Testing
+
+- Infraestructura en `server/tests/` con unified runner
+- Ejecutar: `cd server && python tests/run.py --type unit|integration|feature`
+- pytest-django con `--import-mode=importlib`
+- pytest-bdd para feature tests con flujos cross-app (Gherkin opcional)
+- Settings de test: `config.settings.test` (SQLite in-memory)
+- Markers estrictos: `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.feature`, `@pytest.mark.slow`
+- factory-boy para fixtures (composable, explicito)
+- hypothesis para property-based testing en validaciones (RUT chileno, RUC peruano, slots de disponibilidad)
+- Mockear APIs externas (providers) en conftest.py
+- Testear services y selectors directamente (unit), views completas (integration), flujos negocio (feature con Gherkin si aplica)
+
+### BDD-style en docstring (obligatorio)
+
+Mantener AAA como estructura del cuerpo. El docstring describe el comportamiento
+en formato Given/When/Then. Convencion completa: ver `python.md` (seccion BDD-style)
+y `ai-testing-independence.md`.
+
+### Unit tests (path mirroring)
+
+- Ubicacion: `tests/unit/src/` espeja la estructura de `server/`
+- Archivos SIN prefijo `test_` (descubiertos via `pytest_collect_file` hook)
+- `pytestmark = pytest.mark.unit` obligatorio en cada archivo
+- Asserts EXACTOS (enforced por hook `weak_assertion`); ver `ai-testing-independence.md`
+
+### Integration tests (por seccion)
+
+- Ubicacion: `tests/integration/<seccion>/`
+- `pytestmark = pytest.mark.integration` obligatorio
+- Ejecutar seccion: `python tests/run.py --type integration --section generation`
+
+### Feature tests (pytest-bdd, opcional)
+
+- Ubicacion: `tests/feature/<dominio>/` (DRF APIClient + seed_db)
+- `pytestmark = pytest.mark.feature`
+- Para flujos que cruzan >= 2 apps, usar Gherkin:
+  - `tests/feature/<dominio>/features/<feature>.feature` (humano-redactado)
+  - `tests/feature/<dominio>/test_<feature>.py` (steps via `pytest_bdd.scenarios()`)
+- Para flujos atomicos en una sola app, AAA + docstring BDD del unit test es suficiente
+- Convenciones detalladas en `feature-tests.md`
+
+### Mutation testing (calidad de tests)
+
+Coverage 80% no demuestra que los tests maten bugs. Mutation testing si.
+
+```bash
+python devtools/run.py mutation_testing --paths=apps/appointments
+```
+
+Thresholds: 85% critical (`apps/appointments`, `apps/auth`), 70% standard,
+30% experimental. Config en `devtools/mutation_testing/config.py`. Pre-push step
+`mutation_testing` opt-in via `.git-hooks/config.json` (default off).
+
+## Docker
+
+- Desarrollo: `python devtools/run.py docker up --env=local`
+- Entrypoint ejecuta: makemigrations + migrate + collectstatic
+- Volumes bind-mount `server/` para hot-reload
+- PG18 con PGDATA custom en volume nombrado
+- Multi-ambiente: local (9976), test (9977); dockerfiles para dev y prod preparados
+
+## Seguridad
+
+- NUNCA `|safe` en templates a menos que sea absolutamente necesario
+- Validar TODO input de usuario en serializer/form layer
+- Produccion: `SECURE_SSL_REDIRECT=True`, `SESSION_COOKIE_SECURE=True`, `CSRF_COOKIE_SECURE=True`
+- NUNCA `CORS_ALLOW_ALL_ORIGINS=True` en produccion
+- Rate limiting para APIs publicas

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,0 +1,383 @@
+---
+description: "Estandares de desarrollo Python 3.14: estilo, estructura de archivos, services/selectors, testing y complejidad"
+globs: "**/*.py"
+---
+
+# Python Development Standards
+
+## Estilo
+
+- Python 3.14 estricto (target-version `py314` en Ruff). Excepciones de bootstrap (`devtools/run.py`, `.git-hooks/*.py`) pinneadas a `py313` via `per-file-target-version` para preservar sintaxis con parentesis en `except`.
+- Ruff como linter y formatter. Cada modulo lleva su propio `ruff.toml` autocontenido: `server/ruff.toml` (Django + Python 3.14) y `devtools/ruff.toml` (CLI + bootstrap py313). Sin base compartida: cada archivo declara reglas, ignores y formatter completos. Ruff los autodetecta cuando el cwd es la raiz del modulo.
+- line-length 80, indent 4, line-ending lf, single quotes (`flake8-quotes` + formatter), trailing commas habilitadas (no auto-agregadas — ver nota abajo).
+- Type hints requeridos en todas las funciones publicas (`ANN`).
+- NO usar `from __future__ import annotations` (PEP 649: Python 3.14 tiene lazy annotations nativo).
+- Usar union syntax moderna: `str | None` en vez de `Optional[str]`.
+- Type parameter syntax (PEP 695): `def first[T](items: list[T]) -> T:`.
+
+### Conflictos formatter vs linter (ignorados intencionalmente)
+
+Estas reglas estan en `ignore` del base porque chocan con el comportamiento del formatter:
+
+- `E501` (line too long): el formatter ya gestiona el corte de lineas
+- `E203` (whitespace before `:`): el formatter ya respeta PEP 8
+- `COM812` (missing trailing comma): conflicto con formatter — ver nota abajo
+- `COM819` (prohibited trailing comma): companion de COM812
+- `ISC001` (implicit string concat single-line): el formatter prefiere doble
+- `Q001` (multiline-quotes): el formatter prefiere comillas dobles en multilinea
+
+### Comillas: convencion semantica
+
+- **Single quotes (`'...'`)** para strings tecnicos: keys de dicts, valores de codigo, identificadores, paths, choices.
+- **Double quotes (`"..."`)** aceptables solo para texto legible por humanos: mensajes de error de usuario, mensajes de log, contenido para UI.
+- **Triple double quotes (`"""..."""`)** para docstrings y strings multilinea.
+
+```python
+# Correcto: distincion semantica clara
+record['status'] = 'pending'
+config = {'host': 'localhost', 'port': 9979}
+logger.error("No se pudo conectar al provider, reintentando")
+raise ValueError("El monto debe ser positivo")
+
+# Incorrecto: comilla doble en string tecnico
+record["status"] = "pending"
+```
+
+Ver `"..."` en el codigo deberia indicar "este string lo veria un humano".
+
+### Trailing commas (motivacion: minimizar git diff)
+
+La regla NO es estetica. Al agregar un item nuevo, solo aparece **una** linea
+modificada en el diff (la nueva), no dos (la nueva mas la coma agregada en la
+anterior).
+
+`COM812` esta en `ignore` (conflicto con formatter), pero el formatter respeta
+trailing commas existentes y `skip-magic-trailing-comma = false` permite que
+una trailing comma fuerce el wrap a multilinea. Resultado: las trailing commas
+se preservan al formatear, y el dev las agrega manualmente al escribir.
+
+```python
+# Correcto: agregar 'd' modifica solo 1 linea en el diff
+my_dict = {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+}
+
+# Incorrecto: agregar 'd' modifica 2 lineas
+my_dict = {
+    'a': 1,
+    'b': 2,
+    'c': 3
+}
+```
+
+### Tipado como auto-documentacion
+
+Los desarrolladores leen mas codigo del que escriben. La firma tipada de una
+funcion es la primera fuente de informacion para entender que hace, sin tener
+que leer el body o el docstring.
+
+```python
+# Mal: hay que leer el cuerpo para saber que retorna
+def fib(n):
+    a, b = 0, 1
+    while a < n:
+        yield a
+        a, b = b, a + b
+
+# Bien: la firma sola dice "iterador de int sobre n int"
+def fib(n: int) -> Iterator[int]:
+    a, b = 0, 1
+    while a < n:
+        yield a
+        a, b = b, a + b
+```
+
+Ruff `ANN` rules hacen enforce de annotations en funciones publicas.
+
+## Estructura de archivos (OBLIGATORIO)
+
+- Un archivo por clase/funcion principal, agrupados en carpetas por tipo
+- Archivos NO deben superar 300-500 lineas como maximo
+- Usar `__init__.py` para re-exportar los nombres publicos del modulo
+- `__init__.py` solo contiene imports y re-exports, NUNCA logica
+
+### Patron correcto (un archivo por entidad)
+
+```
+server/apps/<app_name>/
+├── models/
+│   ├── __init__.py          # from .appointment import Appointment; from .appointment_event import AppointmentEvent
+│   ├── appointment.py       # class Appointment + AppointmentQuerySet + AppointmentManager
+│   └── appointment_event.py # class AppointmentEvent
+├── services/
+│   ├── __init__.py          # re-exports
+│   ├── creation.py          # def create_appointment(*, business, consumer, service, staff, ...)
+│   └── update.py            # def cancel_appointment(*, appointment, actor, reason, ...)
+├── selectors/
+│   ├── __init__.py          # re-exports
+│   ├── appointment_queries.py  # def get_business_appointments(*, business, ...) -> QuerySet
+│   └── slot_queries.py         # def get_available_slots(*, business, service, staff, date, ...)
+├── admin/
+│   ├── __init__.py          # re-exports
+│   ├── appointment.py       # @admin.register(Appointment) class AppointmentAdmin
+│   └── appointment_event.py # @admin.register(AppointmentEvent) class AppointmentEventAdmin
+├── serializers/
+│   ├── __init__.py
+│   ├── input.py             # Serializers de validacion (Serializer puro, no ModelSerializer)
+│   └── output.py            # Serializers de respuesta (ModelSerializer read-only)
+├── enums/
+│   ├── __init__.py
+│   ├── status.py            # class AppointmentStatus(models.TextChoices)
+│   └── payment_status.py    # class PaymentStatus(models.TextChoices)
+├── tasks/
+│   ├── __init__.py
+│   └── reminders.py         # @shared_task def send_appointment_reminder(appointment_id)
+├── exceptions.py            # Custom exceptions de la app
+├── constants.py             # Constantes de la app (UPPER_SNAKE_CASE)
+├── urls.py
+└── apps.py
+```
+
+### Patron incorrecto (archivos monoliticos)
+
+```
+server/apps/<app_name>/
+├── models.py       # Todos los modelos en un solo archivo
+├── admin.py        # Todos los admins en un solo archivo
+├── services.py     # Toda la logica en un solo archivo
+├── enums.py        # Todos los enums en un solo archivo
+└── apps.py
+```
+
+### Reglas de division
+
+- Si un archivo supera 300 lineas, dividirlo inmediatamente
+- Cada modelo Django en su propio archivo dentro de `models/`
+- Cada admin class en su propio archivo dentro de `admin/`
+- Cada enum en su propio archivo dentro de `enums/`
+- Services, selectors, serializers, views, tasks: un archivo por dominio logico
+
+## Services y Selectors (patron obligatorio)
+
+### Services (operaciones de escritura)
+
+- Funciones, NO clases (a menos que se necesite estado complejo)
+- SIEMPRE usar `*` para forzar keyword-only arguments
+- Un service function = una operacion de negocio
+- Usar `@transaction.atomic` para operaciones multi-modelo
+- Retornar la instancia creada/actualizada
+- Lanzar excepciones custom para violaciones de reglas de negocio
+
+```python
+from django.db import transaction
+
+def create_appointment(
+    *,
+    business: Business,
+    consumer: User,
+    service: Service,
+    staff: StaffMember,
+    start: datetime,
+) -> Appointment:
+    appointment = Appointment(
+        business=business,
+        consumer=consumer,
+        service=service,
+        staff=staff,
+        start=start,
+        end=start + timedelta(minutes=service.duration_minutes),
+    )
+    appointment.full_clean()
+    appointment.save()
+    return appointment
+```
+
+### Selectors (operaciones de lectura)
+
+- Retornar `QuerySet` (permite encadenamiento) o tipos primitivos
+- NUNCA realizar escrituras
+- Aplicar `select_related`/`prefetch_related` aqui, no en views
+
+```python
+from django.db.models import QuerySet
+
+def get_business_appointments(
+    *,
+    business: Business,
+    active_only: bool = True,
+) -> QuerySet[Appointment]:
+    qs = Appointment.objects.filter(business=business)
+    if active_only:
+        qs = qs.exclude(status=AppointmentStatus.CANCELLED)
+    return qs.select_related('consumer', 'service', 'staff')
+```
+
+## Excepciones custom (patron obligatorio)
+
+```python
+# common/exceptions.py
+class ApplicationError(Exception):
+    def __init__(self, message: str = '', extra: dict | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.extra = extra or {}
+
+# apps/<app>/exceptions.py
+from common.exceptions import ApplicationError
+
+class BookingConflictError(ApplicationError): ...
+class SlotTakenError(ApplicationError): ...
+class BusinessNotActiveError(ApplicationError): ...
+class AppointmentNotCancellableError(ApplicationError): ...
+```
+
+- NUNCA usar `except:` o `except Exception:` sin re-raise
+- Usar `raise ... from e` para preservar cadena de excepciones
+- Manejar en la capa view/API, no dentro de services
+
+## Logging
+
+- NUNCA f-strings en llamadas a logging (rompe lazy evaluation)
+- Usar logging estructurado con contexto
+
+```python
+# Correcto
+logger.info('Record created', extra={'record_id': str(record.id)})
+logger.warning('Attempt %d failed: %s', attempt, error)
+
+# Incorrecto
+logger.info(f'Record created: {record.id}')
+```
+
+## Estructura de scripts
+
+- Incluir `if __name__ == "__main__":` en scripts ejecutables
+- Usar `logging` module, nunca `print()` para info de ejecucion
+
+## APIs externas
+
+- Retry con backoff exponencial para llamadas a APIs
+- Timeout explicito en todas las requests (default: 30s)
+- Validar respuestas antes de procesar
+- Nunca hardcodear API keys — usar `.env` con `python-dotenv`
+
+## Testing
+
+- Framework: pytest (+ `pytest-bdd` para feature tests del server)
+- Coverage minimo: 80% per-file (enforced en pre-push)
+- Patron AAA en el cuerpo + **BDD-style en el docstring** (Given/When/Then)
+- Un concepto de assertion por test (multiples `assert` ok si validan lo mismo)
+- factory-boy sobre fixtures para datos de test
+- Nomenclatura metodos: `test_<unit>_<scenario>_<expected>`
+- Nomenclatura archivos: SIN prefijo `test_` (path mirroring, descubiertos via hook)
+- `pytestmark = pytest.mark.unit` o `pytest.mark.integration` obligatorio por archivo
+- `@pytest.mark.parametrize` para multiples escenarios de input
+- Server: `cd server && python tests/run.py --type unit|integration`
+- Coverage: `python devtools/run.py test_runner --module=server --type=coverage`
+- Mutation testing (calidad de tests): `python devtools/run.py mutation_testing --paths=apps/<app>` (ver `ai-testing-independence.md`)
+
+### BDD-style obligatorio en el docstring
+
+Mantener AAA como estructura del cuerpo. El docstring describe el
+comportamiento en formato Given/When/Then — facilita lectura sin contexto
+IA y traza el test al AC humano.
+
+```python
+def test_create_appointment_when_slot_taken_raises_booking_conflict():
+    """
+    Given un negocio con un profesional que ya tiene cita a las 10:00,
+    When un consumer intenta reservar el mismo slot,
+    Then lanza BookingConflictError con codigo SLOT_TAKEN.
+    """
+    # Arrange
+    business = BusinessFactory.create()
+    staff = StaffMemberFactory.create(business=business)
+    service = ServiceFactory.create(business=business, duration_minutes=60)
+    start = datetime(2026, 6, 1, 10, 0, tzinfo=UTC)
+    AppointmentFactory.create(business=business, staff=staff, start=start)
+
+    # Act / Assert
+    with pytest.raises(BookingConflictError) as exc:
+        create_appointment(
+            business=business,
+            consumer=UserFactory.create(),
+            service=service,
+            staff=staff,
+            start=start,
+        )
+    assert exc.value.extra['code'] == 'SLOT_TAKEN'
+```
+
+### Asserts EXACTOS, no rangos (enforced en pre-commit)
+
+El hook `weak_assertion` (`.git-hooks/weak_assertion_detector.py`) rechaza
+asserts vagos en archivos de test staged. Reglas:
+
+```python
+# Rechazado:
+assert x > 0
+assert result is not None
+assert isinstance(result, dict)
+assert len(items) >= 1
+
+# Aceptado:
+assert x == 42
+assert result == {'status': 'ok'}
+assert items == [item1, item2]
+```
+
+Si necesitas range/type assertions justificadas, usar `# noqa: WEAK-ASSERT`
+inline (con razon en comentario).
+
+### Que mockear vs que no
+
+- MOCKEAR: APIs HTTP externas, email, file storage (S3), time/datetime
+- NO MOCKEAR: Base de datos, Django ORM, services/selectors propios, request/response Django
+
+### Property-based testing (Hypothesis)
+
+Para algoritmos puros + validaciones criticas (RUT chileno, RUC peruano,
+calculos de slots de disponibilidad), preferir `hypothesis` sobre tests
+parametrizados manuales. Es agnostico al modelo IA y deriva tests de los
+type hints.
+
+```python
+from hypothesis import given, strategies as st
+
+
+@given(duration=st.integers(min_value=15, max_value=240))
+def test_slot_end_is_consistent_with_duration(duration: int) -> None:
+    """
+    Property: el slot end = start + duration_minutes, para cualquier duracion valida.
+    Given una cita con duracion arbitraria,
+    When calcular el end,
+    Then end - start == duration en minutos.
+    """
+    start = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    slot = calculate_slot_end(start=start, duration_minutes=duration)
+    assert (slot - start).seconds // 60 == duration
+```
+
+### AI-testing independence
+
+Cualquier test (humano o AI-asistido) debe ser mantenible si la IA
+desaparece manana. Politica completa, workflow Three Amigos + AI, mutation
+testing thresholds (70% standard / 85% critical) y compliance EU AI Act:
+ver `ai-testing-independence.md`.
+
+## Complejidad
+
+- Max complejidad ciclomatica por funcion: 10 (enforced via Ruff C90)
+- Max argumentos posicionales: 5 (usar dataclasses/TypedDict para mas)
+- Max lineas por funcion: ~50 (soft limit)
+- No anidar try/except — extraer a funciones separadas
+
+## Dependencias
+
+- Server: `server/pyproject.toml` (PEP 621 `[project.dependencies]` para prod, PEP 735 `[dependency-groups.dev]` para test/lint) + `server/uv.lock`
+- Devtools: `devtools/pyproject.toml` (ruff, GitPython, httpx, pytest) + `devtools/uv.lock`
+- Pinear versiones exactas en produccion (`==X.Y.Z`); `>=` aceptable para tooling de devtools
+- Gestionar via uv: `uv add <pkg>` para agregar, `uv lock --upgrade-package <pkg>` para actualizar uno solo, `uv sync --frozen` para reproducir; `python devtools/run.py upgrade_deps --dry-run` para ver el cuadro completo de upgrades disponibles
+- En containers: `uv sync --frozen --no-install-project --no-dev` para prod; sin `--no-dev` para dev/local/test

--- a/.claude/skills/django-6/SKILL.md
+++ b/.claude/skills/django-6/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: django-6
+description: >
+  Django 6 documentation reference for Python web dev. ALWAYS invoke this skill
+  BEFORE answering ANY Django question, including questions that mention legacy
+  alternatives (Celery, django-rq, huey, dramatiq) or general async/background
+  tasks in Django. NEVER answer Django 6 questions from training data alone —
+  the docs contain version-specific changes that override generic knowledge.
+  Triggers: "django", "django 6", "django docs", "@task decorator",
+  "CSP middleware", "template partials", "AsyncPaginator", "GeneratedField",
+  "full-text search django", "como configurar django", "celery", "celery vs",
+  "django celery", "django background tasks", "django tasks framework",
+  "django async tasks", "tareas async django", "django-rq", "huey", "dramatiq".
+  More keywords: .claude/docs/skills/django-6.md
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "tema: api | tasks | todo"
+metadata:
+  version: "2.0"
+---
+
+# Django 6 - Documentacion de Referencia
+
+Lee la documentacion de Django 6 desde `.claude/docs/django-6/` y presenta la informacion relevante al usuario.
+
+## Instrucciones
+
+1. Determina que necesita el usuario segun su pregunta o el argumento proporcionado
+2. Lee los archivos correspondientes de la documentacion
+
+### Mapeo de temas a archivos
+
+| Argumento / Tema | Archivo a leer |
+|-----------------|----------------|
+| `api`, `reference`, `configuracion`, `settings`, `code`, `codigo`, `csp`, `email`, `async`, `lexeme`, `generated`, `deprecaciones`, `orm`, `migracion` | `.claude/docs/django-6/01-api-reference.md` |
+| `tasks`, `background`, `@task`, `enqueue`, `retry`, `tareas` | `.claude/docs/django-6/02-background-tasks.md` |
+| `todo`, `completo`, `all` | Todos los archivos |
+
+3. Si no hay argumento, lee el README: `.claude/docs/django-6/README.md` y presenta el indice
+4. Responde en espanol con terminos tecnicos en ingles
+5. Si el usuario pregunta algo especifico, busca en los archivos con Grep antes de leer todo
+
+## Ejecucion
+
+1. Lee `.claude/docs/django-6/README.md` para obtener el indice
+2. Segun el tema solicitado, lee el archivo correspondiente
+3. Presenta la informacion de forma concisa y directa
+4. Si el usuario necesita codigo, prioriza los ejemplos de codigo del archivo relevante

--- a/.claude/skills/django-admin/SKILL.md
+++ b/.claude/skills/django-admin/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: django-admin
+description: >
+  Django 6 admin customization docs (dynamic admin, JS, mixins, widgets,
+  inlines, performance, security). ALWAYS invoke for Django admin reference.
+  Triggers: "django admin", "admin custom", "admin dinamico", "admin
+  javascript", "admin mixin", "admin widget", "admin inline", "admin
+  permissions", "mejorar admin", "admin avanzado". More keywords:
+  .claude/docs/skills/django-admin.md
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "tema: dynamic | js | views | mixins | performance | widgets | libraries | all"
+metadata:
+  version: "1.0"
+---
+
+# Django Admin Avanzado - Documentacion de Referencia
+
+Lee la documentacion de Django Admin avanzado desde `.claude/docs/django-admin/` y presenta la informacion relevante al usuario.
+
+## Instrucciones
+
+1. Determina que necesita el usuario segun su pregunta o el argumento proporcionado
+2. Lee los archivos correspondientes de la documentacion
+
+### Mapeo de temas a archivos
+
+| Argumento / Tema | Archivo a leer |
+|-----------------|----------------|
+| `dynamic`, `dinamico`, `fieldsets`, `list_display`, `get_`, `conditional` | `.claude/docs/django-admin/01-dynamic-admin.md` |
+| `ts`, `typescript`, `vanilla`, `fetch`, `htmx`, `alpine`, `es modules`, `esbuild` | `.claude/docs/django-admin/02-typescript-moderno.md` |
+| `views`, `vistas`, `custom views`, `dashboard`, `get_urls`, `templates` | `.claude/docs/django-admin/03-custom-views-templates.md` |
+| `mixins`, `reusable`, `reutilizable`, `base class`, `patterns`, `escalable` | `.claude/docs/django-admin/04-reusable-patterns.md` |
+| `performance`, `security`, `seguridad`, `permissions`, `N+1`, `optimize` | `.claude/docs/django-admin/05-performance-security.md` |
+| `widgets`, `inlines`, `forms`, `formsets`, `sortable`, `nested` | `.claude/docs/django-admin/06-widgets-inlines-forms.md` |
+| `libraries`, `librerias`, `unfold`, `jazzmin`, `import-export`, `third-party` | `.claude/docs/django-admin/07-third-party-libraries.md` |
+| `all`, `todo`, `completo` | Todos los archivos en orden |
+
+3. Si no hay argumento, lee el README: `.claude/docs/django-admin/README.md` y presenta el indice
+4. Responde en espanol con terminos tecnicos en ingles
+5. Si el usuario pregunta algo especifico, busca en los archivos con Grep antes de leer todo
+6. Cuando muestres ejemplos de codigo, adaptalos al contexto del proyecto rezebra (TimestampedModel, UUIDv7, etc.)
+7. Para patrones JavaScript, SIEMPRE mostrar vanilla JS (NO jQuery) compatible con Django admin

--- a/.claude/skills/django-performance/SKILL.md
+++ b/.claude/skills/django-performance/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: django-performance
+description: >
+  DOC REFERENCE for Django ORM performance (N+1, select_related,
+  prefetch_related, indexes, EXPLAIN, PG18 UUIDv7/GIN/virtual). ALWAYS invoke
+  this skill BEFORE answering ANY ORM optimization question, including
+  questions framed only as "ORM" or "queryset" without mentioning Django
+  explicitly. NEVER answer ORM-perf questions from training data alone —
+  this project has consolidated patterns that override generic advice.
+  Use this (not db-optimizer agent) for documentation lookup; agent for
+  active profiling. Triggers: "performance", "rendimiento", "slow query",
+  "N+1", "n+1 queries", "N plus 1", "select_related", "prefetch_related",
+  "diferencia select_related prefetch_related", "EXPLAIN", "EXPLAIN ANALYZE",
+  "query plan", "query optimization", "queries lentas", "queryset
+  optimization", "demasiadas queries", "too many queries", "django orm",
+  "orm performance", "ORM lento", "GIN index django", "django index".
+  More keywords: .claude/docs/skills/django-performance.md
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "scope: full | app-name | file-path"
+metadata:
+  version: "1.1"
+---
+
+# Django Performance - Optimizacion ORM
+
+Analisis y optimizacion de queries Django para rezebra (PostgreSQL 18).
+
+## Workflow
+
+### Paso 1: Identificar scope
+
+- `full`: Analizar todos los selectors y views en `server/apps/*/`
+- `<app-name>`: Solo una app
+- `<file-path>`: Solo un archivo especifico
+
+### Paso 2: Buscar selectors y views
+
+```
+Glob: server/apps/*/selectors/*.py
+Glob: server/apps/*/views/*.py
+Glob: server/apps/*/services/*.py
+```
+
+### Paso 3: Analizar patrones problematicos
+
+#### N+1 Queries (CRITICO)
+
+Buscar loops que acceden a relaciones FK sin prefetch:
+
+```python
+# MAL — N+1: 1 query por record + 1 por cada related
+for record in Record.objects.all():
+    items = record.related_items.all()  # N queries extra
+
+# BIEN — 2 queries total
+records = Record.objects.prefetch_related("related_items").all()
+for record in records:
+    items = record.related_items.all()  # Ya en cache
+```
+
+#### select_related faltante (FK directas)
+
+```python
+# MAL — N+1 en FK
+items = Item.objects.all()
+for item in items:
+    print(item.owner.name)  # Query extra por cada item
+
+# BIEN — JOIN en una query
+items = Item.objects.select_related("owner").all()
+```
+
+#### QuerySets sin limites
+
+```python
+# MAL — carga toda la tabla en memoria
+all_items = Item.objects.all()
+
+# BIEN — paginado o limitado
+recent_items = Item.objects.order_by("-created_at")[:50]
+```
+
+#### Indices faltantes
+
+Verificar campos usados en `filter()`, `order_by()`, `exclude()`:
+
+```python
+# Si se filtra frecuentemente por status + provider:
+class Meta:
+    indexes = [
+        models.Index(fields=["status", "provider"]),
+    ]
+```
+
+### Paso 4: Generar reporte
+
+```markdown
+## Performance Analysis: [scope]
+
+### N+1 Queries detectados
+| Archivo | Linea | Relacion | Fix |
+|---------|-------|----------|-----|
+
+### select_related/prefetch_related faltantes
+| Archivo | Linea | Campo FK | Fix |
+|---------|-------|----------|-----|
+
+### Indices recomendados
+| Modelo | Campos | Razon |
+|--------|--------|-------|
+
+### QuerySets sin limites
+| Archivo | Linea | Fix |
+|---------|-------|-----|
+
+### Oportunidades de cache
+| Dato | TTL sugerido | Razon |
+|------|-------------|-------|
+```
+
+## Reglas
+
+- SIEMPRE leer el codigo fuente antes de sugerir optimizaciones
+- SIEMPRE verificar que la relacion existe en el modelo antes de sugerir select_related
+- NUNCA sugerir `select_related` para relaciones M2M (usar `prefetch_related`)
+- NUNCA sugerir cache para datos que cambian frecuentemente sin TTL corto
+- Priorizar: N+1 > select_related > indices > cache
+- Para `Prefetch` objects complejos, verificar que el queryset base es eficiente

--- a/.claude/skills/docker-django/SKILL.md
+++ b/.claude/skills/docker-django/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: docker-django
+description: >
+  Docker docs for containerizing Django + PostgreSQL. ALWAYS invoke for Docker
+  reference in Django projects. Triggers: "docker", "dockerfile", "docker
+  compose", "containerizar", "docker django", "docker postgres", "multi-stage
+  build", "docker volume", "como dockerizar", "compose.yml", "docker
+  production". More keywords: .claude/docs/skills/docker-django.md
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "tema: dockerfile | compose | todo"
+metadata:
+  version: "2.0"
+---
+
+# Docker para Django - Documentacion de Referencia
+
+Lee la documentacion de Docker para Django desde `.claude/docs/docker-django/` y presenta la informacion relevante al usuario.
+
+## Instrucciones
+
+1. Determina que necesita el usuario segun su pregunta o el argumento proporcionado
+2. Lee los archivos correspondientes de la documentacion
+
+### Mapeo de temas a archivos
+
+| Argumento / Tema | Archivo a leer |
+|-----------------|----------------|
+| `dockerfile`, `image`, `build`, `multi-stage`, `uv`, `pip`, `non-root`, `entrypoint`, `dockerignore`, `layers`, `base` | `.claude/docs/docker-django/01-dockerfile.md` |
+| `compose`, `services`, `volumes`, `network`, `health`, `secrets`, `migraciones`, `dev`, `prod`, `comandos`, `pgdata` | `.claude/docs/docker-django/02-docker-compose.md` |
+| `todo`, `completo`, `all` | Todos los archivos |
+
+3. Si no hay argumento, lee el README: `.claude/docs/docker-django/README.md` y presenta el indice
+4. Responde en espanol con terminos tecnicos en ingles
+5. Si el usuario pregunta algo especifico, busca en los archivos con Grep antes de leer todo
+
+## Ejecucion
+
+1. Lee `.claude/docs/docker-django/README.md` para obtener el indice
+2. Segun el tema solicitado, lee el archivo correspondiente
+3. Presenta la informacion de forma concisa y directa
+4. Si el usuario necesita codigo, prioriza los ejemplos de codigo del archivo relevante

--- a/.claude/skills/next-django-integration/SKILL.md
+++ b/.claude/skills/next-django-integration/SKILL.md
@@ -1,0 +1,515 @@
+---
+name: next-django-integration
+description: >
+  Next.js 16 SPA + Django DRF integration (JWT via SimpleJWT en localStorage,
+  lib/api-client.ts CSR-only, refresh interceptor, CORS). Use when the user
+  says "django integration", "JWT", "SimpleJWT", "api client",
+  "lib/api-client", "access token", "refresh token", "Authorization Bearer",
+  "next-django", "cors next django", "integracion django", "token JWT". More
+  keywords: .claude/docs/skills/next-django-integration.md
+user-invocable: true
+allowed-tools: Read, Write, Edit, Glob, Grep
+argument-hint: "<endpoint-or-feature>"
+---
+
+# Next.js 16 + Django DRF — Integration Patterns
+
+## Arquitectura de auth
+
+```
+Browser (cliente)
+  ↓ HTML + JS
+Next.js (app server, Node 24)
+  ↓ Set-Cookie httpOnly
+  ↓ fetch desde Server Components/Actions
+Django API (api.localhost:9979)
+  ↓ TokenAuthentication
+PostgreSQL 18
+```
+
+## Cookie httpOnly como container del DRF token
+
+NO almacenar el token en `localStorage` (vulnerable a XSS). Usar cookie con flags `__Host-`:
+
+| Flag | Razon |
+|------|-------|
+| `httpOnly: true` | JS no puede leerla — no afectada por XSS |
+| `secure: true` | Solo via HTTPS |
+| `sameSite: 'lax'` | Permite navegacion top-level con cookie, bloquea cross-origin POST |
+| `path: '/'` | Disponible en toda la app |
+| `name: '__Host-auth-token'` | Prefix `__Host-` exige Secure + Path=/ + sin Domain (refuerza scope) |
+
+## lib/api-client.ts — wrapper con auth automatica
+
+```typescript
+// dashboard/lib/api-client.ts
+import { cookies } from 'next/headers'
+
+const API_BASE = process.env.API_URL ?? 'http://api.localhost:9979/v1'
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+    public readonly fieldErrors?: Record<string, string[]>,
+  ) {
+    super(message)
+  }
+}
+
+async function authedFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const cookieStore = await cookies()
+  const token = cookieStore.get('__Host-auth-token')?.value
+  const url = `${API_BASE}${path}`
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token && { Authorization: `Token ${token}` }),
+      ...init.headers,
+    },
+    cache: 'no-store',
+  })
+
+  if (!res.ok) {
+    let body: unknown
+    try { body = await res.json() } catch { /* ignore */ }
+    const code = (body as { code?: string })?.code ?? `HTTP_${res.status}`
+    const message = (body as { error?: string })?.error ?? res.statusText
+    const fieldErrors = (body as { errors?: Record<string, string[]> })?.errors
+    throw new ApiError(res.status, code, message, fieldErrors)
+  }
+
+  return res.json() as Promise<T>
+}
+
+export const api = {
+  get: <T>(path: string) => authedFetch<T>(path, { method: 'GET' }),
+  post: <T>(path: string, body: unknown) => authedFetch<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: unknown) => authedFetch<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
+  delete: <T>(path: string) => authedFetch<T>(path, { method: 'DELETE' }),
+}
+```
+
+## proxy.ts — auth gate ligero
+
+```typescript
+// dashboard/proxy.ts (Next 16: REEMPLAZA middleware.ts)
+import { type NextRequest, NextResponse } from 'next/server'
+
+const PROTECTED_PREFIXES = ['/items', '/settings', '/']
+const AUTH_PREFIXES = ['/auth/login', '/auth/register', '/auth/forgot-password']
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const token = request.cookies.get('__Host-auth-token')?.value
+
+  const isAuth = AUTH_PREFIXES.some((p) => pathname.startsWith(p))
+  const isProtected = PROTECTED_PREFIXES.some((p) => pathname.startsWith(p)) && !isAuth
+
+  if (isProtected && !token) {
+    const url = new URL('/auth/login', request.url)
+    url.searchParams.set('next', pathname)
+    return NextResponse.redirect(url)
+  }
+
+  if (isAuth && token) {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\.).*)']
+}
+```
+
+`proxy.ts` solo decide redirect/no-redirect basado en presencia de cookie. Validacion profunda (consultar `/api/v1/auth/verify/`) se hace en `(dashboard)/layout.tsx` server-side.
+
+## Login Server Action setea cookie
+
+```typescript
+// modules/auth/actions/login.ts
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { loginSchema, type LoginInput } from '../schemas/auth.schemas'
+
+const API_BASE = process.env.API_URL ?? 'http://api.localhost:9979/v1'
+const COOKIE_NAME = '__Host-auth-token'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7  // 7 dias
+
+type LoginResult = { ok: true } | { ok: false; error: string; fieldErrors?: Record<string, string[]> }
+
+export async function loginAction(input: LoginInput): Promise<LoginResult> {
+  const parsed = loginSchema.safeParse(input)
+  if (!parsed.success) {
+    return { ok: false, error: 'invalid_input', fieldErrors: parsed.error.flatten().fieldErrors }
+  }
+
+  const res = await fetch(`${API_BASE}/auth/login/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(parsed.data),
+    cache: 'no-store',
+  })
+
+  if (!res.ok) {
+    return { ok: false, error: res.status === 401 ? 'invalid_credentials' : `api_error_${res.status}` }
+  }
+
+  const data = (await res.json()) as { token: string; user: { id: string; email: string } }
+  const cookieStore = await cookies()
+  cookieStore.set(COOKIE_NAME, data.token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: COOKIE_MAX_AGE,
+  })
+
+  redirect('/')
+}
+```
+
+## Logout
+
+```typescript
+// modules/auth/actions/logout.ts
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export async function logoutAction() {
+  const cookieStore = await cookies()
+  const token = cookieStore.get('__Host-auth-token')?.value
+
+  if (token) {
+    // best-effort: avisar al backend
+    await fetch(`${process.env.API_URL}/v1/auth/logout/`, {
+      method: 'POST',
+      headers: { Authorization: `Token ${token}` },
+    }).catch(() => undefined)
+  }
+
+  cookieStore.delete('__Host-auth-token')
+  redirect('/auth/login')
+}
+```
+
+## Validacion profunda en layout protegido
+
+```typescript
+// app/(dashboard)/layout.tsx — Server Component
+import { redirect } from 'next/navigation'
+import { cookies } from 'next/headers'
+import { api } from '@/lib/api-client'
+import type { User } from '@/modules/auth/types/auth.types'
+
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies()
+  const token = cookieStore.get('__Host-auth-token')?.value
+  if (!token) redirect('/auth/login')
+
+  let user: User
+  try {
+    user = await api.get<User>('/auth/me/')
+  } catch {
+    cookieStore.delete('__Host-auth-token')
+    redirect('/auth/login')
+  }
+
+  return <DashboardShell user={user}>{children}</DashboardShell>
+}
+```
+
+## CORS en Django
+
+`server/config/settings/local.py`:
+
+```python
+CORS_ALLOWED_ORIGINS = [
+    'http://dashboard.localhost:9979',
+    'http://localhost:9979',
+]
+CORS_ALLOW_CREDENTIALS = True  # IMPRESCINDIBLE para cookies cross-origin
+CSRF_TRUSTED_ORIGINS = [
+    'http://dashboard.localhost:9979',
+    'http://localhost:9979',
+]
+```
+
+## Variables de entorno
+
+`dashboard/.env.local`:
+
+```bash
+API_URL=http://api.localhost:9979/v1                  # server-only
+NEXT_PUBLIC_APP_URL=http://dashboard.localhost:9979   # cliente publico
+NEXT_PUBLIC_SENTRY_DSN=                                # opcional
+```
+
+## Tipos crudos vs internos (snake_case ↔ camelCase)
+
+> Patron de aislamiento del backend, adaptado de
+> `debtflow-botox-n02/app/docs/conventions/typescript.md` (seccion "Tipos
+> crudos vs tipos internos").
+
+DRF serializa en snake_case (`is_active`, `created_at`). El frontend
+prefiere camelCase (`isActive`, `createdAt`). Mezclar ambos en el codigo
+del dashboard genera ruido visual y acopla la UI a decisiones del backend.
+
+**Regla**: cuando un endpoint tiene MAS DE 3 campos snake_case o se consume
+desde >1 lugar, separar en dos juegos de tipos + un mapper. Para endpoints
+triviales (1-3 campos planos), aceptar snake_case directo es OK.
+
+### Estructura recomendada por dominio
+
+```
+modules/<X>/
+├── api/
+│   └── <X>.api.ts            # llama a lib/api-client, retorna tipos crudos
+├── types/
+│   ├── <X>-api.types.ts      # snake_case (mirror exacto del backend)
+│   └── <X>.types.ts          # camelCase (consumido por componentes/stores)
+├── mappers/
+│   └── <X>.mapper.ts         # mapFromApi + mapToApi
+├── queries.ts                # queryOptions (consume mappers)
+└── ...
+```
+
+### Estado actual del proyecto (2026-05)
+
+Hoy `modules/items/types/item.types.ts` expone `is_active`, `created_at`
+directos del backend. Esto es **aceptable mientras el modelo sea trivial**.
+Cuando crezca o aparezca un segundo consumidor, refactorizar al patron de
+abajo.
+
+### Patron canonico
+
+```ts
+// modules/items/types/items-api.types.ts (CRUDO — mirror del backend)
+export interface ItemApi {
+  id: string
+  name: string
+  description: string | null
+  category: 'general' | 'special'
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface ItemListApi {
+  results: ItemApi[]
+  count: number
+  next: string | null
+  previous: string | null
+}
+```
+
+```ts
+// modules/items/types/items.types.ts (INTERNO — usado por la UI)
+export interface Item {
+  id: string
+  name: string
+  description: string | null
+  category: 'general' | 'special'
+  isActive: boolean
+  createdAt: Date           // string ISO -> Date
+  updatedAt: Date
+}
+
+export interface ItemList {
+  results: Item[]
+  count: number
+  nextPage: number | null   // url paginada -> page number
+  previousPage: number | null
+}
+```
+
+```ts
+// modules/items/mappers/items.mapper.ts
+import type { Item, ItemList } from '../types/items.types'
+import type { ItemApi, ItemListApi } from '../types/items-api.types'
+
+const extractPage = (url: string | null): number | null => {
+  if (!url) return null
+  const match = url.match(/[?&]page=(\d+)/)
+  return match ? Number.parseInt(match[1], 10) : null
+}
+
+export function mapItemFromApi(api: ItemApi): Item {
+  return {
+    id: api.id,
+    name: api.name,
+    description: api.description,
+    category: api.category,
+    isActive: api.is_active,
+    createdAt: new Date(api.created_at),
+    updatedAt: new Date(api.updated_at),
+  }
+}
+
+export function mapItemListFromApi(api: ItemListApi): ItemList {
+  return {
+    results: api.results.map(mapItemFromApi),
+    count: api.count,
+    nextPage: extractPage(api.next),
+    previousPage: extractPage(api.previous),
+  }
+}
+
+// Inverso (para POST/PATCH): omitir campos del backend (id, timestamps)
+export type ItemInput = Pick<Item, 'name' | 'description' | 'category' | 'isActive'>
+
+export function mapItemToApi(input: ItemInput): Partial<ItemApi> {
+  return {
+    name: input.name,
+    description: input.description,
+    category: input.category,
+    is_active: input.isActive,
+  }
+}
+```
+
+```ts
+// modules/items/api/items.api.ts (consume tipos CRUDOS)
+import { api } from '@/lib/api-client'
+import type { ItemApi, ItemListApi } from '../types/items-api.types'
+
+export const itemsApi = {
+  list: (page = 1) => api.get<ItemListApi>(`/items/?page=${page}`),
+  get: (id: string) => api.get<ItemApi>(`/items/${id}/`),
+  create: (input: Partial<ItemApi>) => api.post<ItemApi>('/items/', input),
+}
+```
+
+```ts
+// modules/items/queries.ts (mappea CRUDO → INTERNO via queryOptions)
+import { queryOptions } from '@tanstack/react-query'
+import { itemsApi } from './api/items.api'
+import { mapItemFromApi, mapItemListFromApi } from './mappers/items.mapper'
+
+export const itemsKeys = {
+  all: ['items'] as const,
+  lists: () => [...itemsKeys.all, 'list'] as const,
+  list: (filters: { page: number }) => [...itemsKeys.lists(), filters] as const,
+  detail: (id: string) => [...itemsKeys.all, 'detail', id] as const,
+}
+
+export const itemsListQuery = (page: number) =>
+  queryOptions({
+    queryKey: itemsKeys.list({ page }),
+    queryFn: async () => mapItemListFromApi(await itemsApi.list(page)),
+  })
+
+export const itemDetailQuery = (id: string) =>
+  queryOptions({
+    queryKey: itemsKeys.detail(id),
+    queryFn: async () => mapItemFromApi(await itemsApi.get(id)),
+  })
+```
+
+```ts
+// components/features/items/items-list.tsx (consume tipos INTERNOS)
+'use client'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { itemsListQuery } from '@/modules/items/queries'
+
+export function ItemsList({ page }: { page: number }) {
+  const { data } = useSuspenseQuery(itemsListQuery(page))
+  return (
+    <ul>
+      {data.results.map((item) => (
+        <li key={item.id}>
+          {item.name} — {item.isActive ? 'activo' : 'inactivo'}
+          <time>{item.createdAt.toLocaleDateString('es-CL')}</time>
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### Beneficios
+
+1. **Aislamiento del backend**: si Django renombra `is_active` →
+   `enabled`, solo cambia el mapper y el tipo crudo. Componentes y stores
+   intactos.
+2. **Type safety**: TS distingue `Item` (interno) de `ItemApi` (crudo). Si
+   un componente recibe `ItemApi` por error (ej: alguien hizo bypass del
+   mapper), el typecheck falla.
+3. **Transformaciones en un solo lugar**: parseo de fechas (`string` →
+   `Date`), URLs paginadas a numeros, normalizacion de nulls (`null` ↔
+   `undefined`).
+4. **Mockear es trivial**: en tests de componentes consumis `Item`
+   (interno). En tests de mappers, los inputs son `ItemApi` (crudos). Sin
+   union type ambiguo.
+
+### Cuando NO aplicar el patron
+
+- Endpoint con 1-3 campos planos sin transformacion (overkill).
+- Endpoint que se consume una sola vez en el codebase y no muta.
+- POC / spike (refactorizar despues si la feature sobrevive).
+
+### Convenciones internas que el mapper enforza
+
+| Backend (DRF) | Interno (TS) |
+|---------------|--------------|
+| `is_active: boolean` | `isActive: boolean` |
+| `created_at: string (ISO 8601)` | `createdAt: Date` |
+| `next: string \| null` (url paginada) | `nextPage: number \| null` |
+| `null` (DRF) | preservar como `null`, no `undefined` (consistencia) |
+| `decimal_string: '1234.56'` | `amount: number` (parseo en mapper) |
+
+**Excepcion al snake_case**: identificadores ya estandarizados culturalmente
+no se traducen. `RUT`, `RFC`, `DNI` se mantienen como en el backend.
+
+### Plan de migracion para `modules/items/`
+
+Hoy:
+
+```ts
+// modules/items/types/item.types.ts (snake_case directo)
+export interface Item {
+  is_active: boolean
+  created_at: string
+}
+```
+
+Migracion sugerida (cuando se agregue el segundo dominio o el modelo crezca):
+
+1. Renombrar tipo actual a `ItemApi` y mover a `items-api.types.ts`.
+2. Crear `Item` (camelCase) en `items.types.ts`.
+3. Crear `mappers/items.mapper.ts` con `mapItemFromApi`.
+4. Actualizar `queries.ts` para mappear.
+5. Buscar consumidores de `is_active`, `created_at` y reemplazar.
+6. `python devtools/run.py test_runner --module=dashboard --type=typecheck`
+   para confirmar.
+
+## Anti-patterns
+
+- ❌ Usar `localStorage` para token (XSS-vulnerable)
+- ❌ `Authorization` header desde cliente (deja el token en JS bundle)
+- ❌ CORS `Access-Control-Allow-Origin: *` con `Allow-Credentials: true` (rechazado por browser)
+- ❌ Proxy.ts hace fetch a Django (lento, fragil — mover a layout server-side)
+- ❌ Olvidar `cache: 'no-store'` en fetch a Django (cache global puede mezclar usuarios)
+- ❌ Hardcodear `http://api.localhost:9979` (usar `process.env.API_URL`)
+- ❌ Throw error desde la action en vez de retornar discriminated union
+- ❌ Mezclar snake_case y camelCase en el mismo modulo (todo crudo o todo interno)
+- ❌ Mappear dentro del componente (`item.is_active ?? item.isActive`) — eso es responsabilidad del mapper
+- ❌ Usar `as ItemApi` para silenciar TS sin pasar por el mapper
+
+## Verificacion
+
+- [ ] Cookie tiene flags `httpOnly + secure + sameSite + __Host-` prefix
+- [ ] Server Action de login setea cookie ANTES de redirect
+- [ ] Server Action de logout limpia cookie
+- [ ] proxy.ts solo verifica presencia, no profundidad
+- [ ] Layout `(dashboard)` valida contra Django + redirect si invalido
+- [ ] api-client centralizado (NO `fetch()` esparcido en components)
+- [ ] Test cubre 200, 401, 403, 500 paths

--- a/.claude/skills/postgresql-18/SKILL.md
+++ b/.claude/skills/postgresql-18/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: postgresql-18
+description: >
+  PostgreSQL 18 documentation reference (DB setup + features). ALWAYS invoke
+  this skill BEFORE answering ANY PostgreSQL question, including questions
+  about generated columns, generated fields, computed columns, or column
+  expressions (PG18 introduced VIRTUAL generated columns). NEVER answer
+  PostgreSQL questions from training data alone — PG18 has version-specific
+  features that override generic knowledge. Triggers: "postgresql", "postgres",
+  "pg18", "postgresql 18", "AIO", "uuidv7", "uuid v7", "virtual generated
+  columns", "generated column", "generated columns", "columnas generadas",
+  "STORED column", "VIRTUAL column", "GeneratedField", "computed column",
+  "skip scan", "RETURNING OLD NEW", "RETURNING OLD", "RETURNING NEW",
+  "psycopg3", "psycopg2 to psycopg3", "django postgres", "como configurar
+  postgres", "postgres async io". More keywords:
+  .claude/docs/skills/postgresql-18.md
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "tema: api | django | todo"
+metadata:
+  version: "2.0"
+---
+
+# PostgreSQL 18 - Documentacion de Referencia
+
+Lee la documentacion de PostgreSQL 18 desde `.claude/docs/postgresql-18/` y presenta la informacion relevante al usuario.
+
+## Instrucciones
+
+1. Determina que necesita el usuario segun su pregunta o el argumento proporcionado
+2. Lee los archivos correspondientes de la documentacion
+
+### Mapeo de temas a archivos
+
+| Argumento / Tema | Archivo a leer |
+|-----------------|----------------|
+| `api`, `reference`, `features`, `aio`, `uuidv7`, `columns`, `skip`, `returning`, `oauth`, `breaking`, `config`, `pgdata` | `.claude/docs/postgresql-18/01-api-reference.md` |
+| `django`, `integration`, `psycopg`, `orm`, `models`, `fields`, `search`, `indices`, `performance`, `integracion` | `.claude/docs/postgresql-18/02-django-integration.md` |
+| `todo`, `completo`, `all` | Todos los archivos |
+
+3. Si no hay argumento, lee el README: `.claude/docs/postgresql-18/README.md` y presenta el indice
+4. Responde en espanol con terminos tecnicos en ingles
+5. Si el usuario pregunta algo especifico, busca en los archivos con Grep antes de leer todo
+
+## Ejecucion
+
+1. Lee `.claude/docs/postgresql-18/README.md` para obtener el indice
+2. Segun el tema solicitado, lee el archivo correspondiente
+3. Presenta la informacion de forma concisa y directa
+4. Si el usuario necesita codigo, prioriza los ejemplos de codigo del archivo relevante

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,10 @@ Antes de trabajar, identifica que contexto necesitas:
 | Astro + Biome + TS | [.claude/rules/astro-landing.md](.claude/rules/astro-landing.md) | Antes de crear componente / página / utility |
 | Design System | [.claude/rules/design-system.md](.claude/rules/design-system.md) | Tokens CSS, dark/light, tipografia, fonts |
 | Docstrings | [.claude/rules/docstring-standard.md](.claude/rules/docstring-standard.md) | Antes de documentar cualquier unidad de codigo |
+| Python 3.14 + Ruff | [.claude/rules/python.md](.claude/rules/python.md) | Antes de tocar `.py` en `devtools/` o `.git-hooks/` |
+| Devtools (CLI) | [.claude/rules/devtools.md](.claude/rules/devtools.md) | Antes de agregar/modificar scripts en `devtools/` |
+| Django (referencia futura) | [.claude/rules/django.md](.claude/rules/django.md) | Solo si se agrega backend Django |
+| Database (referencia futura) | [.claude/rules/database.md](.claude/rules/database.md) | Solo si se agrega DB (PostgreSQL) |
 | Verify-before-done | [.claude/rules/verify-before-done.md](.claude/rules/verify-before-done.md) | Antes de reportar trabajo completado |
 | Git workflow | [.claude/rules/git-workflow.md](.claude/rules/git-workflow.md) | Antes de commit / push / PR |
 | Git hooks | [.claude/rules/git-hooks.md](.claude/rules/git-hooks.md) | Quality gates pre-commit / pre-push |
@@ -256,6 +260,8 @@ Antes de trabajar, identifica que contexto necesitas:
 Invocables manualmente con `/<nombre>` o automáticamente según keywords del
 prompt. Detalles del frontmatter: [.claude/rules/skills.md](.claude/rules/skills.md).
 
+### Activas en el portfolio (frontend Astro)
+
 | Skill | Uso |
 |-------|-----|
 | `astro-portfolio` | Referencia obligatoria para cualquier decisión de estructura, SEO, GEO, ATS, diseño o stack del portfolio |
@@ -268,6 +274,25 @@ prompt. Detalles del frontmatter: [.claude/rules/skills.md](.claude/rules/skills
 | `research` | Deep research de tecnologías y librerías (skill con web habilitada) |
 | `spec-workflow` | Descomponer features en specs + tareas atómicas |
 | `tdd-workflow` | TDD obligatorio (Red-Green-Refactor) antes de implementar |
+
+### Referencia futura (backend Python/Django — no aplican hoy)
+
+Estas skills llegaron desde el template `mvp-template-full-stack` para
+preservarlas como referencia. El portfolio actual es Astro estático SIN
+backend, por lo que se activan solo si el prompt menciona explícitamente
+Django/PostgreSQL/Docker-Django. Quedan invocables manualmente con `/<nombre>`.
+
+| Skill | Uso |
+|-------|-----|
+| `django-6` | Referencia Django 6 (API, `@task` decorator, CSP middleware, `AsyncPaginator`, `GeneratedField`) |
+| `django-admin` | Personalización del admin Django (dynamic admin, JS, mixins, widgets, inlines, performance, security) |
+| `django-performance` | ORM performance (N+1, `select_related`, `prefetch_related`, indexes, `EXPLAIN`) |
+| `docker-django` | Containerizar Django + PostgreSQL (multi-stage build, compose, production) |
+| `postgresql-18` | PostgreSQL 18 (AIO, UUIDv7, virtual generated columns, skip scan, `RETURNING OLD/NEW`, psycopg3) |
+| `next-django-integration` | Next.js 16 SPA + Django DRF (JWT via SimpleJWT, `lib/api-client.ts`, refresh interceptor, CORS) |
+
+La arquitectura del server Django del template fuente fue archivada (no como skill) en
+[.claude/docs/templates/server-architecture-from-mvp-template/](.claude/docs/templates/server-architecture-from-mvp-template/) — leerla solo si se planea agregar un backend Django concreto.
 
 ## Convenciones (resumen)
 


### PR DESCRIPTION
## Problema

Falta contenido Python-related en `.claude/` del portfolio:

1. Sin rules Python 3.14 + Ruff aplicables a `devtools/` (CLI Python de orquestación del proyecto)
2. Sin rules de devtools/CLI scripts
3. Sin skills/docs de referencia Django/PostgreSQL/Docker-Django (preparación futura si se agrega backend)

El template `mvp-template-full-stack` tiene este contenido consolidado y validado, pero estaba duplicándose mentalmente en lugar de existir como referencia versionada en el portfolio.

## Solucion

1. Copia 4 rules: `python.md` (Python 3.14 + Ruff, aplica a `devtools/`), `devtools.md` (estructura de scripts), `django.md` y `database.md` (referencia futura)
2. Copia 6 skills activas con frontmatter detectado por el harness: `django-6`, `django-admin`, `django-performance`, `docker-django`, `postgresql-18`, `next-django-integration`
3. Copia 5 carpetas docs (`django-6/`, `django-admin/`, `docker-django/`, `postgresql-18/`) y 7 índices en `docs/skills/`
4. Archiva `server-architecture` en `.claude/docs/templates/server-architecture-from-mvp-template/` (skill 2/5 PASS porque describe arquitectura del template fuente que no existe en este portfolio Astro estático)
5. Aplica fixes de frontmatter en 3 skills (4/5 y 2/5 PASS) tras validación con `claude -p` en 5 ángulos: directiva ALWAYS/NEVER + keywords legacy/sinónimos
6. Actualiza `CLAUDE.md`: 4 entradas nuevas en árbol de conocimiento + tabla skills dividida en "Activas" (10) y "Referencia futura" (6) + nota sobre archivo de `server-architecture`

## Como probar

### Inspección visual

```bash
# 1. Ver estructura de archivos importados
eza -T -L 3 .claude/rules/ .claude/skills/ .claude/docs/templates/

# 2. Confirmar que las skills se cargan en el harness
# Iniciar nueva sesion Claude Code en /home/bypabloc/projects/bypabloc/portfolio
# Verificar que aparecen: django-6, django-admin, django-performance,
# docker-django, postgresql-18, next-django-integration en el listado
# de "Available skills" del system-reminder.
```

### Smoke test de skills (opcional, demora ~2 min cada una)

```bash
# Probar que django-6 con keywords legacy ahora SI se invoca:
claude --permission-mode bypassPermissions \
  --disallowedTools "WebSearch" "WebFetch" \
  --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
  --output-format json \
  -p "como uso celery con django 6 para tareas async" 2>&1 | tail -20
# Esperado: num_turns > 1 (post-fix)

# Probar que postgresql-18 con sinonimo en espanol ahora SI se invoca:
claude --permission-mode bypassPermissions \
  --disallowedTools "WebSearch" "WebFetch" \
  --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
  --output-format json \
  -p "como creo columnas generadas en postgres" 2>&1 | tail -20
# Esperado: num_turns > 1 (post-fix)
```

### Verificar quality gates pasen

```bash
# Ya verificado en pre-push hook del commit:
# 1/6 conformance (Biome) - OK
# 2/6 frontend_purity - OK
# 3/6 typecheck (astro check + tsc) - OK
# 4/6 unit_tests (Vitest) - OK
# 5/6 build (pnpm run build de las 6 apps) - OK
# 6/6 feature_tests (35 Playwright tests) - OK en 10.7s
```

## TODO

- Re-validar `django-6`, `postgresql-18`, `django-performance` post-fix con los mismos prompts que originalmente fallaron, para confirmar 5/5 PASS (opcional, no bloquea merge).
- Decidir si las skills "Referencia futura" deberian quedar como `disable-model-invocation: true` para que solo se invoquen con `/<nombre>` (actualmente son `user-invocable: true` con keywords muy especificos que no se solapan con el portfolio Astro).