### PR TITLE
feat: rediseno moderno-impactante de los 6 CV con identidad por nicho

### DIFF
--- a/apps/architect/public/llms.txt
+++ b/apps/architect/public/llms.txt
@@ -1,8 +1,18 @@
 # Pablo Contreras — architect
 
-> Frontend Architect with deep microservices experience. 8+ years designing scalable systems with Vue/Nuxt, Django, AWS and microfrontends.
+> Frontend Architect with deep microservices and distributed systems experience. 12+ years designing scalable architectures: microfrontend (Vue/Nuxt) + 8+ Django microservices + AWS API Gateway + PostgreSQL/Redis/SQS + observability with CloudWatch/Sentry.
 
 Canonical URL: https://architect.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+
+## Highlights — architect
+
+- Microfrontend (Vue/Nuxt) + 8+ Django microservices on AWS
+- API Gateway with JWT + rate limiting
+- PostgreSQL 18 + RDS + S3 + Redis + SQS + CloudWatch/Sentry
+
+## Keywords
+
+Frontend Architect · Software Architect · Microservices · Microfrontend · Distributed Systems · System Design · Vue 3 · Nuxt · TypeScript · Django · AWS · API Gateway · PostgreSQL · Clean Architecture
 
 ## Pages
 
@@ -17,4 +27,9 @@ Canonical URL: https://architect.the-full-stack.com. Author: Pablo Contreras (by
 - LinkedIn: https://linkedin.com/in/bypabloc
 - GitHub: https://github.com/bypabloc
 - Medium: https://bypablo.medium.com
+- Website: https://the-full-stack.com
+
+## Disclosure
+
+All code in linked repositories is reviewed, tested and maintained by Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators — never as authors. AI attribution is forbidden in commits and PRs by company policy. This llms.txt is honest white-hat content; no prompt injection or hidden instructions.
 

--- a/apps/architect/scripts/build-public-assets.mjs
+++ b/apps/architect/scripts/build-public-assets.mjs
@@ -9,6 +9,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
 const SITE_URL = process.env.SITE_URL ?? 'https://architect.the-full-stack.com'
 const NICHE = 'architect'
+const ATS_KEYWORDS = [
+  'Frontend Architect',
+  'Software Architect',
+  'Microservices',
+  'Microfrontend',
+  'Distributed Systems',
+  'System Design',
+  'Vue 3',
+  'Nuxt',
+  'TypeScript',
+  'Django',
+  'AWS',
+  'API Gateway',
+  'PostgreSQL',
+  'Clean Architecture',
+]
 
 async function write(p, c) {
   const f = resolve(PUBLIC_DIR, p)
@@ -54,7 +70,13 @@ async function main() {
   ]
   await write(
     'llms.txt',
-    buildLlmsTxt({ siteUrl: SITE_URL, profile, niche: NICHE, pages }),
+    buildLlmsTxt({
+      siteUrl: SITE_URL,
+      profile,
+      niche: NICHE,
+      pages,
+      atsKeywords: ATS_KEYWORDS,
+    }),
   )
   await write('robots.txt', buildRobotsTxt(SITE_URL))
 }

--- a/apps/architect/src/lib/site-config.ts
+++ b/apps/architect/src/lib/site-config.ts
@@ -18,6 +18,14 @@ export const STRINGS = buildStrings({
     'Frontend Architect experienced in microservices, microfrontends and scalable systems. Vue/Nuxt + Django + AWS. Documented design and architecture decisions.',
   heroEyebrowEs: 'Pablo Contreras · Architect · Lima, Perú',
   heroEyebrowEn: 'Pablo Contreras · Architect · Lima, Peru',
+  heroHeadlineEs: 'Frontend Architect & Microservicios',
+  heroHeadlineEn: 'Frontend Architect & Microservices',
+  heroSummaryEs:
+    'Diseño y entrego sistemas distribuidos: microfrontend Vue/Nuxt + 8+ microservicios Django sobre AWS. Cada decisión arquitectónica está documentada y testeada en producción fintech.',
+  heroSummaryEn:
+    'I design and ship distributed systems: Vue/Nuxt microfrontend + 8+ Django microservices on AWS. Every architectural decision is documented and tested in fintech production.',
+  nicheLabelEs: 'Architect',
+  nicheLabelEn: 'Architect',
   experienceSubtitleEs:
     'Roles de arquitectura y liderazgo técnico destacados (Destacame, Dibal).',
   experienceSubtitleEn:
@@ -26,4 +34,24 @@ export const STRINGS = buildStrings({
     'Proyectos con decisiones arquitectónicas explícitas y stack documentado.',
   projectsSubtitleEn:
     'Projects with explicit architectural decisions and a documented stack.',
+  atsKeywords: [
+    'Frontend Architect',
+    'Software Architect',
+    'Microservices',
+    'Microfrontend',
+    'Distributed Systems',
+    'System Design',
+    'Vue 3',
+    'Nuxt',
+    'TypeScript',
+    'Django',
+    'AWS',
+    'EC2',
+    'RDS',
+    'S3',
+    'AutoScaling',
+    'API Gateway',
+    'PostgreSQL',
+    'Clean Architecture',
+  ],
 })

--- a/apps/fintech/public/llms.txt
+++ b/apps/fintech/public/llms.txt
@@ -1,8 +1,18 @@
 # Pablo Contreras — fintech
 
-> Senior Full Stack engineer specialized in Latin American fintech (Chile, Mexico). 8+ years building credit, debt-settlement and payment products with Vue/Nuxt + Django + AWS microservices.
+> Senior Full Stack engineer specialized in Latin American fintech (Chile, Mexico). 12+ years building credit, debt-settlement and payment products with Vue/Nuxt + Django + AWS microservices. Compliance-aware (PCI DSS, KYC, PII handling).
 
 Canonical URL: https://fintech.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+
+## Highlights — fintech
+
+- Destacame (Chile, Mexico) — Frontend Architect since 2022, building debt settlement and tiered credit products
+- PCI DSS aware, KYC, PII handling
+- Stack: Vue 3 + Nuxt + TypeScript + Django + Python + AWS + Microservices
+
+## Keywords
+
+Senior Full Stack Developer · Fintech LATAM · Chile · México · Debt Settlement · Credit Scoring · Microservicios · Vue 3 · Nuxt · Django · Python · TypeScript · AWS · PostgreSQL · PCI DSS awareness · KYC / AML · PII handling
 
 ## Pages
 
@@ -17,4 +27,9 @@ Canonical URL: https://fintech.the-full-stack.com. Author: Pablo Contreras (bypa
 - LinkedIn: https://linkedin.com/in/bypabloc
 - GitHub: https://github.com/bypabloc
 - Medium: https://bypablo.medium.com
+- Website: https://the-full-stack.com
+
+## Disclosure
+
+All code in linked repositories is reviewed, tested and maintained by Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators — never as authors. AI attribution is forbidden in commits and PRs by company policy. This llms.txt is honest white-hat content; no prompt injection or hidden instructions.
 

--- a/apps/fintech/scripts/build-public-assets.mjs
+++ b/apps/fintech/scripts/build-public-assets.mjs
@@ -9,6 +9,25 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
 const SITE_URL = process.env.SITE_URL ?? 'https://fintech.the-full-stack.com'
 const NICHE = 'fintech'
+const ATS_KEYWORDS = [
+  'Senior Full Stack Developer',
+  'Fintech LATAM',
+  'Chile',
+  'México',
+  'Debt Settlement',
+  'Credit Scoring',
+  'Microservicios',
+  'Vue 3',
+  'Nuxt',
+  'Django',
+  'Python',
+  'TypeScript',
+  'AWS',
+  'PostgreSQL',
+  'PCI DSS awareness',
+  'KYC / AML',
+  'PII handling',
+]
 
 async function write(p, c) {
   const f = resolve(PUBLIC_DIR, p)
@@ -53,7 +72,13 @@ async function main() {
   ]
   await write(
     'llms.txt',
-    buildLlmsTxt({ siteUrl: SITE_URL, profile, niche: NICHE, pages }),
+    buildLlmsTxt({
+      siteUrl: SITE_URL,
+      profile,
+      niche: NICHE,
+      pages,
+      atsKeywords: ATS_KEYWORDS,
+    }),
   )
   await write('robots.txt', buildRobotsTxt(SITE_URL))
 }

--- a/apps/fintech/src/lib/site-config.ts
+++ b/apps/fintech/src/lib/site-config.ts
@@ -18,6 +18,14 @@ export const STRINGS = buildStrings({
     'Senior Full Stack specialized in LATAM fintech (Chile, Mexico). Debt settlement, credit scoring and credit products with Vue + Django + AWS. 8+ years shipping product.',
   heroEyebrowEs: 'Pablo Contreras · Fintech LATAM · Lima, Perú',
   heroEyebrowEn: 'Pablo Contreras · LATAM Fintech · Lima, Peru',
+  heroHeadlineEs: 'Senior Full Stack Fintech LATAM',
+  heroHeadlineEn: 'Senior Full Stack LATAM Fintech',
+  heroSummaryEs:
+    'Entrego productos fintech en Chile y México desde Destacame: saldar deudas, scoring crediticio y créditos por tramos. Vue + Nuxt + Django + AWS + microservicios con foco en compliance y experiencia del usuario.',
+  heroSummaryEn:
+    'I ship fintech products in Chile and Mexico from Destacame: debt settlement, credit scoring and tiered credit. Vue + Nuxt + Django + AWS + microservices with focus on compliance and user experience.',
+  nicheLabelEs: 'Fintech LATAM',
+  nicheLabelEn: 'LATAM Fintech',
   experienceSubtitleEs:
     'Roles fintech destacados primero: Destacame (Chile, México) y GoodMeal.',
   experienceSubtitleEn:
@@ -26,4 +34,24 @@ export const STRINGS = buildStrings({
     'Case studies de productos fintech LATAM (bajo NDA) + side projects.',
   projectsSubtitleEn:
     'Case studies of LATAM fintech products (under NDA) + side projects.',
+  atsKeywords: [
+    'Senior Full Stack Developer',
+    'Fintech LATAM',
+    'Chile',
+    'México',
+    'Debt Settlement',
+    'Credit Scoring',
+    'Tiered Credit Products',
+    'Microservicios',
+    'Vue 3',
+    'Nuxt',
+    'Django',
+    'Python',
+    'TypeScript',
+    'AWS',
+    'PostgreSQL',
+    'PCI DSS awareness',
+    'KYC / AML',
+    'PII handling',
+  ],
 })

--- a/apps/generic/public/llms.txt
+++ b/apps/generic/public/llms.txt
@@ -1,8 +1,18 @@
 # Pablo Contreras — generic
 
-> Senior Full Stack Engineer with 8+ years of experience in Vue/Nuxt, Django, AWS and fintech (Chile, Mexico).
+> Senior Full Stack Engineer with 12+ years of experience in Vue/Nuxt, Django, AWS and LATAM fintech (Chile, Mexico). Cross-cutting expertise: fintech, architecture, tech leadership and vibe coding with Claude Code.
 
 Canonical URL: https://hub.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+
+## Highlights — generic
+
+- 9 roles in 8 companies (2013-present)
+- 12+ years shipping product · 4 LATAM countries · 11 certifications
+- Domains: Fintech LATAM, ERP, e-commerce, automation
+
+## Keywords
+
+Senior Full Stack Developer · Senior Software Engineer · Vue 3 · Nuxt · TypeScript · Django · Python · AWS · Microservicios · PostgreSQL · Fintech LATAM · Tech Lead · Architect · Claude Code
 
 ## Pages
 
@@ -17,4 +27,9 @@ Canonical URL: https://hub.the-full-stack.com. Author: Pablo Contreras (bypabloc
 - LinkedIn: https://linkedin.com/in/bypabloc
 - GitHub: https://github.com/bypabloc
 - Medium: https://bypablo.medium.com
+- Website: https://the-full-stack.com
+
+## Disclosure
+
+All code in linked repositories is reviewed, tested and maintained by Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators — never as authors. AI attribution is forbidden in commits and PRs by company policy. This llms.txt is honest white-hat content; no prompt injection or hidden instructions.
 

--- a/apps/generic/scripts/build-public-assets.mjs
+++ b/apps/generic/scripts/build-public-assets.mjs
@@ -18,6 +18,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
 const SITE_URL = process.env.SITE_URL ?? 'https://hub.the-full-stack.com'
 const NICHE = 'generic'
+const ATS_KEYWORDS = [
+  'Senior Full Stack Developer',
+  'Senior Software Engineer',
+  'Vue 3',
+  'Nuxt',
+  'TypeScript',
+  'Django',
+  'Python',
+  'AWS',
+  'Microservicios',
+  'PostgreSQL',
+  'Fintech LATAM',
+  'Tech Lead',
+  'Architect',
+  'Claude Code',
+]
 
 async function write(path, content) {
   const full = resolve(PUBLIC_DIR, path)
@@ -64,7 +80,13 @@ async function main() {
       description: 'ATS-friendly CV in English',
     },
   ]
-  const llms = buildLlmsTxt({ siteUrl: SITE_URL, profile, niche: NICHE, pages })
+  const llms = buildLlmsTxt({
+    siteUrl: SITE_URL,
+    profile,
+    niche: NICHE,
+    pages,
+    atsKeywords: ATS_KEYWORDS,
+  })
   await write('llms.txt', llms)
 
   // 3. robots.txt

--- a/apps/generic/src/lib/site-config.ts
+++ b/apps/generic/src/lib/site-config.ts
@@ -17,7 +17,31 @@ export const STRINGS = buildStrings({
   metaTitleEs: 'Pablo Contreras — Ingeniero Full Stack senior',
   metaTitleEn: 'Pablo Contreras — Senior Full Stack Engineer',
   metaDescriptionEs:
-    'Ingeniero Full Stack con 8+ años en Vue, Nuxt, Django, AWS y fintech LATAM (Chile, México). Portfolio + experiencia + proyectos.',
+    'Ingeniero Full Stack con 12+ años en Vue, Nuxt, Django, AWS y fintech LATAM (Chile, México). Portfolio + experiencia + proyectos.',
   metaDescriptionEn:
-    'Senior Full Stack Engineer with 8+ years in Vue, Nuxt, Django, AWS and LATAM fintech (Chile, Mexico). Portfolio + experience + projects.',
+    'Senior Full Stack Engineer with 12+ years in Vue, Nuxt, Django, AWS and LATAM fintech (Chile, Mexico). Portfolio + experience + projects.',
+  heroHeadlineEs: 'Senior Full Stack Engineer',
+  heroHeadlineEn: 'Senior Full Stack Engineer',
+  heroSummaryEs:
+    'Más de 12 años entregando producto fintech LATAM, sistemas ERP y e-commerce. Stack actual: Vue 3 + Nuxt + Django + AWS + microservicios. Especialización transversal: fintech, arquitectura, tech leadership y vibe coding con Claude Code.',
+  heroSummaryEn:
+    '12+ years shipping LATAM fintech products, ERP systems and e-commerce. Current stack: Vue 3 + Nuxt + Django + AWS + microservices. Cross-cutting expertise: fintech, architecture, tech leadership and vibe coding with Claude Code.',
+  nicheLabelEs: 'Full Stack',
+  nicheLabelEn: 'Full Stack',
+  atsKeywords: [
+    'Senior Full Stack Developer',
+    'Senior Software Engineer',
+    'Vue 3',
+    'Nuxt',
+    'TypeScript',
+    'Django',
+    'Python',
+    'AWS',
+    'Microservicios',
+    'PostgreSQL',
+    'Fintech LATAM',
+    'Tech Lead',
+    'Architect',
+    'Claude Code',
+  ],
 })

--- a/apps/hub/src/pages/en/index.astro
+++ b/apps/hub/src/pages/en/index.astro
@@ -1,7 +1,9 @@
 ---
 import { profile } from '@portfolio/content'
 import { buildPersonSchema } from '@portfolio/seo'
+import { nicheTokensToCssVars } from '@portfolio/ui'
 import Footer from '@portfolio/ui/components/Footer.astro'
+import MeshGradientBg from '@portfolio/ui/components/MeshGradientBg.astro'
 /**
  * @page index (en) — hub selector
  */
@@ -32,6 +34,8 @@ const jsonLd = buildPersonSchema({
     'Cursor',
   ],
 })
+
+const hubStyle = nicheTokensToCssVars('hub')
 ---
 
 <BaseLayout
@@ -42,38 +46,56 @@ const jsonLd = buildPersonSchema({
   jsonLd={jsonLd}
   ogImage={`${SITE}/og-image.svg`}
 >
-  <section class="container-medium hub-hero">
-    <p class="text-label hub-hero__eyebrow">Pablo Contreras · Lima, Peru</p>
-    <h1 class="text-display-1 hub-hero__title">
-      Five angles.<br />
-      Pick the one that fits.
-    </h1>
-    <p class="text-body-lg text-muted hub-hero__intro">
-      I am a senior Full Stack engineer with 8+ years in Vue, Django and AWS.
-      Each site tells the same story with a different accent. Pick any — all
-      five stay in sync.
-    </p>
-    <p class="text-mono hub-hero__lang">
-      <a href="/">Versión en español →</a>
-    </p>
-  </section>
+  <div class="hub-root" data-niche="hub" style={hubStyle}>
+    <section class="container-medium hub-hero">
+      <MeshGradientBg variant="vivid" aurora />
+      <p class="text-mono-label hub-hero__eyebrow">
+        <span class="hub-hero__dot" aria-hidden="true"></span>
+        Pablo Contreras · Lima, Peru
+      </p>
+      <h1 class="text-display-mega hub-hero__title">
+        <span class="gradient-text">Five</span><br />
+        <span>angles.</span><br />
+        <span class="hub-hero__title-light">Pick the one that fits.</span>
+      </h1>
+      <p class="text-body-lg text-muted hub-hero__intro">
+        I am a senior Full Stack engineer with 12+ years in Vue, Django and
+        AWS. Each site tells the same story with a different accent. Pick any
+        — all five stay in sync.
+      </p>
+      <p class="text-mono hub-hero__lang">
+        <a href="/" class="anim-underline">Versión en español →</a>
+      </p>
+    </section>
 
-  <section class="container-medium hub-grid">
-    {
-      NICHE_CARDS.map((card, i) => (
-        <a
-          class="hub-card reveal-on-scroll"
-          href={card.url}
-          style={`--accent: ${card.accent}; --i: ${i};`}
-        >
-          <span class="hub-card__niche text-mono">{card.niche}</span>
-          <h2 class="hub-card__title text-h3">{card.title.en}</h2>
-          <p class="hub-card__blurb text-body text-muted">{card.blurb.en}</p>
-          <span class="hub-card__cta text-mono">Enter →</span>
-        </a>
-      ))
-    }
-  </section>
+    <section class="container-medium hub-grid">
+      {
+        NICHE_CARDS.map((card, i) => (
+          <a
+            class="hub-card tilt-3d scroll-reveal"
+            href={card.url}
+            style={`--accent: ${card.accent}; --i: ${i};`}
+            data-niche={card.niche}
+          >
+            <div class="tilt-3d__inner hub-card__inner">
+              <span class="hub-card__niche text-mono-label">
+                <span class="hub-card__niche-dot" aria-hidden="true"></span>
+                {card.niche}
+              </span>
+              <h2 class="hub-card__title text-h3">{card.title.en}</h2>
+              <p class="hub-card__blurb text-body text-muted">{card.blurb.en}</p>
+              <span class="hub-card__cta text-mono">
+                Enter
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                  <path d="M3 11L11 3M11 3H5M11 3V9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+            </div>
+          </a>
+        ))
+      }
+    </section>
+  </div>
 
   <Footer
     slot="footer"
@@ -84,16 +106,42 @@ const jsonLd = buildPersonSchema({
 </BaseLayout>
 
 <style>
+  .hub-root {
+    display: contents;
+  }
   .hub-hero {
+    position: relative;
     padding-block: var(--space-100) var(--space-56);
     text-align: left;
+    overflow: hidden;
+    isolation: isolate;
   }
   .hub-hero__eyebrow {
-    color: var(--color-primary);
-    margin-bottom: var(--space-16);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-24);
+  }
+  .hub-hero__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 12px var(--niche-glow);
+    animation: hub-pulse 2.4s ease-in-out infinite;
+  }
+  @keyframes hub-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.7; transform: scale(1.2); }
   }
   .hub-hero__title {
-    margin-bottom: var(--space-24);
+    margin: 0 0 var(--space-32) 0;
+    line-height: 0.92;
+  }
+  .hub-hero__title-light {
+    color: var(--color-text-muted);
+    font-variation-settings: 'wght' 600;
   }
   .hub-hero__intro {
     max-width: 56ch;
@@ -101,6 +149,7 @@ const jsonLd = buildPersonSchema({
   }
   .hub-hero__lang a {
     color: var(--color-text-muted);
+    text-decoration: none;
   }
   .hub-grid {
     display: grid;
@@ -109,21 +158,17 @@ const jsonLd = buildPersonSchema({
     padding-bottom: var(--space-100);
   }
   .hub-card {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-12);
-    padding: var(--space-32);
+    text-decoration: none;
+    color: var(--color-text);
+    isolation: isolate;
+    overflow: hidden;
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
-    color: var(--color-text);
-    text-decoration: none;
-    transition:
-      border-color var(--motion-fast) var(--easing-out),
-      transform var(--motion-fast) var(--easing-out),
-      box-shadow var(--motion-fast) var(--easing-out);
     position: relative;
-    overflow: hidden;
+    transition:
+      border-color var(--motion-base) var(--easing-out),
+      box-shadow var(--motion-base) var(--easing-out);
   }
   .hub-card::before {
     content: '';
@@ -133,31 +178,69 @@ const jsonLd = buildPersonSchema({
     background: var(--accent);
     transform: scaleX(0);
     transform-origin: left;
-    transition: transform var(--motion-base) var(--easing-out);
+    transition: transform var(--motion-slow) var(--easing-out);
+    z-index: 2;
+  }
+  .hub-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      500px circle at 50% 100%,
+      color-mix(in srgb, var(--accent) 18%, transparent),
+      transparent 60%
+    );
+    opacity: 0;
+    transition: opacity var(--motion-slow) var(--easing-out);
+    pointer-events: none;
+    z-index: 0;
   }
   .hub-card:hover {
     border-color: var(--accent);
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-medium);
+    box-shadow: 0 12px 48px color-mix(in srgb, var(--accent) 22%, transparent);
   }
   .hub-card:hover::before {
     transform: scaleX(1);
   }
+  .hub-card:hover::after {
+    opacity: 1;
+  }
+  .hub-card__inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-12);
+    padding: var(--space-32);
+    height: 100%;
+  }
   .hub-card__niche {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
     color: var(--accent);
-    font-size: var(--font-size-11);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-widest);
+  }
+  .hub-card__niche-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 50%, transparent);
   }
   .hub-card__title {
     color: var(--color-text);
+    margin: 0;
+  }
+  .hub-card__blurb {
+    margin: 0;
+    flex-grow: 1;
   }
   .hub-card__cta {
-    margin-top: auto;
-    color: var(--color-text-muted);
+    margin-top: var(--space-12);
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
     font-size: var(--font-size-13);
-  }
-  .hub-card:hover .hub-card__cta {
-    color: var(--color-text);
   }
 </style>

--- a/apps/hub/src/pages/index.astro
+++ b/apps/hub/src/pages/index.astro
@@ -1,10 +1,13 @@
 ---
 import { profile } from '@portfolio/content'
 import { buildPersonSchema } from '@portfolio/seo'
+import { nicheTokensToCssVars } from '@portfolio/ui'
 import Footer from '@portfolio/ui/components/Footer.astro'
+import MeshGradientBg from '@portfolio/ui/components/MeshGradientBg.astro'
 /**
  * @page index (es) — hub selector
  * @description Landing en the-full-stack.com. 5 cards para los 5 sitios.
+ *   Mesh gradient global + tilt 3D en cards + display mega headline.
  */
 import BaseLayout from '@portfolio/ui/layouts/BaseLayout.astro'
 import { NICHE_CARDS } from '../lib/niches'
@@ -33,6 +36,8 @@ const jsonLd = buildPersonSchema({
     'Cursor',
   ],
 })
+
+const hubStyle = nicheTokensToCssVars('hub')
 ---
 
 <BaseLayout
@@ -43,39 +48,56 @@ const jsonLd = buildPersonSchema({
   jsonLd={jsonLd}
   ogImage={`${SITE}/og-image.svg`}
 >
-  <section class="container-medium hub-hero">
-    <p class="text-label hub-hero__eyebrow">Pablo Contreras · Lima, Perú</p>
-    <h1 class="text-display-1 hub-hero__title">
-      Cinco enfoques.<br />
-      Elige el que conecta.
-    </h1>
-    <p class="text-body-lg text-muted hub-hero__intro">
-      Soy ingeniero Full Stack senior con 8+ años en Vue, Django y AWS. Cada
-      sitio cuenta la misma historia con un acento diferente. Entra por el que
-      te interese, las cinco versiones están al día.
-    </p>
-    <p class="text-mono hub-hero__lang">
-      <a href="/en/">English version →</a>
-    </p>
-  </section>
+  <div class="hub-root" data-niche="hub" style={hubStyle}>
+    <section class="container-medium hub-hero">
+      <MeshGradientBg variant="vivid" aurora />
+      <p class="text-mono-label hub-hero__eyebrow">
+        <span class="hub-hero__dot" aria-hidden="true"></span>
+        Pablo Contreras · Lima, Perú
+      </p>
+      <h1 class="text-display-mega hub-hero__title">
+        <span class="gradient-text">Cinco</span><br />
+        <span>enfoques.</span><br />
+        <span class="hub-hero__title-light">Elige el que conecta.</span>
+      </h1>
+      <p class="text-body-lg text-muted hub-hero__intro">
+        Soy ingeniero Full Stack senior con 12+ años en Vue, Django y AWS. Cada
+        sitio cuenta la misma historia con un acento diferente. Entra por el que
+        te interese — las cinco versiones están al día.
+      </p>
+      <p class="text-mono hub-hero__lang">
+        <a href="/en/" class="anim-underline">English version →</a>
+      </p>
+    </section>
 
-  <section class="container-medium hub-grid">
-    {
-      NICHE_CARDS.map((card, i) => (
-        <a
-          class="hub-card reveal-on-scroll"
-          href={card.url}
-          style={`--accent: ${card.accent}; --i: ${i};`}
-          data-niche={card.niche}
-        >
-          <span class="hub-card__niche text-mono">{card.niche}</span>
-          <h2 class="hub-card__title text-h3">{card.title.es}</h2>
-          <p class="hub-card__blurb text-body text-muted">{card.blurb.es}</p>
-          <span class="hub-card__cta text-mono">Entrar →</span>
-        </a>
-      ))
-    }
-  </section>
+    <section class="container-medium hub-grid">
+      {
+        NICHE_CARDS.map((card, i) => (
+          <a
+            class="hub-card tilt-3d scroll-reveal"
+            href={card.url}
+            style={`--accent: ${card.accent}; --i: ${i};`}
+            data-niche={card.niche}
+          >
+            <div class="tilt-3d__inner hub-card__inner">
+              <span class="hub-card__niche text-mono-label">
+                <span class="hub-card__niche-dot" aria-hidden="true"></span>
+                {card.niche}
+              </span>
+              <h2 class="hub-card__title text-h3">{card.title.es}</h2>
+              <p class="hub-card__blurb text-body text-muted">{card.blurb.es}</p>
+              <span class="hub-card__cta text-mono">
+                Entrar
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                  <path d="M3 11L11 3M11 3H5M11 3V9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+            </div>
+          </a>
+        ))
+      }
+    </section>
+  </div>
 
   <Footer
     slot="footer"
@@ -86,16 +108,42 @@ const jsonLd = buildPersonSchema({
 </BaseLayout>
 
 <style>
+  .hub-root {
+    display: contents;
+  }
   .hub-hero {
+    position: relative;
     padding-block: var(--space-100) var(--space-56);
     text-align: left;
+    overflow: hidden;
+    isolation: isolate;
   }
   .hub-hero__eyebrow {
-    color: var(--color-primary);
-    margin-bottom: var(--space-16);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-24);
+  }
+  .hub-hero__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 12px var(--niche-glow);
+    animation: hub-pulse 2.4s ease-in-out infinite;
+  }
+  @keyframes hub-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.7; transform: scale(1.2); }
   }
   .hub-hero__title {
-    margin-bottom: var(--space-24);
+    margin: 0 0 var(--space-32) 0;
+    line-height: 0.92;
+  }
+  .hub-hero__title-light {
+    color: var(--color-text-muted);
+    font-variation-settings: 'wght' 600;
   }
   .hub-hero__intro {
     max-width: 56ch;
@@ -103,6 +151,7 @@ const jsonLd = buildPersonSchema({
   }
   .hub-hero__lang a {
     color: var(--color-text-muted);
+    text-decoration: none;
   }
   .hub-grid {
     display: grid;
@@ -111,21 +160,17 @@ const jsonLd = buildPersonSchema({
     padding-bottom: var(--space-100);
   }
   .hub-card {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-12);
-    padding: var(--space-32);
+    text-decoration: none;
+    color: var(--color-text);
+    isolation: isolate;
+    overflow: hidden;
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
-    color: var(--color-text);
-    text-decoration: none;
-    transition:
-      border-color var(--motion-fast) var(--easing-out),
-      transform var(--motion-fast) var(--easing-out),
-      box-shadow var(--motion-fast) var(--easing-out);
     position: relative;
-    overflow: hidden;
+    transition:
+      border-color var(--motion-base) var(--easing-out),
+      box-shadow var(--motion-base) var(--easing-out);
   }
   .hub-card::before {
     content: '';
@@ -135,32 +180,69 @@ const jsonLd = buildPersonSchema({
     background: var(--accent);
     transform: scaleX(0);
     transform-origin: left;
-    transition: transform var(--motion-base) var(--easing-out);
+    transition: transform var(--motion-slow) var(--easing-out);
+    z-index: 2;
+  }
+  .hub-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      500px circle at 50% 100%,
+      color-mix(in srgb, var(--accent) 18%, transparent),
+      transparent 60%
+    );
+    opacity: 0;
+    transition: opacity var(--motion-slow) var(--easing-out);
+    pointer-events: none;
+    z-index: 0;
   }
   .hub-card:hover {
     border-color: var(--accent);
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-medium);
-    color: var(--color-text);
+    box-shadow: 0 12px 48px color-mix(in srgb, var(--accent) 22%, transparent);
   }
   .hub-card:hover::before {
     transform: scaleX(1);
   }
+  .hub-card:hover::after {
+    opacity: 1;
+  }
+  .hub-card__inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-12);
+    padding: var(--space-32);
+    height: 100%;
+  }
   .hub-card__niche {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
     color: var(--accent);
-    font-size: var(--font-size-11);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-widest);
+  }
+  .hub-card__niche-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--accent) 50%, transparent);
   }
   .hub-card__title {
     color: var(--color-text);
+    margin: 0;
+  }
+  .hub-card__blurb {
+    margin: 0;
+    flex-grow: 1;
   }
   .hub-card__cta {
-    margin-top: auto;
-    color: var(--color-text-muted);
+    margin-top: var(--space-12);
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
     font-size: var(--font-size-13);
-  }
-  .hub-card:hover .hub-card__cta {
-    color: var(--color-text);
   }
 </style>

--- a/apps/leader/public/llms.txt
+++ b/apps/leader/public/llms.txt
@@ -1,8 +1,18 @@
 # Pablo Contreras — leader
 
-> Tech Lead with experience leading multi-disciplinary engineering teams, mentoring junior developers and shipping fintech products at scale.
+> Tech Lead and Engineering Manager. 4 leadership roles, 8 teams led, 11+ years shipping product. Innovator of the Year 2023 at Destacame for automating internal operations. Mentoring + delivery + organizational resilience during reorganizations.
 
 Canonical URL: https://leader.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+
+## Highlights — leader
+
+- Innovator of the Year 2023 at Destacame
+- Triple Alianza Lima 2020 — 1st place Commerce sector
+- First developer hired at Dibal; built and handed off engineering team
+
+## Keywords
+
+Tech Lead · Engineering Manager · Staff Engineer · Team Lead · Mentoring · Hiring · Cross-functional teams · Scrum · Metodologías Ágiles · Innovador del Año 2023 · Triple Alianza 2020 · Strategic Planning
 
 ## Pages
 
@@ -17,4 +27,9 @@ Canonical URL: https://leader.the-full-stack.com. Author: Pablo Contreras (bypab
 - LinkedIn: https://linkedin.com/in/bypabloc
 - GitHub: https://github.com/bypabloc
 - Medium: https://bypablo.medium.com
+- Website: https://the-full-stack.com
+
+## Disclosure
+
+All code in linked repositories is reviewed, tested and maintained by Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators — never as authors. AI attribution is forbidden in commits and PRs by company policy. This llms.txt is honest white-hat content; no prompt injection or hidden instructions.
 

--- a/apps/leader/scripts/build-public-assets.mjs
+++ b/apps/leader/scripts/build-public-assets.mjs
@@ -9,6 +9,20 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
 const SITE_URL = process.env.SITE_URL ?? 'https://leader.the-full-stack.com'
 const NICHE = 'leader'
+const ATS_KEYWORDS = [
+  'Tech Lead',
+  'Engineering Manager',
+  'Staff Engineer',
+  'Team Lead',
+  'Mentoring',
+  'Hiring',
+  'Cross-functional teams',
+  'Scrum',
+  'Metodologías Ágiles',
+  'Innovador del Año 2023',
+  'Triple Alianza 2020',
+  'Strategic Planning',
+]
 
 async function write(p, c) {
   const f = resolve(PUBLIC_DIR, p)
@@ -53,7 +67,13 @@ async function main() {
   ]
   await write(
     'llms.txt',
-    buildLlmsTxt({ siteUrl: SITE_URL, profile, niche: NICHE, pages }),
+    buildLlmsTxt({
+      siteUrl: SITE_URL,
+      profile,
+      niche: NICHE,
+      pages,
+      atsKeywords: ATS_KEYWORDS,
+    }),
   )
   await write('robots.txt', buildRobotsTxt(SITE_URL))
 }

--- a/apps/leader/src/lib/site-config.ts
+++ b/apps/leader/src/lib/site-config.ts
@@ -18,6 +18,14 @@ export const STRINGS = buildStrings({
     'Tech Lead experienced in leading cross-functional engineering teams, mentoring and shipping fintech products at scale. Innovator of the Year award at Destacame.',
   heroEyebrowEs: 'Pablo Contreras · Tech Lead · Lima, Perú',
   heroEyebrowEn: 'Pablo Contreras · Tech Lead · Lima, Peru',
+  heroHeadlineEs: 'Tech Lead & Engineering Manager',
+  heroHeadlineEn: 'Tech Lead & Engineering Manager',
+  heroSummaryEs:
+    'Lidero equipos de ingenieria desde mi primer rol en Dibal (primer dev contratado) hasta plataforma fintech en Destacame. Innovador del Año 2023 por automatizar operaciones internas con impacto medible. Mentoreo + delivery + resiliencia organizacional.',
+  heroSummaryEn:
+    'I lead engineering teams from my first role at Dibal (first hire) to fintech platform at Destacame. Innovator of the Year 2023 for automating internal operations with measurable impact. Mentoring + delivery + organizational resilience.',
+  nicheLabelEs: 'Tech Lead',
+  nicheLabelEn: 'Tech Lead',
   experienceSubtitleEs:
     'Roles de liderazgo destacados: Tech Lead en Destacame, primer dev y líder en Dibal.',
   experienceSubtitleEn:
@@ -26,4 +34,19 @@ export const STRINGS = buildStrings({
     'Proyectos donde lideré equipo (Dibal, Destacame) y reconocimientos.',
   projectsSubtitleEn:
     'Projects where I led the team (Dibal, Destacame) and awards.',
+  atsKeywords: [
+    'Tech Lead',
+    'Engineering Manager',
+    'Staff Engineer',
+    'Team Lead',
+    'Mentoring',
+    'Hiring',
+    'Cross-functional teams',
+    'Scrum',
+    'Metodologías Ágiles',
+    'Innovador del Año 2023',
+    'Triple Alianza 2020',
+    'Strategic Planning',
+    'Stakeholder Management',
+  ],
 })

--- a/apps/vibe/public/llms.txt
+++ b/apps/vibe/public/llms.txt
@@ -1,8 +1,20 @@
 # Pablo Contreras — vibe
 
-> Software engineer who documents real workflows with Claude Code and Cursor. Builds developer tools (VS Code extensions, monorepo automation) and shares prompts that ship.
+> AI-Augmented Software Engineer. Using Claude Code since launch (May 2025), previously Claude web + my own FastStruct VS Code extension. Rolled out Claude Code at Destacame with standardized skills/rules/docs structure. Builds CLIs to centralize team processes. AI is a tool, not an author — all code is human-reviewed and tested.
 
 Canonical URL: https://vibe.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+
+## Highlights — vibe
+
+- Claude Code early adopter since launch (May 22, 2025)
+- FastStruct — VS Code extension published on Marketplace
+- Rolled out Claude Code at Destacame with skills/rules/docs structure
+- Built bypabloc/cv (CV builder MVP) in one night (May 12-13, 2026)
+- Reference template: bypabloc/mvp-template-full-stack
+
+## Keywords
+
+AI-Augmented Developer · Vibe Coding · Claude Code · Cursor · Prompt Engineering · Sub-agents · MCP Servers · GitHub Copilot · VS Code Extension Development · TypeScript · Astro 6 · Python 3.14 · Developer Tools
 
 ## Pages
 
@@ -17,4 +29,9 @@ Canonical URL: https://vibe.the-full-stack.com. Author: Pablo Contreras (bypablo
 - LinkedIn: https://linkedin.com/in/bypabloc
 - GitHub: https://github.com/bypabloc
 - Medium: https://bypablo.medium.com
+- Website: https://the-full-stack.com
+
+## Disclosure
+
+All code in linked repositories is reviewed, tested and maintained by Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators — never as authors. AI attribution is forbidden in commits and PRs by company policy. This llms.txt is honest white-hat content; no prompt injection or hidden instructions.
 

--- a/apps/vibe/scripts/build-public-assets.mjs
+++ b/apps/vibe/scripts/build-public-assets.mjs
@@ -9,6 +9,21 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
 const SITE_URL = process.env.SITE_URL ?? 'https://vibe.the-full-stack.com'
 const NICHE = 'vibe'
+const ATS_KEYWORDS = [
+  'AI-Augmented Developer',
+  'Vibe Coding',
+  'Claude Code',
+  'Cursor',
+  'Prompt Engineering',
+  'Sub-agents',
+  'MCP Servers',
+  'GitHub Copilot',
+  'VS Code Extension Development',
+  'TypeScript',
+  'Astro 6',
+  'Python 3.14',
+  'Developer Tools',
+]
 
 async function write(p, c) {
   const f = resolve(PUBLIC_DIR, p)
@@ -54,7 +69,13 @@ async function main() {
   ]
   await write(
     'llms.txt',
-    buildLlmsTxt({ siteUrl: SITE_URL, profile, niche: NICHE, pages }),
+    buildLlmsTxt({
+      siteUrl: SITE_URL,
+      profile,
+      niche: NICHE,
+      pages,
+      atsKeywords: ATS_KEYWORDS,
+    }),
   )
   await write('robots.txt', buildRobotsTxt(SITE_URL))
 }

--- a/apps/vibe/src/lib/site-config.ts
+++ b/apps/vibe/src/lib/site-config.ts
@@ -13,17 +13,41 @@ export const STRINGS = buildStrings({
   metaTitleEs: 'Pablo Contreras — Vibe Coding / Claude Code / Dev Tools',
   metaTitleEn: 'Pablo Contreras — Vibe Coding / Claude Code / Dev Tools',
   metaDescriptionEs:
-    'Ingeniero que documenta workflows reales con Claude Code y Cursor. FastStruct (VS Code), este propio portfolio (monorepo Astro) y prompts que entregan producto.',
+    'Ingeniero que documenta workflows reales con Claude Code (desde el lanzamiento, mayo 2025) y antes Claude web + FastStruct. FastStruct (VS Code), monorepo Astro de este portfolio y un CV builder construido en una sola noche.',
   metaDescriptionEn:
-    'Engineer documenting real workflows with Claude Code and Cursor. FastStruct (VS Code), this portfolio (Astro monorepo) and prompts that ship product.',
+    'Engineer documenting real workflows with Claude Code (since launch, May 2025) and previously Claude web + FastStruct. FastStruct (VS Code), Astro monorepo of this portfolio and a CV builder shipped in a single night.',
   heroEyebrowEs: 'Pablo Contreras · Vibe Coding · Lima, Perú',
   heroEyebrowEn: 'Pablo Contreras · Vibe Coding · Lima, Peru',
+  heroHeadlineEs: 'AI-Augmented Full Stack · Claude Code',
+  heroHeadlineEn: 'AI-Augmented Full Stack · Claude Code',
+  heroSummaryEs:
+    'Llevo usando Claude Code desde su lanzamiento (mayo 2025). Antes ya pasaba contexto a Claude web con mi propia extensión FastStruct. Construyo herramientas que aceleran ese flujo y publico prompts reales. La IA es herramienta — el código lo reviso, testeo y mantengo yo.',
+  heroSummaryEn:
+    'I have been using Claude Code since launch (May 2025). Before that I was already piping context to Claude web with my own FastStruct extension. I build tools that accelerate that flow and publish real prompts. AI is a tool — I review, test and maintain the code myself.',
+  nicheLabelEs: 'Vibe Coding',
+  nicheLabelEn: 'Vibe Coding',
   experienceSubtitleEs:
     'Roles donde integro IA en el día a día (Destacame actual).',
   experienceSubtitleEn:
     'Roles where I integrate AI into daily work (current role at Destacame).',
   projectsSubtitleEs:
-    'FastStruct + monorepo Astro de este portfolio. Tools que uso para entregar.',
+    'FastStruct + CV builder (bypabloc/cv) + monorepo Astro de este portfolio. Tools que uso para entregar.',
   projectsSubtitleEn:
-    'FastStruct + Astro monorepo of this portfolio. Tools I use to ship.',
+    'FastStruct + CV builder (bypabloc/cv) + Astro monorepo of this portfolio. Tools I use to ship.',
+  atsKeywords: [
+    'AI-Augmented Developer',
+    'Vibe Coding',
+    'Claude Code',
+    'Cursor',
+    'Prompt Engineering',
+    'Sub-agents',
+    'MCP Servers',
+    'GitHub Copilot',
+    'VS Code Extension Development',
+    'TypeScript',
+    'Astro 6',
+    'Python 3.14',
+    'Developer Tools',
+    'AI Workflow Documentation',
+  ],
 })

--- a/packages/app-shared/src/components/AiWorkflowSection.astro
+++ b/packages/app-shared/src/components/AiWorkflowSection.astro
@@ -1,0 +1,225 @@
+---
+/**
+ * @component AiWorkflowSection
+ * @description Seccion exclusiva del nicho `vibe`. Documenta de forma honesta
+ *   el workflow de Pablo con Claude Code, Cursor y subagentes. White-hat:
+ *   prompts reales, narrativa transparente, no marketing.
+ *
+ *   Cumple recomendacion de developer-portfolios-vibe-coding/09-documentacion-uso-ia.md.
+ *
+ * @props {'es' | 'en'} locale
+ * @props {string} [titleOverride]
+ *
+ * @example
+ *   <AiWorkflowSection locale="es" />
+ */
+interface Props {
+  locale: 'es' | 'en'
+  titleOverride?: string
+}
+
+const { locale, titleOverride } = Astro.props
+const isEs = locale === 'es'
+
+const title = titleOverride ?? (isEs ? 'AI workflow' : 'AI workflow')
+const subtitle = isEs
+  ? 'Cómo trabajo con Claude Code, Cursor y subagentes. Sin gimmicks: prompts reales, transparencia sobre el output, métricas concretas.'
+  : 'How I work with Claude Code, Cursor and subagents. No gimmicks: real prompts, transparent output, concrete metrics.'
+
+const cards = isEs
+  ? [
+      {
+        label: 'Historia',
+        title: 'Claude web + FastStruct → Claude Code (mayo 2025)',
+        body: 'Antes de Claude Code usaba la interfaz web de Claude para programar y pasaba contexto con mi propia extensión FastStruct (publicada en VS Code Marketplace). Cuando Claude Code salió en mayo 2025 fui early adopter desde día uno.',
+      },
+      {
+        label: 'Adopción empresarial',
+        title: 'Implementé Claude Code en Destacame',
+        body: 'Fui quien introdujo Claude Code en mi equipo actual en Destacame. Armé estructura de skills, rules y docs para estandarizar el uso entre developers, definir prompts canónicos por tarea, evitar duplicación de descubrimientos y mantener coherencia en quality gates.',
+      },
+      {
+        label: 'CLI tooling',
+        title: 'CLIs propias con Claude Code',
+        body: 'Suelo construir CLIs (orquestador devtools en Python 3.14, scripts de scan/verify/feature tests, etc.) con Claude Code para centralizar procesos repetitivos del equipo. Cada CLI es código revisado, testeado y mantenible — no scripts desechables.',
+      },
+      {
+        label: 'Stack actual',
+        title: 'Claude Code · Cursor · Sub-agentes',
+        body: 'Claude Code como driver principal (91% CSAT, 54 NPS). Cursor para refactors visuales puntuales. Sub-agentes (researcher / Explore / code-reviewer) en outputs largos para no quemar contexto del orquestador.',
+      },
+      {
+        label: 'Prompt real',
+        title: 'Pattern explore → plan → implement → commit',
+        body: '"Explora estos 3 archivos y dime qué componentes son candidatos a refactor por duplicación. Escribe tu reporte en tmp/explore_X.md, responde una sola línea." → Reduce 80% del consumo de tokens en orquestador.',
+      },
+      {
+        label: 'Referencia abierta',
+        title: 'bypabloc/mvp-template-full-stack',
+        body: 'Repositorio público que uso como template y referencia del flujo: estructura .claude/, skills, rules, hooks, devtools CLI, conformance y testing. Sirve como blueprint para nuevos proyectos y para mostrar el workflow de vibe coding completo.',
+      },
+      {
+        label: 'Output reciente',
+        title: 'bypabloc/cv — MVP en una noche (12-13 mayo 2026)',
+        body: 'CV builder construido en una sola noche con Claude Code. Repo público bypabloc/cv. Demuestra que la combinación Claude Code + revisión humana entrega producto sin sacrificar mantenibilidad.',
+      },
+      {
+        label: 'Métricas',
+        title: '5x faster + 0% atribución IA',
+        body: 'Tiempo de instrucción a un LLM cae 5x al usar FastStruct. Zero "Generated with Claude Code" en commits/PRs gracias a hook prepare-commit-msg que escanea y limpia atribución IA por política de empresa.',
+      },
+      {
+        label: 'Reglas',
+        title: 'AI = herramienta, no autor',
+        body: 'Todo el código se revisa, testea (Vitest + Playwright) y mantiene por mí. Quality gates en pre-commit y pre-push (Biome + tsc + astro check + coverage ≥80% + build). Atribución IA prohibida por política — ni en commits, ni en PRs, ni en docs.',
+      },
+    ]
+  : [
+      {
+        label: 'History',
+        title: 'Claude web + FastStruct → Claude Code (May 2025)',
+        body: 'Before Claude Code I used the Claude web interface to code and piped context with my own FastStruct extension (published on the VS Code Marketplace). When Claude Code launched in May 2025 I was an early adopter from day one.',
+      },
+      {
+        label: 'Enterprise adoption',
+        title: 'I rolled out Claude Code at Destacame',
+        body: 'I was the one who introduced Claude Code in my current team at Destacame. I built a skills/rules/docs structure to standardize usage across developers, define canonical prompts per task, avoid duplicated discoveries and keep coherence in quality gates.',
+      },
+      {
+        label: 'CLI tooling',
+        title: 'Custom CLIs built with Claude Code',
+        body: 'I regularly build CLIs (Python 3.14 devtools orchestrator, scan/verify/feature-test scripts, etc.) with Claude Code to centralize repetitive team processes. Each CLI is reviewed, tested and maintainable code — not throwaway scripts.',
+      },
+      {
+        label: 'Current stack',
+        title: 'Claude Code · Cursor · Sub-agents',
+        body: 'Claude Code as primary driver (91% CSAT, 54 NPS). Cursor for targeted visual refactors. Sub-agents (researcher / Explore / code-reviewer) on long outputs to avoid burning the orchestrator context.',
+      },
+      {
+        label: 'Real prompt',
+        title: 'Pattern explore → plan → implement → commit',
+        body: '"Explore these 3 files and tell me which components are refactor candidates due to duplication. Write your report to tmp/explore_X.md, respond a single line." → Cuts 80% of orchestrator token consumption.',
+      },
+      {
+        label: 'Open reference',
+        title: 'bypabloc/mvp-template-full-stack',
+        body: 'Public repository I use as template and reference for the workflow: .claude/ structure, skills, rules, hooks, devtools CLI, conformance and testing. Serves as blueprint for new projects and to showcase the full vibe coding workflow.',
+      },
+      {
+        label: 'Recent output',
+        title: 'bypabloc/cv — MVP in one night (May 12-13, 2026)',
+        body: 'CV builder built in a single night with Claude Code. Public repo bypabloc/cv. Demonstrates that the Claude Code + human review combo ships product without sacrificing maintainability.',
+      },
+      {
+        label: 'Metrics',
+        title: '5x faster + 0% AI attribution',
+        body: 'Time spent instructing an LLM drops 5x with FastStruct. Zero "Generated with Claude Code" in commits/PRs via prepare-commit-msg hook that scans and strips AI attribution by company policy.',
+      },
+      {
+        label: 'Rules',
+        title: 'AI = tool, not author',
+        body: 'All code is reviewed, tested (Vitest + Playwright) and maintained by me. Quality gates in pre-commit and pre-push (Biome + tsc + astro check + coverage ≥80% + build). AI attribution forbidden by policy — not in commits, not in PRs, not in docs.',
+      },
+    ]
+---
+
+<section class="ai-workflow scroll-reveal" data-section="ai-workflow">
+  <header class="ai-workflow__header">
+    <span class="ai-workflow__eyebrow text-mono-label">
+      <span class="ai-workflow__dot" aria-hidden="true"></span>
+      Vibe Coding · 2026
+    </span>
+    <h2 class="ai-workflow__title text-h2 gradient-text">{title}</h2>
+    <p class="ai-workflow__subtitle text-body-lg text-muted">{subtitle}</p>
+  </header>
+  <div class="ai-workflow__grid">
+    {
+      cards.map((c) => (
+        <article class="ai-workflow__card tilt-3d">
+          <div class="tilt-3d__inner ai-workflow__card-inner">
+            <span class="ai-workflow__card-label text-mono-label">{c.label}</span>
+            <h3 class="ai-workflow__card-title text-h4">{c.title}</h3>
+            <p class="ai-workflow__card-body text-body text-muted">{c.body}</p>
+          </div>
+        </article>
+      ))
+    }
+  </div>
+  <p class="ai-workflow__disclaimer text-mono text-subtle">
+    {
+      isEs
+        ? '// Disclosure: todo el codigo es revisado, testeado (Vitest + Playwright) y mantenido por mi. La IA es herramienta, no autor. NUNCA en atribucion de commits.'
+        : '// Disclosure: all code is reviewed, tested (Vitest + Playwright) and maintained by me. AI is a tool, not an author. NEVER in commit attribution.'
+    }
+  </p>
+</section>
+
+<style>
+  .ai-workflow {
+    padding-block: var(--space-72);
+  }
+  .ai-workflow__header {
+    display: grid;
+    gap: var(--space-16);
+    margin-bottom: var(--space-40);
+    max-width: 720px;
+  }
+  .ai-workflow__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    color: var(--niche-accent);
+  }
+  .ai-workflow__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 12px var(--niche-glow);
+  }
+  .ai-workflow__title {
+    margin: 0;
+  }
+  .ai-workflow__subtitle {
+    margin: 0;
+  }
+  .ai-workflow__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--space-20);
+  }
+  .ai-workflow__card {
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.2);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    overflow: hidden;
+    isolation: isolate;
+    transition: border-color var(--motion-slow) var(--easing-out);
+  }
+  .ai-workflow__card:hover {
+    border-color: var(--niche-accent);
+  }
+  .ai-workflow__card-inner {
+    display: grid;
+    gap: var(--space-12);
+    padding: var(--space-24);
+  }
+  .ai-workflow__card-label {
+    color: var(--niche-accent);
+  }
+  .ai-workflow__card-title {
+    margin: 0;
+    font-family: var(--font-mono-display);
+    font-size: var(--font-size-16);
+    font-weight: 700;
+  }
+  .ai-workflow__card-body {
+    margin: 0;
+  }
+  .ai-workflow__disclaimer {
+    margin-top: var(--space-32);
+    padding-top: var(--space-24);
+    border-top: 1px dashed var(--color-border);
+    font-family: var(--font-mono);
+  }
+</style>

--- a/packages/app-shared/src/components/ArchitectureDiagram.astro
+++ b/packages/app-shared/src/components/ArchitectureDiagram.astro
@@ -1,0 +1,200 @@
+---
+/**
+ * @component ArchitectureDiagram
+ * @description Seccion exclusiva del nicho `architect`. Diagrama ASCII de
+ *   arquitectura de microservicios + microfrontends + descripcion de capas.
+ *
+ * @props {'es' | 'en'} locale
+ *
+ * @example
+ *   <ArchitectureDiagram locale="es" />
+ */
+interface Props {
+  locale: 'es' | 'en'
+}
+
+const { locale } = Astro.props
+const isEs = locale === 'es'
+
+const title = isEs ? 'Arquitectura' : 'Architecture'
+const subtitle = isEs
+  ? 'Patron real usado en productos fintech LATAM: microfrontend (Vue/Nuxt) + API gateway + microservicios Django + cola asincrona + observabilidad.'
+  : 'Real pattern shipped in LATAM fintech products: microfrontend (Vue/Nuxt) + API gateway + Django microservices + async queue + observability.'
+
+const layers = isEs
+  ? [
+      { label: 'Frontend', tech: 'Vue 3 · Nuxt · TypeScript · Microfrontends' },
+      {
+        label: 'Gateway',
+        tech: 'AWS API Gateway · Auth (JWT) · Rate limiting',
+      },
+      {
+        label: 'Servicios',
+        tech: 'Django + DRF · Python 3.12+ · 8+ microservicios',
+      },
+      { label: 'Data', tech: 'PostgreSQL 18 · RDS · S3 · Redis' },
+      { label: 'Async', tech: 'SQS · Celery workers · EventBridge' },
+      {
+        label: 'Observabilidad',
+        tech: 'CloudWatch · Sentry · Logs estructurados',
+      },
+    ]
+  : [
+      { label: 'Frontend', tech: 'Vue 3 · Nuxt · TypeScript · Microfrontends' },
+      {
+        label: 'Gateway',
+        tech: 'AWS API Gateway · Auth (JWT) · Rate limiting',
+      },
+      {
+        label: 'Services',
+        tech: 'Django + DRF · Python 3.12+ · 8+ microservices',
+      },
+      { label: 'Data', tech: 'PostgreSQL 18 · RDS · S3 · Redis' },
+      { label: 'Async', tech: 'SQS · Celery workers · EventBridge' },
+      { label: 'Observability', tech: 'CloudWatch · Sentry · Structured logs' },
+    ]
+---
+
+<section class="arch scroll-reveal" data-section="architecture-diagram">
+  <header class="arch__header">
+    <span class="arch__eyebrow text-mono-label">
+      <span class="arch__dot" aria-hidden="true"></span>
+      System Design
+    </span>
+    <h2 class="arch__title text-h2 gradient-text">{title}</h2>
+    <p class="arch__subtitle text-body-lg text-muted">{subtitle}</p>
+  </header>
+
+  <div class="arch__layout">
+    <pre class="arch__ascii text-mono" aria-label={title}>
+{`        ┌──────────────────────────────────────────────┐
+        │   Browser · PWA · Mobile · Tablet            │
+        └──────────────────┬───────────────────────────┘
+                           │ HTTPS
+                ┌──────────▼──────────┐
+                │  Microfrontend       │
+                │  Vue 3 · Nuxt · TS   │
+                └──────────┬──────────┘
+                           │
+                ┌──────────▼──────────┐
+                │  AWS API Gateway     │
+                │  JWT · Rate limit    │
+                └──────────┬──────────┘
+            ┌──────────────┼──────────────┐
+            ▼              ▼              ▼
+    ┌───────────┐  ┌───────────┐  ┌───────────┐
+    │ µ-service │  │ µ-service │  │ µ-service │
+    │  Django   │  │  Django   │  │  Django   │
+    │  Credit   │  │  Debt     │  │  KYC      │
+    └─────┬─────┘  └─────┬─────┘  └─────┬─────┘
+          │              │              │
+          ▼              ▼              ▼
+     ┌───────────────────────────────────────┐
+     │   PostgreSQL · Redis · S3 · SQS       │
+     └───────────────────────────────────────┘
+                           │
+                ┌──────────▼──────────┐
+                │  Observability      │
+                │  CloudWatch · Sentry │
+                └─────────────────────┘`}
+    </pre>
+
+    <ol class="arch__layers">
+      {
+        layers.map((l, idx) => (
+          <li class="arch__layer">
+            <span class="arch__layer-index text-mono-label">{String(idx + 1).padStart(2, '0')}</span>
+            <div>
+              <h3 class="arch__layer-label text-h5">{l.label}</h3>
+              <p class="arch__layer-tech text-mono text-muted">{l.tech}</p>
+            </div>
+          </li>
+        ))
+      }
+    </ol>
+  </div>
+</section>
+
+<style>
+  .arch {
+    padding-block: var(--space-72);
+  }
+  .arch__header {
+    display: grid;
+    gap: var(--space-16);
+    margin-bottom: var(--space-40);
+    max-width: 720px;
+  }
+  .arch__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    color: var(--niche-accent);
+  }
+  .arch__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 12px var(--niche-glow);
+  }
+  .arch__title {
+    margin: 0;
+  }
+  .arch__subtitle {
+    margin: 0;
+  }
+  .arch__layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: var(--space-32);
+    align-items: start;
+  }
+  @media (max-width: 900px) {
+    .arch__layout {
+      grid-template-columns: 1fr;
+    }
+  }
+  .arch__ascii {
+    margin: 0;
+    padding: var(--space-24);
+    background: var(--color-surface);
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.2);
+    border-radius: var(--radius-md);
+    overflow-x: auto;
+    font-size: var(--font-size-11);
+    line-height: 1.4;
+    color: var(--niche-accent);
+    white-space: pre;
+  }
+  .arch__layers {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-12);
+  }
+  .arch__layer {
+    display: flex;
+    gap: var(--space-16);
+    padding: var(--space-16) var(--space-20);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    transition: border-color var(--motion-base) var(--easing-out);
+  }
+  .arch__layer:hover {
+    border-color: rgba(var(--niche-accent-rgb), 0.4);
+  }
+  .arch__layer-index {
+    color: var(--niche-accent);
+    flex-shrink: 0;
+    align-self: center;
+  }
+  .arch__layer-label {
+    margin: 0 0 var(--space-4) 0;
+  }
+  .arch__layer-tech {
+    margin: 0;
+  }
+</style>

--- a/packages/app-shared/src/components/AtsKeywordsPills.astro
+++ b/packages/app-shared/src/components/AtsKeywordsPills.astro
@@ -1,0 +1,99 @@
+---
+/**
+ * @component AtsKeywordsPills
+ * @description Seccion exclusiva del nicho `fintech`. Pills visibles (no
+ *   hidden text — white-hat) con keywords ATS que los reclutadores buscan
+ *   literal: job title, regulacion, mercados, stack.
+ *
+ *   Cumple recomendacion de modern-portfolios/02-optimizacion-ats.md.
+ *
+ * @props {'es' | 'en'} locale
+ * @props {string[]} keywords - Lista de keywords ATS literales
+ *
+ * @example
+ *   <AtsKeywordsPills locale="es" keywords={['PCI DSS','Chile','Mexico']} />
+ */
+interface Props {
+  locale: 'es' | 'en'
+  keywords: string[]
+}
+
+const { locale, keywords } = Astro.props
+const isEs = locale === 'es'
+
+const title = isEs ? 'Stack & especialidad' : 'Stack & specialty'
+const subtitle = isEs
+  ? 'Job titles, regulaciones, mercados y tecnologias relevantes para reclutadores fintech LATAM.'
+  : 'Job titles, regulations, markets and technologies relevant to LATAM fintech recruiters.'
+---
+
+<section class="ats-pills scroll-reveal" data-section="ats-keywords">
+  <header class="ats-pills__header">
+    <span class="ats-pills__eyebrow text-mono-label">
+      <span class="ats-pills__dot" aria-hidden="true"></span>
+      ATS · LATAM Fintech
+    </span>
+    <h2 class="ats-pills__title text-h2 gradient-text">{title}</h2>
+    <p class="ats-pills__subtitle text-body-lg text-muted">{subtitle}</p>
+  </header>
+  <ul class="ats-pills__list">
+    {
+      keywords.map((kw) => (
+        <li class="ats-pills__pill text-mono">{kw}</li>
+      ))
+    }
+  </ul>
+</section>
+
+<style>
+  .ats-pills {
+    padding-block: var(--space-72);
+  }
+  .ats-pills__header {
+    display: grid;
+    gap: var(--space-16);
+    margin-bottom: var(--space-32);
+    max-width: 720px;
+  }
+  .ats-pills__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    color: var(--niche-accent);
+  }
+  .ats-pills__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 12px var(--niche-glow);
+  }
+  .ats-pills__title {
+    margin: 0;
+  }
+  .ats-pills__subtitle {
+    margin: 0;
+  }
+  .ats-pills__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-8);
+  }
+  .ats-pills__pill {
+    padding: var(--space-8) var(--space-16);
+    border-radius: var(--radius-pill);
+    background: rgba(var(--niche-accent-rgb), 0.08);
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.3);
+    color: var(--niche-accent);
+    font-size: var(--font-size-13);
+    transition: transform var(--motion-fast) var(--easing-out);
+    cursor: default;
+  }
+  .ats-pills__pill:hover {
+    transform: translateY(-2px);
+    background: rgba(var(--niche-accent-rgb), 0.15);
+  }
+</style>

--- a/packages/app-shared/src/components/CvSections.astro
+++ b/packages/app-shared/src/components/CvSections.astro
@@ -1,5 +1,6 @@
 ---
 import {
+  awards,
   experiences,
   filterByNiche,
   formatRange,
@@ -9,18 +10,38 @@ import {
   skills,
   sortByPriority,
 } from '@portfolio/content'
+import AwardCard from '@portfolio/ui/components/AwardCard.astro'
+import CaseStudyExpander from '@portfolio/ui/components/CaseStudyExpander.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
-import ExperienceCard from '@portfolio/ui/components/ExperienceCard.astro'
+import ExperienceTimeline from '@portfolio/ui/components/ExperienceTimeline.astro'
 /**
  * @component CvSections
- * @description Bloques principales (experience, projects, skills, contact)
- *   ya filtrados por nicho. Recibe locale, niche y strings localizadas.
+ * @description Orquesta los bloques del CV filtrados por nicho:
+ *   HeroImpact + StatsBar + (extras por nicho) + Timeline + Bento + Marquee
+ *   + SkillsGrid + Awards + Contact.
+ *
+ *   Las "extras" se renderizan segun getNicheExtras(niche).
+ *
+ * @props {Niche} niche
+ * @props {'es'|'en'} locale
+ * @props {I18nStrings} strings
+ * @props {string} [cvHref='/cv.html']
  */
-import Hero from '@portfolio/ui/components/Hero.astro'
-import ProjectCard from '@portfolio/ui/components/ProjectCard.astro'
+import HeroImpact from '@portfolio/ui/components/HeroImpact.astro'
+import ProjectBentoCard from '@portfolio/ui/components/ProjectBentoCard.astro'
+import ProjectsBento from '@portfolio/ui/components/ProjectsBento.astro'
 import SectionHeader from '@portfolio/ui/components/SectionHeader.astro'
 import SkillsGrid from '@portfolio/ui/components/SkillsGrid.astro'
+import SkillsMarquee from '@portfolio/ui/components/SkillsMarquee.astro'
+import StatsBar from '@portfolio/ui/components/StatsBar.astro'
+import TimelineItem from '@portfolio/ui/components/TimelineItem.astro'
+import { buildStats } from '../lib/build-stats'
+import { getNicheExtras } from '../lib/get-niche-extras'
 import type { I18nStrings } from '../lib/site-config'
+import AiWorkflowSection from './AiWorkflowSection.astro'
+import ArchitectureDiagram from './ArchitectureDiagram.astro'
+import AtsKeywordsPills from './AtsKeywordsPills.astro'
+import LeadershipStats from './LeadershipStats.astro'
 
 interface Props {
   niche: Niche
@@ -35,13 +56,28 @@ const projs = sortByPriority(filterByNiche(projects, niche), niche)
 const sks = filterByNiche(skills, niche)
 const technicalSkills = sks.filter((s) => s.kind === 'technical')
 const softSkills = sks.filter((s) => s.kind === 'soft')
+const stats = buildStats(profile)
+const extras = getNicheExtras(niche)
+const nicheAwards = filterByNiche(awards, niche)
+
+// Stack para marquee: top 5 skills tecnicas, top 5 dominios/herramientas
+const marqueeRowOne = technicalSkills
+  .slice(0, 2)
+  .flatMap((c) => c.skills.slice(0, 5))
+const marqueeRowTwo = technicalSkills
+  .slice(2, 4)
+  .flatMap((c) => c.skills.slice(0, 5))
+
+// Bento spans: primer project = lg, segundo = md, tercer = md, cuarto = lg, resto md
+const bentoSpans: Array<'sm' | 'md' | 'lg' | 'xl'> = ['lg', 'md', 'md', 'lg']
 ---
 
 <section class="container-wide">
-  <Hero
+  <HeroImpact
     eyebrow={t.hero.eyebrow}
-    headline={profile.headline[locale]}
-    summary={profile.summary[locale]}
+    headline={t.hero.headline}
+    summary={t.hero.summary}
+    nicheLabel={t.hero.nicheLabel}
     ctas={[
       { href: '#experience', label: t.hero.ctaPrimary, variant: 'primary' },
       { href: cvHref, label: t.hero.ctaSecondary, variant: 'ghost' },
@@ -49,31 +85,100 @@ const softSkills = sks.filter((s) => s.kind === 'soft')
   />
 </section>
 
+{
+  extras.includes('StatsBar') && (
+    <section class="container-wide section section--compact">
+      <StatsBar
+        eyebrow={t.stats.eyebrow}
+        items={[
+          {
+            label: t.stats.yearsExperience,
+            value: stats.yearsExperience,
+            suffix: '+',
+          },
+          { label: t.stats.companies, value: stats.companies },
+          { label: t.stats.countries, value: stats.countries },
+          { label: t.stats.certifications, value: stats.certifications },
+        ]}
+      />
+    </section>
+  )
+}
+
+{
+  extras.includes('AtsKeywordsPills') && t.atsKeywords.length > 0 && (
+    <section class="container-wide">
+      <AtsKeywordsPills locale={locale} keywords={t.atsKeywords} />
+    </section>
+  )
+}
+
+{
+  extras.includes('ArchitectureDiagram') && (
+    <section class="container-wide">
+      <ArchitectureDiagram locale={locale} />
+    </section>
+  )
+}
+
+{
+  extras.includes('LeadershipStats') && (
+    <section class="container-wide">
+      <LeadershipStats locale={locale} />
+    </section>
+  )
+}
+
+{
+  extras.includes('AwardsHighlight') && nicheAwards.length > 0 && (
+    <section id="awards" class="container-wide section">
+      <SectionHeader
+        eyebrow="A1"
+        title={t.sections.awards.title}
+        subtitle={t.sections.awards.subtitle}
+      />
+      <div class="awards-grid">
+        {nicheAwards.map((a, idx) => (
+          <AwardCard
+            title={a.title[locale]}
+            issuer={a.issuer}
+            date={a.date}
+            motivation={a.motivation[locale]}
+            url={a.url}
+            featured={idx === 0}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
 <section id="experience" class="container-wide section">
   <SectionHeader
     eyebrow="01"
     title={t.sections.experience.title}
     subtitle={t.sections.experience.subtitle}
   />
-  <div class="experience-list">
+  <ExperienceTimeline ariaLabel={t.sections.experience.title}>
     {
-      exps.map((e) => (
-        <ExperienceCard
+      exps.map((e, idx) => (
+        <TimelineItem
           role={e.role[locale]}
           company={e.company}
           companyUrl={e.companyUrl}
           dateRange={formatRange(e.start, e.end, locale)}
           skills={e.skillsTechnical}
+          current={idx === 0 && !e.end}
         >
           <ul class="exp-bullets">
             {e.responsibilities[locale].slice(0, 3).map((r) => (
               <li>{r}</li>
             ))}
           </ul>
-        </ExperienceCard>
+        </TimelineItem>
       ))
     }
-  </div>
+  </ExperienceTimeline>
 </section>
 
 <section id="projects" class="container-wide section">
@@ -82,10 +187,10 @@ const softSkills = sks.filter((s) => s.kind === 'soft')
     title={t.sections.projects.title}
     subtitle={t.sections.projects.subtitle}
   />
-  <div class="projects-grid">
+  <ProjectsBento ariaLabel={t.sections.projects.title}>
     {
-      projs.map((p) => (
-        <ProjectCard
+      projs.map((p, idx) => (
+        <ProjectBentoCard
           name={p.name}
           summary={p.summary[locale]}
           stack={p.stack}
@@ -93,12 +198,56 @@ const softSkills = sks.filter((s) => s.kind === 'soft')
           repo={p.repo}
           status={p.status}
           isConfidential={p.isConfidential}
+          bentoSpan={bentoSpans[idx % bentoSpans.length] ?? 'md'}
           caseStudyLabel={t.labels.confidential}
         />
       ))
     }
-  </div>
+  </ProjectsBento>
+
+  {
+    projs.filter((p) => p.caseStudyDetailed).length > 0 && (
+      <div class="case-studies">
+        {projs
+          .filter((p) => p.caseStudyDetailed)
+          .map((p) => (
+            <CaseStudyExpander
+              title={p.name}
+              problem={p.caseStudyDetailed!.problem[locale]}
+              process={p.caseStudyDetailed!.process[locale]}
+              result={p.caseStudyDetailed!.result[locale]}
+              metrics={p.metrics ? Object.values(p.metrics) : []}
+              labels={{
+                cta: t.labels.caseStudyCta,
+                problem: t.labels.caseStudyProblem,
+                process: t.labels.caseStudyProcess,
+                result: t.labels.caseStudyResult,
+                metricsTitle: t.labels.caseStudyMetrics,
+              }}
+            />
+          ))}
+      </div>
+    )
+  }
 </section>
+
+{
+  extras.includes('SkillsMarquee') && marqueeRowOne.length > 0 && (
+    <SkillsMarquee
+      rowOne={marqueeRowOne}
+      rowTwo={marqueeRowTwo.length > 0 ? marqueeRowTwo : undefined}
+      ariaLabel={t.sections.skills.title}
+    />
+  )
+}
+
+{
+  extras.includes('AiWorkflowSection') && (
+    <section class="container-wide">
+      <AiWorkflowSection locale={locale} />
+    </section>
+  )
+}
 
 <section id="skills" class="container-wide section">
   <SectionHeader
@@ -159,21 +308,25 @@ const softSkills = sks.filter((s) => s.kind === 'soft')
   .section {
     padding-block: var(--space-72);
   }
-  .experience-list {
-    display: grid;
-    gap: var(--space-20);
+  .section--compact {
+    padding-block: var(--space-40);
   }
   .exp-bullets {
     list-style: disc inside;
     margin-top: var(--space-8);
+    padding: 0;
   }
   .exp-bullets li {
     margin-bottom: var(--space-4);
   }
-  .projects-grid {
+  .awards-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: var(--space-20);
+  }
+  .case-studies {
+    display: grid;
+    gap: var(--space-16);
+    margin-top: var(--space-32);
   }
   .skills-block {
     display: grid;

--- a/packages/app-shared/src/components/LeadershipStats.astro
+++ b/packages/app-shared/src/components/LeadershipStats.astro
@@ -1,0 +1,185 @@
+---
+/**
+ * @component LeadershipStats
+ * @description Seccion exclusiva del nicho `leader`. Stats de liderazgo +
+ *   contexto de equipos liderados + mentoria + reorganizaciones navegadas.
+ *
+ * @props {'es' | 'en'} locale
+ *
+ * @example
+ *   <LeadershipStats locale="es" />
+ */
+interface Props {
+  locale: 'es' | 'en'
+}
+
+const { locale } = Astro.props
+const isEs = locale === 'es'
+
+const title = isEs ? 'Leadership track record' : 'Leadership track record'
+const subtitle = isEs
+  ? 'Liderazgo de equipos, navegacion de cambios organizacionales y entrega continua en contexto fintech LATAM.'
+  : 'Team leadership, organizational change navigation and continuous delivery in LATAM fintech context.'
+
+const stats = isEs
+  ? [
+      { value: 4, label: 'Roles de liderazgo' },
+      { value: 8, label: 'Equipos liderados' },
+      { value: 11, label: 'Años entregando producto' },
+      { value: 1, label: 'Premio Innovador del Año' },
+    ]
+  : [
+      { value: 4, label: 'Leadership roles' },
+      { value: 8, label: 'Teams led' },
+      { value: 11, label: 'Years shipping product' },
+      { value: 1, label: 'Innovator of the Year award' },
+    ]
+
+const pillars = isEs
+  ? [
+      {
+        title: 'Tech leadership',
+        body: 'Lider del equipo inicial en Dibal (primer dev contratado). Decision de arquitectura, hiring, mentoria a juniors, hand-off a equipos sucesores cuando la empresa crece.',
+      },
+      {
+        title: 'Organizational resilience',
+        body: 'Navegue reducciones de personal en Destacame manteniendo entrega y moral del equipo. Adaptacion entre frontend → microservices → equipo de plataforma sin perder velocidad.',
+      },
+      {
+        title: 'Mentoring + delivery',
+        body: 'Triple Alianza 2020: 1er lugar sector Comercio. Premio Innovador del Año 2023 Destacame por implementar soluciones automatizadas con impacto medible en operaciones.',
+      },
+    ]
+  : [
+      {
+        title: 'Tech leadership',
+        body: 'Led initial team at Dibal (first hire). Architecture decisions, hiring, mentoring juniors, hand-off to successor teams as the company scaled.',
+      },
+      {
+        title: 'Organizational resilience',
+        body: 'Navigated headcount reductions at Destacame while maintaining delivery and team morale. Shifted between frontend → microservices → platform team without losing pace.',
+      },
+      {
+        title: 'Mentoring + delivery',
+        body: 'Triple Alliance 2020: 1st place Commerce sector. Innovator of the Year 2023 Destacame for shipping automated solutions with measurable ops impact.',
+      },
+    ]
+---
+
+<section class="leadership scroll-reveal" data-section="leadership-stats">
+  <header class="leadership__header">
+    <span class="leadership__eyebrow text-mono-label">
+      <span class="leadership__dot" aria-hidden="true"></span>
+      Tech Lead · Engineering Manager
+    </span>
+    <h2 class="leadership__title text-h2 gradient-text">{title}</h2>
+    <p class="leadership__subtitle text-body-lg text-muted">{subtitle}</p>
+  </header>
+
+  <dl class="leadership__stats">
+    {
+      stats.map((s) => (
+        <div class="leadership__stat">
+          <dt class="leadership__stat-label text-mono-label text-muted">{s.label}</dt>
+          <dd class="leadership__stat-value text-display-sm">
+            <span class="stat-number gradient-text" data-target={s.value}>0</span>
+          </dd>
+        </div>
+      ))
+    }
+  </dl>
+
+  <div class="leadership__pillars">
+    {
+      pillars.map((p, idx) => (
+        <article class="leadership__pillar">
+          <span class="leadership__pillar-index text-mono-label">
+            {String(idx + 1).padStart(2, '0')}
+          </span>
+          <h3 class="leadership__pillar-title text-h4">{p.title}</h3>
+          <p class="leadership__pillar-body text-body text-muted">{p.body}</p>
+        </article>
+      ))
+    }
+  </div>
+</section>
+
+<style>
+  .leadership {
+    padding-block: var(--space-72);
+  }
+  .leadership__header {
+    display: grid;
+    gap: var(--space-16);
+    margin-bottom: var(--space-40);
+    max-width: 720px;
+  }
+  .leadership__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    color: var(--niche-accent);
+  }
+  .leadership__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 12px var(--niche-glow);
+  }
+  .leadership__title {
+    margin: 0;
+  }
+  .leadership__subtitle {
+    margin: 0;
+  }
+  .leadership__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-24);
+    margin: 0 0 var(--space-56) 0;
+    padding: var(--space-32);
+    background: var(--color-surface);
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.25);
+    border-radius: var(--radius-md);
+  }
+  .leadership__stat {
+    display: grid;
+    gap: var(--space-6);
+  }
+  .leadership__stat-label {
+    margin: 0;
+  }
+  .leadership__stat-value {
+    margin: 0;
+    font-variation-settings: 'wght' 800;
+  }
+  .leadership__pillars {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--space-20);
+  }
+  .leadership__pillar {
+    padding: var(--space-24);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    display: grid;
+    gap: var(--space-12);
+    transition: border-color var(--motion-slow) var(--easing-out);
+  }
+  .leadership__pillar:hover {
+    border-color: rgba(var(--niche-accent-rgb), 0.4);
+  }
+  .leadership__pillar-index {
+    color: var(--niche-accent);
+    margin: 0;
+  }
+  .leadership__pillar-title {
+    margin: 0;
+  }
+  .leadership__pillar-body {
+    margin: 0;
+    line-height: var(--line-height-relaxed);
+  }
+</style>

--- a/packages/app-shared/src/index.ts
+++ b/packages/app-shared/src/index.ts
@@ -1,6 +1,9 @@
 /**
  * @module @portfolio/app-shared
  */
+export { buildStats } from './lib/build-stats'
+export type { NicheExtra } from './lib/get-niche-extras'
+export { getNicheExtras } from './lib/get-niche-extras'
 export type { I18nStrings, NavItem, SiteContext } from './lib/site-config'
 export { buildStrings } from './lib/site-config'
 export type { SiteKey } from './lib/site-urls'

--- a/packages/app-shared/src/layouts/SitePageLayout.astro
+++ b/packages/app-shared/src/layouts/SitePageLayout.astro
@@ -1,12 +1,15 @@
 ---
 import type { Niche } from '@portfolio/content'
 import { filterByNiche, profile, skills } from '@portfolio/content'
-import { buildPersonSchema } from '@portfolio/seo'
+import { buildProfilePageSchema } from '@portfolio/seo'
+import { nicheTokensToCssVars } from '@portfolio/ui'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import Nav from '@portfolio/ui/components/Nav.astro'
 /**
  * @layout SitePageLayout
  * @description Wrapper compartido. Cada app pasa siteUrl + niche + strings.
+ *   Inyecta tokens visuales del nicho (--niche-accent, --niche-glow, ...)
+ *   en el <main> y bootstrappea magnetic-cursor + number-counters.
  *
  * @props {string} title - title HTML
  * @props {string} description - meta description
@@ -16,6 +19,7 @@ import Nav from '@portfolio/ui/components/Nav.astro'
  * @props {string} siteUrl - base canonical del sitio
  * @props {import('@portfolio/content').Niche} niche
  * @props {Array<{href, label}>} navItems
+ * @props {string} [ogImage]
  */
 import BaseLayout from '@portfolio/ui/layouts/BaseLayout.astro'
 
@@ -52,13 +56,15 @@ const canonicalUrl = `${siteUrl}${canonicalPath}`
 const knowsAbout = filterByNiche(skills, niche).flatMap((c) =>
   c.skills.slice(0, 5),
 )
-const jsonLd = buildPersonSchema({
+const jsonLd = buildProfilePageSchema({
   profile,
   niche,
   locale,
   canonicalUrl,
   knowsAbout,
 })
+
+const nicheStyle = nicheTokensToCssVars(niche)
 ---
 
 <BaseLayout
@@ -77,11 +83,35 @@ const jsonLd = buildPersonSchema({
     currentLocale={locale}
     otherLocaleHref={otherLocalePath}
   />
-  <slot />
+  <div class="niche-root" data-niche={niche} style={nicheStyle}>
+    <slot />
+  </div>
   <Footer
     slot="footer"
     name="Pablo Contreras"
     contacts={profile.contacts}
     locale={locale}
   />
+  <script>
+    import { initMagneticCursor, initNumberCounters } from '@portfolio/ui'
+
+    let magneticCleanup: (() => void) | undefined
+    let counterCleanup: (() => void) | undefined
+
+    const boot = () => {
+      magneticCleanup?.()
+      counterCleanup?.()
+      magneticCleanup = initMagneticCursor()
+      counterCleanup = initNumberCounters()
+    }
+
+    boot()
+    document.addEventListener('astro:after-swap', boot)
+  </script>
 </BaseLayout>
+
+<style is:global>
+  .niche-root {
+    display: contents;
+  }
+</style>

--- a/packages/app-shared/src/lib/build-stats.ts
+++ b/packages/app-shared/src/lib/build-stats.ts
@@ -1,0 +1,65 @@
+/**
+ * @module build-stats
+ * @description Deriva stats numericos del CV (years, companies, countries,
+ *   certifications) para StatsBar. Prioriza valores declarados en
+ *   profile.stats; si no existen, calcula desde experiences[] y certificates[].
+ */
+import {
+  certificates,
+  experiences,
+  type Profile,
+  type ProfileStats,
+  profile,
+} from '@portfolio/content'
+
+/**
+ * Cuenta companias unicas desde experiences[] (slug company / company name).
+ */
+function countCompanies(): number {
+  const unique = new Set(experiences.map((e) => e.company))
+  return unique.size
+}
+
+/**
+ * Calcula years of experience desde la fecha de inicio mas antigua.
+ */
+function calcYearsExperience(): number {
+  const starts = experiences
+    .map((e) => e.start)
+    .sort((a, b) => a.localeCompare(b))
+  if (starts.length === 0) {
+    return 0
+  }
+  const [year, month] = (starts[0] ?? '2013-01').split('-').map(Number)
+  const earliest = new Date(year ?? 2013, (month ?? 1) - 1, 1)
+  const now = new Date()
+  const diffYears =
+    now.getFullYear() -
+    earliest.getFullYear() +
+    (now.getMonth() - earliest.getMonth()) / 12
+  return Math.max(0, Math.floor(diffYears))
+}
+
+/**
+ * @function buildStats
+ * @description Construye stats finales para StatsBar. Si profile.stats existe,
+ *   usa esos valores; si no, calcula desde data.
+ *
+ * @param {Profile} [p=profile] - Profile singleton (default: imported profile)
+ * @returns {ProfileStats} Stats listos para renderizar
+ *
+ * @example
+ *   const stats = buildStats()
+ *   // { yearsExperience: 12, companies: 8, countries: 4, certifications: 11 }
+ */
+export function buildStats(p: Profile = profile): ProfileStats {
+  if (p.stats) {
+    return p.stats
+  }
+  return {
+    yearsExperience: calcYearsExperience(),
+    companies: countCompanies(),
+    countries: 4,
+    certifications: certificates.length,
+  }
+}

--- a/packages/app-shared/src/lib/build-stats.ts
+++ b/packages/app-shared/src/lib/build-stats.ts
@@ -6,38 +6,53 @@
  */
 import {
   certificates,
+  type Experience,
   experiences,
   type Profile,
   type ProfileStats,
   profile,
 } from '@portfolio/content'
 
-/**
- * Cuenta companias unicas desde experiences[] (slug company / company name).
- */
-function countCompanies(): number {
-  const unique = new Set(experiences.map((e) => e.company))
-  return unique.size
-}
+const DEFAULT_COUNTRIES = 4
 
 /**
- * Calcula years of experience desde la fecha de inicio mas antigua.
+ * @function calcYearsExperience
+ * @description Calcula years of experience desde la fecha de inicio mas antigua.
+ *
+ * @param {readonly Experience[]} list - Lista de experiencias a analizar
+ * @returns {number} Anos completos desde el primer rol al momento actual
+ *
+ * @example
+ *   calcYearsExperience([{ start: '2013-01', ... }])  // 13
+ *   calcYearsExperience([])  // 0
  */
-function calcYearsExperience(): number {
-  const starts = experiences
-    .map((e) => e.start)
-    .sort((a, b) => a.localeCompare(b))
-  if (starts.length === 0) {
+export function calcYearsExperience(list: readonly Experience[]): number {
+  if (list.length === 0) {
     return 0
   }
-  const [year, month] = (starts[0] ?? '2013-01').split('-').map(Number)
-  const earliest = new Date(year ?? 2013, (month ?? 1) - 1, 1)
+  const starts = list.map((e) => e.start).sort((a, b) => a.localeCompare(b))
+  // starts[0] siempre existe porque list.length > 0 (guard arriba)
+  const earliestStr = starts[0] as string
+  const [yearStr, monthStr] = earliestStr.split('-')
+  const earliest = new Date(Number(yearStr), Number(monthStr) - 1, 1)
   const now = new Date()
   const diffYears =
     now.getFullYear() -
     earliest.getFullYear() +
     (now.getMonth() - earliest.getMonth()) / 12
   return Math.max(0, Math.floor(diffYears))
+}
+
+/**
+ * @function countCompanies
+ * @description Cuenta companias unicas en la lista de experiences (por
+ *   `company` field).
+ *
+ * @param {readonly Experience[]} list - Lista de experiencias
+ * @returns {number} Conteo de companias unicas
+ */
+export function countCompanies(list: readonly Experience[]): number {
+  return new Set(list.map((e) => e.company)).size
 }
 
 /**
@@ -50,16 +65,16 @@ function calcYearsExperience(): number {
  *
  * @example
  *   const stats = buildStats()
- *   // { yearsExperience: 12, companies: 8, countries: 4, certifications: 11 }
+ *   // { yearsExperience: 12, companies: 5, countries: 4, certifications: 11 }
  */
 export function buildStats(p: Profile = profile): ProfileStats {
   if (p.stats) {
     return p.stats
   }
   return {
-    yearsExperience: calcYearsExperience(),
-    companies: countCompanies(),
-    countries: 4,
+    yearsExperience: calcYearsExperience(experiences),
+    companies: countCompanies(experiences),
+    countries: DEFAULT_COUNTRIES,
     certifications: certificates.length,
   }
 }

--- a/packages/app-shared/src/lib/get-niche-extras.ts
+++ b/packages/app-shared/src/lib/get-niche-extras.ts
@@ -1,0 +1,44 @@
+/**
+ * @module get-niche-extras
+ * @description Mapeo niche -> secciones extras renderizadas por CvSections.
+ *   Permite que cada nicho tenga secciones unicas mas alla del Hero/Experience/
+ *   Projects/Skills/Contact comunes.
+ */
+import type { Niche } from '@portfolio/content'
+
+/** Secciones extras renderizadas por CvSections segun nicho. */
+export type NicheExtra =
+  | 'StatsBar'
+  | 'SkillsMarquee'
+  | 'AiWorkflowSection'
+  | 'ArchitectureDiagram'
+  | 'LeadershipStats'
+  | 'AtsKeywordsPills'
+  | 'AwardsHighlight'
+  | 'EducationSection'
+
+/**
+ * Tabla niche -> extras. Orden importa (se renderiza en orden).
+ */
+const EXTRAS_BY_NICHE: Record<Niche, NicheExtra[]> = {
+  generic: ['StatsBar', 'SkillsMarquee'],
+  fintech: ['StatsBar', 'AtsKeywordsPills', 'SkillsMarquee'],
+  architect: ['StatsBar', 'ArchitectureDiagram', 'SkillsMarquee'],
+  leader: ['StatsBar', 'LeadershipStats', 'AwardsHighlight', 'SkillsMarquee'],
+  vibe: ['StatsBar', 'AiWorkflowSection', 'SkillsMarquee'],
+}
+
+/**
+ * @function getNicheExtras
+ * @description Lista de secciones extras a renderizar para un nicho.
+ *
+ * @param {Niche} niche - Identificador del nicho
+ * @returns {NicheExtra[]} Lista ordenada de extras
+ *
+ * @example
+ *   getNicheExtras('vibe')
+ *   // ['StatsBar', 'AiWorkflowSection', 'SkillsMarquee']
+ */
+export function getNicheExtras(niche: Niche): NicheExtra[] {
+  return EXTRAS_BY_NICHE[niche]
+}

--- a/packages/app-shared/src/lib/site-config.ts
+++ b/packages/app-shared/src/lib/site-config.ts
@@ -18,8 +18,18 @@ export interface I18nStrings {
   nav: NavItem[]
   hero: {
     eyebrow: string
+    headline: string
+    summary: string
+    nicheLabel: string
     ctaPrimary: string
     ctaSecondary: string
+  }
+  stats: {
+    eyebrow: string
+    yearsExperience: string
+    companies: string
+    countries: string
+    certifications: string
   }
   sections: {
     experience: { title: string; subtitle: string }
@@ -29,7 +39,7 @@ export interface I18nStrings {
     contact: { title: string; subtitle: string }
     certificates: { title: string; subtitle: string }
     publications: { title: string }
-    awards: { title: string }
+    awards: { title: string; subtitle: string }
     education: { title: string }
     languages: { title: string }
     references: { title: string }
@@ -40,7 +50,13 @@ export interface I18nStrings {
     confidential: string
     technicalSkills: string
     softSkills: string
+    caseStudyCta: string
+    caseStudyProblem: string
+    caseStudyProcess: string
+    caseStudyResult: string
+    caseStudyMetrics: string
   }
+  atsKeywords: string[]
 }
 
 interface SiteOverrides {
@@ -50,10 +66,17 @@ interface SiteOverrides {
   metaDescriptionEn: string
   heroEyebrowEs?: string
   heroEyebrowEn?: string
+  heroHeadlineEs?: string
+  heroHeadlineEn?: string
+  heroSummaryEs?: string
+  heroSummaryEn?: string
+  nicheLabelEs?: string
+  nicheLabelEn?: string
   experienceSubtitleEs?: string
   experienceSubtitleEn?: string
   projectsSubtitleEs?: string
   projectsSubtitleEn?: string
+  atsKeywords?: string[]
 }
 
 const navEs = (basePrefix: string): NavItem[] => [
@@ -86,8 +109,20 @@ export function buildStrings(
       nav: navEs(''),
       hero: {
         eyebrow: overrides.heroEyebrowEs ?? 'Pablo Contreras · Lima, Perú',
+        headline: overrides.heroHeadlineEs ?? 'Senior Full Stack Engineer',
+        summary:
+          overrides.heroSummaryEs ??
+          'Más de 12 años entregando producto. Especialización en fintech LATAM, microservicios, AWS y plataformas Vue / Django.',
+        nicheLabel: overrides.nicheLabelEs ?? 'Full Stack',
         ctaPrimary: 'Ver experiencia',
         ctaSecondary: 'Descargar CV',
+      },
+      stats: {
+        eyebrow: 'Track record',
+        yearsExperience: 'Años entregando producto',
+        companies: 'Empresas',
+        countries: 'Países LATAM',
+        certifications: 'Certificaciones',
       },
       sections: {
         experience: {
@@ -118,7 +153,10 @@ export function buildStrings(
           subtitle: 'Certificaciones técnicas relevantes para este perfil.',
         },
         publications: { title: 'Publicaciones' },
-        awards: { title: 'Premios' },
+        awards: {
+          title: 'Premios',
+          subtitle: 'Reconocimientos por impacto técnico y de negocio.',
+        },
         education: { title: 'Educación' },
         languages: { title: 'Idiomas' },
         references: { title: 'Referencias' },
@@ -129,7 +167,13 @@ export function buildStrings(
         confidential: 'Bajo NDA — métricas detalladas en privado',
         technicalSkills: 'Técnicas',
         softSkills: 'Blandas',
+        caseStudyCta: 'Ver caso de estudio',
+        caseStudyProblem: 'Problema',
+        caseStudyProcess: 'Proceso',
+        caseStudyResult: 'Resultado',
+        caseStudyMetrics: 'Métricas',
       },
+      atsKeywords: overrides.atsKeywords ?? [],
     },
     en: {
       meta: {
@@ -139,8 +183,20 @@ export function buildStrings(
       nav: navEn('/en'),
       hero: {
         eyebrow: overrides.heroEyebrowEn ?? 'Pablo Contreras · Lima, Peru',
+        headline: overrides.heroHeadlineEn ?? 'Senior Full Stack Engineer',
+        summary:
+          overrides.heroSummaryEn ??
+          '12+ years shipping product. Specialized in LATAM fintech, microservices, AWS and Vue / Django platforms.',
+        nicheLabel: overrides.nicheLabelEn ?? 'Full Stack',
         ctaPrimary: 'View experience',
         ctaSecondary: 'Download CV',
+      },
+      stats: {
+        eyebrow: 'Track record',
+        yearsExperience: 'Years shipping product',
+        companies: 'Companies',
+        countries: 'LATAM countries',
+        certifications: 'Certifications',
       },
       sections: {
         experience: {
@@ -170,7 +226,10 @@ export function buildStrings(
           subtitle: 'Technical certifications relevant for this profile.',
         },
         publications: { title: 'Publications' },
-        awards: { title: 'Awards' },
+        awards: {
+          title: 'Awards',
+          subtitle: 'Recognition for technical and business impact.',
+        },
         education: { title: 'Education' },
         languages: { title: 'Languages' },
         references: { title: 'References' },
@@ -181,7 +240,13 @@ export function buildStrings(
         confidential: 'Under NDA — detailed metrics on request',
         technicalSkills: 'Technical',
         softSkills: 'Soft',
+        caseStudyCta: 'View case study',
+        caseStudyProblem: 'Problem',
+        caseStudyProcess: 'Process',
+        caseStudyResult: 'Result',
+        caseStudyMetrics: 'Metrics',
       },
+      atsKeywords: overrides.atsKeywords ?? [],
     },
   }
 }

--- a/packages/app-shared/tests/unit/lib/build-stats.test.ts
+++ b/packages/app-shared/tests/unit/lib/build-stats.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @description Tests para buildStats: derivacion de stats desde profile o
+ *   calculo desde data si profile.stats no esta definido.
+ */
+import type { Experience, Profile } from '@portfolio/content'
+import { describe, expect, it } from 'vitest'
+import {
+  buildStats,
+  calcYearsExperience,
+  countCompanies,
+} from '../../../src/lib/build-stats'
+
+const baseProfile: Profile = {
+  name: 'Test',
+  handle: 'test',
+  headline: { es: 'h-es', en: 'h-en' },
+  summary: { es: 's-es', en: 's-en' },
+  location: 'Lima',
+  contacts: {
+    email: 'a@b.com',
+    linkedin: 'https://linkedin.com/in/test',
+    github: 'https://github.com/test',
+  },
+  avatarUrl: 'https://example.com/a.jpg',
+  niches: ['generic'],
+}
+
+describe('buildStats', () => {
+  it('Given profile con stats explicitos When buildStats Then retorna esos stats sin recalcular', () => {
+    const profileWithStats: Profile = {
+      ...baseProfile,
+      stats: {
+        yearsExperience: 15,
+        companies: 9,
+        countries: 5,
+        certifications: 20,
+      },
+    }
+    const result = buildStats(profileWithStats)
+    expect(result).toStrictEqual({
+      yearsExperience: 15,
+      companies: 9,
+      countries: 5,
+      certifications: 20,
+    })
+  })
+
+  it('Given profile con stats yearsExperience=0 When buildStats Then retorna 0 (no fallback)', () => {
+    const profileWithStats: Profile = {
+      ...baseProfile,
+      stats: {
+        yearsExperience: 0,
+        companies: 0,
+        countries: 0,
+        certifications: 0,
+      },
+    }
+    const result = buildStats(profileWithStats)
+    expect(result.yearsExperience).toBe(0)
+    expect(result.companies).toBe(0)
+    expect(result.countries).toBe(0)
+    expect(result.certifications).toBe(0)
+  })
+
+  it('Given profile sin stats When buildStats Then retorna objeto con 4 claves exactas', () => {
+    const profileWithoutStats: Profile = { ...baseProfile, stats: undefined }
+    const result = buildStats(profileWithoutStats)
+    expect(Object.keys(result).sort()).toStrictEqual([
+      'certifications',
+      'companies',
+      'countries',
+      'yearsExperience',
+    ])
+  })
+
+  it('Given profile sin stats When buildStats Then countries siempre es 4 (default declarado)', () => {
+    const profileWithoutStats: Profile = { ...baseProfile, stats: undefined }
+    const result = buildStats(profileWithoutStats)
+    expect(result.countries).toBe(4)
+  })
+
+  it('Given profile sin stats When buildStats Then companies refleja experiences unicas (5: Destacame, Dibal, GoodMeal, Independiente/Academico, Laboratorio Cofasa)', () => {
+    const profileWithoutStats: Profile = { ...baseProfile, stats: undefined }
+    const result = buildStats(profileWithoutStats)
+    // experiences.ts tiene 9 roles agrupados en 5 companias unicas
+    expect(result.companies).toBe(5)
+  })
+
+  it('Given profile sin stats When buildStats Then certifications coincide con array certificates', () => {
+    const profileWithoutStats: Profile = { ...baseProfile, stats: undefined }
+    const result = buildStats(profileWithoutStats)
+    // certificates.ts tiene 11 entradas segun el CV
+    expect(result.certifications).toBe(11)
+  })
+
+  it('Given profile sin stats When buildStats Then yearsExperience es 12 o 13 (basado en earliest 2013-01)', () => {
+    // Cubre la rama de calculo dinamico via Date.now(). Asercion exacta
+    // contra el valor calculado en este momento del tiempo.
+    const profileWithoutStats: Profile = { ...baseProfile, stats: undefined }
+    const result = buildStats(profileWithoutStats)
+    const now = new Date()
+    const expected = Math.floor(
+      now.getFullYear() - 2013 + (now.getMonth() - 0) / 12,
+    )
+    expect(result.yearsExperience).toBe(expected)
+  })
+})
+
+describe('calcYearsExperience', () => {
+  it('Given lista vacia When calcYearsExperience Then retorna 0', () => {
+    expect(calcYearsExperience([])).toBe(0)
+  })
+
+  it('Given una sola experience con start 2020-01 When calcYearsExperience Then retorna anos desde 2020-01', () => {
+    const exp = {
+      slug: 'test',
+      role: { es: 'r', en: 'r' },
+      company: 'C',
+      start: '2020-01' as const,
+      niches: ['generic'],
+      priority: {},
+      responsibilities: { es: ['x'], en: ['x'] },
+      achievements: { es: [], en: [] },
+      skillsTechnical: [],
+      skillsSoft: [],
+    } as unknown as Experience
+    const result = calcYearsExperience([exp])
+    const now = new Date()
+    const expected = Math.floor(
+      now.getFullYear() - 2020 + (now.getMonth() - 0) / 12,
+    )
+    expect(result).toBe(expected)
+  })
+})
+
+describe('countCompanies', () => {
+  it('Given lista vacia When countCompanies Then retorna 0', () => {
+    expect(countCompanies([])).toBe(0)
+  })
+
+  it('Given 3 experiences con 2 companies distintas When countCompanies Then retorna 2', () => {
+    const make = (company: string): Experience =>
+      ({
+        slug: 's',
+        role: { es: 'r', en: 'r' },
+        company,
+        start: '2020-01' as const,
+        niches: ['generic'],
+        priority: {},
+        responsibilities: { es: ['x'], en: ['x'] },
+        achievements: { es: [], en: [] },
+        skillsTechnical: [],
+        skillsSoft: [],
+      }) as unknown as Experience
+    const list = [make('A'), make('A'), make('B')]
+    expect(countCompanies(list)).toBe(2)
+  })
+})

--- a/packages/app-shared/tests/unit/lib/get-niche-extras.test.ts
+++ b/packages/app-shared/tests/unit/lib/get-niche-extras.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @description Tests para getNicheExtras: mapeo niche -> secciones extras.
+ */
+import { describe, expect, it } from 'vitest'
+import { getNicheExtras } from '../../../src/lib/get-niche-extras'
+
+describe('getNicheExtras', () => {
+  it('Given niche generic When getNicheExtras Then retorna StatsBar y SkillsMarquee', () => {
+    const result = getNicheExtras('generic')
+    expect(result).toStrictEqual(['StatsBar', 'SkillsMarquee'])
+  })
+
+  it('Given niche fintech When getNicheExtras Then incluye AtsKeywordsPills', () => {
+    const result = getNicheExtras('fintech')
+    expect(result).toStrictEqual([
+      'StatsBar',
+      'AtsKeywordsPills',
+      'SkillsMarquee',
+    ])
+  })
+
+  it('Given niche architect When getNicheExtras Then incluye ArchitectureDiagram', () => {
+    const result = getNicheExtras('architect')
+    expect(result).toStrictEqual([
+      'StatsBar',
+      'ArchitectureDiagram',
+      'SkillsMarquee',
+    ])
+  })
+
+  it('Given niche leader When getNicheExtras Then incluye LeadershipStats y AwardsHighlight', () => {
+    const result = getNicheExtras('leader')
+    expect(result).toStrictEqual([
+      'StatsBar',
+      'LeadershipStats',
+      'AwardsHighlight',
+      'SkillsMarquee',
+    ])
+  })
+
+  it('Given niche vibe When getNicheExtras Then incluye AiWorkflowSection', () => {
+    const result = getNicheExtras('vibe')
+    expect(result).toStrictEqual([
+      'StatsBar',
+      'AiWorkflowSection',
+      'SkillsMarquee',
+    ])
+  })
+
+  it('Given todos los niches When getNicheExtras Then todos contienen StatsBar primero', () => {
+    const niches = [
+      'generic',
+      'fintech',
+      'architect',
+      'leader',
+      'vibe',
+    ] as const
+    for (const n of niches) {
+      const result = getNicheExtras(n)
+      expect(result[0]).toBe('StatsBar')
+    }
+  })
+
+  it('Given todos los niches When getNicheExtras Then todos terminan con SkillsMarquee', () => {
+    const niches = [
+      'generic',
+      'fintech',
+      'architect',
+      'leader',
+      'vibe',
+    ] as const
+    for (const n of niches) {
+      const result = getNicheExtras(n)
+      expect(result[result.length - 1]).toBe('SkillsMarquee')
+    }
+  })
+})

--- a/packages/content/src/data/profile.ts
+++ b/packages/content/src/data/profile.ts
@@ -27,4 +27,10 @@ export const profile: Profile = ProfileSchema.parse({
   },
   avatarUrl: 'https://images-bypabloc.s3.sa-east-1.amazonaws.com/cv/1.avif',
   niches: ['fintech', 'architect', 'leader', 'vibe', 'generic'],
+  stats: {
+    yearsExperience: 12,
+    companies: 8,
+    countries: 4,
+    certifications: 11,
+  },
 })

--- a/packages/content/src/data/projects.ts
+++ b/packages/content/src/data/projects.ts
@@ -16,8 +16,8 @@ const raw: Project[] = [
       en: 'VS Code extension that visualizes and documents a project structure in seconds, optimized for AI workflows.',
     },
     description: {
-      es: 'Genera documentación clara y bien formateada de la estructura de directorios e incluye contenido de archivos cuando sea necesario. Nació de la necesidad real de pasarle contexto estructural a un LLM sin copiar manualmente.',
-      en: 'Generates clear, well-formatted documentation of a directory tree, optionally including file contents. Born from the actual need to feed structural context to an LLM without copy-pasting.',
+      es: 'Genera documentación clara y bien formateada de la estructura de directorios e incluye contenido de archivos cuando sea necesario. Nació antes de Claude Code para pasarle contexto estructural a la interfaz web de Claude sin copiar manualmente.',
+      en: 'Generates clear, well-formatted documentation of a directory tree, optionally including file contents. Born before Claude Code to feed structural context to the Claude web interface without copy-pasting.',
     },
     url: 'https://marketplace.visualstudio.com/items?itemName=the-full-stack.faststruct',
     repo: 'https://github.com/bypabloc/faststruct',
@@ -28,6 +28,103 @@ const raw: Project[] = [
     caseStudy: {
       es: 'Problema: pasarle estructura de proyecto a Claude/ChatGPT requería pegar manualmente cada path. Solución: extensión que genera markdown estructurado con un click. Impacto: workflow personal 5x más rápido al instruir IAs.',
       en: 'Problem: feeding project structure to Claude/ChatGPT meant pasting each path manually. Solution: an extension that produces structured markdown in one click. Impact: 5x faster personal workflow when instructing AIs.',
+    },
+    caseStudyDetailed: {
+      problem: {
+        es: 'Antes de Claude Code (mayo 2025) usaba la interfaz web de Claude para programar. Pasarle el contexto de un proyecto significaba copiar archivo por archivo manualmente.',
+        en: 'Before Claude Code (May 2025) I used the Claude web interface to code. Sharing project context meant copy-pasting file by file manually.',
+      },
+      process: {
+        es: 'Construí FastStruct como extensión VS Code en TypeScript: comando único que escanea workspace, respeta .gitignore, formatea en markdown estructurado y copia al portapapeles. Patrones de exclusión configurables.',
+        en: 'I built FastStruct as a TypeScript VS Code extension: single command that scans the workspace, honors .gitignore, formats structured markdown and copies to clipboard. Configurable exclusion patterns.',
+      },
+      result: {
+        es: 'Workflow personal 5x más rápido para instruir IAs. Publicada en Marketplace, sigue siendo útil incluso ahora con Claude Code para casos donde necesito contexto compacto para sub-agentes o resumenes externos.',
+        en: '5x faster personal workflow when instructing AIs. Published in the Marketplace, still useful even now with Claude Code for cases where I need compact context for sub-agents or external summaries.',
+      },
+    },
+    metrics: {
+      speedup: '5x faster context handoff',
+      adoption: 'Marketplace published',
+      precursor: 'Pre-Claude-Code era (< May 2025)',
+    },
+    isConfidential: false,
+  },
+  {
+    slug: 'mvp-template-full-stack',
+    name: 'MVP template Full Stack',
+    summary: {
+      es: 'Template público que uso de referencia para nuevos proyectos: estructura .claude/ con skills, rules, hooks, devtools CLI, conformance y testing.',
+      en: 'Public template I use as reference for new projects: .claude/ structure with skills, rules, hooks, devtools CLI, conformance and testing.',
+    },
+    description: {
+      es: 'Blueprint del flujo vibe coding completo: Astro 6 + Django stack-ready, harness de Claude Code estandarizado, quality gates en pre-commit/pre-push, devtools CLI en Python 3.14 con uv. Mismo patrón que adopté en Destacame al introducir Claude Code en el equipo.',
+      en: 'Blueprint of the full vibe coding workflow: Astro 6 + Django stack-ready, standardized Claude Code harness, quality gates in pre-commit/pre-push, Python 3.14 + uv devtools CLI. Same pattern I adopted at Destacame when rolling out Claude Code in the team.',
+    },
+    url: 'https://github.com/bypabloc/mvp-template-full-stack',
+    repo: 'https://github.com/bypabloc/mvp-template-full-stack',
+    status: 'active',
+    niches: ['vibe', 'architect', 'generic'],
+    priority: { vibe: 92, architect: 75, generic: 65 },
+    stack: [
+      'Claude Code',
+      'Astro 6',
+      'TypeScript',
+      'Python 3.14',
+      'Django',
+      'Biome v2',
+      'uv',
+    ],
+    caseStudy: {
+      es: 'Blueprint para arrancar proyectos full stack con flujo vibe coding estandarizado: harness Claude Code + quality gates + devtools CLI. Mismo patrón usado al implementar Claude Code en Destacame.',
+      en: 'Blueprint to bootstrap full stack projects with a standardized vibe coding workflow: Claude Code harness + quality gates + devtools CLI. Same pattern used when rolling out Claude Code at Destacame.',
+    },
+    metrics: {
+      coverage: 'Skills + Rules + Hooks + Devtools',
+      role: 'Reference for Destacame Claude Code rollout',
+      stack: 'Astro + Django + Python 3.14 + uv',
+    },
+    isConfidential: false,
+  },
+  {
+    slug: 'cv-builder',
+    name: 'CV builder (bypabloc/cv)',
+    summary: {
+      es: 'CV builder construido en una sola noche con Claude Code (12 mayo 2026). Demo end-to-end del flujo vibe coding moderno: data → render → deploy.',
+      en: 'CV builder shipped in a single night with Claude Code (May 12, 2026). End-to-end demo of the modern vibe coding workflow: data → render → deploy.',
+    },
+    description: {
+      es: 'Proyecto que empecé la noche del 12/05/2026 y terminé al día siguiente. Demuestra cómo construir una herramienta funcional en pocas horas usando Claude Code como copiloto. Código revisado, testeado y mantenido por mí — la IA es herramienta, no autor.',
+      en: 'Project I started on the night of 2026-05-12 and finished the next day. Demonstrates building a functional tool in a few hours using Claude Code as a copilot. Code reviewed, tested and maintained by me — AI is a tool, not an author.',
+    },
+    url: 'https://github.com/bypabloc/cv',
+    repo: 'https://github.com/bypabloc/cv',
+    status: 'active',
+    niches: ['vibe', 'generic'],
+    priority: { vibe: 98, generic: 70 },
+    stack: ['TypeScript', 'Claude Code', 'Astro', 'Vibe Coding'],
+    caseStudy: {
+      es: 'Problema: necesitaba un CV builder propio que pudiera iterar rápido. Solución: vibe coding session con Claude Code, prompts iterativos, code review en cada commit. Impacto: MVP funcional en una noche.',
+      en: 'Problem: I needed a CV builder I could iterate on fast. Solution: vibe coding session with Claude Code, iterative prompts, code review on every commit. Impact: working MVP in one night.',
+    },
+    caseStudyDetailed: {
+      problem: {
+        es: 'Necesitaba un CV builder propio para iterar rápido sobre datos del CV sin tocar a mano cada exportación. Calendario apretado: una noche disponible.',
+        en: 'I needed my own CV builder to iterate fast on CV data without hand-editing each export. Tight timeline: one night available.',
+      },
+      process: {
+        es: 'Sesión vibe coding con Claude Code el 12/05/2026: prompts iterativos para definir esquema de datos, render, themes y export. Code review humano en cada commit. Nada de copy-paste sin entender.',
+        en: 'Vibe coding session with Claude Code on 2026-05-12: iterative prompts to define data schema, render, themes and export. Human code review on every commit. No copy-paste without understanding.',
+      },
+      result: {
+        es: 'MVP funcional en una sola noche, repo público en bypabloc/cv. Demuestra que la combinación Claude Code + revision humana entrega producto sin sacrificar mantenibilidad.',
+        en: 'Working MVP in a single night, public repo at bypabloc/cv. Demonstrates that Claude Code + human review combo ships product without sacrificing maintainability.',
+      },
+    },
+    metrics: {
+      timeline: 'Built in one night (May 12-13, 2026)',
+      ai_tool: 'Claude Code as copilot',
+      attribution: '0 AI attribution in commits (company policy)',
     },
     isConfidential: false,
   },
@@ -77,6 +174,25 @@ const raw: Project[] = [
       es: 'Problema: los usuarios chilenos no tenían un canal claro para regularizar deudas y las instituciones perdían cobranzas. Solución: orquestación entre microservicios fintech con un flujo guiado de elegibilidad → oferta → pago. Impacto: mejora medible en la eficiencia operativa de cobranza y en la experiencia del usuario final (detalles bajo NDA).',
       en: 'Problem: Chilean users lacked a clear channel to regularize debts and institutions lost collections. Solution: orchestration across fintech microservices with a guided eligibility → offer → payment flow. Impact: measurable improvement in collection operational efficiency and end-user experience (details under NDA).',
     },
+    caseStudyDetailed: {
+      problem: {
+        es: 'Los usuarios chilenos no tenian un canal claro para regularizar deudas y las instituciones financieras perdian cobranzas significativas. Datos sensibles (PII) + compliance financiero LATAM.',
+        en: 'Chilean users lacked a clear channel to regularize debts and financial institutions were losing significant collections. Sensitive data (PII) + LATAM financial compliance.',
+      },
+      process: {
+        es: 'Como Frontend Architect orqueste microservicios Django con frontend Vue/Nuxt: elegibilidad → oferta → pago. Manejo de PII con encriptacion en transito y reposo. Integracion con bureaus + verificacion KYC.',
+        en: 'As Frontend Architect I orchestrated Django microservices with Vue/Nuxt frontend: eligibility → offer → payment. PII handling with encryption in transit and at rest. Bureau integrations + KYC verification.',
+      },
+      result: {
+        es: 'Mejora medible en eficiencia operativa de cobranza y experiencia del usuario final. Plataforma sigue en produccion sirviendo el mercado chileno (metricas detalladas bajo NDA).',
+        en: 'Measurable improvement in collection operational efficiency and end-user experience. Platform still in production serving the Chilean market (detailed metrics under NDA).',
+      },
+    },
+    metrics: {
+      market: 'Chile',
+      compliance: 'PCI DSS aware · KYC · PII handling',
+      architecture: 'Vue/Nuxt + Django microservices + AWS',
+    },
     isConfidential: true,
   },
   {
@@ -105,6 +221,25 @@ const raw: Project[] = [
     caseStudy: {
       es: 'Problema: los usuarios mexicanos necesitaban créditos accesibles con onboarding rápido. Solución: producto con niveles de crédito, scoring integrado y flujo de aprobación que minimiza fricción. Impacto: contribución al portafolio fintech LATAM de Destacame en el mercado mexicano (detalles bajo NDA).',
       en: 'Problem: Mexican users needed accessible credit with fast onboarding. Solution: tiered-credit product with embedded scoring and a low-friction approval flow. Impact: contribution to Destacame LATAM fintech portfolio in the Mexican market (details under NDA).',
+    },
+    caseStudyDetailed: {
+      problem: {
+        es: 'Mercado mexicano requeria creditos personales accesibles con onboarding rapido. Restricciones regulatorias locales + fricciones de KYC + integracion con bureaus de credito.',
+        en: 'Mexican market required accessible personal credit with fast onboarding. Local regulatory constraints + KYC friction + credit bureau integrations.',
+      },
+      process: {
+        es: 'Producto con tramos de credito + scoring embebido + flujo de aprobacion de baja friccion. Frontend Vue/Nuxt + microservicios Django + integraciones con bureaus mexicanos. Decisiones de arquitectura documentadas para sucesores.',
+        en: 'Tiered-credit product + embedded scoring + low-friction approval flow. Vue/Nuxt frontend + Django microservices + Mexican credit bureau integrations. Documented architecture decisions for successors.',
+      },
+      result: {
+        es: 'Contribucion clave al portafolio fintech LATAM de Destacame en el mercado mexicano. Reutilizacion de patrones del producto Chile con adaptacion regulatoria local (metricas bajo NDA).',
+        en: 'Key contribution to Destacame LATAM fintech portfolio in the Mexican market. Pattern reuse from the Chilean product with local regulatory adaptation (metrics under NDA).',
+      },
+    },
+    metrics: {
+      market: 'México',
+      product: 'Tiered credit + embedded scoring',
+      architecture: 'Vue/Nuxt + Django + Bureau integrations',
     },
     isConfidential: true,
   },

--- a/packages/content/src/schemas.ts
+++ b/packages/content/src/schemas.ts
@@ -50,6 +50,15 @@ export const PriorityByNicheSchema = z.object({
 })
 export type PriorityByNiche = z.infer<typeof PriorityByNicheSchema>
 
+/** Stats derivados / declarados (cards de StatsBar). */
+export const ProfileStatsSchema = z.object({
+  yearsExperience: z.number().int().nonnegative(),
+  companies: z.number().int().nonnegative(),
+  countries: z.number().int().nonnegative(),
+  certifications: z.number().int().nonnegative(),
+})
+export type ProfileStats = z.infer<typeof ProfileStatsSchema>
+
 /** Profile (singleton). */
 export const ProfileSchema = z.object({
   name: z.string().min(1),
@@ -67,6 +76,7 @@ export const ProfileSchema = z.object({
   }),
   avatarUrl: z.string().url(),
   niches: z.array(NicheSchema).min(1),
+  stats: ProfileStatsSchema.optional(),
 })
 export type Profile = z.infer<typeof ProfileSchema>
 
@@ -108,6 +118,13 @@ export const ProjectSchema = z.object({
   stack: z.array(z.string().min(1)),
   caseStudy: BiLangSchema.optional(),
   metrics: z.record(z.string(), z.string()).optional(),
+  caseStudyDetailed: z
+    .object({
+      problem: BiLangSchema,
+      process: BiLangSchema,
+      result: BiLangSchema,
+    })
+    .optional(),
   isConfidential: z.boolean().default(false),
 })
 export type Project = z.infer<typeof ProjectSchema>

--- a/packages/seo/src/index.ts
+++ b/packages/seo/src/index.ts
@@ -4,4 +4,5 @@
 
 export { buildLlmsTxt } from './lib/build-llms-txt'
 export { buildPersonSchema } from './lib/build-person-schema'
+export { buildProfilePageSchema } from './lib/build-profile-page-schema'
 export { buildRobotsTxt, buildSitemap } from './lib/build-sitemap'

--- a/packages/seo/src/lib/build-llms-txt.ts
+++ b/packages/seo/src/lib/build-llms-txt.ts
@@ -4,7 +4,10 @@
  *   Formato: spec llms.txt (https://llmstxt.org). En INGLES (audiencia: crawlers
  *   de IA en cualquier idioma).
  *
- *   Cubre AC-3: cada subdominio sirve llms.txt con páginas y resumenes.
+ *   Incluye narrativa por nicho + ATS keywords + projects highlight + AI tooling
+ *   history (white-hat: honesto, sin manipulacion).
+ *
+ *   Cubre AC-3 y recomendacion ai-prompt-optimization/03c-llms-robots-sitemap.md.
  */
 import type { Niche, Profile } from '@portfolio/content'
 
@@ -19,22 +22,53 @@ interface BuildLlmsTxtInput {
   profile: Profile
   niche: Niche
   pages: PageEntry[]
+  atsKeywords?: string[]
 }
 
 const NICHE_DESCRIPTION: Record<Niche, string> = {
   fintech:
-    'Senior Full Stack engineer specialized in Latin American fintech (Chile, Mexico). 8+ years building credit, debt-settlement and payment products with Vue/Nuxt + Django + AWS microservices.',
+    'Senior Full Stack engineer specialized in Latin American fintech (Chile, Mexico). 12+ years building credit, debt-settlement and payment products with Vue/Nuxt + Django + AWS microservices. Compliance-aware (PCI DSS, KYC, PII handling).',
   architect:
-    'Frontend Architect with deep microservices experience. 8+ years designing scalable systems with Vue/Nuxt, Django, AWS and microfrontends.',
+    'Frontend Architect with deep microservices and distributed systems experience. 12+ years designing scalable architectures: microfrontend (Vue/Nuxt) + 8+ Django microservices + AWS API Gateway + PostgreSQL/Redis/SQS + observability with CloudWatch/Sentry.',
   leader:
-    'Tech Lead with experience leading multi-disciplinary engineering teams, mentoring junior developers and shipping fintech products at scale.',
-  vibe: 'Software engineer who documents real workflows with Claude Code and Cursor. Builds developer tools (VS Code extensions, monorepo automation) and shares prompts that ship.',
+    'Tech Lead and Engineering Manager. 4 leadership roles, 8 teams led, 11+ years shipping product. Innovator of the Year 2023 at Destacame for automating internal operations. Mentoring + delivery + organizational resilience during reorganizations.',
+  vibe: 'AI-Augmented Software Engineer. Using Claude Code since launch (May 2025), previously Claude web + my own FastStruct VS Code extension. Rolled out Claude Code at Destacame with standardized skills/rules/docs structure. Builds CLIs to centralize team processes. AI is a tool, not an author — all code is human-reviewed and tested.',
   generic:
-    'Senior Full Stack Engineer with 8+ years of experience in Vue/Nuxt, Django, AWS and fintech (Chile, Mexico).',
+    'Senior Full Stack Engineer with 12+ years of experience in Vue/Nuxt, Django, AWS and LATAM fintech (Chile, Mexico). Cross-cutting expertise: fintech, architecture, tech leadership and vibe coding with Claude Code.',
+}
+
+const NICHE_HIGHLIGHTS: Record<Niche, string[]> = {
+  fintech: [
+    'Destacame (Chile, Mexico) — Frontend Architect since 2022, building debt settlement and tiered credit products',
+    'PCI DSS aware, KYC, PII handling',
+    'Stack: Vue 3 + Nuxt + TypeScript + Django + Python + AWS + Microservices',
+  ],
+  architect: [
+    'Microfrontend (Vue/Nuxt) + 8+ Django microservices on AWS',
+    'API Gateway with JWT + rate limiting',
+    'PostgreSQL 18 + RDS + S3 + Redis + SQS + CloudWatch/Sentry',
+  ],
+  leader: [
+    'Innovator of the Year 2023 at Destacame',
+    'Triple Alianza Lima 2020 — 1st place Commerce sector',
+    'First developer hired at Dibal; built and handed off engineering team',
+  ],
+  vibe: [
+    'Claude Code early adopter since launch (May 22, 2025)',
+    'FastStruct — VS Code extension published on Marketplace',
+    'Rolled out Claude Code at Destacame with skills/rules/docs structure',
+    'Built bypabloc/cv (CV builder MVP) in one night (May 12-13, 2026)',
+    'Reference template: bypabloc/mvp-template-full-stack',
+  ],
+  generic: [
+    '9 roles in 8 companies (2013-present)',
+    '12+ years shipping product · 4 LATAM countries · 11 certifications',
+    'Domains: Fintech LATAM, ERP, e-commerce, automation',
+  ],
 }
 
 export function buildLlmsTxt(input: BuildLlmsTxtInput): string {
-  const { siteUrl, profile, niche, pages } = input
+  const { siteUrl, profile, niche, pages, atsKeywords = [] } = input
   const lines: string[] = []
   lines.push(`# ${profile.name} — ${niche}`)
   lines.push('')
@@ -44,6 +78,21 @@ export function buildLlmsTxt(input: BuildLlmsTxtInput): string {
     `Canonical URL: ${siteUrl}. Author: ${profile.name} (${profile.handle}). Location: ${profile.location}. Contact: ${profile.contacts.email}.`,
   )
   lines.push('')
+
+  lines.push(`## Highlights — ${niche}`)
+  lines.push('')
+  for (const h of NICHE_HIGHLIGHTS[niche]) {
+    lines.push(`- ${h}`)
+  }
+  lines.push('')
+
+  if (atsKeywords.length > 0) {
+    lines.push('## Keywords')
+    lines.push('')
+    lines.push(atsKeywords.join(' · '))
+    lines.push('')
+  }
+
   lines.push('## Pages')
   lines.push('')
   for (const page of pages) {
@@ -53,6 +102,7 @@ export function buildLlmsTxt(input: BuildLlmsTxtInput): string {
     lines.push(`- [${page.title}](${url}): ${page.description}`)
   }
   lines.push('')
+
   lines.push('## Identity')
   lines.push('')
   lines.push(`- LinkedIn: ${profile.contacts.linkedin}`)
@@ -60,6 +110,17 @@ export function buildLlmsTxt(input: BuildLlmsTxtInput): string {
   if (profile.contacts.medium) {
     lines.push(`- Medium: ${profile.contacts.medium}`)
   }
+  if (profile.contacts.website) {
+    lines.push(`- Website: ${profile.contacts.website}`)
+  }
   lines.push('')
+
+  lines.push('## Disclosure')
+  lines.push('')
+  lines.push(
+    'All code in linked repositories is reviewed, tested and maintained by Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators — never as authors. AI attribution is forbidden in commits and PRs by company policy. This llms.txt is honest white-hat content; no prompt injection or hidden instructions.',
+  )
+  lines.push('')
+
   return `${lines.join('\n')}\n`
 }

--- a/packages/seo/src/lib/build-profile-page-schema.ts
+++ b/packages/seo/src/lib/build-profile-page-schema.ts
@@ -1,0 +1,100 @@
+/**
+ * @function buildProfilePageSchema
+ * @description Construye un schema.org ProfilePage que envuelve un Person.
+ *   ProfilePage es el tipo recomendado para portfolios personales (vs solo
+ *   Person en un WebPage genérico) — mejora GEO en ChatGPT/Claude/Perplexity.
+ *
+ *   Recomendado por modern-portfolios/03-geo-llm-seo.md +
+ *   ai-prompt-optimization/03a-json-ld-schemas.md.
+ *
+ * @param input - profile, niche, locale, canonicalUrl, knowsAbout
+ * @returns JSON-LD stringificado del ProfilePage (con Person embebido)
+ *
+ * @example
+ *   const ld = buildProfilePageSchema({
+ *     profile, niche: 'fintech', locale: 'es',
+ *     canonicalUrl: 'https://fintech.the-full-stack.com/',
+ *     knowsAbout: ['Vue', 'Django']
+ *   })
+ */
+import type { Niche, Profile } from '@portfolio/content'
+
+interface BuildProfilePageSchemaInput {
+  profile: Profile
+  niche: Niche
+  locale: 'es' | 'en'
+  canonicalUrl: string
+  knowsAbout: string[]
+}
+
+const JOB_TITLE_BY_NICHE: Record<Niche, { es: string; en: string }> = {
+  fintech: {
+    es: 'Ingeniero Full Stack senior — Fintech LATAM',
+    en: 'Senior Full Stack Engineer — LATAM Fintech',
+  },
+  architect: {
+    es: 'Arquitecto de Software y Microservicios',
+    en: 'Software and Microservices Architect',
+  },
+  leader: {
+    es: 'Tech Lead / Engineering Manager',
+    en: 'Tech Lead / Engineering Manager',
+  },
+  vibe: {
+    es: 'Ingeniero de Software AI-Augmented (Claude Code, Cursor)',
+    en: 'AI-Augmented Software Engineer (Claude Code, Cursor)',
+  },
+  generic: {
+    es: 'Ingeniero de Software Full Stack senior',
+    en: 'Senior Full Stack Software Engineer',
+  },
+}
+
+export function buildProfilePageSchema(
+  input: BuildProfilePageSchemaInput,
+): string {
+  const { profile, niche, locale, canonicalUrl, knowsAbout } = input
+  const jobTitle = JOB_TITLE_BY_NICHE[niche][locale]
+  const description = profile.summary[locale]
+
+  const sameAs = [profile.contacts.linkedin, profile.contacts.github]
+  if (profile.contacts.medium) {
+    sameAs.push(profile.contacts.medium)
+  }
+  if (profile.contacts.website) {
+    sameAs.push(profile.contacts.website)
+  }
+
+  const ld = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    dateModified: new Date().toISOString().split('T')[0],
+    mainEntity: {
+      '@type': 'Person',
+      name: profile.name,
+      alternateName: profile.handle,
+      jobTitle,
+      description,
+      url: canonicalUrl,
+      email: profile.contacts.email,
+      image: profile.avatarUrl,
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: profile.location,
+      },
+      sameAs,
+      knowsAbout,
+      hasOccupation: {
+        '@type': 'Occupation',
+        name: jobTitle,
+        occupationLocation: {
+          '@type': 'Country',
+          name: locale === 'es' ? 'Perú' : 'Peru',
+        },
+        skills: knowsAbout.join(', '),
+      },
+    },
+  }
+
+  return JSON.stringify(ld)
+}

--- a/packages/seo/tests/unit/build-profile-page-schema.test.ts
+++ b/packages/seo/tests/unit/build-profile-page-schema.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @description Tests para buildProfilePageSchema. Cubre AC-7 (JSON-LD
+ *   ProfilePage enriquecido para GEO).
+ */
+
+import { profile } from '@portfolio/content'
+import { describe, expect, it } from 'vitest'
+import { buildProfilePageSchema } from '../../src/lib/build-profile-page-schema'
+
+describe('buildProfilePageSchema', () => {
+  it('Given fintech niche en When build Then top-level is ProfilePage con mainEntity Person', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'fintech',
+      locale: 'en',
+      canonicalUrl: 'https://fintech.the-full-stack.com/',
+      knowsAbout: ['Vue', 'Django'],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed['@context']).toBe('https://schema.org')
+    expect(parsed['@type']).toBe('ProfilePage')
+    expect(parsed.mainEntity['@type']).toBe('Person')
+    expect(parsed.mainEntity.name).toBe('Pablo Contreras')
+    expect(parsed.mainEntity.email).toBe('pacg1991@gmail.com')
+  })
+
+  it('Given fintech niche en When build Then jobTitle matches LATAM Fintech', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'fintech',
+      locale: 'en',
+      canonicalUrl: 'https://fintech.the-full-stack.com/',
+      knowsAbout: ['Vue', 'Django'],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.jobTitle).toBe(
+      'Senior Full Stack Engineer — LATAM Fintech',
+    )
+  })
+
+  it('Given architect niche es When build Then jobTitle es en espanol', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'architect',
+      locale: 'es',
+      canonicalUrl: 'https://architect.the-full-stack.com/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.jobTitle).toBe(
+      'Arquitecto de Software y Microservicios',
+    )
+  })
+
+  it('Given vibe niche en When build Then jobTitle menciona Claude Code', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'vibe',
+      locale: 'en',
+      canonicalUrl: 'https://vibe.the-full-stack.com/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.jobTitle).toBe(
+      'AI-Augmented Software Engineer (Claude Code, Cursor)',
+    )
+  })
+
+  it('Given build Then hasOccupation con skills concatenadas con coma-espacio', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'generic',
+      locale: 'en',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: ['Vue', 'Django', 'AWS'],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.hasOccupation['@type']).toBe('Occupation')
+    expect(parsed.mainEntity.hasOccupation.skills).toBe('Vue, Django, AWS')
+  })
+
+  it('Given locale es When build Then occupationLocation country es "Perú"', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'generic',
+      locale: 'es',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.hasOccupation.occupationLocation.name).toBe('Perú')
+  })
+
+  it('Given locale en When build Then occupationLocation country es "Peru"', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'generic',
+      locale: 'en',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.hasOccupation.occupationLocation.name).toBe('Peru')
+  })
+
+  it('Given build Then sameAs contiene linkedin, github y medium', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'generic',
+      locale: 'en',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.sameAs).toContain(
+      'https://linkedin.com/in/bypabloc',
+    )
+    expect(parsed.mainEntity.sameAs).toContain('https://github.com/bypabloc')
+    expect(parsed.mainEntity.sameAs).toContain('https://bypablo.medium.com')
+  })
+
+  it('Given build Then dateModified es ISO date YYYY-MM-DD', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'generic',
+      locale: 'en',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}$/u)
+  })
+
+  it('Given profile sin medium ni website When build Then sameAs solo tiene linkedin+github', () => {
+    const profileMinimal = {
+      ...profile,
+      contacts: {
+        email: profile.contacts.email,
+        linkedin: profile.contacts.linkedin,
+        github: profile.contacts.github,
+      },
+    }
+    const ld = buildProfilePageSchema({
+      profile: profileMinimal,
+      niche: 'generic',
+      locale: 'en',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.sameAs).toHaveLength(2)
+  })
+})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,9 @@
   "dependencies": {
     "@portfolio/content": "workspace:*",
     "@fontsource/space-grotesk": "^5.1.1",
-    "@fontsource/space-mono": "^5.1.1"
+    "@fontsource/space-mono": "^5.1.1",
+    "@fontsource-variable/space-grotesk": "^5.2.5",
+    "@fontsource-variable/jetbrains-mono": "^5.2.5"
   },
   "peerDependencies": {
     "astro": "^5.0.0"

--- a/packages/ui/src/components/AwardCard.astro
+++ b/packages/ui/src/components/AwardCard.astro
@@ -1,0 +1,171 @@
+---
+/**
+ * @component AwardCard
+ * @description Card destacado de premio/reconocimiento. Diseño "trophy"
+ *   con borde brillante usando --niche-accent y mesh gradient sutil.
+ *
+ * @props {string} title - Nombre del premio
+ * @props {string} issuer - Otorgante
+ * @props {string} date - Fecha (YYYY-MM formateada externamente, ej. "enero 2024")
+ * @props {string} motivation - Motivacion
+ * @props {string} [url] - Link al certificado / fuente
+ * @props {boolean} [featured=true] - Estilo "destacado" con mesh
+ *
+ * @example
+ *   <AwardCard
+ *     title="Innovador del año 2023"
+ *     issuer="Destacame"
+ *     date="enero 2024"
+ *     motivation="..."
+ *     url="https://..."
+ *     featured
+ *   />
+ */
+interface Props {
+  title: string
+  issuer: string
+  date: string
+  motivation: string
+  url?: string
+  featured?: boolean
+}
+
+const { title, issuer, date, motivation, url, featured = true } = Astro.props
+---
+
+<article class:list={['award-card', featured && 'award-card--featured', 'scroll-reveal']}>
+  {featured && <div class="award-card__mesh" aria-hidden="true"></div>}
+  <div class="award-card__inner">
+    <div class="award-card__badge">
+      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+        <path d="M16 2L20 11L29 12L22 19L24 28L16 23L8 28L10 19L3 12L12 11L16 2Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+      </svg>
+    </div>
+    <div class="award-card__content">
+      <header class="award-card__header">
+        <h3 class="award-card__title text-h3">{title}</h3>
+        <p class="award-card__meta text-mono-label text-muted">
+          <span class="award-card__issuer">{issuer}</span>
+          <span aria-hidden="true">·</span>
+          <span>{date}</span>
+        </p>
+      </header>
+      <p class="award-card__motivation text-body text-muted">{motivation}</p>
+      {
+        url && (
+          <a href={url} target="_blank" rel="noopener" class="award-card__link magnetic">
+            Ver certificado
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M3 11L11 3M11 3H5M11 3V9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </a>
+        )
+      }
+    </div>
+  </div>
+</article>
+
+<style>
+  .award-card {
+    position: relative;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    overflow: hidden;
+    isolation: isolate;
+    transition:
+      border-color var(--motion-slow) var(--easing-out),
+      box-shadow var(--motion-slow) var(--easing-out);
+  }
+  .award-card--featured {
+    border-color: rgba(var(--niche-accent-rgb), 0.45);
+    box-shadow: 0 8px 40px rgba(var(--niche-accent-rgb), 0.18);
+  }
+  .award-card__mesh {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background:
+      radial-gradient(
+        500px circle at 0% 0%,
+        rgba(var(--niche-accent-rgb), 0.2),
+        transparent 60%
+      ),
+      radial-gradient(
+        400px circle at 100% 100%,
+        rgba(var(--niche-accent-rgb), 0.12),
+        transparent 50%
+      );
+    opacity: 0.6;
+    pointer-events: none;
+  }
+  .award-card__inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    gap: var(--space-20);
+    padding: var(--space-32);
+    align-items: flex-start;
+  }
+  .award-card__badge {
+    flex-shrink: 0;
+    width: 64px;
+    height: 64px;
+    border-radius: var(--radius-md);
+    background: rgba(var(--niche-accent-rgb), 0.12);
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.3);
+    color: var(--niche-accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .award-card__content {
+    flex-grow: 1;
+    display: grid;
+    gap: var(--space-12);
+  }
+  .award-card__title {
+    margin: 0;
+    background: var(--niche-gradient);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+  }
+  .award-card__meta {
+    margin: 0;
+    display: flex;
+    gap: var(--space-8);
+    flex-wrap: wrap;
+  }
+  .award-card__issuer {
+    color: var(--niche-accent);
+  }
+  .award-card__motivation {
+    margin: 0;
+    line-height: var(--line-height-relaxed);
+  }
+  .award-card__link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
+    padding: var(--space-8) var(--space-16);
+    border-radius: var(--radius-pill);
+    background: var(--niche-accent);
+    color: #0a0a0a;
+    font-size: var(--font-size-13);
+    font-weight: 600;
+    text-decoration: none;
+    align-self: start;
+    margin-top: var(--space-8);
+    transition: box-shadow var(--motion-base) var(--easing-out);
+  }
+  .award-card__link:hover {
+    box-shadow: 0 4px 20px var(--niche-glow);
+  }
+  @media (max-width: 640px) {
+    .award-card__inner {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/packages/ui/src/components/CaseStudyExpander.astro
+++ b/packages/ui/src/components/CaseStudyExpander.astro
@@ -1,0 +1,167 @@
+---
+/**
+ * @component CaseStudyExpander
+ * @description Expandible 3-bloques Problem -> Process -> Result. Usa
+ *   <details> nativo HTML para accesibilidad y sin JS.
+ *
+ * @props {string} title - Titulo del case study
+ * @props {string} problem - Texto del bloque "Problema"
+ * @props {string} process - Texto del bloque "Proceso"
+ * @props {string} result - Texto del bloque "Resultado"
+ * @props {string[]} [metrics] - Lista de metricas (ej. ["5x faster", "0.1% bug rate"])
+ * @props {Object} [labels] - Override de labels
+ *
+ * @example
+ *   <CaseStudyExpander
+ *     title="Sistema de saldar deudas Chile"
+ *     problem="..."
+ *     process="..."
+ *     result="..."
+ *     metrics={['+30% conversion', '0 incidentes PCI DSS']}
+ *   />
+ */
+interface Props {
+  title: string
+  problem: string
+  process: string
+  result: string
+  metrics?: string[]
+  labels?: {
+    problem?: string
+    process?: string
+    result?: string
+    metricsTitle?: string
+    cta?: string
+  }
+}
+
+const {
+  title,
+  problem,
+  process: processText,
+  result,
+  metrics = [],
+  labels = {},
+} = Astro.props
+
+const l = {
+  problem: labels.problem ?? 'Problema',
+  process: labels.process ?? 'Proceso',
+  result: labels.result ?? 'Resultado',
+  metricsTitle: labels.metricsTitle ?? 'Métricas',
+  cta: labels.cta ?? 'Ver caso de estudio',
+}
+---
+
+<details class="case-study scroll-reveal">
+  <summary class="case-study__summary">
+    <span class="case-study__title text-h4">{title}</span>
+    <span class="case-study__cta text-mono-label">{l.cta}</span>
+    <svg class="case-study__chevron" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  </summary>
+  <div class="case-study__body">
+    <div class="case-study__block case-study__block--problem">
+      <h4 class="case-study__heading text-mono-label">01 · {l.problem}</h4>
+      <p>{problem}</p>
+    </div>
+    <div class="case-study__block case-study__block--process">
+      <h4 class="case-study__heading text-mono-label">02 · {l.process}</h4>
+      <p>{processText}</p>
+    </div>
+    <div class="case-study__block case-study__block--result">
+      <h4 class="case-study__heading text-mono-label">03 · {l.result}</h4>
+      <p>{result}</p>
+    </div>
+    {
+      metrics.length > 0 && (
+        <div class="case-study__metrics">
+          <h4 class="case-study__heading text-mono-label">{l.metricsTitle}</h4>
+          <ul>
+            {metrics.map((m) => (
+              <li class="text-mono">{m}</li>
+            ))}
+          </ul>
+        </div>
+      )
+    }
+  </div>
+</details>
+
+<style>
+  .case-study {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    transition:
+      border-color var(--motion-base) var(--easing-out),
+      box-shadow var(--motion-base) var(--easing-out);
+  }
+  .case-study[open] {
+    border-color: rgba(var(--niche-accent-rgb), 0.4);
+    box-shadow: 0 8px 32px rgba(var(--niche-accent-rgb), 0.08);
+  }
+  .case-study__summary {
+    list-style: none;
+    cursor: pointer;
+    padding: var(--space-20) var(--space-24);
+    display: flex;
+    align-items: center;
+    gap: var(--space-16);
+    flex-wrap: wrap;
+  }
+  .case-study__summary::-webkit-details-marker {
+    display: none;
+  }
+  .case-study__title {
+    flex-grow: 1;
+    margin: 0;
+  }
+  .case-study__cta {
+    color: var(--niche-accent);
+  }
+  .case-study__chevron {
+    color: var(--niche-accent);
+    transition: transform var(--motion-base) var(--easing-out);
+  }
+  .case-study[open] .case-study__chevron {
+    transform: rotate(180deg);
+  }
+  .case-study__body {
+    display: grid;
+    gap: var(--space-24);
+    padding: var(--space-20) var(--space-24) var(--space-24);
+    border-top: 1px solid var(--color-border);
+  }
+  .case-study__block,
+  .case-study__metrics {
+    display: grid;
+    gap: var(--space-8);
+  }
+  .case-study__heading {
+    margin: 0;
+    color: var(--niche-accent);
+  }
+  .case-study__body p {
+    margin: 0;
+    color: var(--color-text-muted);
+    line-height: var(--line-height-relaxed);
+  }
+  .case-study__metrics ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-8);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .case-study__metrics li {
+    padding: var(--space-6) var(--space-12);
+    border-radius: var(--radius-pill);
+    background: rgba(var(--niche-accent-rgb), 0.08);
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.25);
+    color: var(--niche-accent);
+    font-size: var(--font-size-12);
+  }
+</style>

--- a/packages/ui/src/components/ExperienceTimeline.astro
+++ b/packages/ui/src/components/ExperienceTimeline.astro
@@ -1,0 +1,57 @@
+---
+/**
+ * @component ExperienceTimeline
+ * @description Timeline vertical de experiencias laborales con dot conector
+ *   animado. Cada item usa scroll-reveal-slide-right para entrar al scroll.
+ *   Slot por item permite renderizar el body custom (bullets de responsabilidades).
+ *
+ *   Espera children renderizados con <TimelineItem> o markup equivalente.
+ *
+ * @props {string} [ariaLabel='Experiencia profesional']
+ *
+ * @example
+ *   <ExperienceTimeline>
+ *     <TimelineItem ... />
+ *   </ExperienceTimeline>
+ */
+interface Props {
+  ariaLabel?: string
+}
+
+const { ariaLabel = 'Experiencia profesional' } = Astro.props
+---
+
+<ol class="timeline" aria-label={ariaLabel}>
+  <slot />
+</ol>
+
+<style>
+  .timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    padding-left: var(--space-32);
+  }
+  .timeline::before {
+    content: '';
+    position: absolute;
+    left: 8px;
+    top: 16px;
+    bottom: 16px;
+    width: 1px;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      var(--niche-accent) 8%,
+      var(--niche-accent) 92%,
+      transparent 100%
+    );
+    opacity: 0.55;
+  }
+  @media (max-width: 640px) {
+    .timeline {
+      padding-left: var(--space-20);
+    }
+  }
+</style>

--- a/packages/ui/src/components/HeroImpact.astro
+++ b/packages/ui/src/components/HeroImpact.astro
@@ -1,0 +1,215 @@
+---
+/**
+ * @component HeroImpact
+ * @description Hero moderno 2026: display-mega headline + mesh gradient bg +
+ *   eyebrow badge nicho + summary fluido + 2 CTAs con magnetic + niche
+ *   accent integrado. Reemplazo recomendado de Hero.astro.
+ *
+ * @props {string} eyebrow - Texto pequeño arriba (ej. "Pablo Contreras · Fintech LATAM")
+ * @props {string} headline - H1 principal (clamp 3rem-10vw-12rem)
+ * @props {string} summary - Parrafo descriptivo
+ * @props {Array<{href, label, variant?}>} [ctas] - Hasta 2 CTAs
+ * @props {string} [nicheLabel] - Label del nicho a la derecha del eyebrow
+ * @props {boolean} [mesh=true] - Mostrar fondo mesh gradient
+ *
+ * @example
+ *   <HeroImpact
+ *     eyebrow="Pablo Contreras · Lima, Perú"
+ *     headline="Senior Full Stack Engineer"
+ *     summary="..."
+ *     ctas={[{href:'#projects', label:'Proyectos', variant:'primary'}]}
+ *     nicheLabel="Fintech LATAM"
+ *   />
+ */
+import MeshGradientBg from './MeshGradientBg.astro'
+
+interface Cta {
+  href: string
+  label: string
+  variant?: 'primary' | 'ghost'
+}
+
+interface Props {
+  eyebrow: string
+  headline: string
+  summary: string
+  ctas?: Cta[]
+  nicheLabel?: string
+  mesh?: boolean
+}
+
+const {
+  eyebrow,
+  headline,
+  summary,
+  ctas = [],
+  nicheLabel,
+  mesh = true,
+} = Astro.props
+---
+
+<section class="hero-impact">
+  {mesh && <MeshGradientBg variant="vivid" aurora />}
+  <div class="container-wide hero-impact__inner">
+    <header class="hero-impact__top">
+      <p class="hero-impact__eyebrow text-mono-label">
+        <span class="hero-impact__dot" aria-hidden="true"></span>
+        {eyebrow}
+      </p>
+      {
+        nicheLabel && (
+          <span class="hero-impact__niche-badge text-mono-label">
+            {nicheLabel}
+          </span>
+        )
+      }
+    </header>
+
+    <h1 class="hero-impact__headline text-display-mega" style="view-transition-name: hero-headline;">
+      <span class="hero-impact__headline-text">{headline}</span>
+    </h1>
+
+    <p class="hero-impact__summary text-body-lg text-muted">{summary}</p>
+
+    {
+      ctas.length > 0 && (
+        <div class="hero-impact__ctas">
+          {ctas.map((cta) => (
+            <a
+              href={cta.href}
+              class:list={[
+                'hero-impact__cta',
+                'magnetic',
+                `hero-impact__cta--${cta.variant ?? 'primary'}`,
+              ]}
+            >
+              {cta.label}
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <path d="M3 11L11 3M11 3H5M11 3V9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </a>
+          ))}
+        </div>
+      )
+    }
+  </div>
+</section>
+
+<style>
+  .hero-impact {
+    position: relative;
+    padding-block: var(--space-100) var(--space-72);
+    overflow: hidden;
+    isolation: isolate;
+  }
+  .hero-impact__inner {
+    position: relative;
+    z-index: 1;
+  }
+  .hero-impact__top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-16);
+    margin-bottom: var(--space-32);
+    flex-wrap: wrap;
+  }
+  .hero-impact__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+  .hero-impact__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 12px var(--niche-glow);
+    animation: pulse-soft 2.4s ease-in-out infinite;
+  }
+  .hero-impact__niche-badge {
+    color: var(--niche-accent);
+    padding: var(--space-6) var(--space-12);
+    border: 1px solid currentColor;
+    border-radius: var(--radius-pill);
+    background: rgba(var(--niche-accent-rgb), 0.08);
+  }
+  .hero-impact__headline {
+    margin: 0 0 var(--space-32) 0;
+    color: var(--color-text);
+    max-width: 14ch;
+  }
+  .hero-impact__headline-text {
+    background: var(--niche-gradient);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+  }
+  .hero-impact__summary {
+    max-width: 56ch;
+    margin: 0 0 var(--space-40) 0;
+  }
+  .hero-impact__ctas {
+    display: flex;
+    gap: var(--space-12);
+    flex-wrap: wrap;
+  }
+  .hero-impact__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-8);
+    padding: var(--space-12) var(--space-24);
+    border-radius: var(--radius-pill);
+    font-size: var(--font-size-14);
+    font-weight: 600;
+    text-decoration: none;
+    transition:
+      background-color var(--motion-base) var(--easing-out),
+      border-color var(--motion-base) var(--easing-out),
+      box-shadow var(--motion-base) var(--easing-out),
+      color var(--motion-base) var(--easing-out);
+  }
+  .hero-impact__cta--primary {
+    background: var(--niche-accent);
+    color: #0a0a0a;
+    box-shadow: 0 4px 24px var(--niche-glow);
+  }
+  .hero-impact__cta--primary:hover,
+  .hero-impact__cta--primary:focus-visible {
+    background: var(--niche-accent);
+    box-shadow: 0 8px 40px var(--niche-glow);
+  }
+  .hero-impact__cta--ghost {
+    background: rgba(var(--niche-accent-rgb), 0.04);
+    color: var(--color-text);
+    border: 1px solid var(--color-border-strong);
+  }
+  .hero-impact__cta--ghost:hover,
+  .hero-impact__cta--ghost:focus-visible {
+    border-color: var(--niche-accent);
+    color: var(--niche-accent);
+    background: rgba(var(--niche-accent-rgb), 0.08);
+  }
+  @media (max-width: 640px) {
+    .hero-impact {
+      padding-block: var(--space-72) var(--space-56);
+    }
+    .hero-impact__headline {
+      max-width: 100%;
+    }
+  }
+  @keyframes pulse-soft {
+    0%,
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.7;
+      transform: scale(1.2);
+    }
+  }
+</style>

--- a/packages/ui/src/components/MeshGradientBg.astro
+++ b/packages/ui/src/components/MeshGradientBg.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * @component MeshGradientBg
+ * @description Fondo mesh gradient animado para hero / secciones impact.
+ *   Usa --niche-accent del SitePageLayout, asi cada nicho tiene tinte propio.
+ *   Pausado automaticamente con prefers-reduced-motion.
+ *
+ * @props {'soft' | 'vivid'} [variant='soft'] - Intensidad del gradient
+ * @props {boolean} [aurora=true] - Agrega capa aurora encima
+ * @props {boolean} [fixed=false] - position: fixed (cuerpo completo) vs absolute
+ *
+ * @example
+ *   <MeshGradientBg variant="vivid" />
+ *   <MeshGradientBg variant="soft" fixed />
+ */
+interface Props {
+  variant?: 'soft' | 'vivid'
+  aurora?: boolean
+  fixed?: boolean
+}
+
+const { variant = 'soft', aurora = true, fixed = false } = Astro.props
+const meshClass =
+  variant === 'vivid' ? 'mesh-bg mesh-bg--vivid' : 'mesh-bg mesh-bg--soft'
+---
+
+<div class:list={['mesh-wrap', fixed && 'mesh-wrap--fixed']} aria-hidden="true">
+  <div class={meshClass}></div>
+  {aurora && <div class="aurora-layer"></div>}
+</div>
+
+<style>
+  .mesh-wrap {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: -1;
+  }
+  .mesh-wrap--fixed {
+    position: fixed;
+    inset: 0;
+  }
+</style>

--- a/packages/ui/src/components/NicheBadge.astro
+++ b/packages/ui/src/components/NicheBadge.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * @component NicheBadge
+ * @description Chip pequeño mostrando el label del nicho actual con su accent.
+ *
+ * @props {string} label - Texto del badge (ej. "Fintech LATAM")
+ * @props {'sm' | 'md'} [size='md'] - Tamaño del badge
+ *
+ * @example
+ *   <NicheBadge label="Fintech LATAM" />
+ */
+interface Props {
+  label: string
+  size?: 'sm' | 'md'
+}
+
+const { label, size = 'md' } = Astro.props
+---
+
+<span class:list={['niche-badge', `niche-badge--${size}`]}>
+  <span class="niche-badge__dot" aria-hidden="true"></span>
+  {label}
+</span>
+
+<style>
+  .niche-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.35);
+    border-radius: var(--radius-pill);
+    background: rgba(var(--niche-accent-rgb), 0.08);
+    color: var(--niche-accent);
+    font-family: var(--font-mono);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+    white-space: nowrap;
+  }
+  .niche-badge--sm {
+    padding: var(--space-3) var(--space-10);
+    font-size: var(--font-size-10);
+  }
+  .niche-badge--md {
+    padding: var(--space-6) var(--space-12);
+    font-size: var(--font-size-11);
+  }
+  .niche-badge__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--niche-accent);
+    box-shadow: 0 0 8px var(--niche-glow);
+  }
+</style>

--- a/packages/ui/src/components/ProjectBentoCard.astro
+++ b/packages/ui/src/components/ProjectBentoCard.astro
@@ -1,0 +1,288 @@
+---
+/**
+ * @component ProjectBentoCard
+ * @description Card individual del bento grid. Span configurable (sm=3, md=6,
+ *   lg=8, xl=12 cols en desktop). Tilt 3D opcional, glow on hover, mesh
+ *   gradient sutil de fondo.
+ *
+ * @props {string} name - Nombre del proyecto
+ * @props {string} summary - Descripcion corta (max ~140 chars)
+ * @props {string[]} stack - Stack tecnologico (max 6 visibles)
+ * @props {string} [url] - URL del producto
+ * @props {string} [repo] - URL del repo
+ * @props {'active' | 'inactive' | 'concept'} status
+ * @props {boolean} [isConfidential=false]
+ * @props {'sm' | 'md' | 'lg' | 'xl'} [bentoSpan='md']
+ * @props {string} [caseStudyLabel='Caso bajo NDA']
+ *
+ * @example
+ *   <ProjectBentoCard
+ *     name="FastStruct"
+ *     summary="VS Code extension..."
+ *     stack={['TypeScript', 'VS Code']}
+ *     url="https://..."
+ *     status="active"
+ *     bentoSpan="lg"
+ *   />
+ */
+interface Props {
+  name: string
+  summary: string
+  stack: string[]
+  url?: string
+  repo?: string
+  status: 'active' | 'inactive' | 'concept'
+  isConfidential?: boolean
+  bentoSpan?: 'sm' | 'md' | 'lg' | 'xl'
+  caseStudyLabel?: string
+}
+
+const {
+  name,
+  summary,
+  stack,
+  url,
+  repo,
+  status,
+  isConfidential = false,
+  bentoSpan = 'md',
+  caseStudyLabel = 'Caso bajo NDA',
+} = Astro.props
+
+const visibleStack = stack.slice(0, 6)
+const remaining = Math.max(0, stack.length - visibleStack.length)
+const statusLabel = {
+  active: 'Activo',
+  inactive: 'Inactivo',
+  concept: 'Concepto',
+}[status]
+---
+
+<article
+  class:list={['bento-card', `bento-card--${bentoSpan}`, 'tilt-3d', 'scroll-reveal']}
+  role="listitem"
+>
+  <div class="bento-card__mesh" aria-hidden="true"></div>
+  <div class="tilt-3d__inner bento-card__inner">
+    <header class="bento-card__header">
+      <h3 class="bento-card__name text-h3">{name}</h3>
+      <span class:list={['bento-card__status', `bento-card__status--${status}`]}>
+        <span class="bento-card__status-dot" aria-hidden="true"></span>
+        {statusLabel}
+      </span>
+    </header>
+    <p class="bento-card__summary text-body text-muted">{summary}</p>
+    {
+      visibleStack.length > 0 && (
+        <ul class="bento-card__stack">
+          {visibleStack.map((s) => (
+            <li class="bento-card__chip text-mono">{s}</li>
+          ))}
+          {remaining > 0 && (
+            <li class="bento-card__chip bento-card__chip--more text-mono">+{remaining}</li>
+          )}
+        </ul>
+      )
+    }
+    <footer class="bento-card__footer">
+      {
+        url && !isConfidential ? (
+          <a href={url} target="_blank" rel="noopener" class="bento-card__link magnetic">
+            Ver producto
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M3 11L11 3M11 3H5M11 3V9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </a>
+        ) : isConfidential ? (
+          <span class="bento-card__confidential text-mono-label text-muted">{caseStudyLabel}</span>
+        ) : null
+      }
+      {
+        repo && (
+          <a href={repo} target="_blank" rel="noopener" class="bento-card__link bento-card__link--ghost magnetic">
+            Repo
+          </a>
+        )
+      }
+    </footer>
+  </div>
+</article>
+
+<style>
+  .bento-card {
+    position: relative;
+    grid-column: span 6;
+    padding: var(--space-32);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    overflow: hidden;
+    isolation: isolate;
+    transition:
+      border-color var(--motion-slow) var(--easing-out),
+      box-shadow var(--motion-slow) var(--easing-out);
+  }
+  .bento-card--sm {
+    grid-column: span 4;
+  }
+  .bento-card--md {
+    grid-column: span 6;
+  }
+  .bento-card--lg {
+    grid-column: span 8;
+  }
+  .bento-card--xl {
+    grid-column: span 12;
+  }
+  @media (max-width: 960px) {
+    .bento-card--sm,
+    .bento-card--md,
+    .bento-card--lg,
+    .bento-card--xl {
+      grid-column: span 6;
+    }
+  }
+  @media (max-width: 600px) {
+    .bento-card--sm,
+    .bento-card--md,
+    .bento-card--lg,
+    .bento-card--xl {
+      grid-column: 1 / -1;
+    }
+  }
+  .bento-card__mesh {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background:
+      radial-gradient(
+        400px circle at 0% 100%,
+        rgba(var(--niche-accent-rgb), 0.18),
+        transparent 60%
+      ),
+      radial-gradient(
+        500px circle at 100% 0%,
+        rgba(var(--niche-accent-rgb), 0.08),
+        transparent 50%
+      );
+    opacity: 0.5;
+    transition: opacity var(--motion-slow) var(--easing-out);
+    pointer-events: none;
+  }
+  .bento-card:hover {
+    border-color: rgba(var(--niche-accent-rgb), 0.4);
+    box-shadow: 0 16px 48px rgba(var(--niche-accent-rgb), 0.18);
+  }
+  .bento-card:hover .bento-card__mesh {
+    opacity: 1;
+  }
+  .bento-card__inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-16);
+    height: 100%;
+  }
+  .bento-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-12);
+  }
+  .bento-card__name {
+    margin: 0;
+    background: var(--niche-gradient);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+  }
+  .bento-card__status {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
+    padding: var(--space-3) var(--space-10);
+    border-radius: var(--radius-pill);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-10);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wide);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-2);
+    color: var(--color-text-muted);
+  }
+  .bento-card__status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .bento-card__status--active .bento-card__status-dot {
+    background: var(--color-success);
+    box-shadow: 0 0 8px rgba(46, 194, 126, 0.6);
+  }
+  .bento-card__status--inactive .bento-card__status-dot {
+    background: var(--color-text-subtle);
+  }
+  .bento-card__status--concept .bento-card__status-dot {
+    background: var(--color-warning);
+  }
+  .bento-card__summary {
+    margin: 0;
+    flex-grow: 1;
+  }
+  .bento-card__stack {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-6);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .bento-card__chip {
+    padding: var(--space-3) var(--space-10);
+    border-radius: var(--radius-pill);
+    background: rgba(var(--niche-accent-rgb), 0.06);
+    border: 1px solid rgba(var(--niche-accent-rgb), 0.2);
+    color: var(--color-text);
+    font-size: var(--font-size-11);
+  }
+  .bento-card__chip--more {
+    background: transparent;
+    color: var(--niche-accent);
+  }
+  .bento-card__footer {
+    display: flex;
+    gap: var(--space-16);
+    flex-wrap: wrap;
+    margin-top: var(--space-8);
+  }
+  .bento-card__link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-6);
+    padding: var(--space-8) var(--space-16);
+    border-radius: var(--radius-pill);
+    background: var(--niche-accent);
+    color: #0a0a0a;
+    font-size: var(--font-size-13);
+    font-weight: 600;
+    text-decoration: none;
+    transition: box-shadow var(--motion-base) var(--easing-out);
+  }
+  .bento-card__link:hover {
+    box-shadow: 0 4px 24px var(--niche-glow);
+  }
+  .bento-card__link--ghost {
+    background: transparent;
+    color: var(--color-text);
+    border: 1px solid var(--color-border-strong);
+  }
+  .bento-card__link--ghost:hover {
+    border-color: var(--niche-accent);
+    color: var(--niche-accent);
+  }
+  .bento-card__confidential {
+    align-self: center;
+  }
+</style>

--- a/packages/ui/src/components/ProjectsBento.astro
+++ b/packages/ui/src/components/ProjectsBento.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * @component ProjectsBento
+ * @description Bento grid 12-col asimetrico para proyectos. Cada celda usa
+ *   tilt 3D + mesh gradient sutil + scroll-reveal. El span se calcula
+ *   automaticamente: 1ra y 4ta celda (cada 3 items) son "lg", el resto "md".
+ *
+ *   Usa <ProjectBentoCard> como children (no acepta ProjectCard legacy).
+ *
+ * @props {string} [ariaLabel='Proyectos destacados']
+ *
+ * @example
+ *   <ProjectsBento>
+ *     <ProjectBentoCard ... bentoSpan="lg" />
+ *     <ProjectBentoCard ... bentoSpan="md" />
+ *   </ProjectsBento>
+ */
+interface Props {
+  ariaLabel?: string
+}
+
+const { ariaLabel = 'Proyectos destacados' } = Astro.props
+---
+
+<div class="bento-grid" role="list" aria-label={ariaLabel}>
+  <slot />
+</div>
+
+<style>
+  .bento-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: var(--space-20);
+  }
+  @media (max-width: 960px) {
+    .bento-grid {
+      grid-template-columns: repeat(6, 1fr);
+    }
+  }
+  @media (max-width: 600px) {
+    .bento-grid {
+      grid-template-columns: 1fr;
+      gap: var(--space-16);
+    }
+  }
+</style>

--- a/packages/ui/src/components/SkillsMarquee.astro
+++ b/packages/ui/src/components/SkillsMarquee.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * @component SkillsMarquee
+ * @description Marquee infinito de chips (2 filas, direcciones opuestas).
+ *   CSS puro, GPU-friendly. Se pausa con hover y en prefers-reduced-motion.
+ *
+ *   El loop seamless se logra duplicando la lista (aria-hidden la copia).
+ *
+ * @props {string[]} rowOne - Items de la primera fila (mueve a la izquierda)
+ * @props {string[]} [rowTwo] - Items de la segunda fila (mueve a la derecha, default = rowOne reversa)
+ * @props {string} [ariaLabel='Skills marquee'] - Accesibilidad
+ *
+ * @example
+ *   <SkillsMarquee
+ *     rowOne={['Vue 3', 'Nuxt', 'TypeScript', 'Django', 'Python']}
+ *     rowTwo={['AWS', 'Microservicios', 'PostgreSQL', 'Docker']}
+ *   />
+ */
+interface Props {
+  rowOne: string[]
+  rowTwo?: string[]
+  ariaLabel?: string
+}
+
+const { rowOne, rowTwo, ariaLabel = 'Skills marquee' } = Astro.props
+const row2 = rowTwo ?? [...rowOne].reverse()
+---
+
+<section class="skills-marquee" aria-label={ariaLabel}>
+  <div class="marquee">
+    <ul class="marquee__track">
+      {rowOne.map((s) => <li class="skills-marquee__chip">{s}</li>)}
+      {rowOne.map((s) => <li class="skills-marquee__chip" aria-hidden="true">{s}</li>)}
+    </ul>
+  </div>
+  <div class="marquee">
+    <ul class="marquee__track marquee__track--reverse marquee__track--fast">
+      {row2.map((s) => <li class="skills-marquee__chip skills-marquee__chip--accent">{s}</li>)}
+      {row2.map((s) => <li class="skills-marquee__chip skills-marquee__chip--accent" aria-hidden="true">{s}</li>)}
+    </ul>
+  </div>
+</section>
+
+<style>
+  .skills-marquee {
+    display: grid;
+    gap: var(--space-16);
+    padding-block: var(--space-32);
+    border-block: 1px solid var(--color-border);
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      rgba(var(--niche-accent-rgb), 0.03) 50%,
+      transparent 100%
+    );
+  }
+  .skills-marquee__chip {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--space-8) var(--space-20);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-pill);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-13);
+    color: var(--color-text);
+    background: var(--color-surface);
+    white-space: nowrap;
+    flex-shrink: 0;
+    list-style: none;
+  }
+  .skills-marquee__chip--accent {
+    border-color: rgba(var(--niche-accent-rgb), 0.35);
+    color: var(--niche-accent);
+    background: rgba(var(--niche-accent-rgb), 0.06);
+  }
+</style>

--- a/packages/ui/src/components/StatsBar.astro
+++ b/packages/ui/src/components/StatsBar.astro
@@ -1,0 +1,102 @@
+---
+/**
+ * @component StatsBar
+ * @description Stats bar con 4 numeros animados (counter on-scroll) y labels.
+ *   Usa el script global initNumberCounters() para activar el conteo.
+ *
+ * @props {Array<{label: string; value: number; suffix?: string}>} items - Hasta 4 stats
+ * @props {string} [eyebrow] - Etiqueta superior opcional
+ *
+ * @example
+ *   <StatsBar
+ *     eyebrow="Track record"
+ *     items={[
+ *       { label: 'Años de experiencia', value: 12, suffix: '+' },
+ *       { label: 'Empresas', value: 8 },
+ *       { label: 'Países LATAM', value: 4 },
+ *       { label: 'Certificaciones', value: 11 },
+ *     ]}
+ *   />
+ */
+interface StatItem {
+  label: string
+  value: number
+  suffix?: string
+}
+
+interface Props {
+  items: StatItem[]
+  eyebrow?: string
+}
+
+const { items, eyebrow } = Astro.props
+---
+
+<section class="stats-bar scroll-reveal" aria-label={eyebrow ?? 'Stats'}>
+  {eyebrow && <p class="stats-bar__eyebrow text-mono-label text-muted">{eyebrow}</p>}
+  <dl class="stats-bar__grid">
+    {
+      items.map((item) => (
+        <div class="stats-bar__item">
+          <dt class="stats-bar__label text-mono-label text-muted">
+            {item.label}
+          </dt>
+          <dd class="stats-bar__value-row">
+            <span
+              class="stats-bar__value stat-number text-display-md gradient-text"
+              data-target={item.value}
+            >
+              0
+            </span>
+            {item.suffix && (
+              <span class="stats-bar__suffix text-display-md">{item.suffix}</span>
+            )}
+          </dd>
+        </div>
+      ))
+    }
+  </dl>
+</section>
+
+<style>
+  .stats-bar {
+    padding-block: var(--space-56);
+    border-block: 1px solid var(--color-border);
+  }
+  .stats-bar__eyebrow {
+    margin-bottom: var(--space-32);
+  }
+  .stats-bar__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-32);
+    margin: 0;
+  }
+  .stats-bar__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-8);
+  }
+  .stats-bar__label {
+    margin: 0;
+  }
+  .stats-bar__value-row {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-4);
+    margin: 0;
+  }
+  .stats-bar__value {
+    font-variation-settings: 'wght' 800;
+  }
+  .stats-bar__suffix {
+    color: var(--niche-accent);
+    font-weight: 700;
+  }
+  @media (max-width: 640px) {
+    .stats-bar__grid {
+      grid-template-columns: repeat(2, 1fr);
+      gap: var(--space-24);
+    }
+  }
+</style>

--- a/packages/ui/src/components/TimelineItem.astro
+++ b/packages/ui/src/components/TimelineItem.astro
@@ -1,0 +1,168 @@
+---
+/**
+ * @component TimelineItem
+ * @description Item individual del ExperienceTimeline. Dot conector +
+ *   role/company/date + body via <slot/> + skills chips.
+ *
+ * @props {string} role - Cargo
+ * @props {string} company - Empresa
+ * @props {string} [companyUrl]
+ * @props {string} dateRange - Texto formateado
+ * @props {string[]} [skills] - Tags (max 8)
+ * @props {boolean} [current=false] - Marca rol actual con animacion adicional
+ *
+ * @example
+ *   <TimelineItem
+ *     role="Frontend Architect"
+ *     company="Destacame"
+ *     dateRange="2022-08 — Actual"
+ *     skills={['Vue', 'Django', 'AWS']}
+ *     current
+ *   >
+ *     <ul><li>Microservicios fintech...</li></ul>
+ *   </TimelineItem>
+ */
+interface Props {
+  role: string
+  company: string
+  companyUrl?: string
+  dateRange: string
+  skills?: string[]
+  current?: boolean
+}
+
+const {
+  role,
+  company,
+  companyUrl,
+  dateRange,
+  skills = [],
+  current = false,
+} = Astro.props
+const visibleSkills = skills.slice(0, 8)
+const remaining = Math.max(0, skills.length - visibleSkills.length)
+---
+
+<li class:list={['timeline-item', 'scroll-reveal-slide-right', current && 'timeline-item--current']}>
+  <span class:list={['timeline-item__dot', current && 'timeline-item__dot--glow']} aria-hidden="true"></span>
+  <article class="timeline-item__card">
+    <header class="timeline-item__header">
+      <div>
+        <h3 class="timeline-item__role text-h4">{role}</h3>
+        <p class="timeline-item__company text-body">
+          {companyUrl ? (
+            <a href={companyUrl} target="_blank" rel="noopener" class="anim-underline">{company}</a>
+          ) : (
+            company
+          )}
+        </p>
+      </div>
+      <p class="timeline-item__date text-mono-label text-muted">{dateRange}</p>
+    </header>
+    <div class="timeline-item__body">
+      <slot />
+    </div>
+    {
+      visibleSkills.length > 0 && (
+        <ul class="timeline-item__skills">
+          {visibleSkills.map((s) => (
+            <li class="timeline-item__skill text-mono">{s}</li>
+          ))}
+          {remaining > 0 && (
+            <li class="timeline-item__skill timeline-item__skill--more text-mono">+{remaining}</li>
+          )}
+        </ul>
+      )
+    }
+  </article>
+</li>
+
+<style>
+  .timeline-item {
+    position: relative;
+    padding-bottom: var(--space-40);
+  }
+  .timeline-item:last-child {
+    padding-bottom: 0;
+  }
+  .timeline-item__dot {
+    position: absolute;
+    left: -32px;
+    top: 22px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--color-bg);
+    border: 2px solid var(--niche-accent);
+    box-shadow: 0 0 0 4px rgba(var(--niche-accent-rgb), 0.08);
+  }
+  .timeline-item__dot--glow {
+    background: var(--niche-accent);
+    animation: pulse-glow 2.4s ease-in-out infinite;
+  }
+  @keyframes pulse-glow {
+    0%, 100% {
+      box-shadow: 0 0 0 4px rgba(var(--niche-accent-rgb), 0.1);
+    }
+    50% {
+      box-shadow: 0 0 0 12px rgba(var(--niche-accent-rgb), 0);
+    }
+  }
+  .timeline-item__card {
+    padding: var(--space-24);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    transition:
+      border-color var(--motion-base) var(--easing-out),
+      transform var(--motion-base) var(--easing-out),
+      box-shadow var(--motion-base) var(--easing-out);
+  }
+  .timeline-item__card:hover {
+    border-color: rgba(var(--niche-accent-rgb), 0.4);
+    transform: translateX(4px);
+    box-shadow: 0 8px 32px rgba(var(--niche-accent-rgb), 0.12);
+  }
+  .timeline-item__header {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-16);
+    margin-bottom: var(--space-16);
+    flex-wrap: wrap;
+  }
+  .timeline-item__role {
+    margin: 0 0 var(--space-4) 0;
+  }
+  .timeline-item__company {
+    color: var(--color-text-muted);
+  }
+  .timeline-item__company a {
+    color: var(--color-text);
+  }
+  .timeline-item__body {
+    color: var(--color-text-muted);
+    line-height: var(--line-height-relaxed);
+    font-size: var(--font-size-14);
+  }
+  .timeline-item__skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-6);
+    margin: var(--space-16) 0 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  .timeline-item__skill {
+    padding: var(--space-3) var(--space-10);
+    border-radius: var(--radius-pill);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-11);
+  }
+  .timeline-item__skill--more {
+    background: transparent;
+    color: var(--niche-accent);
+    border-color: rgba(var(--niche-accent-rgb), 0.3);
+  }
+</style>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,6 +8,14 @@
  *   import { applyTheme } from '@portfolio/ui'
  */
 
+export { initMagneticCursor } from './lib/magnetic-cursor'
+export {
+  getNicheTokens,
+  NICHE_TOKENS,
+  type NicheTokens,
+  nicheTokensToCssVars,
+} from './lib/niche-tokens'
+export { initNumberCounters } from './lib/number-counter'
 export { deobfuscateEmail, obfuscateEmail } from './lib/obfuscate-email'
 export { initRevealOnScroll } from './lib/reveal-on-scroll'
 export type { Theme } from './lib/theme-toggle'

--- a/packages/ui/src/layouts/BaseLayout.astro
+++ b/packages/ui/src/layouts/BaseLayout.astro
@@ -18,6 +18,8 @@ import '../styles/tokens.css'
 import '../styles/fonts.css'
 import '../styles/typography.css'
 import '../styles/animations.css'
+import '../styles/mesh-gradients.css'
+import '../styles/scroll-driven.css'
 import '../styles/global.css'
 
 interface Props {

--- a/packages/ui/src/lib/magnetic-cursor.ts
+++ b/packages/ui/src/lib/magnetic-cursor.ts
@@ -1,0 +1,90 @@
+/**
+ * @module magnetic-cursor
+ * @description Vanilla JS magnetic hover: elementos con clase `.magnetic`
+ *   se mueven sutilmente hacia el cursor cuando esta cerca.
+ *
+ *   Desactivado en touch devices (hover: none) y prefers-reduced-motion.
+ *   Bundle: ~1.4 KB minificado.
+ *
+ * @example
+ *   import { initMagneticCursor } from '@portfolio/ui/lib/magnetic-cursor'
+ *   initMagneticCursor()
+ */
+
+const MAX_DISTANCE = 60
+const TRANSLATE_FACTOR = 0.25
+
+function isInteractionAllowed(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  if (window.matchMedia('(hover: none)').matches) {
+    return false
+  }
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return false
+  }
+  return true
+}
+
+function attachMagnetic(el: HTMLElement): () => void {
+  const handleMove = (event: MouseEvent): void => {
+    const rect = el.getBoundingClientRect()
+    const cx = rect.left + rect.width / 2
+    const cy = rect.top + rect.height / 2
+    const dx = event.clientX - cx
+    const dy = event.clientY - cy
+    const distance = Math.hypot(dx, dy)
+
+    if (distance > MAX_DISTANCE) {
+      el.style.transform = 'translate3d(0, 0, 0)'
+      return
+    }
+
+    const x = dx * TRANSLATE_FACTOR
+    const y = dy * TRANSLATE_FACTOR
+    el.style.transform = `translate3d(${x}px, ${y}px, 0)`
+  }
+
+  const handleLeave = (): void => {
+    el.style.transform = 'translate3d(0, 0, 0)'
+  }
+
+  el.addEventListener('mousemove', handleMove)
+  el.addEventListener('mouseleave', handleLeave)
+
+  return () => {
+    el.removeEventListener('mousemove', handleMove)
+    el.removeEventListener('mouseleave', handleLeave)
+  }
+}
+
+/**
+ * @function initMagneticCursor
+ * @description Activa el efecto magnetico en todos los `.magnetic` del DOM.
+ *
+ * @returns {() => void} Cleanup function para remover listeners
+ *
+ * @example
+ *   const cleanup = initMagneticCursor()
+ *   // Mas tarde:
+ *   cleanup()
+ */
+export function initMagneticCursor(): () => void {
+  if (!isInteractionAllowed()) {
+    return () => {
+      /* noop */
+    }
+  }
+
+  const elements = Array.from(
+    document.querySelectorAll<HTMLElement>('.magnetic'),
+  )
+  const cleanups = elements.map((el) => attachMagnetic(el))
+
+  return () => {
+    for (const cleanup of cleanups) {
+      cleanup()
+    }
+  }
+}

--- a/packages/ui/src/lib/niche-tokens.ts
+++ b/packages/ui/src/lib/niche-tokens.ts
@@ -1,0 +1,123 @@
+/**
+ * @module niche-tokens
+ * @description Mapeo type-safe de niches a tokens visuales (accent, glow,
+ *   gradient, mood). Consumido por SitePageLayout para inyectar variables
+ *   CSS dinamicas sin fragmentar el bundle por app.
+ *
+ *   Cada nicho tiene una identidad visual distintiva:
+ *   - generic:   electric blue, full-stack confiable
+ *   - hub:       multi-accent, selector / wayfinder
+ *   - fintech:   cyan teal, LATAM compliance
+ *   - architect: rose-pink, sistemas / microservicios
+ *   - leader:    amber gold, liderazgo / gestion
+ *   - vibe:      purple-violet, AI-augmented
+ */
+import type { Niche } from '@portfolio/content'
+
+export interface NicheTokens {
+  /** Color principal del nicho (hex) */
+  accent: string
+  /** RGB triplet del accent, para usar en rgba(var(--niche-accent-rgb), x) */
+  accentRgb: string
+  /** Color glow para sombras y mesh gradients */
+  glow: string
+  /** Gradient lineal de identidad */
+  gradient: string
+  /** Mood tipografico: 'sans' (default) o 'mono' (vibe + architect labels) */
+  mood: 'sans' | 'mono'
+  /** Etiqueta humana corta del nicho */
+  label: string
+}
+
+/**
+ * Tabla de tokens por nicho. Hub es la landing maestra y usa multi-accent.
+ */
+export const NICHE_TOKENS: Record<Niche | 'hub', NicheTokens> = {
+  generic: {
+    accent: '#4f6ef7',
+    accentRgb: '79, 110, 247',
+    glow: 'rgba(79, 110, 247, 0.35)',
+    gradient: 'linear-gradient(135deg, #4f6ef7 0%, #b97cf2 100%)',
+    mood: 'sans',
+    label: 'Full Stack',
+  },
+  hub: {
+    accent: '#9b9bff',
+    accentRgb: '155, 155, 255',
+    glow: 'rgba(155, 155, 255, 0.32)',
+    gradient:
+      'linear-gradient(135deg, #4f6ef7 0%, #38d9d6 35%, #f06e9c 70%, #f4b740 100%)',
+    mood: 'sans',
+    label: 'Hub',
+  },
+  fintech: {
+    accent: '#38d9d6',
+    accentRgb: '56, 217, 214',
+    glow: 'rgba(56, 217, 214, 0.35)',
+    gradient: 'linear-gradient(135deg, #38d9d6 0%, #4f6ef7 100%)',
+    mood: 'sans',
+    label: 'Fintech LATAM',
+  },
+  architect: {
+    accent: '#f06e9c',
+    accentRgb: '240, 110, 156',
+    glow: 'rgba(240, 110, 156, 0.32)',
+    gradient: 'linear-gradient(135deg, #f06e9c 0%, #b97cf2 100%)',
+    mood: 'mono',
+    label: 'Architect',
+  },
+  leader: {
+    accent: '#f4b740',
+    accentRgb: '244, 183, 64',
+    glow: 'rgba(244, 183, 64, 0.32)',
+    gradient: 'linear-gradient(135deg, #f4b740 0%, #f06e9c 100%)',
+    mood: 'sans',
+    label: 'Tech Lead',
+  },
+  vibe: {
+    accent: '#b97cf2',
+    accentRgb: '185, 124, 242',
+    glow: 'rgba(185, 124, 242, 0.40)',
+    gradient: 'linear-gradient(135deg, #b97cf2 0%, #4f6ef7 100%)',
+    mood: 'mono',
+    label: 'Vibe Coding',
+  },
+}
+
+/**
+ * @function getNicheTokens
+ * @description Retorna los tokens visuales de un nicho. Type-safe.
+ *
+ * @param {Niche | 'hub'} niche - Identificador del nicho
+ * @returns {NicheTokens} Tokens del nicho
+ *
+ * @example
+ *   const { accent, gradient } = getNicheTokens('fintech')
+ *   // accent === '#38d9d6'
+ */
+export function getNicheTokens(niche: Niche | 'hub'): NicheTokens {
+  return NICHE_TOKENS[niche]
+}
+
+/**
+ * @function nicheTokensToCssVars
+ * @description Construye un string `style="..."` con las custom vars CSS
+ *   del nicho, listo para inyectar en el root de SitePageLayout.
+ *
+ * @param {Niche | 'hub'} niche - Identificador del nicho
+ * @returns {string} String con CSS custom props
+ *
+ * @example
+ *   nicheTokensToCssVars('vibe')
+ *   // "--niche-accent: #b97cf2; --niche-accent-rgb: 185, 124, 242; ..."
+ */
+export function nicheTokensToCssVars(niche: Niche | 'hub'): string {
+  const t = getNicheTokens(niche)
+  return [
+    `--niche-accent: ${t.accent}`,
+    `--niche-accent-rgb: ${t.accentRgb}`,
+    `--niche-glow: ${t.glow}`,
+    `--niche-gradient: ${t.gradient}`,
+    `--niche-mood: ${t.mood}`,
+  ].join('; ')
+}

--- a/packages/ui/src/lib/number-counter.ts
+++ b/packages/ui/src/lib/number-counter.ts
@@ -1,0 +1,110 @@
+/**
+ * @module number-counter
+ * @description IntersectionObserver-based animated number counter.
+ *   Cada elemento .stat-number con data-target="<number>" cuenta de 0 al
+ *   target al entrar viewport (una sola vez).
+ *
+ *   En prefers-reduced-motion: reduce, escribe el target instantaneo.
+ *   Bundle: ~0.9 KB minificado.
+ *
+ * @example
+ *   <span class="stat-number" data-target="12">0</span>
+ *   <script>initNumberCounters()</script>
+ */
+
+const ANIMATION_DURATION = 1400
+const FRAME_MS = 16
+
+function isReducedMotion(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function animateCounter(el: HTMLElement, target: number): void {
+  const start = performance.now()
+
+  const tick = (now: number): void => {
+    const elapsed = now - start
+    const progress = Math.min(elapsed / ANIMATION_DURATION, 1)
+    // easeOutCubic
+    const eased = 1 - (1 - progress) ** 3
+    const current = Math.floor(eased * target)
+    el.textContent = String(current)
+
+    if (progress < 1) {
+      requestAnimationFrame(tick)
+    } else {
+      el.textContent = String(target)
+    }
+  }
+
+  requestAnimationFrame(tick)
+}
+
+/**
+ * @function initNumberCounters
+ * @description Activa animaciones de contador en todos los `.stat-number[data-target]`.
+ *
+ * @returns {() => void} Cleanup function para desconectar el observer
+ *
+ * @example
+ *   const cleanup = initNumberCounters()
+ */
+export function initNumberCounters(): () => void {
+  if (typeof window === 'undefined') {
+    return () => {
+      /* noop */
+    }
+  }
+
+  const elements = Array.from(
+    document.querySelectorAll<HTMLElement>('.stat-number[data-target]'),
+  )
+
+  if (elements.length === 0) {
+    return () => {
+      /* noop */
+    }
+  }
+
+  if (isReducedMotion()) {
+    for (const el of elements) {
+      const target = Number(el.dataset.target ?? '0')
+      el.textContent = String(target)
+      el.dataset.counted = 'true'
+    }
+    return () => {
+      /* noop */
+    }
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        const el = entry.target as HTMLElement
+        if (entry.isIntersecting && el.dataset.counted !== 'true') {
+          const target = Number(el.dataset.target ?? '0')
+          el.dataset.counted = 'true'
+          if (Number.isInteger(target) && target > 0) {
+            const intervalId = setInterval(() => {
+              // bridge to RAF via timeout to keep imports light
+              clearInterval(intervalId)
+              animateCounter(el, target)
+            }, FRAME_MS)
+          }
+        }
+      }
+    },
+    { threshold: 0.4 },
+  )
+
+  for (const el of elements) {
+    observer.observe(el)
+  }
+
+  return () => {
+    observer.disconnect()
+  }
+}

--- a/packages/ui/src/styles/animations.css
+++ b/packages/ui/src/styles/animations.css
@@ -2,7 +2,169 @@
  * @config animations.css
  * @description Keyframes y animaciones reutilizables, todas respetando
  *   prefers-reduced-motion. Vanilla CSS - cero JS, cero libs externas.
+ *
+ *   Complementado por: mesh-gradients.css, scroll-driven.css.
  */
+
+/* === Variable font weight-shift (hover / loop) === */
+@keyframes weight-shift {
+  0%,
+  100% {
+    font-variation-settings: "wght" 400;
+  }
+  50% {
+    font-variation-settings: "wght" 700;
+  }
+}
+
+.weight-shift-hover {
+  transition: font-variation-settings var(--motion-slow) var(--easing-out);
+}
+
+.weight-shift-hover:hover {
+  font-variation-settings: "wght" 800;
+}
+
+/* === Marquee infinito CSS puro === */
+@keyframes marquee-left {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(-50%, 0, 0);
+  }
+}
+
+@keyframes marquee-right {
+  from {
+    transform: translate3d(-50%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.marquee {
+  display: flex;
+  overflow: hidden;
+  mask-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    black 8%,
+    black 92%,
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    black 8%,
+    black 92%,
+    transparent 100%
+  );
+}
+
+.marquee__track {
+  display: flex;
+  gap: var(--space-32);
+  white-space: nowrap;
+  animation: marquee-left 40s linear infinite;
+  will-change: transform;
+  flex-shrink: 0;
+}
+
+.marquee__track--reverse {
+  animation-name: marquee-right;
+}
+
+.marquee__track--fast {
+  animation-duration: 22s;
+}
+
+.marquee:hover .marquee__track {
+  animation-play-state: paused;
+}
+
+/* === Tilt 3D suave (CSS only, sin JS) === */
+.tilt-3d {
+  perspective: 1000px;
+  transform-style: preserve-3d;
+}
+
+.tilt-3d__inner {
+  transition: transform var(--motion-slow) var(--easing-out);
+  transform: rotateX(0) rotateY(0);
+  transform-style: preserve-3d;
+  will-change: transform;
+}
+
+@media (hover: hover) {
+  .tilt-3d:hover .tilt-3d__inner {
+    transform: rotateX(2deg) rotateY(-3deg) translateZ(8px);
+  }
+}
+
+/* === Magnetic hover preparation (vanilla JS lo controla en runtime) === */
+.magnetic {
+  transition: transform var(--motion-fast) var(--easing-out);
+  will-change: transform;
+}
+
+/* === Spotlight cursor (mask + radial gradient seguiendo mouse) === */
+.spotlight {
+  position: relative;
+  overflow: hidden;
+}
+
+.spotlight::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    320px circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
+    rgba(var(--niche-accent-rgb), 0.18),
+    transparent 65%
+  );
+  opacity: 0;
+  transition: opacity var(--motion-base) var(--easing-out);
+}
+
+.spotlight:hover::before {
+  opacity: 1;
+}
+
+/* === Animated underline === */
+@keyframes underline-grow {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.anim-underline {
+  position: relative;
+  display: inline-block;
+}
+
+.anim-underline::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--niche-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--motion-slow) var(--easing-out);
+}
+
+.anim-underline:hover::after,
+.anim-underline:focus-visible::after {
+  transform: scaleX(1);
+}
 
 @keyframes fade-in-up {
   from {

--- a/packages/ui/src/styles/fonts.css
+++ b/packages/ui/src/styles/fonts.css
@@ -1,11 +1,18 @@
 /**
  * @config fonts.css
- * @description Self-hosted fonts via @fontsource. GDPR-friendly + CSP estricto.
+ * @description Self-hosted variable fonts via @fontsource-variable. GDPR-friendly + CSP estricto.
  *   NUNCA importar desde fonts.googleapis.com.
+ *
+ *   Variable fonts: una sola request por familia, weight animable en hover/scroll
+ *   con font-variation-settings.
+ *
+ *   Fallback static fonts mantenidos para navegadores antiguos sin variable support.
  */
-@import "@fontsource/space-grotesk/400.css";
-@import "@fontsource/space-grotesk/500.css";
-@import "@fontsource/space-grotesk/600.css";
-@import "@fontsource/space-grotesk/700.css";
+
+/* Variable fonts (preferidas) */
+@import "@fontsource-variable/space-grotesk";
+@import "@fontsource-variable/jetbrains-mono";
+
+/* Fallback static (kept for back-compat con Space Mono que no tiene variable) */
 @import "@fontsource/space-mono/400.css";
 @import "@fontsource/space-mono/700.css";

--- a/packages/ui/src/styles/mesh-gradients.css
+++ b/packages/ui/src/styles/mesh-gradients.css
@@ -1,0 +1,123 @@
+/**
+ * @config mesh-gradients.css
+ * @description Mesh / aurora / spotlight gradients animados.
+ *   Compositor-friendly (GPU): solo animan background-position y filter.
+ *
+ *   Consume var(--niche-accent-rgb) y var(--mesh-1/2/3) para tener una
+ *   identidad visual distinta por nicho sin fragmentar el bundle.
+ *
+ *   IMPORTANTE: prefers-reduced-motion pausa las animaciones,
+ *   pero el gradiente sigue visible (estatico).
+ */
+
+@keyframes mesh-drift {
+  0%,
+  100% {
+    background-position:
+      0% 0%,
+      100% 100%,
+      50% 50%;
+  }
+  50% {
+    background-position:
+      100% 100%,
+      0% 0%,
+      50% 50%;
+  }
+}
+
+@keyframes aurora-flow {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: translate3d(2%, -1%, 0) scale(1.05);
+    opacity: 1;
+  }
+}
+
+@keyframes glow-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--niche-glow);
+  }
+  50% {
+    box-shadow: 0 0 32px 8px var(--niche-glow);
+  }
+}
+
+.mesh-bg {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    radial-gradient(
+      900px circle at 20% 30%,
+      rgba(var(--niche-accent-rgb), 0.35) 0%,
+      transparent 55%
+    ),
+    radial-gradient(700px circle at 75% 65%, var(--mesh-2) 0%, transparent 50%),
+    radial-gradient(900px circle at 50% 80%, var(--mesh-3) 0%, transparent 60%);
+  background-size:
+    220% 220%,
+    220% 220%,
+    220% 220%;
+  background-position:
+    0% 0%,
+    100% 100%,
+    50% 50%;
+  filter: blur(0);
+  animation: mesh-drift 32s ease-in-out infinite;
+  will-change: background-position;
+}
+
+.mesh-bg--soft {
+  opacity: 0.55;
+  filter: blur(40px) saturate(1.1);
+}
+
+.mesh-bg--vivid {
+  opacity: 0.92;
+  filter: saturate(1.1) brightness(1.05);
+}
+
+.aurora-layer {
+  position: absolute;
+  inset: -10%;
+  z-index: -2;
+  pointer-events: none;
+  background-image: radial-gradient(
+    ellipse at center,
+    rgba(var(--niche-accent-rgb), 0.18) 0%,
+    transparent 65%
+  );
+  animation: aurora-flow 18s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.glow-on-hover {
+  transition: box-shadow var(--motion-slow) var(--easing-out);
+}
+
+.glow-on-hover:hover {
+  box-shadow: 0 0 32px var(--niche-glow);
+}
+
+/* Gradient text que usa --niche-gradient */
+.gradient-text {
+  background: var(--niche-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mesh-bg,
+  .aurora-layer {
+    animation: none;
+  }
+}

--- a/packages/ui/src/styles/scroll-driven.css
+++ b/packages/ui/src/styles/scroll-driven.css
@@ -1,0 +1,133 @@
+/**
+ * @config scroll-driven.css
+ * @description Scroll-driven animations CSS nativas (animation-timeline: view()).
+ *   Chrome 115+, Safari 18+, Firefox 144+ soportan. Fallback con
+ *   @supports not (animation-timeline: view()) para navegadores antiguos.
+ *
+ *   GPU-friendly: anima opacity y transform, jamas top/left/margin.
+ */
+
+/* Estado base: visible. La animacion overridea para anaadir el reveal cuando hay scroll-timeline. */
+.scroll-reveal,
+.scroll-reveal-fade,
+.scroll-reveal-slide-left,
+.scroll-reveal-slide-right,
+.scroll-scale-in {
+  opacity: 1;
+  transform: none;
+}
+
+/* Reveal de cards al entrar en viewport */
+@supports (animation-timeline: view()) {
+  .scroll-reveal {
+    animation: scroll-reveal linear;
+    animation-timeline: view();
+    animation-range: entry 0% cover 25%;
+  }
+
+  .scroll-reveal-fade {
+    animation: scroll-reveal-fade linear;
+    animation-timeline: view();
+    animation-range: entry 0% cover 30%;
+  }
+
+  .scroll-reveal-slide-left {
+    animation: scroll-reveal-slide-left linear;
+    animation-timeline: view();
+    animation-range: entry 0% cover 25%;
+  }
+
+  .scroll-reveal-slide-right {
+    animation: scroll-reveal-slide-right linear;
+    animation-timeline: view();
+    animation-range: entry 0% cover 25%;
+  }
+
+  .scroll-scale-in {
+    animation: scroll-scale-in linear;
+    animation-timeline: view();
+    animation-range: entry 0% cover 50%;
+  }
+
+  /* Parallax sutil (max 12% de movimiento total) */
+  .scroll-parallax-slow {
+    animation: scroll-parallax-slow linear;
+    animation-timeline: scroll();
+  }
+}
+
+@keyframes scroll-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(48px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes scroll-reveal-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes scroll-reveal-slide-left {
+  from {
+    opacity: 0;
+    transform: translateX(-48px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scroll-reveal-slide-right {
+  from {
+    opacity: 0;
+    transform: translateX(48px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scroll-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes scroll-parallax-slow {
+  from {
+    transform: translate3d(0, -6%, 0);
+  }
+  to {
+    transform: translate3d(0, 6%, 0);
+  }
+}
+
+/* Reduced motion: todo se muestra al instante, sin movimiento */
+@media (prefers-reduced-motion: reduce) {
+  .scroll-reveal,
+  .scroll-reveal-fade,
+  .scroll-reveal-slide-left,
+  .scroll-reveal-slide-right,
+  .scroll-scale-in,
+  .scroll-parallax-slow {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -55,9 +55,20 @@
 
   /* === Tipografia === */
   --font-sans:
-    "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    sans-serif;
-  --font-mono: "Space Mono", "Menlo", "Monaco", "Courier New", monospace;
+    "Space Grotesk Variable", "Space Grotesk", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono:
+    "JetBrains Mono Variable", "Space Mono", "Menlo", "Monaco", "Courier New",
+    monospace;
+  --font-mono-display:
+    "JetBrains Mono Variable", "Space Mono", "Menlo", monospace;
+
+  /* === Variation settings (variable fonts) === */
+  --font-wght-body: 400;
+  --font-wght-medium: 500;
+  --font-wght-semibold: 600;
+  --font-wght-bold: 700;
+  --font-wght-black: 800;
 
   --font-size-8: 0.5rem;
   --font-size-10: 0.625rem;
@@ -71,6 +82,16 @@
   --font-size-32: 2rem;
   --font-size-40: 2.5rem;
   --font-size-52: 3.25rem;
+  --font-size-72: 4.5rem;
+  --font-size-96: 6rem;
+  --font-size-128: 8rem;
+  --font-size-160: 10rem;
+
+  /* === Display fluido (clamp para fluido entre breakpoints) === */
+  --font-size-display-sm: clamp(2rem, 5vw, 3rem);
+  --font-size-display-md: clamp(2.5rem, 7vw, 5rem);
+  --font-size-display-lg: clamp(3rem, 9vw, 8rem);
+  --font-size-display-mega: clamp(3rem, 10vw, 12rem);
 
   --line-height-tight: 1;
   --line-height-snug: 1.35;
@@ -121,8 +142,22 @@
   --motion-fast: 120ms;
   --motion-base: 220ms;
   --motion-slow: 320ms;
+  --motion-very-slow: 640ms;
   --easing-out: cubic-bezier(0.16, 1, 0.3, 1);
   --easing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --easing-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* === Niche identity (defaults override en SitePageLayout) === */
+  --niche-accent: var(--color-primary);
+  --niche-accent-rgb: 79, 110, 247;
+  --niche-glow: rgba(79, 110, 247, 0.35);
+  --niche-gradient: linear-gradient(135deg, #4f6ef7 0%, #b97cf2 100%);
+  --niche-mood: sans;
+
+  /* === Mesh gradient palette (mezcla con --niche-accent en runtime) === */
+  --mesh-1: rgba(79, 110, 247, 0.28);
+  --mesh-2: rgba(185, 124, 242, 0.22);
+  --mesh-3: rgba(56, 217, 214, 0.16);
 }
 
 /* === Modo light explicito (clase .light en <html>) === */

--- a/packages/ui/src/styles/typography.css
+++ b/packages/ui/src/styles/typography.css
@@ -92,10 +92,69 @@
   font-size: var(--font-size-13);
 }
 
+.text-mono-display {
+  font-family: var(--font-mono-display);
+  font-size: var(--font-size-display-md);
+  font-weight: 700;
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+  font-variation-settings: "wght" 700;
+}
+
+/* === Display impactantes (clamp fluido) === */
+.text-display-sm {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-display-sm);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  font-variation-settings: "wght" 700;
+}
+
+.text-display-md {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-display-md);
+  font-weight: 700;
+  line-height: 0.98;
+  letter-spacing: -0.025em;
+  font-variation-settings: "wght" 700;
+}
+
+.text-display-lg {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-display-lg);
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  font-variation-settings: "wght" 800;
+}
+
+.text-display-mega {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-display-mega);
+  font-weight: 800;
+  line-height: 0.92;
+  letter-spacing: -0.035em;
+  font-variation-settings: "wght" 800;
+}
+
+.text-mono-label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-11);
+  font-weight: 500;
+  line-height: var(--line-height-tight);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wide);
+}
+
 .text-muted {
   color: var(--color-text-muted);
 }
 
 .text-subtle {
   color: var(--color-text-subtle);
+}
+
+.text-accent {
+  color: var(--niche-accent);
 }

--- a/packages/ui/tests/unit/magnetic-cursor.test.ts
+++ b/packages/ui/tests/unit/magnetic-cursor.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @description Tests para initMagneticCursor. Verifica que respeta hover:none
+ *   y prefers-reduced-motion, y que adjunta listeners a .magnetic.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initMagneticCursor } from '../../src/lib/magnetic-cursor'
+
+describe('initMagneticCursor', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    // Default media-query: hover support + no reduced-motion
+    window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+      matches: q === '(hover: hover)',
+      media: q,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('Given touch device (hover: none) When init Then retorna noop sin error', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true, // todo matchea (incluye hover:none)
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as typeof window.matchMedia
+    const cleanup = initMagneticCursor()
+    expect(typeof cleanup).toBe('function')
+    cleanup()
+  })
+
+  it('Given prefers-reduced-motion: reduce When init Then retorna noop', () => {
+    window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+      matches: q === '(prefers-reduced-motion: reduce)',
+      media: q,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia
+    const cleanup = initMagneticCursor()
+    expect(typeof cleanup).toBe('function')
+    cleanup()
+  })
+
+  it('Given hover support y no .magnetic en DOM When init Then retorna cleanup noop', () => {
+    const cleanup = initMagneticCursor()
+    expect(typeof cleanup).toBe('function')
+    cleanup()
+  })
+
+  it('Given hover support y .magnetic en DOM When mousemove cerca Then aplica translate3d', () => {
+    const btn = document.createElement('button')
+    btn.className = 'magnetic'
+    Object.defineProperty(btn, 'getBoundingClientRect', {
+      value: () => ({
+        left: 100,
+        top: 100,
+        width: 100,
+        height: 40,
+        right: 200,
+        bottom: 140,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      }),
+    })
+    document.body.appendChild(btn)
+    initMagneticCursor()
+    // cursor en (110, 110): cerca del centro (150, 120), distancia ~41px < 60
+    btn.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 110, clientY: 110 }),
+    )
+    expect(btn.style.transform).toMatch(/translate3d/u)
+  })
+
+  it('Given hover support y mousemove lejos Then resetea transform a (0,0,0)', () => {
+    const btn = document.createElement('button')
+    btn.className = 'magnetic'
+    Object.defineProperty(btn, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 50,
+        height: 20,
+        right: 50,
+        bottom: 20,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    })
+    document.body.appendChild(btn)
+    initMagneticCursor()
+    btn.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 999, clientY: 999 }),
+    )
+    expect(btn.style.transform).toBe('translate3d(0, 0, 0)')
+  })
+
+  it('Given mouseleave Then resetea transform', () => {
+    const btn = document.createElement('button')
+    btn.className = 'magnetic'
+    Object.defineProperty(btn, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 50,
+        height: 20,
+        right: 50,
+        bottom: 20,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    })
+    document.body.appendChild(btn)
+    initMagneticCursor()
+    btn.style.transform = 'translate3d(5px, 5px, 0)'
+    btn.dispatchEvent(new Event('mouseleave'))
+    expect(btn.style.transform).toBe('translate3d(0, 0, 0)')
+  })
+})

--- a/packages/ui/tests/unit/niche-tokens.test.ts
+++ b/packages/ui/tests/unit/niche-tokens.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @description Tests para niche-tokens: mapeo type-safe niche -> tokens
+ *   visuales (accent, glow, gradient, mood).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  getNicheTokens,
+  NICHE_TOKENS,
+  nicheTokensToCssVars,
+} from '../../src/lib/niche-tokens'
+
+describe('NICHE_TOKENS', () => {
+  it('Given NICHE_TOKENS Then contiene los 5 niches + hub (6 entries)', () => {
+    expect(Object.keys(NICHE_TOKENS).sort()).toStrictEqual([
+      'architect',
+      'fintech',
+      'generic',
+      'hub',
+      'leader',
+      'vibe',
+    ])
+  })
+})
+
+describe('getNicheTokens', () => {
+  it('Given niche fintech Then accent es cyan #38d9d6', () => {
+    expect(getNicheTokens('fintech').accent).toBe('#38d9d6')
+  })
+
+  it('Given niche architect Then accent es rose #f06e9c y mood es mono', () => {
+    const t = getNicheTokens('architect')
+    expect(t.accent).toBe('#f06e9c')
+    expect(t.mood).toBe('mono')
+  })
+
+  it('Given niche leader Then accent es amber #f4b740', () => {
+    expect(getNicheTokens('leader').accent).toBe('#f4b740')
+  })
+
+  it('Given niche vibe Then accent es purple #b97cf2 y mood es mono', () => {
+    const t = getNicheTokens('vibe')
+    expect(t.accent).toBe('#b97cf2')
+    expect(t.mood).toBe('mono')
+  })
+
+  it('Given niche generic Then accent es electric blue #4f6ef7 y mood es sans', () => {
+    const t = getNicheTokens('generic')
+    expect(t.accent).toBe('#4f6ef7')
+    expect(t.mood).toBe('sans')
+  })
+
+  it('Given niche hub Then label es "Hub"', () => {
+    expect(getNicheTokens('hub').label).toBe('Hub')
+  })
+
+  it('Given todos los niches Then accentRgb es triplet "r, g, b"', () => {
+    const niches = [
+      'generic',
+      'hub',
+      'fintech',
+      'architect',
+      'leader',
+      'vibe',
+    ] as const
+    for (const n of niches) {
+      const t = getNicheTokens(n)
+      expect(t.accentRgb).toMatch(/^\d+, \d+, \d+$/u)
+    }
+  })
+})
+
+describe('nicheTokensToCssVars', () => {
+  it('Given niche fintech Then string contiene 5 custom props separadas por "; "', () => {
+    const css = nicheTokensToCssVars('fintech')
+    expect(css).toBe(
+      '--niche-accent: #38d9d6; --niche-accent-rgb: 56, 217, 214; --niche-glow: rgba(56, 217, 214, 0.35); --niche-gradient: linear-gradient(135deg, #38d9d6 0%, #4f6ef7 100%); --niche-mood: sans',
+    )
+  })
+
+  it('Given niche vibe Then incluye mood: mono', () => {
+    const css = nicheTokensToCssVars('vibe')
+    expect(css).toContain('--niche-mood: mono')
+  })
+})

--- a/packages/ui/tests/unit/number-counter.test.ts
+++ b/packages/ui/tests/unit/number-counter.test.ts
@@ -77,9 +77,10 @@ describe('initNumberCounters', () => {
   })
 
   it('Given .stat-number con data-target=0 When intersecting Then marca counted pero no dispara animateCounter', () => {
-    let savedCallback:
-      | ((entries: { isIntersecting: boolean; target: HTMLElement }[]) => void)
-      | null = null
+    type Cb = (
+      entries: { isIntersecting: boolean; target: HTMLElement }[],
+    ) => void
+    let savedCallback: Cb | null = null as Cb | null
     class MockIO {
       constructor(
         cb: (
@@ -109,9 +110,10 @@ describe('initNumberCounters', () => {
   })
 
   it('Given IntersectionObserver callback con isIntersecting=false Then no marca counted', () => {
-    let savedCallback:
-      | ((entries: { isIntersecting: boolean; target: HTMLElement }[]) => void)
-      | null = null
+    type Cb = (
+      entries: { isIntersecting: boolean; target: HTMLElement }[],
+    ) => void
+    let savedCallback: Cb | null = null as Cb | null
     class MockIO {
       constructor(
         cb: (
@@ -141,9 +143,10 @@ describe('initNumberCounters', () => {
   })
 
   it('Given IntersectionObserver callback con isIntersecting Then marca counted y dispara animacion', () => {
-    let savedCallback:
-      | ((entries: { isIntersecting: boolean; target: HTMLElement }[]) => void)
-      | null = null
+    type Cb = (
+      entries: { isIntersecting: boolean; target: HTMLElement }[],
+    ) => void
+    let savedCallback: Cb | null = null as Cb | null
     class MockIO {
       constructor(
         cb: (

--- a/packages/ui/tests/unit/number-counter.test.ts
+++ b/packages/ui/tests/unit/number-counter.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @description Tests para initNumberCounters. Verifica el comportamiento
+ *   en prefers-reduced-motion (escribe target instantaneo) y en modo normal
+ *   (IntersectionObserver dispara animacion via requestAnimationFrame).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initNumberCounters } from '../../src/lib/number-counter'
+
+describe('initNumberCounters', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as typeof window.matchMedia
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('Given DOM sin .stat-number When init Then retorna cleanup noop', () => {
+    const cleanup = initNumberCounters()
+    expect(typeof cleanup).toBe('function')
+    cleanup()
+  })
+
+  it('Given prefers-reduced-motion: reduce When init Then escribe target instantaneo y marca counted', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as typeof window.matchMedia
+    const el = document.createElement('span')
+    el.className = 'stat-number'
+    el.dataset.target = '42'
+    el.textContent = '0'
+    document.body.appendChild(el)
+
+    const cleanup = initNumberCounters()
+    expect(el.textContent).toBe('42')
+    expect(el.dataset.counted).toBe('true')
+    cleanup()
+  })
+
+  it('Given .stat-number con data-target When init Then crea IntersectionObserver y observa el elemento', () => {
+    const observeSpy = vi.fn()
+    const disconnectSpy = vi.fn()
+    class MockIO {
+      observe = observeSpy
+      disconnect = disconnectSpy
+      unobserve = vi.fn()
+      takeRecords = vi.fn().mockReturnValue([])
+      root = null
+      rootMargin = ''
+      thresholds: number[] = []
+    }
+    vi.stubGlobal('IntersectionObserver', MockIO)
+
+    const el = document.createElement('span')
+    el.className = 'stat-number'
+    el.dataset.target = '12'
+    document.body.appendChild(el)
+
+    const cleanup = initNumberCounters()
+    expect(observeSpy).toHaveBeenCalledTimes(1)
+    cleanup()
+    expect(disconnectSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('Given .stat-number con data-target=0 When intersecting Then marca counted pero no dispara animateCounter', () => {
+    let savedCallback:
+      | ((entries: { isIntersecting: boolean; target: HTMLElement }[]) => void)
+      | null = null
+    class MockIO {
+      constructor(
+        cb: (
+          entries: { isIntersecting: boolean; target: HTMLElement }[],
+        ) => void,
+      ) {
+        savedCallback = cb
+      }
+      observe = vi.fn()
+      disconnect = vi.fn()
+      unobserve = vi.fn()
+      takeRecords = vi.fn().mockReturnValue([])
+      root = null
+      rootMargin = ''
+      thresholds: number[] = []
+    }
+    vi.stubGlobal('IntersectionObserver', MockIO)
+
+    const el = document.createElement('span')
+    el.className = 'stat-number'
+    el.dataset.target = '0'
+    document.body.appendChild(el)
+
+    initNumberCounters()
+    savedCallback?.([{ isIntersecting: true, target: el }])
+    expect(el.dataset.counted).toBe('true')
+  })
+
+  it('Given IntersectionObserver callback con isIntersecting=false Then no marca counted', () => {
+    let savedCallback:
+      | ((entries: { isIntersecting: boolean; target: HTMLElement }[]) => void)
+      | null = null
+    class MockIO {
+      constructor(
+        cb: (
+          entries: { isIntersecting: boolean; target: HTMLElement }[],
+        ) => void,
+      ) {
+        savedCallback = cb
+      }
+      observe = vi.fn()
+      disconnect = vi.fn()
+      unobserve = vi.fn()
+      takeRecords = vi.fn().mockReturnValue([])
+      root = null
+      rootMargin = ''
+      thresholds: number[] = []
+    }
+    vi.stubGlobal('IntersectionObserver', MockIO)
+
+    const el = document.createElement('span')
+    el.className = 'stat-number'
+    el.dataset.target = '10'
+    document.body.appendChild(el)
+
+    initNumberCounters()
+    savedCallback?.([{ isIntersecting: false, target: el }])
+    expect(el.dataset.counted).toBeUndefined()
+  })
+
+  it('Given IntersectionObserver callback con isIntersecting Then marca counted y dispara animacion', () => {
+    let savedCallback:
+      | ((entries: { isIntersecting: boolean; target: HTMLElement }[]) => void)
+      | null = null
+    class MockIO {
+      constructor(
+        cb: (
+          entries: { isIntersecting: boolean; target: HTMLElement }[],
+        ) => void,
+      ) {
+        savedCallback = cb
+      }
+      observe = vi.fn()
+      disconnect = vi.fn()
+      unobserve = vi.fn()
+      takeRecords = vi.fn().mockReturnValue([])
+      root = null
+      rootMargin = ''
+      thresholds: number[] = []
+    }
+    vi.stubGlobal('IntersectionObserver', MockIO)
+    vi.useFakeTimers()
+
+    const el = document.createElement('span')
+    el.className = 'stat-number'
+    el.dataset.target = '5'
+    document.body.appendChild(el)
+
+    initNumberCounters()
+    expect(savedCallback).not.toBeNull()
+    savedCallback?.([{ isIntersecting: true, target: el }])
+    // setInterval(16) -> animateCounter via RAF
+    vi.advanceTimersByTime(40)
+    expect(el.dataset.counted).toBe('true')
+
+    vi.useRealTimers()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,12 @@ importers:
 
   packages/ui:
     dependencies:
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.5
+        version: 5.2.8
+      '@fontsource-variable/space-grotesk':
+        specifier: ^5.2.5
+        version: 5.2.10
       '@fontsource/space-grotesk':
         specifier: ^5.1.1
         version: 5.2.10
@@ -957,6 +963,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
+
+  '@fontsource-variable/space-grotesk@5.2.10':
+    resolution: {integrity: sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==}
 
   '@fontsource/space-grotesk@5.2.10':
     resolution: {integrity: sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==}
@@ -3477,6 +3489,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
+
+  '@fontsource-variable/space-grotesk@5.2.10': {}
 
   '@fontsource/space-grotesk@5.2.10': {}
 

--- a/tests/feature/smoke/cv-screenshots.spec.ts
+++ b/tests/feature/smoke/cv-screenshots.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @feature CV screenshots - portfolio multi-niche
+ * @description Captura screenshots de hero + secciones de los 6 sitios
+ *   del portfolio post-rediseño. Output en results/<niche>/<viewport>/.
+ *
+ *   Solo desktop-chromium (corre rapido en feature tests, suficiente para
+ *   evidencia visual del PR).
+ */
+
+import { expect, subdomainUrl, test } from '../fixtures/index.js'
+import { captureScreenshot } from '../helpers/screenshot.js'
+
+const SITES = [
+  { name: 'generic', host: undefined, label: 'Full Stack' },
+  { name: 'hub', host: 'hub', label: 'Hub' },
+  { name: 'fintech', host: 'fintech', label: 'Fintech LATAM' },
+  { name: 'architect', host: 'architect', label: 'Architect' },
+  { name: 'leader', host: 'leader', label: 'Tech Lead' },
+  { name: 'vibe', host: 'vibe', label: 'Vibe Coding' },
+] as const
+
+test.describe('Feature: CV screenshots - 6 niches', () => {
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Solo desktop-chromium para reducir tiempo de captura',
+  )
+
+  for (const site of SITES) {
+    test(`When visito ${site.name} Then el hero renderiza con niche tokens y captura screenshot`, async ({
+      page,
+    }, testInfo) => {
+      const url = subdomainUrl(site.host)
+      await page.goto(`${url}/`, { waitUntil: 'domcontentloaded' })
+      await page
+        .waitForLoadState('networkidle', { timeout: 10_000 })
+        .catch(() => {
+          // tolerar networkidle timeouts en HMR
+        })
+
+      // hero visible
+      const h1 = page.locator('h1').first()
+      await expect(h1).toBeVisible()
+
+      // capturar hero (top)
+      await captureScreenshot(page, testInfo, `${site.name}-01-hero`)
+
+      // scroll a 50% (mid) y capturar
+      await page.evaluate(() => {
+        window.scrollTo({ top: window.innerHeight * 1.5, behavior: 'instant' })
+      })
+      await page.waitForTimeout(600)
+      await captureScreenshot(page, testInfo, `${site.name}-02-mid`)
+
+      // scroll al final
+      await page.evaluate(() => {
+        window.scrollTo({
+          top: document.body.scrollHeight,
+          behavior: 'instant',
+        })
+      })
+      await page.waitForTimeout(600)
+      await captureScreenshot(page, testInfo, `${site.name}-03-bottom`)
+    })
+  }
+})


### PR DESCRIPTION
## Problema

Los 6 sitios del portfolio (`generic`, `hub`, `fintech`, `architect`, `leader`, `vibe`) compartían el mismo layout/tokens/animaciones sin identidad visual distintiva por nicho. El contenido del CV no aprovechaba las 3 investigaciones del repo (`modern-portfolios`, `developer-portfolios-vibe-coding`, `ai-prompt-optimization`) y el research nuevo 2026:

1. Sin display fonts gigantes, mesh gradients, scroll-driven, bento grids ni marquee.
2. Premio "Innovador del año 2023 Destacame" invisible en el portfolio.
3. Sin narrativa real de adopción de Claude Code (mayo 2025), FastStruct previo, ni la implementación en Destacame.
4. JSON-LD era solo `Person` (no `ProfilePage` recomendado para GEO).
5. llms.txt era genérico sin narrativa específica por nicho ni ATS keywords visibles.

## Solución

Redesign completo en 6 fases secuenciales (aprobado en plan inicial):

**F1 — Foundation**: variable fonts (Space Grotesk + JetBrains Mono Variable), escala display fluida `clamp(3rem, 10vw, 12rem)`, tokens `--niche-accent/glow/gradient/mood`, libs `niche-tokens.ts` + `magnetic-cursor.ts` + `number-counter.ts`, CSS `mesh-gradients.css` + `scroll-driven.css` + tilt/marquee/spotlight/weight-shift en `animations.css`.

**F2 — Core components**: 11 componentes Astro nuevos: `HeroImpact`, `MeshGradientBg`, `StatsBar`, `SkillsMarquee`, `NicheBadge`, `ExperienceTimeline` + `TimelineItem`, `ProjectsBento` + `ProjectBentoCard`, `CaseStudyExpander`, `AwardCard`.

**F3 — Niche-specific sections**: 4 secciones exclusivas: `AiWorkflowSection` (vibe, 9 cards con historia real), `ArchitectureDiagram` (architect, ASCII + 6 layers), `LeadershipStats` (leader, 4 stats + 3 pillars), `AtsKeywordsPills` (fintech, white-hat ATS).

**F4 — Wire-up**: `SitePageLayout` inyecta tokens del nicho via `style` inline + bootstrapea `initMagneticCursor` + `initNumberCounters`. `CvSections` orquesta extras via `getNicheExtras()`. Las 5 apps + hub actualizadas con identidad propia (heroHeadline, heroSummary, nicheLabel, atsKeywords[]).

**F5 — SEO/AI white-hat**: nuevo `buildProfilePageSchema` (ProfilePage > Person + Occupation con occupationLocation). `buildLlmsTxt` enriquecido con `NICHE_HIGHLIGHTS` por nicho + ATS keywords + disclosure honesto.

**F6 — Tests + screenshots**: 53 tests unit nuevos (coverage 100% en libs nuevas), spec `cv-screenshots.spec.ts` para Playwright. 87 E2E tests verdes en stack local Docker.

### Identidad por nicho

| Nicho | Accent | Headline | Sección exclusiva |
|---|---|---|---|
| generic | `#4f6ef7` electric blue | Senior Full Stack Engineer | StatsBar + marquee |
| hub | mesh 4-accents | "Cinco enfoques. Elige el que conecta." | 5 niche cards tilt 3D |
| fintech | `#38d9d6` cyan teal | Senior Full Stack Fintech LATAM | ATS pills (PCI DSS, Chile, México, KYC) |
| architect | `#f06e9c` rose pink | Frontend Architect & Microservicios | ASCII diagram microservicios + 6 layers |
| leader | `#f4b740` amber gold | Tech Lead & Engineering Manager | LeadershipStats + Premio Innovador 2023 destacado |
| vibe | `#b97cf2` purple violet | AI-Augmented Full Stack · Claude Code | AiWorkflow (9 cards) + FastStruct + bypabloc/cv + mvp-template |

### Contenido nuevo del CV

- `projects.ts`: 2 proyectos nuevos del nicho vibe:
  - `bypabloc/cv` — CV builder MVP construido en una noche (12-13 mayo 2026) con Claude Code
  - `bypabloc/mvp-template-full-stack` — template referencia del flujo vibe coding
- `caseStudyDetailed` (problem/process/result + metrics) en FastStruct + Destacame Chile + Destacame México
- `profile.stats`: 12 años, 8 empresas, 4 países LATAM, 11 certificaciones

### Narrativa real de Claude Code (sección vibe)

9 cards con la historia completa de Pablo:
1. Antes de Claude Code → Claude web + FastStruct (extensión propia)
2. **Implementó Claude Code en Destacame** con estructura skills/rules/docs estándar
3. **Construye CLIs propias** (devtools Python 3.14) para centralizar procesos del equipo
4. Stack actual (Claude Code 91% CSAT + Cursor + Sub-agentes)
5. Prompt real: pattern explore→plan→implement→commit
6. Referencia abierta: bypabloc/mvp-template-full-stack
7. Output reciente: bypabloc/cv en una noche
8. Métricas: 5x faster + 0% atribución IA
9. Reglas: AI = herramienta, no autor

## Cómo probar

```bash
# 1. Levantar stack local (6 apps Astro + nginx + Playwright)
python devtools/run.py docker up --env=local

# 2. Visitar cada subdominio en browser
open http://localhost:9970         # generic
open http://hub.localhost:9970     # hub (mesh gradient + tilt cards)
open http://fintech.localhost:9970 # cyan teal + ATS pills + case studies
open http://architect.localhost:9970 # rose + ASCII diagram microservicios
open http://leader.localhost:9970  # amber + LeadershipStats + Premio 2023
open http://vibe.localhost:9970    # purple + AI Workflow 9 cards

# 3. Verificar JSON-LD enriquecido
curl -s -H "Host: fintech.localhost" http://localhost:9970/ \
  | grep -oE '"@type":"[^"]+"'
# Esperado: ProfilePage, Person, PostalAddress, Occupation, Country

# 4. Verificar llms.txt enriquecido
curl -s -H "Host: vibe.localhost" http://localhost:9970/llms.txt

# 5. Tests E2E
python devtools/run.py test_runner --module=feature --type=feature --env=local

# 6. Screenshots (18 PNGs en tmp/screenshots/)
ls tmp/screenshots/

# 7. Probar prefers-reduced-motion en Chrome DevTools:
# Rendering > Emulate CSS media feature prefers-reduced-motion: reduce
# Verificar: mesh gradient pausado, marquee pausado, sin tilt 3D, counters instant
```

### Quality gates pasadas (pre-push)

- ✅ Conformance (Biome lint + format)
- ✅ Frontend Type Purity (solo .ts/.astro)
- ✅ TypeScript typecheck (tsc + astro check en 6 apps)
- ✅ Unit tests + coverage ≥80% per-file
- ✅ Build estático (6 apps construyen sin errores)
- ✅ Feature tests Playwright (88 passing, 12 skipped)

## TODO

- Validar JSON-LD con Google Rich Results Test post-deploy
- Lighthouse audit en producción para confirmar LCP < 2.0s
- Considerar agregar `BreadcrumbList` schema cuando se agregue `/about/timeline` u otras subpáginas
- Avatars actualizados al perfil más reciente en producción (asset S3)