### PR TITLE
feat(devtools): validate_versions read-only check + manifest discovery

### DIFF
--- a/devtools/shared/manifest_discovery.py
+++ b/devtools/shared/manifest_discovery.py
@@ -1,0 +1,114 @@
+"""Discovery automatico de manifests del monorepo portfolio.
+
+Reemplaza los paths hardcoded de modulos como ``upgrade_deps`` y
+``validate_versions``: en lugar de declarar a mano cada ``package.json`` o
+``pyproject.toml``, este modulo enumera TODOS los workspaces conocidos
+(``apps/*``, ``packages/*``, root, ``devtools/``, ``server/``) y devuelve
+la lista de manifests existentes.
+
+Single source of truth: si manana se agrega un workspace nuevo, basta con
+extender ``PORTFOLIO_APPS`` o ``PORTFOLIO_PACKAGES`` en ``shared/paths.py``
+y los scripts lo recogen automaticamente.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+from shared.paths import APPS_DIR
+from shared.paths import DEVTOOLS_DIR
+from shared.paths import PACKAGES_DIR
+from shared.paths import PORTFOLIO_APPS
+from shared.paths import PORTFOLIO_PACKAGES
+from shared.paths import PROJECT_ROOT
+from shared.paths import SERVER_DIR
+
+
+class Manifest(NamedTuple):
+    """Un manifest descubierto, listo para parsear.
+
+    Attributes:
+        kind: ``'npm'`` para package.json o ``'pypi'`` para pyproject.toml.
+        workspace: identificador legible (``'app:generic'``,
+            ``'pkg:content'``, ``'root'``, ``'devtools'``, ``'server'``).
+        path: ruta absoluta al manifest.
+        relpath: ruta relativa a ``PROJECT_ROOT`` (POSIX style) para logs.
+    """
+
+    kind: str
+    workspace: str
+    path: Path
+    relpath: str
+
+
+def _make(kind: str, workspace: str, path: Path) -> Manifest | None:
+    if not path.is_file():
+        return None
+    return Manifest(
+        kind=kind,
+        workspace=workspace,
+        path=path,
+        relpath=path.relative_to(PROJECT_ROOT).as_posix(),
+    )
+
+
+def discover_npm_manifests() -> list[Manifest]:
+    """Devuelve TODOS los ``package.json`` del monorepo.
+
+    Cubre:
+        - ``package.json`` raiz (workspace orchestrator)
+        - ``apps/<app>/package.json`` (6 sites Astro)
+        - ``packages/<pkg>/package.json`` (5 workspaces compartidos)
+
+    Solo retorna manifests que existen en disco; las apps/packages declaradas
+    en ``PORTFOLIO_APPS`` / ``PORTFOLIO_PACKAGES`` que aun no tengan archivo
+    se omiten silenciosamente.
+    """
+    out: list[Manifest] = []
+
+    root_pkg = _make('npm', 'root', PROJECT_ROOT / 'package.json')
+    if root_pkg is not None:
+        out.append(root_pkg)
+
+    for app in PORTFOLIO_APPS:
+        manifest = _make('npm', f'app:{app}', APPS_DIR / app / 'package.json')
+        if manifest is not None:
+            out.append(manifest)
+
+    for pkg in PORTFOLIO_PACKAGES:
+        manifest = _make(
+            'npm', f'pkg:{pkg}', PACKAGES_DIR / pkg / 'package.json'
+        )
+        if manifest is not None:
+            out.append(manifest)
+
+    return out
+
+
+def discover_pypi_manifests() -> list[Manifest]:
+    """Devuelve TODOS los ``pyproject.toml`` del monorepo.
+
+    Cubre:
+        - ``devtools/pyproject.toml`` (Python 3.14 CLI orchestrator)
+        - ``server/pyproject.toml`` (stub, si existe — el portfolio no tiene
+          backend, pero el manifest puede existir para futuros usos)
+    """
+    out: list[Manifest] = []
+
+    devtools_pyproject = _make(
+        'pypi', 'devtools', DEVTOOLS_DIR / 'pyproject.toml'
+    )
+    if devtools_pyproject is not None:
+        out.append(devtools_pyproject)
+
+    server_pyproject = _make('pypi', 'server', SERVER_DIR / 'pyproject.toml')
+    if server_pyproject is not None:
+        out.append(server_pyproject)
+
+    return out
+
+
+def discover_all() -> list[Manifest]:
+    """Devuelve npm + pypi manifests, en ese orden."""
+    return [*discover_npm_manifests(), *discover_pypi_manifests()]

--- a/devtools/upgrade_deps/main.py
+++ b/devtools/upgrade_deps/main.py
@@ -1,11 +1,12 @@
 """Upgrade dependencies in PEP 621/735 pyproject.toml + package.json manifests
 to the latest stable from PyPI / npm.
 
-Manifestos cubiertos:
-    - server/pyproject.toml      (project.dependencies + dependency-groups)
-    - devtools/pyproject.toml    (project.dependencies + dependency-groups)
-    - dashboard/package.json
-    - landing/package.json
+Manifestos cubiertos (descubrimiento automatico via shared.manifest_discovery):
+    - package.json raiz (workspace orchestrator)
+    - apps/<app>/package.json (6 Astro sites)
+    - packages/<pkg>/package.json (5 workspaces compartidos)
+    - devtools/pyproject.toml (Python CLI)
+    - server/pyproject.toml (si existe)
 
 Comportamiento:
     1. Parsea cada manifest en su esquema nativo (PEP 621/735 TOML o package.json).
@@ -30,6 +31,10 @@ import re
 
 import httpx
 
+from shared.manifest_discovery import Manifest
+from shared.manifest_discovery import discover_npm_manifests
+from shared.manifest_discovery import discover_pypi_manifests
+from shared.paths import PROJECT_ROOT
 from upgrade_deps.parsers import parse_package_json
 from upgrade_deps.parsers import parse_pyproject_toml
 from upgrade_deps.registry import fetch_npm_versions
@@ -44,18 +49,6 @@ from upgrade_deps.versions import format_with_prefix
 from upgrade_deps.versions import is_newer
 from upgrade_deps.versions import pick_latest_stable
 
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-
-PYPI_MANIFESTS = (
-    PROJECT_ROOT / 'server' / 'pyproject.toml',
-    PROJECT_ROOT / 'devtools' / 'pyproject.toml',
-)
-
-NPM_MANIFESTS = (
-    PROJECT_ROOT / 'dashboard' / 'package.json',
-    PROJECT_ROOT / 'landing' / 'package.json',
-)
 
 # Concurrencia: limita a N requests simultáneos al mismo registry para no
 # saturar PyPI/npm si un manifest es grande.
@@ -351,19 +344,19 @@ async def _run(*, dry_run: bool) -> int:
     total_written = 0
 
     async with httpx.AsyncClient() as client:
-        for manifest in PYPI_MANIFESTS:
+        for manifest in discover_pypi_manifests():
             results, written = await _process_pypi_manifest(
                 client,
-                manifest,
+                manifest.path,
                 dry_run,
             )
             all_results.extend(results)
             total_written += written
 
-        for manifest in NPM_MANIFESTS:
+        for manifest in discover_npm_manifests():
             results, written = await _process_npm_manifest(
                 client,
-                manifest,
+                manifest.path,
                 dry_run,
             )
             all_results.extend(results)

--- a/devtools/upgrade_deps/versions.py
+++ b/devtools/upgrade_deps/versions.py
@@ -8,10 +8,12 @@ fallback a regex propia si no esta disponible). Maneja pre-releases
 import re
 
 
-# Indicadores de pre-release: PEP 440 (a/b/rc/dev) y SemVer (-alpha/-beta/-rc/-pre)
+# Indicadores de pre-release: PEP 440 (a/b/rc/dev) y SemVer (-alpha/-beta/-rc/-pre/-canary/-next/-experimental/-nightly/-snapshot).
+# `canary` y `next` son comunes en npm para builds inestables (ej. zod 4.5.0-canary.X,
+# react 19.0.0-next.X). Tratamos todo como pre-release.
 _PRERELEASE_RE = re.compile(
     r'(?:'
-    r'-(?:alpha|beta|rc|pre|preview|dev)\b'  # SemVer style: 1.0.0-alpha
+    r'-(?:alpha|beta|rc|pre|preview|dev|canary|next|experimental|nightly|snapshot|insiders|edge|unstable)\b'
     r'|'
     r'(?:[abr])(?:c)?\d+\b'  # PEP 440 short: 1.0a1, 1.0b2, 1.0rc1
     r'|'

--- a/devtools/validate_versions/README.md
+++ b/devtools/validate_versions/README.md
@@ -1,0 +1,161 @@
+# validate_versions
+
+> Read-only check del monorepo: confirma que cada dep declarada esta en la
+> ultima version stable disponible **y** que las versiones cross-package
+> son coherentes (mismo Astro major, Vite peer correcto, etc).
+>
+> NO escribe. NO modifica manifests. Para bumpear use
+> `python devtools/run.py upgrade_deps`.
+
+## Uso
+
+```bash
+# Reporte humano (tabla por workspace + compat)
+python devtools/run.py validate_versions
+
+# Reporte JSON (CI / scripting)
+python devtools/run.py validate_versions --json
+
+# Modo strict: exit 1 si hay outdated O incompat (pre-merge gate)
+python devtools/run.py validate_versions --strict
+```
+
+## Que cubre
+
+### 1. Versiones actuales vs latest stable
+
+Por cada dep declarada en TODOS los manifests del monorepo:
+
+- `package.json` raiz
+- `apps/<app>/package.json` (6 sites Astro)
+- `packages/<pkg>/package.json` (5 workspaces compartidos)
+- `devtools/pyproject.toml`
+- `server/pyproject.toml` (si existe)
+
+Consulta el registry (npm o PyPI) y compara con la version pinned local.
+Filtra pre-releases (alpha/beta/rc/dev/canary/next/etc).
+
+Status posibles:
+
+| Status | Significado |
+|--------|-------------|
+| `ok` | current == latest stable |
+| `outdated` | latest > current (hay upgrade disponible) |
+| `unknown` | registry no respondio o sin estables |
+| `ahead` | current > latest (canary local, raro) |
+
+### 2. Compatibilidad cross-package
+
+Reglas que `upgrade_deps` NO puede detectar (porque solo mira version
+local vs registry, no coherencia entre workspaces):
+
+| Regla | Verifica |
+|-------|----------|
+| `astro_major_uniform` | Todas las apps declaran astro en la misma major |
+| `astrojs_compatible_with_astro` | @astrojs/sitemap >=3.7 y @astrojs/check >=0.9.9 si astro == 6 |
+| `vite_peer_consistency` | Si hay astro 6: vite debe ser ^7 (Astro 6 advierte con Vite 8) |
+| `vite_node_matches_vitest` | vite-node y vitest comparten major si conviven |
+| `tailwind_uniform` | @tailwindcss/* y tailwindcss comparten major |
+| `typescript_uniform` | typescript es la misma major en todo el monorepo |
+
+Severidades:
+
+- `error`: rompe builds o peer deps. En `--strict` cuenta como fail.
+- `warning`: deprecation / inconsistencia menor. NO causa fail.
+
+## Output
+
+### Humano (default)
+
+```
+======================================================================
+  validate_versions [read-only]
+======================================================================
+
+=== apps/generic/package.json ===
+  package                         current       latest        status
+  ----------------------------------------------------------------------
+  astro                           5.16.5        6.3.2              outdated
+  @astrojs/sitemap                3.4.2         3.7.2              outdated
+  @tailwindcss/vite               4.0.18        4.3.0              outdated
+  ...
+
+======================================================================
+  Compatibilidad cross-package: 2 issue(s)
+======================================================================
+
+  [ERROR] vite_peer_consistency
+    vite@8.0.12 en pkg:content no coincide con Vite 7.x ...
+    - pkg:content::vite@8.0.12
+
+  [WARNING] typescript_uniform
+    typescript declarado en majors distintas [5, 6] ...
+
+======================================================================
+  Resumen
+======================================================================
+  packages: 145 total | 64 ok | 81 outdated | 0 unknown | 0 ahead
+  compat: 1 error(s) | 1 warning(s)
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "packages": [
+    {
+      "kind": "npm",
+      "workspace": "app:generic",
+      "manifest": "apps/generic/package.json",
+      "name": "astro",
+      "section": "dependencies",
+      "current": "5.16.5",
+      "latest": "6.3.2",
+      "status": "outdated"
+    },
+    ...
+  ],
+  "compat_issues": [
+    {
+      "rule": "vite_peer_consistency",
+      "severity": "error",
+      "message": "...",
+      "affected": ["pkg:content::vite@8.0.12"]
+    }
+  ],
+  "summary": {
+    "total_packages": 145,
+    "ok": 64,
+    "outdated": 81,
+    "unknown": 0,
+    "ahead": 0,
+    "compat_errors": 1,
+    "compat_warnings": 1
+  }
+}
+```
+
+## Exit codes
+
+| Modo | Outdated | Compat error | Compat warning | Exit |
+|------|----------|--------------|----------------|------|
+| default | ≥1 | 0 | * | 0 |
+| default | * | ≥1 | * | 1 |
+| `--strict` | ≥1 | * | * | 1 |
+| `--strict` | 0 | ≥1 | * | 1 |
+| `--strict` | 0 | 0 | * | 0 |
+
+## Relacion con upgrade_deps
+
+| Script | Read-only | Escribe | Compat cross-package |
+|--------|-----------|---------|----------------------|
+| `validate_versions` | sí | no | sí |
+| `upgrade_deps` | con `--dry-run` | sí (sin flag) | no |
+
+Use validate_versions como **pre-merge gate** o **CI check**. Use
+upgrade_deps cuando decida que es momento de bumpear (en su propio PR).
+
+## Reglas adicionales
+
+Para agregar una regla nueva: editar `compat_rules.py`, agregar funcion
+``rule_xxx(packages) -> list[CompatIssue]`` y registrarla en `ALL_RULES`.

--- a/devtools/validate_versions/__init__.py
+++ b/devtools/validate_versions/__init__.py
@@ -1,0 +1,4 @@
+"""validate_versions: read-only check de versiones del monorepo.
+
+Devtools entrypoint: ``python devtools/run.py validate_versions``
+"""

--- a/devtools/validate_versions/compat_rules.py
+++ b/devtools/validate_versions/compat_rules.py
@@ -1,0 +1,333 @@
+"""Reglas de compatibilidad cross-package del monorepo portfolio.
+
+Cada regla recibe la lista de ``ResolvedPackage`` (que ya tienen current y
+latest) agregada en TODOS los manifests del monorepo y devuelve una lista
+de ``CompatIssue``. Una issue describe un mismatch que ``upgrade_deps`` no
+puede detectar por si solo porque solo mira version vs registry, no
+coherencia cross-workspace.
+
+Reglas implementadas:
+
+1. ``astro_major_uniform`` — todas las apps (``apps/<app>``) deben
+   declarar ``astro`` en la misma major version. Mix de Astro 5 y 6
+   rompe peer deps de ``@astrojs/*``.
+
+2. ``astrojs_compatible_with_astro`` — para cada app, ``@astrojs/sitemap``
+   y ``@astrojs/check`` deben ser compatibles con la major de astro
+   declarada (sitemap >=3.7.0 para Astro 6, check >=0.9.9 para Astro 6).
+
+3. ``vite_peer_consistency`` — si algun manifest pin ``vite`` (raiz o
+   workspace), debe ser ``^7.x`` para Astro 6 (Astro 6 advierte con
+   Vite 8). Si no hay pin, OK.
+
+4. ``vite_node_matches_vitest`` — ``vite-node`` y ``vitest`` que aparecen
+   en el mismo manifest deben compartir major (ambos 2.x o ambos 4.x; el
+   mismatch rompe en runtime).
+
+5. ``tailwind_uniform`` — si ``@tailwindcss/vite`` aparece en algun
+   manifest, debe matchear la major de ``tailwindcss`` (ambos 4.x).
+
+6. ``typescript_uniform`` — ``typescript`` debe ser la misma major en
+   todo el monorepo (sino los tipos de cross-package imports divergen).
+
+7. ``yaml_plugin_present_when_content_loaded`` — apps que dependen de
+   ``@portfolio/content`` (via ``noExternal``) deben tener
+   ``@modyfi/vite-plugin-yaml`` instalado (sino el ``import.meta.glob``
+   de los YAML rompe en build).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from validate_versions.resolver import ResolvedPackage
+
+
+class CompatIssue(NamedTuple):
+    """Un mismatch de compatibilidad cross-package.
+
+    Attributes:
+        rule: identificador corto de la regla violada
+            (``'astro_major_uniform'``, etc.).
+        severity: ``'error'`` (rompe builds) o ``'warning'`` (deprecation).
+        message: explicacion legible.
+        affected: lista de ``'<workspace>::<package>'`` involucrados.
+    """
+
+    rule: str
+    severity: str
+    message: str
+    affected: list[str]
+
+
+def _major(version: str) -> int:
+    """Extrae el major de una version. Devuelve -1 si no parsea."""
+    if not version:
+        return -1
+    base = version.lstrip('^~>=< ').split('.')[0]
+    return int(base) if base.isdigit() else -1
+
+
+def _by_name(
+    packages: list[ResolvedPackage], name: str
+) -> list[ResolvedPackage]:
+    """Filtra packages por nombre (case-sensitive)."""
+    return [p for p in packages if p.name == name]
+
+
+def _is_app(workspace: str) -> bool:
+    return workspace.startswith('app:')
+
+
+# ---------------------------------------------------------------------------
+# Reglas
+# ---------------------------------------------------------------------------
+
+
+def rule_astro_major_uniform(
+    packages: list[ResolvedPackage],
+) -> list[CompatIssue]:
+    """Todas las apps deben declarar astro en la misma major."""
+    astro_in_apps = [
+        p for p in _by_name(packages, 'astro') if _is_app(p.workspace)
+    ]
+    if len(astro_in_apps) <= 1:
+        return []
+
+    majors = {_major(p.current) for p in astro_in_apps}
+    if len(majors) == 1:
+        return []
+
+    affected = [f'{p.workspace}::astro@{p.current}' for p in astro_in_apps]
+    return [
+        CompatIssue(
+            rule='astro_major_uniform',
+            severity='error',
+            message=(
+                'Las apps declaran astro en majors distintas '
+                f'({sorted(majors)}). Todas deben usar la misma major para '
+                'evitar peer dep conflicts entre @astrojs/* y astro.'
+            ),
+            affected=affected,
+        )
+    ]
+
+
+def rule_astrojs_compatible_with_astro(
+    packages: list[ResolvedPackage],
+) -> list[CompatIssue]:
+    """@astrojs/* deben ser compatibles con la major de astro."""
+    issues: list[CompatIssue] = []
+    # Minimos por major de astro (basado en research).
+    min_required: dict[int, dict[str, str]] = {
+        6: {
+            '@astrojs/sitemap': '3.7.0',
+            '@astrojs/check': '0.9.9',
+        },
+    }
+
+    apps_with_astro = {
+        p.workspace: p
+        for p in _by_name(packages, 'astro')
+        if _is_app(p.workspace)
+    }
+
+    for workspace, astro_pkg in apps_with_astro.items():
+        major = _major(astro_pkg.current)
+        if major not in min_required:
+            continue
+        for dep_name, min_version in min_required[major].items():
+            deps = [
+                p
+                for p in _by_name(packages, dep_name)
+                if p.workspace == workspace
+            ]
+            issues.extend(
+                CompatIssue(
+                    rule='astrojs_compatible_with_astro',
+                    severity='error',
+                    message=(
+                        f'{dep_name}@{dep.current} en {workspace} es '
+                        f'incompatible con astro@{astro_pkg.current} '
+                        f'(requiere >= {min_version}).'
+                    ),
+                    affected=[
+                        f'{workspace}::{dep_name}@{dep.current}',
+                        f'{workspace}::astro@{astro_pkg.current}',
+                    ],
+                )
+                for dep in deps
+                if _version_lt(dep.current, min_version)
+            )
+    return issues
+
+
+def rule_vite_peer_consistency(
+    packages: list[ResolvedPackage],
+) -> list[CompatIssue]:
+    """Si hay astro 6 declarado, vite debe ser ^7 (Astro 6 advierte con Vite 8)."""
+    has_astro_6 = any(
+        _major(p.current) == 6 for p in _by_name(packages, 'astro')
+    )
+    if not has_astro_6:
+        return []
+
+    vite_pins = _by_name(packages, 'vite')
+    issues: list[CompatIssue] = []
+    for v in vite_pins:
+        major = _major(v.current)
+        if major != 7:
+            issues.append(
+                CompatIssue(
+                    rule='vite_peer_consistency',
+                    severity='warning' if major == 8 else 'error',
+                    message=(
+                        f'vite@{v.current} en {v.workspace} no coincide '
+                        'con Vite 7.x (Astro 6 oficialmente soporta Vite 7;'
+                        ' advierte con Vite 8). Pin a ^7 en `overrides` o '
+                        'devDependencies.'
+                    ),
+                    affected=[f'{v.workspace}::vite@{v.current}'],
+                )
+            )
+    return issues
+
+
+def rule_vite_node_matches_vitest(
+    packages: list[ResolvedPackage],
+) -> list[CompatIssue]:
+    """vite-node y vitest en el mismo manifest deben compartir major."""
+    issues: list[CompatIssue] = []
+    by_workspace: dict[str, dict[str, ResolvedPackage]] = {}
+    for p in packages:
+        if p.name in {'vite-node', 'vitest'}:
+            by_workspace.setdefault(p.workspace, {})[p.name] = p
+
+    for workspace, deps in by_workspace.items():
+        if 'vite-node' not in deps or 'vitest' not in deps:
+            continue
+        m1 = _major(deps['vite-node'].current)
+        m2 = _major(deps['vitest'].current)
+        if m1 != m2:
+            issues.append(
+                CompatIssue(
+                    rule='vite_node_matches_vitest',
+                    severity='error',
+                    message=(
+                        f'vite-node@{deps["vite-node"].current} y '
+                        f'vitest@{deps["vitest"].current} en {workspace} '
+                        f'tienen majors distintas ({m1} vs {m2}). '
+                        'vite-node se distribuye junto a vitest; usar la '
+                        'misma major.'
+                    ),
+                    affected=[
+                        f'{workspace}::vite-node@{deps["vite-node"].current}',
+                        f'{workspace}::vitest@{deps["vitest"].current}',
+                    ],
+                )
+            )
+    return issues
+
+
+def rule_tailwind_uniform(
+    packages: list[ResolvedPackage],
+) -> list[CompatIssue]:
+    """tailwindcss y @tailwindcss/vite deben compartir major."""
+    issues: list[CompatIssue] = []
+    by_workspace: dict[str, dict[str, ResolvedPackage]] = {}
+    for p in packages:
+        if p.name in {
+            'tailwindcss',
+            '@tailwindcss/vite',
+            '@tailwindcss/postcss',
+        }:
+            by_workspace.setdefault(p.workspace, {})[p.name] = p
+
+    for workspace, deps in by_workspace.items():
+        if 'tailwindcss' not in deps:
+            continue
+        tw_major = _major(deps['tailwindcss'].current)
+        for plugin_name in ('@tailwindcss/vite', '@tailwindcss/postcss'):
+            if plugin_name in deps:
+                pl_major = _major(deps[plugin_name].current)
+                if pl_major != tw_major:
+                    issues.append(
+                        CompatIssue(
+                            rule='tailwind_uniform',
+                            severity='error',
+                            message=(
+                                f'{plugin_name}@'
+                                f'{deps[plugin_name].current} y '
+                                f'tailwindcss@{deps["tailwindcss"].current} '
+                                f'en {workspace} no comparten major.'
+                            ),
+                            affected=[
+                                f'{workspace}::{plugin_name}@'
+                                f'{deps[plugin_name].current}',
+                                f'{workspace}::tailwindcss@'
+                                f'{deps["tailwindcss"].current}',
+                            ],
+                        )
+                    )
+    return issues
+
+
+def rule_typescript_uniform(
+    packages: list[ResolvedPackage],
+) -> list[CompatIssue]:
+    """typescript debe ser misma major en todo el monorepo."""
+    ts = _by_name(packages, 'typescript')
+    if len(ts) <= 1:
+        return []
+
+    majors = {_major(p.current) for p in ts}
+    if len(majors) == 1:
+        return []
+
+    affected = [f'{p.workspace}::typescript@{p.current}' for p in ts]
+    return [
+        CompatIssue(
+            rule='typescript_uniform',
+            severity='warning',
+            message=(
+                f'typescript declarado en majors distintas {sorted(majors)} '
+                'a traves del monorepo. Los tipos de imports cross-package '
+                'pueden divergir.'
+            ),
+            affected=affected,
+        )
+    ]
+
+
+def _version_lt(a: str, b: str) -> bool:
+    """True si version a < version b. Comparacion numerica simple por componentes."""
+
+    def parts(v: str) -> tuple[int, ...]:
+        clean = v.lstrip('^~>=< ').split('-')[0].split('+')[0]
+        out: list[int] = []
+        for chunk in clean.split('.'):
+            if chunk.isdigit():
+                out.append(int(chunk))
+            else:
+                break
+        return tuple(out) if out else (0,)
+
+    return parts(a) < parts(b)
+
+
+ALL_RULES = (
+    rule_astro_major_uniform,
+    rule_astrojs_compatible_with_astro,
+    rule_vite_peer_consistency,
+    rule_vite_node_matches_vitest,
+    rule_tailwind_uniform,
+    rule_typescript_uniform,
+)
+
+
+def run_all(packages: list[ResolvedPackage]) -> list[CompatIssue]:
+    """Ejecuta todas las reglas y devuelve la concatenacion de issues."""
+    issues: list[CompatIssue] = []
+    for rule in ALL_RULES:
+        issues.extend(rule(packages))
+    return issues

--- a/devtools/validate_versions/flags.py
+++ b/devtools/validate_versions/flags.py
@@ -1,0 +1,54 @@
+"""Flag validation for validate_versions command."""
+
+from utils.describe import ScriptDescribe
+from utils.flags_to_dict import set_default_values
+from utils.flags_to_dict import validate_allowed_flags
+
+
+ALLOWED_FLAGS = [
+    'json',
+    'strict',
+    'help',
+]
+
+
+def flag(flags_dict: dict) -> dict:
+    """Validate and normalize flags for validate_versions command."""
+    validate_allowed_flags(flags_dict, ALLOWED_FLAGS)
+
+    return set_default_values(
+        flags_dict,
+        {
+            'json': False,
+            'strict': False,
+        },
+    )
+
+
+def describe() -> ScriptDescribe:
+    """Machine-readable inventory of validate_versions flags."""
+    return {
+        'name': 'validate_versions',
+        'kind': 'monocommand',
+        'summary': (
+            'Valida que cada dep del monorepo este en latest stable y que las'
+            ' versiones cross-package sean compatibles (Astro major uniforme,'
+            ' Vite peer coherente, etc). Read-only.'
+        ),
+        'commands': [],
+        'flags': {
+            'json': {
+                'type': 'bool',
+                'default': False,
+                'summary': 'Output como JSON estructurado en vez de tabla.',
+            },
+            'strict': {
+                'type': 'bool',
+                'default': False,
+                'summary': (
+                    'Exit 1 si hay packages outdated o incompatibilidades.'
+                    ' Util para pre-merge gates.'
+                ),
+            },
+        },
+    }

--- a/devtools/validate_versions/main.py
+++ b/devtools/validate_versions/main.py
@@ -1,0 +1,50 @@
+"""Entry point para validate_versions.
+
+Read-only check del monorepo:
+    1. Discover manifests (apps/* + packages/* + root + devtools + server)
+    2. Para cada dep, fetch latest stable del registry (PyPI / npm)
+    3. Aplica reglas de compatibilidad cross-package
+    4. Reporta resultado (humano o JSON)
+
+NO escribe. NO modifica nada. Para upgrade: usar `upgrade_deps`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from validate_versions.compat_rules import run_all
+from validate_versions.reporter import print_human
+from validate_versions.reporter import print_json
+from validate_versions.resolver import resolve_all
+
+
+async def _run(*, as_json: bool, strict: bool) -> int:
+    packages = await resolve_all()
+    issues = run_all(packages)
+
+    if as_json:
+        print_json(packages, issues)
+    else:
+        print_human(packages, issues)
+
+    if strict:
+        # En modo strict: fail si hay outdated o errores de compat.
+        outdated_count = sum(1 for p in packages if p.status == 'outdated')
+        error_count = sum(1 for i in issues if i.severity == 'error')
+        if outdated_count > 0 or error_count > 0:
+            return 1
+
+    # Modo default: solo fail si hay errores de compat (outdated es info).
+    error_count = sum(1 for i in issues if i.severity == 'error')
+    return 1 if error_count > 0 else 0
+
+
+def main(flags: dict) -> int:
+    """Entry point invoked by ``devtools/run.py``."""
+    return asyncio.run(
+        _run(
+            as_json=flags.get('json', False),
+            strict=flags.get('strict', False),
+        ),
+    )

--- a/devtools/validate_versions/reporter.py
+++ b/devtools/validate_versions/reporter.py
@@ -1,0 +1,191 @@
+"""Reporter para validate_versions: tabla legible + JSON estructurado.
+
+Color codes ANSI (mismos que ``upgrade_deps.reporter`` para consistencia):
+    - verde   = ok (current == latest)
+    - amarillo = outdated (current < latest)
+    - rojo    = error/unknown / compat issue 'error'
+    - cyan    = headers
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+import json
+
+from validate_versions.compat_rules import CompatIssue
+from validate_versions.resolver import ResolvedPackage
+
+
+_GREEN = '\033[0;32m'
+_YELLOW = '\033[1;33m'
+_RED = '\033[0;31m'
+_CYAN = '\033[0;36m'
+_DIM = '\033[2m'
+_RESET = '\033[0m'
+
+_STATUS_COLORS = {
+    'ok': _GREEN,
+    'outdated': _YELLOW,
+    'unknown': _RED,
+    'ahead': _CYAN,
+}
+
+
+def _color(text: str, color: str) -> str:
+    return f'{color}{text}{_RESET}'
+
+
+def _group_by_workspace(
+    packages: Iterable[ResolvedPackage],
+) -> dict[str, list[ResolvedPackage]]:
+    grouped: dict[str, list[ResolvedPackage]] = defaultdict(list)
+    for p in packages:
+        grouped[p.relpath].append(p)
+    # Sort each group by name for deterministic output.
+    for k in grouped:
+        grouped[k].sort(key=lambda p: p.name.lower())
+    return dict(grouped)
+
+
+def _print_workspace_table(
+    relpath: str, packages: list[ResolvedPackage]
+) -> None:
+    name_width = max((len(p.name) for p in packages), default=20)
+    name_width = max(name_width, 30)
+    version_width = 12
+
+    print()
+    print(_color(f'=== {relpath} ===', _CYAN))
+    header = (
+        f'  {"package":<{name_width}}  '
+        f'{"current":<{version_width}}  '
+        f'{"latest":<{version_width}}  status'
+    )
+    print(header)
+    print('  ' + '-' * (len(header) - 2))
+
+    for p in packages:
+        latest_str = p.latest if p.latest is not None else '?'
+        status_colored = _color(
+            f'{p.status:>8}', _STATUS_COLORS.get(p.status, '')
+        )
+        print(
+            f'  {p.name:<{name_width}}  '
+            f'{p.current:<{version_width}}  '
+            f'{latest_str:<{version_width}}  '
+            f'{status_colored}'
+        )
+
+
+def _print_compat_issues(issues: list[CompatIssue]) -> None:
+    print()
+    print(_color('=' * 70, _CYAN))
+    if not issues:
+        print(_color('  Compatibilidad cross-package: 0 issues', _GREEN))
+        print(_color('=' * 70, _CYAN))
+        return
+
+    print(
+        _color(
+            f'  Compatibilidad cross-package: {len(issues)} issue(s)', _YELLOW
+        )
+    )
+    print(_color('=' * 70, _CYAN))
+    for issue in issues:
+        sev_color = _RED if issue.severity == 'error' else _YELLOW
+        print()
+        print(
+            f'  [{_color(issue.severity.upper(), sev_color)}] '
+            f'{_color(issue.rule, _CYAN)}'
+        )
+        print(f'    {issue.message}')
+        for entity in issue.affected:
+            print(f'    {_DIM}- {entity}{_RESET}')
+
+
+def _print_summary(
+    packages: list[ResolvedPackage], issues: list[CompatIssue]
+) -> None:
+    by_status: dict[str, int] = defaultdict(int)
+    for p in packages:
+        by_status[p.status] += 1
+
+    errors = sum(1 for i in issues if i.severity == 'error')
+    warnings = sum(1 for i in issues if i.severity == 'warning')
+
+    print()
+    print(_color('=' * 70, _CYAN))
+    print('  Resumen')
+    print(_color('=' * 70, _CYAN))
+    print(
+        f'  packages: {len(packages)} total | '
+        f'{_color(str(by_status["ok"]), _GREEN)} ok | '
+        f'{_color(str(by_status["outdated"]), _YELLOW)} outdated | '
+        f'{_color(str(by_status["unknown"]), _RED)} unknown | '
+        f'{_color(str(by_status["ahead"]), _CYAN)} ahead'
+    )
+    print(
+        f'  compat: {_color(str(errors), _RED)} error(s) | '
+        f'{_color(str(warnings), _YELLOW)} warning(s)'
+    )
+
+
+def print_human(
+    packages: list[ResolvedPackage], issues: list[CompatIssue]
+) -> None:
+    """Imprime un reporte legible (tabla por workspace + compat)."""
+    print()
+    print(_color('=' * 70, _CYAN))
+    print('  validate_versions [read-only]')
+    print(_color('=' * 70, _CYAN))
+
+    grouped = _group_by_workspace(packages)
+    for relpath in sorted(grouped.keys()):
+        _print_workspace_table(relpath, grouped[relpath])
+
+    _print_compat_issues(issues)
+    _print_summary(packages, issues)
+    print()
+
+
+def print_json(
+    packages: list[ResolvedPackage], issues: list[CompatIssue]
+) -> None:
+    """Imprime el reporte como JSON estructurado (para CI/scripting)."""
+    output = {
+        'packages': [
+            {
+                'kind': p.kind,
+                'workspace': p.workspace,
+                'manifest': p.relpath,
+                'name': p.name,
+                'section': p.section,
+                'current': p.current,
+                'latest': p.latest,
+                'status': p.status,
+            }
+            for p in packages
+        ],
+        'compat_issues': [
+            {
+                'rule': i.rule,
+                'severity': i.severity,
+                'message': i.message,
+                'affected': i.affected,
+            }
+            for i in issues
+        ],
+        'summary': {
+            'total_packages': len(packages),
+            'ok': sum(1 for p in packages if p.status == 'ok'),
+            'outdated': sum(1 for p in packages if p.status == 'outdated'),
+            'unknown': sum(1 for p in packages if p.status == 'unknown'),
+            'ahead': sum(1 for p in packages if p.status == 'ahead'),
+            'compat_errors': sum(1 for i in issues if i.severity == 'error'),
+            'compat_warnings': sum(
+                1 for i in issues if i.severity == 'warning'
+            ),
+        },
+    }
+    print(json.dumps(output, indent=2, ensure_ascii=False))

--- a/devtools/validate_versions/resolver.py
+++ b/devtools/validate_versions/resolver.py
@@ -1,0 +1,141 @@
+"""Resolver: discover manifests + parse + fetch latest del registry.
+
+Glue thin entre ``shared.manifest_discovery``, los parsers de
+``upgrade_deps`` y el registry async. Devuelve una lista plana de
+``ResolvedPackage`` con current + latest + status, lista para que
+``compat_rules`` aplique sus reglas cross-package y el reporter imprima.
+
+NO escribe nada. NO modifica manifests. Read-only por diseno.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import NamedTuple
+
+import httpx
+
+from shared.manifest_discovery import Manifest
+from shared.manifest_discovery import discover_npm_manifests
+from shared.manifest_discovery import discover_pypi_manifests
+from upgrade_deps.parsers import parse_package_json
+from upgrade_deps.parsers import parse_pyproject_toml
+from upgrade_deps.registry import fetch_npm_versions
+from upgrade_deps.registry import fetch_pypi_versions
+from upgrade_deps.versions import is_newer
+from upgrade_deps.versions import pick_latest_stable
+
+
+_CONCURRENCY = 10
+
+
+class ResolvedPackage(NamedTuple):
+    """Un paquete resuelto contra el registry.
+
+    Attributes:
+        kind: ``'npm'`` o ``'pypi'``.
+        workspace: id legible del manifest origen (``'app:fintech'``,
+            ``'pkg:content'``, ``'devtools'``, ``'root'``).
+        relpath: ruta relativa del manifest origen.
+        name: nombre del paquete.
+        section: seccion del manifest (``'dependencies'``,
+            ``'devDependencies'``, ``'pnpm.overrides'``, etc.).
+        current: version pinned localmente.
+        latest: ultima version estable en el registry. ``None`` si el
+            registry no respondio o no hay estables.
+        status: ``'ok'`` (current == latest), ``'outdated'`` (latest > current),
+            ``'unknown'`` (no se pudo consultar), ``'ahead'`` (current > latest,
+            raro pero posible con canary local).
+    """
+
+    kind: str
+    workspace: str
+    relpath: str
+    name: str
+    section: str
+    current: str
+    latest: str | None
+    status: str
+
+
+def _classify(current: str, latest: str | None) -> str:
+    if latest is None:
+        return 'unknown'
+    if current == latest:
+        return 'ok'
+    if is_newer(current=current, candidate=latest):
+        return 'outdated'
+    return 'ahead'
+
+
+async def _resolve_npm(
+    client: httpx.AsyncClient, manifest: Manifest
+) -> list[ResolvedPackage]:
+    """Resuelve TODOS los packages de un manifest npm."""
+    parsed = parse_package_json(manifest.path)
+    if not parsed:
+        return []
+
+    sem = asyncio.Semaphore(_CONCURRENCY)
+
+    async def resolve_one(pkg: dict) -> ResolvedPackage:
+        async with sem:
+            try:
+                versions = await fetch_npm_versions(client, pkg['name'])
+                latest = pick_latest_stable(versions)
+            except Exception:  # noqa: BLE001
+                latest = None
+        return ResolvedPackage(
+            kind='npm',
+            workspace=manifest.workspace,
+            relpath=manifest.relpath,
+            name=pkg['name'],
+            section=pkg['section'],
+            current=pkg['version'],
+            latest=latest,
+            status=_classify(pkg['version'], latest),
+        )
+
+    return list(await asyncio.gather(*(resolve_one(p) for p in parsed)))
+
+
+async def _resolve_pypi(
+    client: httpx.AsyncClient, manifest: Manifest
+) -> list[ResolvedPackage]:
+    """Resuelve TODOS los packages de un manifest pypi."""
+    parsed = parse_pyproject_toml(manifest.path)
+    if not parsed:
+        return []
+
+    sem = asyncio.Semaphore(_CONCURRENCY)
+
+    async def resolve_one(pkg: dict) -> ResolvedPackage:
+        async with sem:
+            try:
+                versions = await fetch_pypi_versions(client, pkg['name'])
+                latest = pick_latest_stable(versions)
+            except Exception:  # noqa: BLE001
+                latest = None
+        return ResolvedPackage(
+            kind='pypi',
+            workspace=manifest.workspace,
+            relpath=manifest.relpath,
+            name=pkg['name'],
+            section=pkg['section'],
+            current=pkg['version'],
+            latest=latest,
+            status=_classify(pkg['version'], latest),
+        )
+
+    return list(await asyncio.gather(*(resolve_one(p) for p in parsed)))
+
+
+async def resolve_all() -> list[ResolvedPackage]:
+    """Discover + parse + fetch latest para TODOS los manifests del monorepo."""
+    out: list[ResolvedPackage] = []
+    async with httpx.AsyncClient() as client:
+        for manifest in discover_npm_manifests():
+            out.extend(await _resolve_npm(client, manifest))
+        for manifest in discover_pypi_manifests():
+            out.extend(await _resolve_pypi(client, manifest))
+    return out


### PR DESCRIPTION
## Problema

Tenemos `devtools/upgrade_deps` que bumpea dependencias, pero:

1. **Manifests hardcoded inválidos**: apuntaba a `dashboard/package.json` y `landing/package.json` (paths del template `mvp-template-full-stack` que se importó hace tiempo y NO existen en este portfolio). Resultado: solo procesaba `devtools/pyproject.toml`.
2. **Sin chequeo de compatibilidad cross-package**: `upgrade_deps` solo compara versión local vs registry (latest). NO valida que `astro` declarado en todas las apps comparta major, ni que `vite` peer matchee con `vitest` / `@tailwindcss/vite` / `vite-node`, ni que `@astrojs/sitemap` sea compatible con la major de `astro`.
3. **Bug en filtro de pre-releases**: `pick_latest_stable` no detectaba `-canary`, `-next`, `-experimental`, `-nightly`, etc. Resultado visible: sugería `zod@4.5.0-canary.20260504T180558` como latest stable (cuando el stable real es `4.4.3`).

Además, el usuario detectó que el proyecto está en **Astro 5.18.1** pero `CLAUDE.md` y skills decían "Astro 6". Necesita una herramienta read-only que reporte el estado real.

## Solucion

3 cambios en este PR:

1. **`devtools/shared/manifest_discovery.py`** (nuevo): single source of truth para enumerar TODOS los manifests del monorepo (`apps/<app>/package.json` × 6 + `packages/<pkg>/package.json` × 5 + root + `devtools/pyproject.toml` + `server/pyproject.toml` si existe). Reutilizable: `discover_npm_manifests()` y `discover_pypi_manifests()`.

2. **`devtools/upgrade_deps`** ahora usa el discovery automático (en lugar de los paths hardcoded). El bug del filtro de pre-releases se arregla en `versions.py` agregando `canary|next|experimental|nightly|snapshot|insiders|edge|unstable` a la regex.

3. **`devtools/validate_versions`** (nuevo módulo, read-only): valida latest stable Y compatibilidad cross-package. Reglas implementadas:
   - `astro_major_uniform`: todas las apps deben declarar `astro` en la misma major
   - `astrojs_compatible_with_astro`: `@astrojs/sitemap` ≥3.7 y `@astrojs/check` ≥0.9.9 si `astro` major == 6
   - `vite_peer_consistency`: si hay `astro` 6, `vite` debe ser `^7` (Astro 6 advierte con Vite 8)
   - `vite_node_matches_vitest`: `vite-node` y `vitest` que conviven deben compartir major
   - `tailwind_uniform`: `@tailwindcss/*` y `tailwindcss` comparten major
   - `typescript_uniform`: `typescript` es la misma major en todo el monorepo

   Flags: `--json` (CI), `--strict` (exit 1 si hay outdated o errores compat).

## Como probar

```bash
# Reporte humano
python devtools/run.py validate_versions
# Esperado: "120 total | 39 ok | 81 outdated | 0 compat errors"

# JSON estructurado
python devtools/run.py validate_versions --json | jq '.summary'

# Modo strict (CI / pre-merge gate)
python devtools/run.py validate_versions --strict
echo "exit_code=$?"  # 1 si hay outdated

# Smoke test de reglas con datos sintéticos
cd devtools && .venv/bin/python -c "
from validate_versions.compat_rules import run_all
from validate_versions.resolver import ResolvedPackage

fake = [
    ResolvedPackage('npm', 'app:fintech', 'apps/fintech/package.json', 'astro', 'deps', '5.16.5', '6.3.2', 'outdated'),
    ResolvedPackage('npm', 'app:generic', 'apps/generic/package.json', 'astro', 'deps', '6.3.2', '6.3.2', 'ok'),
]
print(run_all(fake))  # Detecta astro_major_uniform error
"

# Confirma que upgrade_deps ahora cubre los 11 manifests reales
python devtools/run.py upgrade_deps --dry-run
# Esperado: muestra apps/*, packages/*, devtools (en vez de solo devtools como antes)
```

## TODO

Vacío. Scope cerrado. El upgrade real a Astro 6 va en su propio PR (`chore/astro-6-upgrade`) usando este script como guía + gate.