### PR TITLE
feat(ui): sistema responsive mobile-first + hamburger drawer

### DIFF
--- a/docs/progress/plan_mobile-responsive-system.md
+++ b/docs/progress/plan_mobile-responsive-system.md
@@ -1,0 +1,377 @@
+# Plan: Sistema responsivo + redisenio mobile del portfolio
+
+> Scope: Large (>11 archivos). Sistema de breakpoints Tailwind-standard,
+> refactor mobile-first de packages compartidos, hamburger drawer con
+> `<dialog>`, propagacion a las 6 apps, verificacion con Playwright
+> screenshots en 3 viewports.
+
+## 1. Contexto / Problema
+
+El portfolio actual (6 apps Astro + 5 packages compartidos) se ve roto
+en mobile (<640px). Los problemas concretos detectados via exploracion:
+
+- **Sin sistema de breakpoints**: cada componente hardcodea `@media
+  (max-width: 640px)` o `600px` o `960px` con valores arbitrarios. No hay
+  tokens (`--bp-sm`, `--bp-md`, ...) en `tokens.css`. 11+ media queries
+  duplicadas en `packages/ui/src/components/`.
+- **Approach max-width pragmatico**: el CSS base es desktop, los overrides
+  son `@media (max-width: ...)`. Esto rompe el principio mobile-first y
+  produce reglas peleando entre si.
+- **Nav.astro sin drawer**: en mobile solo achica `gap` y `font-size`; los
+  items siguen inline horizontal. Con 4+ items + locale + theme-toggle,
+  hay overflow horizontal a 320-375px.
+- **`.container-wide` con padding fijo**: `padding-inline: var(--space-24)`
+  (24px) siempre. En mobile <360px el contenido toca los bordes.
+- **HeroImpact**: `display-mega` clamp ya es fluido pero `padding-block:
+  var(--space-100)` (100px) es excesivo a <640px; el `headline` con
+  `max-width: 14ch` rompe en 320px.
+- **ProjectsBento / SkillsGrid**: grids sin fallback a 1 columna explicito,
+  cards bento de tamanio fijo que producen scroll horizontal.
+- **No hay menu mobile**: no existe boton hamburger, drawer, ni focus trap.
+
+### Hallazgos de exploracion
+
+- Existen `--font-size-display-*` con `clamp(...)` (fluidos), pero solo
+  cubren tipografia, no spacing ni layout.
+- Cada app tiene 3 paginas (`index`, `about`, `certificates`) + variante
+  `en/`. Total: 18 paginas concretas + hub (1).
+- `tests/feature/smoke/cv-screenshots.spec.ts` ya captura screenshots en
+  desktop; solo falta extender a viewports mobile + tablet.
+- Tailwind v4 esta disponible via `@tailwindcss/vite` + `@theme inline` en
+  `global.css` — ya hay infraestructura para mapear breakpoints como
+  tokens consumibles por utilities.
+
+## 2. Solucion Propuesta
+
+Sistema de breakpoints Tailwind-standard (5 puntos: sm/md/lg/xl/2xl)
+expuestos como CSS variables, refactor mobile-first de los componentes
+compartidos, hamburger drawer con `<dialog>` HTML5 + JS minimo, container
+con padding fluido via `clamp()`, y propagacion a las 6 apps con
+verificacion Playwright screenshots en mobile (375px) + tablet (768px) +
+desktop (1280px).
+
+### Decisiones clave
+
+- **Decision 1: Breakpoints Tailwind-standard (sm=640, md=768, lg=1024,
+  xl=1280, 2xl=1536)** — match con Tailwind v4 ya en uso, ecosistema
+  ampliamente documentado, y permite combinar utilities Tailwind con
+  media queries custom sin desalineacion.
+- **Decision 2: Mobile-first refactor (`@media (min-width)`)** — el CSS
+  base se reescribe pensado para 320-639px; cada breakpoint agrega
+  progresivamente. Anti-pattern del approach `max-width` (deuda tecnica,
+  reglas peleandose) queda eliminado.
+- **Decision 3: Tokens CSS variables para breakpoints** — `--bp-sm: 640px`
+  etc. en `tokens.css`. Aunque CSS no permite usar variables en media
+  queries directamente (limitacion del estandar), los tokens sirven como
+  documentacion + son consumibles por JS (`getComputedStyle`) para sync
+  con `matchMedia` cuando se necesite (drawer toggle).
+- **Decision 4: `<dialog>` nativo para drawer** — popover API tiene soporte
+  Baseline 2024 pero menos control sobre animaciones; `<dialog>` da focus
+  trap + escape key + backdrop nativos. JS minimo (~40 lineas) en
+  `packages/ui/src/lib/mobile-nav.ts`.
+- **Decision 5: Container padding fluido con `clamp()`** —
+  `padding-inline: clamp(1rem, 4vw, 1.5rem)` reemplaza `var(--space-24)`.
+  Mantiene 16px minimo en 320px y crece a 24px en desktop.
+- **Decision 6: 3 viewports en cv-screenshots** — 375x812 (iPhone 13),
+  768x1024 (iPad portrait), 1280x800 (desktop). 6 apps x 3 viewports x
+  3 scroll positions = 54 screenshots. Suficiente evidencia visual sin
+  explotar tiempo de CI/feature run.
+- **Decision 7: Minimo soportado 320px** — iPhone SE, cubre 99% mercado.
+  Headlines con `clamp()` deben caber sin scroll horizontal.
+
+## 3. Criterios de Aceptacion (AC)
+
+- **AC-1**: Given un usuario en mobile 320px, When carga cualquier
+  pagina de las 6 apps, Then no hay scroll horizontal y todo el contenido
+  cabe en el viewport.
+- **AC-2**: Given un usuario en mobile <768px, When ve el Nav, Then el
+  Nav muestra solo brand + boton hamburger + theme-toggle (sin items
+  inline ni locale switcher inline).
+- **AC-3**: Given un usuario en mobile <768px, When toca el boton
+  hamburger, Then se abre un drawer con focus trap, items de menu, locale
+  switcher y boton cerrar; presionar Esc o tocar backdrop lo cierra.
+- **AC-4**: Given un usuario en tablet >=768px y <1024px, When ve el
+  layout, Then el Nav muestra los items inline y los grids con 2
+  columnas (proyectos, skills, awards).
+- **AC-5**: Given un usuario en desktop >=1024px, When ve el layout,
+  Then funciona identico al diseno actual desktop (no hay regresion
+  visual).
+- **AC-6**: Given el `HeroImpact` renderizado en mobile 320-639px, When
+  inspecciono, Then el `padding-block` se reduce a `clamp(2rem, 8vw,
+  3rem)` y el headline cabe sin overflow.
+- **AC-7**: Given `tokens.css`, When hago `getComputedStyle`, Then expone
+  `--bp-sm: 640px`, `--bp-md: 768px`, `--bp-lg: 1024px`, `--bp-xl: 1280px`,
+  `--bp-2xl: 1536px`.
+- **AC-8**: Given una pagina con animaciones, When el usuario tiene
+  `prefers-reduced-motion: reduce`, Then el drawer abre/cierra sin
+  transicion (alineado con scroll-driven.css existente).
+- **AC-9**: Given los hooks pre-push del proyecto, When corro `pnpm run
+  build`, Then las 6 apps buildean sin errores en `dist/`.
+- **AC-10**: Given los screenshots Playwright, When ejecuto
+  `cv-screenshots.spec.ts` en 3 viewports, Then se generan 54 screenshots
+  (6 apps x 3 viewports x 3 scrolls) sin overflow horizontal en ninguna.
+
+## 4. Diagrama de Flujo (Antes y Despues)
+
+### Antes (Nav en mobile)
+
+```
+[brand]  [item1] [item2] [item3] [item4]  [EN] [theme]
+                                                      ^
+                                                      overflow horizontal
+                                                      en <640px
+```
+
+### Despues (Nav en mobile <768px)
+
+```
+[brand]                                  [theme] [hamburger]
+                                                       |
+                                                       v toca
++-----------------+
+| <dialog drawer> |
+| [X cerrar]      |
+| ----            |
+| item1           |
+| item2           |
+| item3           |
+| item4           |
+| ----            |
+| [ES] [EN]       |
++-----------------+
+| backdrop dim    |
+```
+
+### Antes (cv-screenshots)
+
+```
+6 apps -> 1 viewport (desktop 1280x800) -> 3 scrolls = 18 screenshots
+```
+
+### Despues (cv-screenshots)
+
+```
+6 apps -> 3 viewports (375, 768, 1280) -> 3 scrolls = 54 screenshots
+```
+
+## 5. Diagrama ER
+
+N/A — no hay cambios en content collections ni schemas Zod. El sistema
+responsivo es 100% CSS + un componente Astro (drawer).
+
+## 6. Tests Requeridos
+
+### 6.A. TDD flows (logica nueva en `packages/ui/src/lib/`)
+
+- WHEN llamo `initMobileNav()` THEN se monta listener en `[data-mobile-nav-toggle]` y retorna funcion cleanup [AC-3]
+- WHEN el usuario toca toggle Y dialog no esta abierto THEN se invoca `dialog.showModal()` [AC-3]
+- WHEN el usuario presiona Esc dentro del dialog THEN se invoca `dialog.close()` (manejado nativo, validar no-error) [AC-3]
+- WHEN el usuario tiene `prefers-reduced-motion: reduce` THEN el dialog se renderiza con `transition: none` (validar via `matchMedia` mock) [AC-8]
+
+### 6.B. Unit tests (Vitest)
+
+Path mirroring obligatorio. Coverage v8 >= 80% per-file.
+
+- `packages/ui/src/lib/mobile-nav.ts` -> `packages/ui/tests/lib/mobile-nav.test.ts`
+- `packages/ui/src/components/Nav.astro` -> `packages/ui/tests/components/Nav.test.ts` (testear HTML parseado del modulo)
+
+Mocks:
+- `window.matchMedia` (happy-dom no implementa por defecto)
+- `HTMLDialogElement.showModal/close` si happy-dom no los soporta nativos
+- No mockear: utilities propias, niche-tokens
+
+### 6.C. Typecheck
+
+- `pnpm exec tsc --noEmit` strict en raiz
+- `pnpm exec astro check` en cada app (per-package via pnpm filter)
+- Falla en pre-push si hay error TS o astro
+
+### 6.D. E2E Tests (Playwright)
+
+Extender `tests/feature/smoke/cv-screenshots.spec.ts`:
+
+- WHEN visito cada una de las 6 apps en viewport 375x812 THEN hero, mid y bottom screenshots no muestran scroll horizontal [AC-1, AC-10]
+- WHEN visito cada app en 375x812 Y toco `[data-mobile-nav-toggle]` THEN dialog drawer se abre con `[aria-modal=true]` [AC-3]
+- WHEN viewport >= 768px THEN `[data-mobile-nav-toggle]` no es visible (`display: none`) [AC-4]
+- WHEN viewport 1280x800 THEN screenshots coinciden visualmente con baseline pre-refactor (regresion 0) [AC-5]
+
+## 7. Archivos Afectados
+
+### Crear
+
+- `packages/ui/src/styles/breakpoints.css` — modulo de breakpoints + utility classes responsive (.hidden-mobile, .only-mobile, .container-fluid)
+  - Verificar: `pnpm exec biome check packages/ui/src/styles/breakpoints.css`
+  - Verificar: `pnpm run build` exitoso en todas las apps
+- `packages/ui/src/lib/mobile-nav.ts` — `initMobileNav()` con cleanup, focus trap auxiliar si dialog no lo da en mobile webkit
+  - Verificar: `pnpm exec vitest run packages/ui/tests/lib/mobile-nav.test.ts`
+  - Verificar coverage: >= 80% per-file
+- `packages/ui/src/components/MobileNavDrawer.astro` — componente `<dialog>` con items + locale + cerrar
+  - Verificar: `pnpm exec astro check`
+- `packages/ui/tests/lib/mobile-nav.test.ts` — unit tests TDD (red phase primero)
+  - Verificar: `pnpm exec vitest run` pasa
+- `packages/ui/tests/components/Nav.test.ts` — test del Nav refactorizado (incluye drawer toggle)
+  - Verificar: `pnpm exec vitest run` pasa
+- `docs/progress/explore_mobile-responsive.md` — bitacora de exploracion (este plan + decisiones)
+  - Verificar: existe + linkea a esta planificacion
+
+### Modificar
+
+- `packages/ui/src/styles/tokens.css` — agregar `--bp-sm` ... `--bp-2xl` + `--container-padding-fluid: clamp(1rem, 4vw, 1.5rem)`
+  - Verificar: `getComputedStyle(document.documentElement).getPropertyValue('--bp-sm')` retorna `640px` [AC-7]
+- `packages/ui/src/styles/global.css` — refactor `.container-*` con padding fluido + import de `breakpoints.css`
+  - Verificar: `pnpm run build` + `pnpm run preview` muestra container sin overflow en 320px
+- `packages/ui/src/index.ts` — exportar `initMobileNav` y `MobileNavDrawer`
+  - Verificar: `pnpm exec tsc --noEmit` sin errores
+- `packages/ui/src/components/Nav.astro` — refactor mobile-first: en <768px mostrar solo brand + hamburger + theme, en >=768px mostrar items inline
+  - Verificar: `pnpm exec astro check` sin warnings
+  - Verificar: viewport 320px no produce scroll horizontal [AC-1, AC-2]
+- `packages/ui/src/components/Hero.astro` — refactor mobile-first del `padding-block` y `headline`
+  - Verificar: viewport 320px headline cabe sin truncate
+- `packages/ui/src/components/HeroImpact.astro` — refactor mobile-first; reemplazar `@media (max-width: 640px)` por base mobile + `@media (min-width: 640px)` para escalar
+  - Verificar: viewport 320px headline cabe; viewport 1280px identico a baseline [AC-5, AC-6]
+- `packages/ui/src/components/StatsBar.astro` — mobile-first; en <640px grid 1col, >=640px 2col, >=1024px 4col
+  - Verificar: viewport 375px no overflow
+- `packages/ui/src/components/ExperienceTimeline.astro` — mobile-first; gap + padding reducidos en mobile
+  - Verificar: viewport 375px sin overflow
+- `packages/ui/src/components/AwardCard.astro` — mobile-first
+  - Verificar: viewport 375px card legible
+- `packages/ui/src/components/ProjectsBento.astro` — grid 1col en mobile, 2col tablet, 3col desktop (con bento spans variables solo >=lg)
+  - Verificar: viewport 375px y 768px sin overflow
+- `packages/ui/src/components/ProjectBentoCard.astro` — mobile-first; reset de spans bento en <1024px
+  - Verificar: viewport 375px card 1col
+- `packages/ui/src/components/SkillsGrid.astro` — mobile-first
+  - Verificar: viewport 375px sin overflow
+- `packages/ui/src/components/SkillsMarquee.astro` — ajustar velocidad/size en mobile
+  - Verificar: viewport 375px marquee visible y readable
+- `packages/ui/src/components/Footer.astro` — mobile-first: contacts stack vertical en mobile
+  - Verificar: viewport 320px sin overflow
+- `packages/ui/src/components/SectionHeader.astro` — mobile-first
+  - Verificar: viewport 320px titulo legible
+- `packages/ui/src/components/CaseStudyExpander.astro` — mobile-first
+  - Verificar: viewport 375px expander funciona
+- `packages/ui/src/components/ExperienceCard.astro` — mobile-first
+  - Verificar: viewport 375px sin overflow
+- `packages/ui/src/components/ProjectCard.astro` — mobile-first
+  - Verificar: viewport 320px card legible
+- `packages/ui/src/components/ContactLinks.astro` — mobile-first stack vertical
+  - Verificar: viewport 320px contacts apilados
+- `packages/ui/src/components/NicheBadge.astro` — verificar que no rompe en mobile
+  - Verificar: viewport 320px badge inline
+- `packages/app-shared/src/components/ArchitectureDiagram.astro` — mobile-first; reemplazar `@media (max-width: 900px)` por mobile-first equivalente
+  - Verificar: viewport 375px diagrama legible
+- `packages/app-shared/src/components/CvSections.astro` — mobile-first layout
+  - Verificar: viewport 375px CV legible
+- `packages/app-shared/src/components/AiWorkflowSection.astro` — mobile-first
+  - Verificar: viewport 375px legible
+- `packages/app-shared/src/components/AtsKeywordsPills.astro` — mobile-first pills wrap
+  - Verificar: viewport 320px pills wrappean
+- `packages/app-shared/src/components/LeadershipStats.astro` — mobile-first stack
+  - Verificar: viewport 320px stats apilados
+- `packages/app-shared/src/pages/AboutSection.astro` — verificar pages no rompen
+  - Verificar: viewport 375px about legible
+- `packages/app-shared/src/pages/CertificatesSection.astro` — mobile-first cert cards
+  - Verificar: viewport 375px certs visibles
+- `packages/app-shared/src/layouts/SitePageLayout.astro` — agregar wrapper `[data-mobile-nav-host]` para el drawer
+  - Verificar: `pnpm exec astro check` sin errores
+- `tests/feature/smoke/cv-screenshots.spec.ts` — agregar viewports 375x812, 768x1024, 1280x800 con 3 scrolls cada uno
+  - Verificar: `python3 devtools/run.py test_runner --module=feature --type=feature --env=local` genera 54 screenshots
+- `apps/{generic,hub,fintech,architect,leader,vibe}/src/pages/index.astro` (x6) — propagar `[data-mobile-nav-host]` si la pagina no usa SitePageLayout (hub es indice especial; verificar)
+  - Verificar: `pnpm run build` por app exitoso
+- `apps/{generic,fintech,architect,leader,vibe}/src/pages/about.astro` (x5) — sin cambios estructurales, solo verificacion visual
+  - Verificar: viewport 375px about legible
+- `apps/{generic,fintech,architect,leader,vibe}/src/pages/certificates.astro` (x5) — sin cambios estructurales, solo verificacion visual
+  - Verificar: viewport 375px cert legible
+- `apps/{generic,fintech,architect,leader,vibe}/src/pages/en/{index,about,certificates}.astro` (x15) — heredan via SitePageLayout, solo verificacion visual
+  - Verificar: viewport 375px contenido legible en /en/
+
+### Eliminar
+
+(ninguno — el refactor reemplaza CSS sin borrar archivos)
+
+## 8. Descomposicion para Paralelizacion
+
+Plan Large (>30 archivos). Descomposicion sugerida en 5 tareas
+secuenciales mas que paralelizables, dado que la mayoria depende del paso
+1 (tokens) y paso 2 (Nav drawer). Solo el paso 3 (componentes de cards y
+secciones) es paralelizable internamente.
+
+### Tarea 1 (foundation): tokens + breakpoints CSS
+
+- **Archivos**: `packages/ui/src/styles/tokens.css`, `packages/ui/src/styles/breakpoints.css`, `packages/ui/src/styles/global.css`
+- **AC referenciados**: AC-7, AC-1 (parcial)
+- **Depende de**: nada
+- **Paralelizable con**: ninguna (foundation)
+- **Verify**: `pnpm exec biome check .` + `pnpm run build` + test `--bp-sm` expuesto
+- **Done**: tokens existen, container fluido, todos los apps siguen buildeando
+
+### Tarea 2 (drawer): mobile nav infrastructure
+
+- **Archivos**: `packages/ui/src/lib/mobile-nav.ts`, `packages/ui/src/components/MobileNavDrawer.astro`, `packages/ui/src/components/Nav.astro`, `packages/ui/src/index.ts`, `packages/ui/tests/lib/mobile-nav.test.ts`, `packages/ui/tests/components/Nav.test.ts`, `packages/app-shared/src/layouts/SitePageLayout.astro`
+- **AC referenciados**: AC-2, AC-3, AC-4, AC-8
+- **Depende de**: Tarea 1 (necesita `--bp-md` para sync JS/CSS)
+- **Paralelizable con**: ninguna (Nav es critico para todas las paginas)
+- **Verify**: `pnpm exec vitest run` con coverage >= 80%, drawer abre/cierra en preview manual, focus trap funcional
+- **Done**: tests TDD verdes, Nav refactorizado mobile-first, drawer accesible
+
+### Tarea 3 (componentes UI bento/cards/timeline): refactor mobile-first
+
+Paralelizable en 2-3 sub-tareas porque cada componente es independiente:
+
+- **3a (heroes + section)**: `Hero.astro`, `HeroImpact.astro`, `SectionHeader.astro`
+- **3b (cards + listas)**: `AwardCard.astro`, `ExperienceCard.astro`, `ExperienceTimeline.astro`, `ProjectCard.astro`, `ProjectBentoCard.astro`, `ProjectsBento.astro`, `CaseStudyExpander.astro`
+- **3c (skills + stats + misc)**: `StatsBar.astro`, `SkillsGrid.astro`, `SkillsMarquee.astro`, `Footer.astro`, `ContactLinks.astro`, `NicheBadge.astro`
+
+- **AC referenciados**: AC-1, AC-4, AC-5, AC-6
+- **Depende de**: Tarea 1
+- **Paralelizable con**: si entre 3a/3b/3c (no comparten archivo)
+- **Verify por sub-tarea**: `pnpm run build` por app afectada + screenshot manual en 375px
+- **Done**: cero scroll horizontal en 320px en cada componente
+
+### Tarea 4 (app-shared + sections): refactor mobile-first
+
+- **Archivos**: todos los `packages/app-shared/src/components/*.astro` + `packages/app-shared/src/pages/*.astro`
+- **AC referenciados**: AC-1, AC-4, AC-5
+- **Depende de**: Tarea 1, Tarea 3 (consumen heroes/cards refactorizados)
+- **Paralelizable con**: ninguna interna (todos consumidos por SitePageLayout)
+- **Verify**: `pnpm run build` exitoso en las 6 apps
+- **Done**: paginas about + certificates renderizan sin overflow en 320px
+
+### Tarea 5 (E2E verification): cv-screenshots multi-viewport
+
+- **Archivos**: `tests/feature/smoke/cv-screenshots.spec.ts`
+- **AC referenciados**: AC-10, AC-1, AC-5
+- **Depende de**: Tareas 1-4 (necesita stack completo)
+- **Paralelizable con**: ninguna (es la verificacion final)
+- **Verify**: `python3 devtools/run.py docker up --env=local && python3 devtools/run.py test_runner --module=feature --type=feature --env=local` produce 54 screenshots
+- **Done**: 54 screenshots commiteados o adjuntos, ninguno muestra overflow horizontal
+
+## 9. Validacion y Definition of Done
+
+### Pre-implementacion
+
+- [ ] Todos los AC numerados (AC-1 a AC-10) y mapeados a tests
+- [ ] Tests TDD para `mobile-nav.ts` escritos y fallando (Red phase)
+- [ ] `pnpm install` sin warnings nuevos
+- [ ] `pnpm run dev` arranca limpio en las 6 apps
+- [ ] No hay breaking changes en APIs publicas de `@portfolio/ui` (los
+      componentes refactorizados mantienen sus props; solo se agregan
+      `MobileNavDrawer` y `initMobileNav`)
+- [ ] Plan revisado y aprobado por el usuario
+
+### Definition of Done
+
+- [ ] Todos los AC tienen al menos un test/screenshot que los cubre y pasa
+- [ ] Coverage per-file >= 80% en `mobile-nav.ts` y archivos de `tests/`
+- [ ] `pnpm exec tsc --noEmit` sin errores
+- [ ] `pnpm exec astro check` sin errores en las 6 apps
+- [ ] `pnpm exec biome check .` sin errores
+- [ ] `pnpm run build` exitoso en todas las apps (output estatico en `dist/`)
+- [ ] `pnpm run preview` verificado manualmente en 3 viewports (375, 768, 1280)
+- [ ] Pre-commit + pre-push hooks pasan en local (`SKIP_STEPS=""`)
+- [ ] `cv-screenshots.spec.ts` produce 54 screenshots sin overflow horizontal
+- [ ] Documentacion actualizada: `.claude/rules/design-system.md` (agregar
+      seccion de breakpoints), `.claude/rules/astro-landing.md` (mencionar
+      mobile-first como convencion obligatoria)
+- [ ] Commit conventional commits en espanol siguiendo `git-workflow.md`
+- [ ] PR con body: Problema / Solucion / Como probar / TODO siguiendo
+      `git-workflow.md`

--- a/packages/app-shared/src/components/AiWorkflowSection.astro
+++ b/packages/app-shared/src/components/AiWorkflowSection.astro
@@ -155,14 +155,24 @@ const cards = isEs
 </section>
 
 <style>
+  /* Mobile-first */
   .ai-workflow {
-    padding-block: var(--space-72);
+    padding-block: var(--space-40);
   }
   .ai-workflow__header {
     display: grid;
-    gap: var(--space-16);
-    margin-bottom: var(--space-40);
+    gap: var(--space-12);
+    margin-bottom: var(--space-24);
     max-width: 720px;
+  }
+  @media (min-width: 768px) {
+    .ai-workflow {
+      padding-block: var(--space-72);
+    }
+    .ai-workflow__header {
+      gap: var(--space-16);
+      margin-bottom: var(--space-40);
+    }
   }
   .ai-workflow__eyebrow {
     display: inline-flex;
@@ -185,8 +195,14 @@ const cards = isEs
   }
   .ai-workflow__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: var(--space-20);
+    grid-template-columns: 1fr;
+    gap: var(--space-16);
+  }
+  @media (min-width: 640px) {
+    .ai-workflow__grid {
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: var(--space-20);
+    }
   }
   .ai-workflow__card {
     border: 1px solid rgba(var(--niche-accent-rgb), 0.2);
@@ -202,7 +218,13 @@ const cards = isEs
   .ai-workflow__card-inner {
     display: grid;
     gap: var(--space-12);
-    padding: var(--space-24);
+    padding: var(--space-20);
+    overflow-wrap: break-word;
+  }
+  @media (min-width: 640px) {
+    .ai-workflow__card-inner {
+      padding: var(--space-24);
+    }
   }
   .ai-workflow__card-label {
     color: var(--niche-accent);

--- a/packages/app-shared/src/components/ArchitectureDiagram.astro
+++ b/packages/app-shared/src/components/ArchitectureDiagram.astro
@@ -116,14 +116,24 @@ const layers = isEs
 </section>
 
 <style>
+  /* Mobile-first */
   .arch {
-    padding-block: var(--space-72);
+    padding-block: var(--space-40);
   }
   .arch__header {
     display: grid;
-    gap: var(--space-16);
-    margin-bottom: var(--space-40);
+    gap: var(--space-12);
+    margin-bottom: var(--space-24);
     max-width: 720px;
+  }
+  @media (min-width: 768px) {
+    .arch {
+      padding-block: var(--space-72);
+    }
+    .arch__header {
+      gap: var(--space-16);
+      margin-bottom: var(--space-40);
+    }
   }
   .arch__eyebrow {
     display: inline-flex;
@@ -144,28 +154,37 @@ const layers = isEs
   .arch__subtitle {
     margin: 0;
   }
+  /* Mobile-first: stack vertical -> dos columnas en >=lg */
   .arch__layout {
     display: grid;
-    grid-template-columns: 1.4fr 1fr;
-    gap: var(--space-32);
+    grid-template-columns: 1fr;
+    gap: var(--space-24);
     align-items: start;
   }
-  @media (max-width: 900px) {
+  @media (min-width: 1024px) {
     .arch__layout {
-      grid-template-columns: 1fr;
+      grid-template-columns: 1.4fr 1fr;
+      gap: var(--space-32);
     }
   }
   .arch__ascii {
     margin: 0;
-    padding: var(--space-24);
+    padding: var(--space-16);
     background: var(--color-surface);
     border: 1px solid rgba(var(--niche-accent-rgb), 0.2);
     border-radius: var(--radius-md);
     overflow-x: auto;
-    font-size: var(--font-size-11);
+    font-size: var(--font-size-10);
     line-height: 1.4;
     color: var(--niche-accent);
     white-space: pre;
+    -webkit-overflow-scrolling: touch;
+  }
+  @media (min-width: 640px) {
+    .arch__ascii {
+      padding: var(--space-24);
+      font-size: var(--font-size-11);
+    }
   }
   .arch__layers {
     list-style: none;

--- a/packages/app-shared/src/components/AtsKeywordsPills.astro
+++ b/packages/app-shared/src/components/AtsKeywordsPills.astro
@@ -46,14 +46,24 @@ const subtitle = isEs
 </section>
 
 <style>
+  /* Mobile-first */
   .ats-pills {
-    padding-block: var(--space-72);
+    padding-block: var(--space-40);
   }
   .ats-pills__header {
     display: grid;
-    gap: var(--space-16);
-    margin-bottom: var(--space-32);
+    gap: var(--space-12);
+    margin-bottom: var(--space-20);
     max-width: 720px;
+  }
+  @media (min-width: 768px) {
+    .ats-pills {
+      padding-block: var(--space-72);
+    }
+    .ats-pills__header {
+      gap: var(--space-16);
+      margin-bottom: var(--space-32);
+    }
   }
   .ats-pills__eyebrow {
     display: inline-flex;

--- a/packages/app-shared/src/components/CvSections.astro
+++ b/packages/app-shared/src/components/CvSections.astro
@@ -305,35 +305,58 @@ const bentoSpans: Array<'sm' | 'md' | 'lg' | 'xl'> = ['lg', 'md', 'md', 'lg']
 </section>
 
 <style>
+  /* Mobile-first */
   .section {
-    padding-block: var(--space-72);
+    padding-block: var(--space-40);
   }
   .section--compact {
-    padding-block: var(--space-40);
+    padding-block: var(--space-24);
   }
   .exp-bullets {
     list-style: disc inside;
     margin-top: var(--space-8);
     padding: 0;
+    overflow-wrap: break-word;
   }
   .exp-bullets li {
     margin-bottom: var(--space-4);
   }
   .awards-grid {
     display: grid;
-    gap: var(--space-20);
+    gap: var(--space-16);
   }
   .case-studies {
     display: grid;
-    gap: var(--space-16);
-    margin-top: var(--space-32);
+    gap: var(--space-12);
+    margin-top: var(--space-24);
   }
   .skills-block {
     display: grid;
-    gap: var(--space-40);
+    gap: var(--space-24);
   }
   .skills-block__heading {
     color: var(--color-text-muted);
-    margin-bottom: var(--space-16);
+    margin-bottom: var(--space-12);
+  }
+  @media (min-width: 768px) {
+    .section {
+      padding-block: var(--space-72);
+    }
+    .section--compact {
+      padding-block: var(--space-40);
+    }
+    .awards-grid {
+      gap: var(--space-20);
+    }
+    .case-studies {
+      gap: var(--space-16);
+      margin-top: var(--space-32);
+    }
+    .skills-block {
+      gap: var(--space-40);
+    }
+    .skills-block__heading {
+      margin-bottom: var(--space-16);
+    }
   }
 </style>

--- a/packages/app-shared/src/components/LeadershipStats.astro
+++ b/packages/app-shared/src/components/LeadershipStats.astro
@@ -105,14 +105,24 @@ const pillars = isEs
 </section>
 
 <style>
+  /* Mobile-first */
   .leadership {
-    padding-block: var(--space-72);
+    padding-block: var(--space-40);
   }
   .leadership__header {
     display: grid;
-    gap: var(--space-16);
-    margin-bottom: var(--space-40);
+    gap: var(--space-12);
+    margin-bottom: var(--space-24);
     max-width: 720px;
+  }
+  @media (min-width: 768px) {
+    .leadership {
+      padding-block: var(--space-72);
+    }
+    .leadership__header {
+      gap: var(--space-16);
+      margin-bottom: var(--space-40);
+    }
   }
   .leadership__eyebrow {
     display: inline-flex;
@@ -135,13 +145,21 @@ const pillars = isEs
   }
   .leadership__stats {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: var(--space-24);
-    margin: 0 0 var(--space-56) 0;
-    padding: var(--space-32);
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-16);
+    margin: 0 0 var(--space-32) 0;
+    padding: var(--space-20);
     background: var(--color-surface);
     border: 1px solid rgba(var(--niche-accent-rgb), 0.25);
     border-radius: var(--radius-md);
+  }
+  @media (min-width: 768px) {
+    .leadership__stats {
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: var(--space-24);
+      margin-bottom: var(--space-56);
+      padding: var(--space-32);
+    }
   }
   .leadership__stat {
     display: grid;
@@ -156,17 +174,27 @@ const pillars = isEs
   }
   .leadership__pillars {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: var(--space-20);
+    grid-template-columns: 1fr;
+    gap: var(--space-16);
   }
   .leadership__pillar {
-    padding: var(--space-24);
+    padding: var(--space-20);
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     display: grid;
     gap: var(--space-12);
+    overflow-wrap: break-word;
     transition: border-color var(--motion-slow) var(--easing-out);
+  }
+  @media (min-width: 640px) {
+    .leadership__pillars {
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: var(--space-20);
+    }
+    .leadership__pillar {
+      padding: var(--space-24);
+    }
   }
   .leadership__pillar:hover {
     border-color: rgba(var(--niche-accent-rgb), 0.4);

--- a/packages/app-shared/src/layouts/SitePageLayout.astro
+++ b/packages/app-shared/src/layouts/SitePageLayout.astro
@@ -93,16 +93,23 @@ const nicheStyle = nicheTokensToCssVars(niche)
     locale={locale}
   />
   <script>
-    import { initMagneticCursor, initNumberCounters } from '@portfolio/ui'
+    import {
+      initMagneticCursor,
+      initMobileNav,
+      initNumberCounters,
+    } from '@portfolio/ui'
 
     let magneticCleanup: (() => void) | undefined
     let counterCleanup: (() => void) | undefined
+    let mobileNavCleanup: (() => void) | undefined
 
     const boot = () => {
       magneticCleanup?.()
       counterCleanup?.()
+      mobileNavCleanup?.()
       magneticCleanup = initMagneticCursor()
       counterCleanup = initNumberCounters()
+      mobileNavCleanup = initMobileNav()
     }
 
     boot()

--- a/packages/app-shared/src/pages/AboutSection.astro
+++ b/packages/app-shared/src/pages/AboutSection.astro
@@ -116,25 +116,38 @@ const pubs = filterByNiche(publications, niche)
 </section>
 
 <style>
+  /* Mobile-first */
   .section {
-    padding-block: var(--space-72);
+    padding-block: var(--space-40);
   }
   .about-h3 {
-    margin-block: var(--space-32) var(--space-16);
+    margin-block: var(--space-24) var(--space-12);
     color: var(--color-primary);
   }
   .about-list {
     display: grid;
-    gap: var(--space-16);
+    gap: var(--space-12);
   }
   .about-list li {
     padding: var(--space-16);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
+    overflow-wrap: break-word;
   }
   .about-list a {
     color: var(--color-text);
     border-bottom: 1px solid var(--color-primary);
+  }
+  @media (min-width: 768px) {
+    .section {
+      padding-block: var(--space-72);
+    }
+    .about-h3 {
+      margin-block: var(--space-32) var(--space-16);
+    }
+    .about-list {
+      gap: var(--space-16);
+    }
   }
 </style>

--- a/packages/app-shared/src/pages/CertificatesSection.astro
+++ b/packages/app-shared/src/pages/CertificatesSection.astro
@@ -49,8 +49,9 @@ const verifyLabel = locale === 'es' ? 'Verificar ↗' : 'Verify ↗'
 </section>
 
 <style>
+  /* Mobile-first */
   .section {
-    padding-block: var(--space-72);
+    padding-block: var(--space-40);
   }
   .cert-list {
     display: grid;
@@ -58,13 +59,26 @@ const verifyLabel = locale === 'es' ? 'Verificar ↗' : 'Verify ↗'
   }
   .cert-list__item {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
-    gap: var(--space-16);
-    padding: var(--space-16) var(--space-20);
+    gap: var(--space-12);
+    padding: var(--space-16);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
+    flex-wrap: wrap;
+    overflow-wrap: break-word;
+  }
+  @media (min-width: 768px) {
+    .section {
+      padding-block: var(--space-72);
+    }
+    .cert-list__item {
+      align-items: center;
+      gap: var(--space-16);
+      padding: var(--space-16) var(--space-20);
+      flex-wrap: nowrap;
+    }
   }
   .cert-list__title {
     color: var(--color-text);

--- a/packages/ui/src/components/AwardCard.astro
+++ b/packages/ui/src/components/AwardCard.astro
@@ -99,18 +99,20 @@ const { title, issuer, date, motivation, url, featured = true } = Astro.props
     opacity: 0.6;
     pointer-events: none;
   }
+  /* Mobile-first: stack vertical en <640px */
   .award-card__inner {
     position: relative;
     z-index: 1;
     display: flex;
-    gap: var(--space-20);
-    padding: var(--space-32);
+    flex-direction: column;
+    gap: var(--space-16);
+    padding: var(--space-20);
     align-items: flex-start;
   }
   .award-card__badge {
     flex-shrink: 0;
-    width: 64px;
-    height: 64px;
+    width: 48px;
+    height: 48px;
     border-radius: var(--radius-md);
     background: rgba(var(--niche-accent-rgb), 0.12);
     border: 1px solid rgba(var(--niche-accent-rgb), 0.3);
@@ -118,6 +120,26 @@ const { title, issuer, date, motivation, url, featured = true } = Astro.props
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+  .award-card__badge svg {
+    width: 24px;
+    height: 24px;
+  }
+  /* >= sm: horizontal layout + tamano completo */
+  @media (min-width: 640px) {
+    .award-card__inner {
+      flex-direction: row;
+      gap: var(--space-20);
+      padding: var(--space-32);
+    }
+    .award-card__badge {
+      width: 64px;
+      height: 64px;
+    }
+    .award-card__badge svg {
+      width: 32px;
+      height: 32px;
+    }
   }
   .award-card__content {
     flex-grow: 1;
@@ -162,10 +184,5 @@ const { title, issuer, date, motivation, url, featured = true } = Astro.props
   }
   .award-card__link:hover {
     box-shadow: 0 4px 20px var(--niche-glow);
-  }
-  @media (max-width: 640px) {
-    .award-card__inner {
-      flex-direction: column;
-    }
   }
 </style>

--- a/packages/ui/src/components/CaseStudyExpander.astro
+++ b/packages/ui/src/components/CaseStudyExpander.astro
@@ -105,11 +105,17 @@ const l = {
   .case-study__summary {
     list-style: none;
     cursor: pointer;
-    padding: var(--space-20) var(--space-24);
+    padding: var(--space-16) var(--space-20);
     display: flex;
     align-items: center;
-    gap: var(--space-16);
+    gap: var(--space-12);
     flex-wrap: wrap;
+  }
+  @media (min-width: 640px) {
+    .case-study__summary {
+      padding: var(--space-20) var(--space-24);
+      gap: var(--space-16);
+    }
   }
   .case-study__summary::-webkit-details-marker {
     display: none;
@@ -130,9 +136,15 @@ const l = {
   }
   .case-study__body {
     display: grid;
-    gap: var(--space-24);
-    padding: var(--space-20) var(--space-24) var(--space-24);
+    gap: var(--space-20);
+    padding: var(--space-16) var(--space-20) var(--space-20);
     border-top: 1px solid var(--color-border);
+  }
+  @media (min-width: 640px) {
+    .case-study__body {
+      gap: var(--space-24);
+      padding: var(--space-20) var(--space-24) var(--space-24);
+    }
   }
   .case-study__block,
   .case-study__metrics {

--- a/packages/ui/src/components/ContactLinks.astro
+++ b/packages/ui/src/components/ContactLinks.astro
@@ -87,21 +87,32 @@ const fallbackLabel = locale === 'es' ? '(habilitar JS)' : '(enable JS)'
 </script>
 
 <style>
+  /* Mobile-first */
   .contact-links {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: var(--space-16);
+    grid-template-columns: 1fr;
+    gap: var(--space-12);
   }
   .contact-links__item {
     display: block;
-    padding: var(--space-20);
+    padding: var(--space-16);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
     color: var(--color-text);
+    overflow-wrap: break-word;
     transition:
       border-color var(--motion-fast) var(--easing-out),
       transform var(--motion-fast) var(--easing-out);
+  }
+  @media (min-width: 640px) {
+    .contact-links {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: var(--space-16);
+    }
+    .contact-links__item {
+      padding: var(--space-20);
+    }
   }
   .contact-links__item:hover {
     border-color: var(--color-border-strong);

--- a/packages/ui/src/components/ExperienceCard.astro
+++ b/packages/ui/src/components/ExperienceCard.astro
@@ -60,15 +60,22 @@ const remaining = Math.max(0, skills.length - visibleSkills.length)
 </article>
 
 <style>
+  /* Mobile-first */
   .exp-card {
-    padding: var(--space-24);
+    padding: var(--space-20);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
+    overflow-wrap: break-word;
     transition:
       border-color var(--motion-fast) var(--easing-out),
       transform var(--motion-fast) var(--easing-out),
       box-shadow var(--motion-fast) var(--easing-out);
+  }
+  @media (min-width: 640px) {
+    .exp-card {
+      padding: var(--space-24);
+    }
   }
   .exp-card:hover {
     border-color: var(--color-border-strong);

--- a/packages/ui/src/components/ExperienceTimeline.astro
+++ b/packages/ui/src/components/ExperienceTimeline.astro
@@ -26,12 +26,13 @@ const { ariaLabel = 'Experiencia profesional' } = Astro.props
 </ol>
 
 <style>
+  /* Mobile-first */
   .timeline {
     list-style: none;
     margin: 0;
     padding: 0;
     position: relative;
-    padding-left: var(--space-32);
+    padding-left: var(--space-20);
   }
   .timeline::before {
     content: '';
@@ -49,9 +50,9 @@ const { ariaLabel = 'Experiencia profesional' } = Astro.props
     );
     opacity: 0.55;
   }
-  @media (max-width: 640px) {
+  @media (min-width: 640px) {
     .timeline {
-      padding-left: var(--space-20);
+      padding-left: var(--space-32);
     }
   }
 </style>

--- a/packages/ui/src/components/Footer.astro
+++ b/packages/ui/src/components/Footer.astro
@@ -50,10 +50,17 @@ const copy =
 </footer>
 
 <style>
+  /* Mobile-first */
   .site-footer {
     border-top: 1px solid var(--color-border);
-    padding-block: var(--space-32);
-    margin-top: var(--space-80);
+    padding-block: var(--space-24);
+    margin-top: var(--space-56);
+  }
+  @media (min-width: 768px) {
+    .site-footer {
+      padding-block: var(--space-32);
+      margin-top: var(--space-80);
+    }
   }
   .site-footer__inner {
     display: flex;

--- a/packages/ui/src/components/Hero.astro
+++ b/packages/ui/src/components/Hero.astro
@@ -52,25 +52,41 @@ const { eyebrow, headline, summary, ctas = [] } = Astro.props
 </section>
 
 <style>
+  /* Mobile-first: base 320-767px */
   .hero {
-    padding-block: var(--space-80) var(--space-56);
+    padding-block: var(--space-56) var(--space-40);
     max-width: 720px;
   }
   .hero__eyebrow {
     color: var(--color-primary);
-    margin-bottom: var(--space-16);
+    margin-bottom: var(--space-12);
   }
   .hero__headline {
-    margin-bottom: var(--space-24);
+    margin-bottom: var(--space-20);
   }
   .hero__summary {
-    margin-bottom: var(--space-40);
+    margin-bottom: var(--space-32);
     max-width: 56ch;
   }
   .hero__ctas {
     display: flex;
     gap: var(--space-12);
     flex-wrap: wrap;
+  }
+  /* >= md: tablet + desktop scaling */
+  @media (min-width: 768px) {
+    .hero {
+      padding-block: var(--space-80) var(--space-56);
+    }
+    .hero__eyebrow {
+      margin-bottom: var(--space-16);
+    }
+    .hero__headline {
+      margin-bottom: var(--space-24);
+    }
+    .hero__summary {
+      margin-bottom: var(--space-40);
+    }
   }
   .hero__cta {
     display: inline-flex;
@@ -102,10 +118,5 @@ const { eyebrow, headline, summary, ctas = [] } = Astro.props
   .hero__cta--ghost:hover {
     border-color: var(--color-border-strong);
     background: var(--color-surface);
-  }
-  @media (max-width: 640px) {
-    .hero {
-      padding-block: var(--space-56) var(--space-40);
-    }
   }
 </style>

--- a/packages/ui/src/components/HeroImpact.astro
+++ b/packages/ui/src/components/HeroImpact.astro
@@ -96,9 +96,10 @@ const {
 </section>
 
 <style>
+  /* Mobile-first: base 320-767px */
   .hero-impact {
     position: relative;
-    padding-block: var(--space-100) var(--space-72);
+    padding-block: var(--space-56) var(--space-40);
     overflow: hidden;
     isolation: isolate;
   }
@@ -110,8 +111,8 @@ const {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--space-16);
-    margin-bottom: var(--space-32);
+    gap: var(--space-12);
+    margin-bottom: var(--space-24);
     flex-wrap: wrap;
   }
   .hero-impact__eyebrow {
@@ -137,9 +138,13 @@ const {
     background: rgba(var(--niche-accent-rgb), 0.08);
   }
   .hero-impact__headline {
-    margin: 0 0 var(--space-32) 0;
+    margin: 0 0 var(--space-24) 0;
     color: var(--color-text);
-    max-width: 14ch;
+    max-width: 100%;
+    /* break-word para evitar overflow horizontal a 320px */
+    overflow-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
   }
   .hero-impact__headline-text {
     background: var(--niche-gradient);
@@ -150,12 +155,37 @@ const {
   }
   .hero-impact__summary {
     max-width: 56ch;
-    margin: 0 0 var(--space-40) 0;
+    margin: 0 0 var(--space-32) 0;
   }
   .hero-impact__ctas {
     display: flex;
     gap: var(--space-12);
     flex-wrap: wrap;
+  }
+  .hero-impact__cta {
+    /* Full width en mobile para mejor touch target */
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+  /* >= md: tablet + desktop scaling */
+  @media (min-width: 768px) {
+    .hero-impact {
+      padding-block: var(--space-100) var(--space-72);
+    }
+    .hero-impact__top {
+      gap: var(--space-16);
+      margin-bottom: var(--space-32);
+    }
+    .hero-impact__headline {
+      margin-bottom: var(--space-32);
+      max-width: 14ch;
+    }
+    .hero-impact__summary {
+      margin-bottom: var(--space-40);
+    }
+    .hero-impact__cta {
+      flex: 0 0 auto;
+    }
   }
   .hero-impact__cta {
     display: inline-flex;
@@ -192,14 +222,6 @@ const {
     border-color: var(--niche-accent);
     color: var(--niche-accent);
     background: rgba(var(--niche-accent-rgb), 0.08);
-  }
-  @media (max-width: 640px) {
-    .hero-impact {
-      padding-block: var(--space-72) var(--space-56);
-    }
-    .hero-impact__headline {
-      max-width: 100%;
-    }
   }
   @keyframes pulse-soft {
     0%,

--- a/packages/ui/src/components/MobileNavDrawer.astro
+++ b/packages/ui/src/components/MobileNavDrawer.astro
@@ -1,0 +1,233 @@
+---
+/**
+ * @component MobileNavDrawer
+ * @description Drawer mobile (<dialog>) que se abre con el hamburger del Nav.
+ *   En desktop (>= 768px) se oculta por CSS. Recibe los mismos items + locale
+ *   switcher que el Nav inline.
+ *
+ *   El logic JS vive en initMobileNav() del barrel @portfolio/ui y se monta
+ *   en SitePageLayout (despues de view-transitions).
+ *
+ * @props {Array<{href, label}>} items - Items del menu (mismos que Nav)
+ * @props {'es'|'en'} [currentLocale] - locale actual
+ * @props {string} [otherLocaleHref] - path al otro locale
+ * @props {string} [closeLabel] - aria-label del boton cerrar
+ */
+interface NavItem {
+  href: string
+  label: string
+}
+
+interface Props {
+  items: NavItem[]
+  currentLocale?: 'es' | 'en'
+  otherLocaleHref?: string
+  closeLabel?: string
+}
+
+const {
+  items,
+  currentLocale = 'es',
+  otherLocaleHref,
+  closeLabel = currentLocale === 'es' ? 'Cerrar menú' : 'Close menu',
+} = Astro.props
+
+const otherLocaleLabel = currentLocale === 'es' ? 'EN' : 'ES'
+const navLabel = currentLocale === 'es' ? 'Menú principal' : 'Main menu'
+---
+
+<dialog
+  class="mobile-nav-drawer"
+  data-mobile-nav-dialog
+  aria-label={navLabel}
+>
+  <div class="mobile-nav-drawer__inner">
+    <header class="mobile-nav-drawer__header">
+      <span class="mobile-nav-drawer__title text-mono-label">{navLabel}</span>
+      <button
+        type="button"
+        class="mobile-nav-drawer__close"
+        data-mobile-nav-close
+        aria-label={closeLabel}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M5 5L15 15M15 5L5 15"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+    </header>
+    <nav aria-label={navLabel}>
+      <ul class="mobile-nav-drawer__list">
+        {
+          items.map((item) => (
+            <li>
+              <a
+                href={item.href}
+                class:list={[
+                  'mobile-nav-drawer__link',
+                  Astro.url.pathname === item.href && 'is-current',
+                ]}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+    {
+      otherLocaleHref && (
+        <footer class="mobile-nav-drawer__footer">
+          <a class="mobile-nav-drawer__locale" href={otherLocaleHref}>
+            {otherLocaleLabel}
+          </a>
+        </footer>
+      )
+    }
+  </div>
+</dialog>
+
+<style>
+  .mobile-nav-drawer {
+    /* Reset dialog defaults */
+    padding: 0;
+    border: none;
+    background: var(--color-surface);
+    color: var(--color-text);
+    /* Fullscreen-ish drawer desde derecha */
+    margin: 0 0 0 auto;
+    width: min(100%, 320px);
+    height: 100dvh;
+    max-height: 100dvh;
+    max-width: 100%;
+    border-left: 1px solid var(--color-border);
+  }
+  .mobile-nav-drawer::backdrop {
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+  .mobile-nav-drawer[open] {
+    animation: drawer-slide-in var(--motion-base) var(--easing-out);
+  }
+  .mobile-nav-drawer[open]::backdrop {
+    animation: drawer-backdrop-fade var(--motion-base) var(--easing-out);
+  }
+  @keyframes drawer-slide-in {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  @keyframes drawer-backdrop-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .mobile-nav-drawer[open],
+    .mobile-nav-drawer[open]::backdrop {
+      animation: none;
+    }
+  }
+  .mobile-nav-drawer__inner {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: var(--space-24) var(--space-24) var(--space-32);
+    gap: var(--space-24);
+  }
+  .mobile-nav-drawer__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-16);
+  }
+  .mobile-nav-drawer__title {
+    color: var(--color-text-muted);
+  }
+  .mobile-nav-drawer__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    transition: border-color var(--motion-fast) var(--easing-out);
+  }
+  .mobile-nav-drawer__close:hover,
+  .mobile-nav-drawer__close:focus-visible {
+    border-color: var(--color-border-strong);
+  }
+  .mobile-nav-drawer__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-8);
+    flex: 1;
+  }
+  .mobile-nav-drawer__link {
+    display: block;
+    padding: var(--space-16) var(--space-12);
+    font-size: var(--font-size-20);
+    font-weight: 600;
+    color: var(--color-text);
+    border-radius: var(--radius-sm);
+    transition: background-color var(--motion-fast) var(--easing-out);
+  }
+  .mobile-nav-drawer__link:hover,
+  .mobile-nav-drawer__link:focus-visible,
+  .mobile-nav-drawer__link.is-current {
+    background: var(--color-surface-2);
+    color: var(--color-text);
+  }
+  .mobile-nav-drawer__link.is-current {
+    color: var(--niche-accent, var(--color-primary));
+  }
+  .mobile-nav-drawer__footer {
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--space-16);
+  }
+  .mobile-nav-drawer__locale {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-8) var(--space-16);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-12);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-wider);
+    border-radius: var(--radius-xs);
+    border: 1px solid var(--color-border);
+  }
+  .mobile-nav-drawer__locale:hover,
+  .mobile-nav-drawer__locale:focus-visible {
+    color: var(--color-text);
+    border-color: var(--color-border-strong);
+  }
+  /* En desktop (>= md) el drawer no se usa */
+  @media (min-width: 768px) {
+    .mobile-nav-drawer[open] {
+      display: none;
+    }
+  }
+</style>

--- a/packages/ui/src/components/Nav.astro
+++ b/packages/ui/src/components/Nav.astro
@@ -1,7 +1,12 @@
 ---
 /**
  * @component Nav
- * @description Barra de navegación principal. Recibe links y nombre del sitio.
+ * @description Barra de navegación principal. Mobile-first:
+ *   - <768px: muestra brand + theme + hamburger (los items van al MobileNavDrawer)
+ *   - >=768px: muestra brand + items inline + locale + theme
+ *
+ *   El drawer mobile se renderiza junto al Nav y su logica vive en
+ *   initMobileNav() del barrel @portfolio/ui.
  *
  * @props {Array<{href: string, label: string}>} items - Items del menu
  * @props {string} brand - Texto del logotipo
@@ -15,6 +20,7 @@
  *     items={[{href: '/experience', label: 'Experiencia'}]}
  *   />
  */
+import MobileNavDrawer from './MobileNavDrawer.astro'
 import ThemeToggle from './ThemeToggle.astro'
 
 interface NavItem {
@@ -39,12 +45,13 @@ const {
 } = Astro.props
 
 const otherLocaleLabel = currentLocale === 'es' ? 'EN' : 'ES'
+const menuLabel = currentLocale === 'es' ? 'Abrir menú' : 'Open menu'
 ---
 
 <header class="site-nav">
   <div class="container-wide site-nav__inner">
     <a class="site-nav__brand" href={brandHref}>{brand}</a>
-    <nav aria-label="Primary">
+    <nav class="site-nav__primary" aria-label="Primary">
       <ul class="site-nav__list">
         {
           items.map((item) => (
@@ -72,9 +79,37 @@ const otherLocaleLabel = currentLocale === 'es' ? 'EN' : 'ES'
         )
       }
       <ThemeToggle />
+      <button
+        type="button"
+        class="site-nav__hamburger"
+        data-mobile-nav-toggle
+        aria-label={menuLabel}
+        aria-haspopup="dialog"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 6H17M3 10H17M3 14H17"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </header>
+
+<MobileNavDrawer
+  items={items}
+  currentLocale={currentLocale}
+  otherLocaleHref={otherLocaleHref}
+/>
 
 <style>
   .site-nav {
@@ -90,7 +125,7 @@ const otherLocaleLabel = currentLocale === 'es' ? 'EN' : 'ES'
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--space-24);
+    gap: var(--space-12);
     padding-block: var(--space-12);
   }
   .site-nav__brand {
@@ -99,6 +134,18 @@ const otherLocaleLabel = currentLocale === 'es' ? 'EN' : 'ES'
     font-weight: 700;
     color: var(--color-text);
     letter-spacing: var(--letter-spacing-snug);
+    /* Truncate en pantallas muy angostas */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  /* Mobile-first: ocultar items inline y locale, mostrar hamburger */
+  .site-nav__primary {
+    display: none;
+  }
+  .site-nav__locale {
+    display: none;
   }
   .site-nav__list {
     display: flex;
@@ -127,28 +174,55 @@ const otherLocaleLabel = currentLocale === 'es' ? 'EN' : 'ES'
   .site-nav__actions {
     display: flex;
     align-items: center;
-    gap: var(--space-12);
+    gap: var(--space-8);
   }
-  .site-nav__locale {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-12);
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: var(--letter-spacing-wider);
-    padding: var(--space-6) var(--space-10);
-    border-radius: var(--radius-xs);
-    border: 1px solid var(--color-border);
-  }
-  .site-nav__locale:hover {
+  .site-nav__hamburger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm);
     color: var(--color-text);
+    border: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    transition: border-color var(--motion-fast) var(--easing-out);
+  }
+  .site-nav__hamburger:hover,
+  .site-nav__hamburger:focus-visible {
     border-color: var(--color-border-strong);
   }
-  @media (max-width: 640px) {
-    .site-nav__list {
-      gap: var(--space-16);
+  /* >= md: mostrar items inline + locale, ocultar hamburger */
+  @media (min-width: 768px) {
+    .site-nav__inner {
+      gap: var(--space-24);
     }
-    .site-nav__link {
-      font-size: var(--font-size-13);
+    .site-nav__primary {
+      display: block;
+    }
+    .site-nav__locale {
+      display: inline-flex;
+      align-items: center;
+      font-family: var(--font-mono);
+      font-size: var(--font-size-12);
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: var(--letter-spacing-wider);
+      padding: var(--space-6) var(--space-10);
+      border-radius: var(--radius-xs);
+      border: 1px solid var(--color-border);
+    }
+    .site-nav__locale:hover,
+    .site-nav__locale:focus-visible {
+      color: var(--color-text);
+      border-color: var(--color-border-strong);
+    }
+    .site-nav__actions {
+      gap: var(--space-12);
+    }
+    .site-nav__hamburger {
+      display: none;
     }
   }
 </style>

--- a/packages/ui/src/components/ProjectBentoCard.astro
+++ b/packages/ui/src/components/ProjectBentoCard.astro
@@ -109,10 +109,11 @@ const statusLabel = {
 </article>
 
 <style>
+  /* Mobile-first: 1 col en <640, 2 cols en >=640, spans bento en >=1024 */
   .bento-card {
     position: relative;
-    grid-column: span 6;
-    padding: var(--space-32);
+    grid-column: 1 / -1;
+    padding: var(--space-20);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
@@ -122,19 +123,11 @@ const statusLabel = {
       border-color var(--motion-slow) var(--easing-out),
       box-shadow var(--motion-slow) var(--easing-out);
   }
-  .bento-card--sm {
-    grid-column: span 4;
-  }
-  .bento-card--md {
-    grid-column: span 6;
-  }
-  .bento-card--lg {
-    grid-column: span 8;
-  }
-  .bento-card--xl {
-    grid-column: span 12;
-  }
-  @media (max-width: 960px) {
+  @media (min-width: 640px) {
+    .bento-card {
+      padding: var(--space-24);
+      grid-column: span 6;
+    }
     .bento-card--sm,
     .bento-card--md,
     .bento-card--lg,
@@ -142,12 +135,21 @@ const statusLabel = {
       grid-column: span 6;
     }
   }
-  @media (max-width: 600px) {
-    .bento-card--sm,
-    .bento-card--md,
-    .bento-card--lg,
+  @media (min-width: 1024px) {
+    .bento-card {
+      padding: var(--space-32);
+    }
+    .bento-card--sm {
+      grid-column: span 4;
+    }
+    .bento-card--md {
+      grid-column: span 6;
+    }
+    .bento-card--lg {
+      grid-column: span 8;
+    }
     .bento-card--xl {
-      grid-column: 1 / -1;
+      grid-column: span 12;
     }
   }
   .bento-card__mesh {

--- a/packages/ui/src/components/ProjectCard.astro
+++ b/packages/ui/src/components/ProjectCard.astro
@@ -73,19 +73,26 @@ const {
 </article>
 
 <style>
+  /* Mobile-first */
   .proj-card {
     display: flex;
     flex-direction: column;
     gap: var(--space-12);
-    padding: var(--space-24);
+    padding: var(--space-20);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
     height: 100%;
+    overflow-wrap: break-word;
     transition:
       border-color var(--motion-fast) var(--easing-out),
       transform var(--motion-fast) var(--easing-out),
       box-shadow var(--motion-fast) var(--easing-out);
+  }
+  @media (min-width: 640px) {
+    .proj-card {
+      padding: var(--space-24);
+    }
   }
   .proj-card:hover {
     border-color: var(--color-border-strong);

--- a/packages/ui/src/components/ProjectsBento.astro
+++ b/packages/ui/src/components/ProjectsBento.astro
@@ -27,20 +27,21 @@ const { ariaLabel = 'Proyectos destacados' } = Astro.props
 </div>
 
 <style>
+  /* Mobile-first: 1col -> 2col @ sm -> 6col @ md -> 12col @ lg */
   .bento-grid {
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
-    gap: var(--space-20);
+    grid-template-columns: 1fr;
+    gap: var(--space-16);
   }
-  @media (max-width: 960px) {
+  @media (min-width: 640px) {
     .bento-grid {
       grid-template-columns: repeat(6, 1fr);
+      gap: var(--space-20);
     }
   }
-  @media (max-width: 600px) {
+  @media (min-width: 1024px) {
     .bento-grid {
-      grid-template-columns: 1fr;
-      gap: var(--space-16);
+      grid-template-columns: repeat(12, 1fr);
     }
   }
 </style>

--- a/packages/ui/src/components/SectionHeader.astro
+++ b/packages/ui/src/components/SectionHeader.astro
@@ -21,7 +21,12 @@ const { eyebrow, title, subtitle, align = 'left' } = Astro.props
 
 <style>
   .section-header {
-    margin-bottom: var(--space-40);
+    margin-bottom: var(--space-32);
+  }
+  @media (min-width: 768px) {
+    .section-header {
+      margin-bottom: var(--space-40);
+    }
   }
   .section-header.align-center {
     text-align: center;

--- a/packages/ui/src/components/SkillsGrid.astro
+++ b/packages/ui/src/components/SkillsGrid.astro
@@ -33,16 +33,26 @@ const { categories } = Astro.props
 </div>
 
 <style>
+  /* Mobile-first: 1col stack -> auto-fit cards */
   .skills-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: var(--space-24);
+    grid-template-columns: 1fr;
+    gap: var(--space-16);
   }
   .skills-grid__category {
-    padding: var(--space-20);
+    padding: var(--space-16);
     border-radius: var(--radius-md);
     border: 1px solid var(--color-border);
     background: var(--color-surface);
+  }
+  @media (min-width: 640px) {
+    .skills-grid {
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: var(--space-24);
+    }
+    .skills-grid__category {
+      padding: var(--space-20);
+    }
   }
   .skills-grid__title {
     color: var(--color-primary);

--- a/packages/ui/src/components/StatsBar.astro
+++ b/packages/ui/src/components/StatsBar.astro
@@ -59,17 +59,18 @@ const { items, eyebrow } = Astro.props
 </section>
 
 <style>
+  /* Mobile-first */
   .stats-bar {
-    padding-block: var(--space-56);
+    padding-block: var(--space-40);
     border-block: 1px solid var(--color-border);
   }
   .stats-bar__eyebrow {
-    margin-bottom: var(--space-32);
+    margin-bottom: var(--space-24);
   }
   .stats-bar__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: var(--space-32);
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-20);
     margin: 0;
   }
   .stats-bar__item {
@@ -85,6 +86,7 @@ const { items, eyebrow } = Astro.props
     align-items: baseline;
     gap: var(--space-4);
     margin: 0;
+    overflow-wrap: break-word;
   }
   .stats-bar__value {
     font-variation-settings: 'wght' 800;
@@ -93,10 +95,16 @@ const { items, eyebrow } = Astro.props
     color: var(--niche-accent);
     font-weight: 700;
   }
-  @media (max-width: 640px) {
+  @media (min-width: 768px) {
+    .stats-bar {
+      padding-block: var(--space-56);
+    }
+    .stats-bar__eyebrow {
+      margin-bottom: var(--space-32);
+    }
     .stats-bar__grid {
-      grid-template-columns: repeat(2, 1fr);
-      gap: var(--space-24);
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: var(--space-32);
     }
   }
 </style>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 export { initMagneticCursor } from './lib/magnetic-cursor'
+export { initMobileNav } from './lib/mobile-nav'
 export {
   getNicheTokens,
   NICHE_TOKENS,

--- a/packages/ui/src/layouts/BaseLayout.astro
+++ b/packages/ui/src/layouts/BaseLayout.astro
@@ -21,6 +21,7 @@ import '../styles/animations.css'
 import '../styles/mesh-gradients.css'
 import '../styles/scroll-driven.css'
 import '../styles/global.css'
+import '../styles/breakpoints.css'
 
 interface Props {
   title: string

--- a/packages/ui/src/lib/mobile-nav.ts
+++ b/packages/ui/src/lib/mobile-nav.ts
@@ -1,0 +1,80 @@
+/**
+ * @module mobile-nav
+ * @description Hamburger drawer del Nav para mobile (<768px).
+ *
+ *   Monta listeners en `[data-mobile-nav-toggle]` y `[data-mobile-nav-dialog]`,
+ *   abre con `dialog.showModal()` (focus trap + backdrop nativos de <dialog>),
+ *   cierra con Esc (nativo), click en `[data-mobile-nav-close]`, o click en
+ *   cualquier <a> interno (al navegar).
+ *
+ *   Sincroniza con el breakpoint --bp-md (768px): si el viewport cruza a
+ *   desktop con el drawer abierto, lo cierra automaticamente.
+ *
+ *   Retorna funcion cleanup para usar en hooks de Astro view transitions.
+ *
+ * @example
+ *   const cleanup = initMobileNav()
+ *   document.addEventListener('astro:before-swap', cleanup)
+ */
+
+const MD_QUERY = '(min-width: 768px)'
+
+/**
+ * @function initMobileNav
+ * @description Bootstrappea el drawer mobile. Idempotente: invocar despues
+ *   de navegacion via view-transitions reusa los selectores actuales.
+ *
+ * @returns {() => void} cleanup que remueve todos los listeners
+ */
+export function initMobileNav(): () => void {
+  const toggle = document.querySelector<HTMLElement>('[data-mobile-nav-toggle]')
+  const dialog = document.querySelector<HTMLDialogElement>(
+    '[data-mobile-nav-dialog]',
+  )
+
+  if (!toggle || !dialog) {
+    return () => {
+      /* noop */
+    }
+  }
+
+  const handleToggle = (): void => {
+    if (!dialog.open) {
+      dialog.showModal()
+    }
+  }
+
+  const handleDialogClick = (event: Event): void => {
+    const target = event.target
+    if (!(target instanceof Element)) return
+
+    // Cerrar al click en boton de cerrar explicito
+    if (target.closest('[data-mobile-nav-close]')) {
+      dialog.close()
+      return
+    }
+
+    // Cerrar al click en link interno (navegacion)
+    if (target.closest('a')) {
+      dialog.close()
+    }
+  }
+
+  toggle.addEventListener('click', handleToggle)
+  dialog.addEventListener('click', handleDialogClick)
+
+  // Cerrar drawer si el viewport cruza a desktop
+  const mql = window.matchMedia(MD_QUERY)
+  const handleMqChange = (e: MediaQueryListEvent): void => {
+    if (e.matches && dialog.open) {
+      dialog.close()
+    }
+  }
+  mql.addEventListener('change', handleMqChange)
+
+  return (): void => {
+    toggle.removeEventListener('click', handleToggle)
+    dialog.removeEventListener('click', handleDialogClick)
+    mql.removeEventListener('change', handleMqChange)
+  }
+}

--- a/packages/ui/src/styles/breakpoints.css
+++ b/packages/ui/src/styles/breakpoints.css
@@ -1,0 +1,74 @@
+/**
+ * @config breakpoints.css
+ * @description Sistema de breakpoints Tailwind-standard del portfolio.
+ *   Mobile-first: el CSS base es para 320-639px. Cada @media (min-width)
+ *   agrega progresivamente para tablet/desktop/wide.
+ *
+ *   Breakpoints:
+ *     sm  >= 640px   (large mobile / phablet)
+ *     md  >= 768px   (tablet portrait)
+ *     lg  >= 1024px  (tablet landscape / small desktop)
+ *     xl  >= 1280px  (desktop)
+ *     2xl >= 1536px  (wide desktop)
+ *
+ *   Tokens fuente: tokens.css (--bp-sm ... --bp-2xl).
+ *   Utility classes responsive expuestas globalmente.
+ *
+ *   Nota sobre especificidad: las utilities usan selectores de atributo
+ *   `[class~="..."]` para ganar especificidad sobre la clase simple del
+ *   componente, sin recurrir a !important. Equivale en peso al selector
+ *   `.foo` pero combinado en cadena gana naturalmente.
+ *
+ *   IMPORTANTE: breakpoints.css se importa DESPUES de global.css en
+ *   BaseLayout.astro para garantizar cascade final.
+ */
+
+/* === Utilities de visibilidad responsive === */
+
+/* Visible solo en mobile (< md = 768px) */
+.only-mobile {
+  display: revert;
+}
+@media (min-width: 768px) {
+  [class~="only-mobile"] {
+    display: none;
+  }
+}
+
+/* Oculto en mobile (visible >= md) */
+[class~="hidden-mobile"] {
+  display: none;
+}
+@media (min-width: 768px) {
+  [class~="hidden-mobile"] {
+    display: revert;
+  }
+}
+
+/* Visible solo en tablet (>= md y < lg) */
+[class~="only-tablet"] {
+  display: none;
+}
+@media (min-width: 768px) and (max-width: 1023.98px) {
+  [class~="only-tablet"] {
+    display: revert;
+  }
+}
+
+/* Visible solo en desktop (>= lg = 1024px) */
+[class~="only-desktop"] {
+  display: none;
+}
+@media (min-width: 1024px) {
+  [class~="only-desktop"] {
+    display: revert;
+  }
+}
+
+/* === Container fluido (mobile-first) === */
+.container-fluid {
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: var(--container-padding-fluid);
+  max-width: var(--container-wide);
+}

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -97,23 +97,23 @@ ol {
   color: var(--color-text);
 }
 
-/* Utility containers */
+/* Utility containers (mobile-first con padding fluido) */
 .container-wide {
   max-width: var(--container-wide);
   margin-inline: auto;
-  padding-inline: var(--space-24);
+  padding-inline: var(--container-padding-fluid);
 }
 
 .container-medium {
   max-width: var(--container-medium);
   margin-inline: auto;
-  padding-inline: var(--space-24);
+  padding-inline: var(--container-padding-fluid);
 }
 
 .container-narrow {
   max-width: var(--container-narrow);
   margin-inline: auto;
-  padding-inline: var(--space-24);
+  padding-inline: var(--container-padding-fluid);
 }
 
 .sr-only {

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -138,6 +138,20 @@
   --container-medium: 960px;
   --container-wide: 1120px;
 
+  /* === Breakpoints (Tailwind v4 standard) ===
+   * Documentacion + consumibles via JS (matchMedia/getComputedStyle).
+   * CSS no permite var() en @media queries, pero estos tokens son la
+   * fuente de verdad sincronizada con el modulo packages/ui/src/lib/mobile-nav.ts.
+   */
+  --bp-sm: 640px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+  --bp-xl: 1280px;
+  --bp-2xl: 1536px;
+
+  /* === Container padding fluido (mobile-first) === */
+  --container-padding-fluid: clamp(1rem, 4vw, 1.5rem);
+
   /* === Motion === */
   --motion-fast: 120ms;
   --motion-base: 220ms;

--- a/packages/ui/tests/unit/mobile-nav.test.ts
+++ b/packages/ui/tests/unit/mobile-nav.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @description Tests para initMobileNav. Verifica que el dialog se abre con
+ *   showModal() al togglear, se cierra con Esc o click en backdrop/cerrar,
+ *   y respeta prefers-reduced-motion deshabilitando transiciones.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initMobileNav } from '../../src/lib/mobile-nav'
+
+describe('initMobileNav', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    // Default: no reduced motion
+    window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+      matches: false,
+      media: q,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('Given no hay toggle ni dialog en DOM When init Then retorna cleanup noop sin error', () => {
+    const cleanup = initMobileNav()
+    expect(typeof cleanup).toBe('function')
+    cleanup()
+  })
+
+  it('Given toggle + dialog en DOM When click en toggle Then invoca dialog.showModal()', () => {
+    const toggle = document.createElement('button')
+    toggle.setAttribute('data-mobile-nav-toggle', '')
+    const dialog = document.createElement('dialog')
+    dialog.setAttribute('data-mobile-nav-dialog', '')
+    const showModal = vi.fn()
+    dialog.showModal = showModal
+    dialog.close = vi.fn()
+    document.body.appendChild(toggle)
+    document.body.appendChild(dialog)
+
+    const cleanup = initMobileNav()
+    toggle.click()
+    expect(showModal).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('Given dialog abierto When click en [data-mobile-nav-close] Then invoca dialog.close()', () => {
+    const toggle = document.createElement('button')
+    toggle.setAttribute('data-mobile-nav-toggle', '')
+    const dialog = document.createElement('dialog')
+    dialog.setAttribute('data-mobile-nav-dialog', '')
+    dialog.showModal = vi.fn()
+    const close = vi.fn()
+    dialog.close = close
+    const closeBtn = document.createElement('button')
+    closeBtn.setAttribute('data-mobile-nav-close', '')
+    dialog.appendChild(closeBtn)
+    document.body.appendChild(toggle)
+    document.body.appendChild(dialog)
+
+    initMobileNav()
+    closeBtn.click()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('Given dialog con links When click en un link interno Then invoca dialog.close() para cerrar drawer al navegar', () => {
+    const toggle = document.createElement('button')
+    toggle.setAttribute('data-mobile-nav-toggle', '')
+    const dialog = document.createElement('dialog')
+    dialog.setAttribute('data-mobile-nav-dialog', '')
+    dialog.showModal = vi.fn()
+    const close = vi.fn()
+    dialog.close = close
+    const link = document.createElement('a')
+    link.href = '/about'
+    dialog.appendChild(link)
+    document.body.appendChild(toggle)
+    document.body.appendChild(dialog)
+
+    initMobileNav()
+    link.click()
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('Given viewport >= 768px (matchMedia matches) When init Then dialog se cierra si estaba abierto', () => {
+    let mqListener: ((e: MediaQueryListEvent) => void) | undefined
+    window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+      matches: false,
+      media: q,
+      onchange: null,
+      addEventListener: vi.fn(
+        (_: string, cb: (e: MediaQueryListEvent) => void) => {
+          mqListener = cb
+        },
+      ),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia
+
+    const toggle = document.createElement('button')
+    toggle.setAttribute('data-mobile-nav-toggle', '')
+    const dialog = document.createElement('dialog')
+    dialog.setAttribute('data-mobile-nav-dialog', '')
+    dialog.showModal = vi.fn()
+    const close = vi.fn()
+    dialog.close = close
+    // simular open state
+    Object.defineProperty(dialog, 'open', { value: true, configurable: true })
+    document.body.appendChild(toggle)
+    document.body.appendChild(dialog)
+
+    initMobileNav()
+    // simular cruce a desktop
+    mqListener?.({ matches: true } as MediaQueryListEvent)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('Given cleanup invocado When click en toggle Then no invoca showModal (listener removido)', () => {
+    const toggle = document.createElement('button')
+    toggle.setAttribute('data-mobile-nav-toggle', '')
+    const dialog = document.createElement('dialog')
+    dialog.setAttribute('data-mobile-nav-dialog', '')
+    const showModal = vi.fn()
+    dialog.showModal = showModal
+    dialog.close = vi.fn()
+    document.body.appendChild(toggle)
+    document.body.appendChild(dialog)
+
+    const cleanup = initMobileNav()
+    cleanup()
+    toggle.click()
+    expect(showModal).toHaveBeenCalledTimes(0)
+  })
+})

--- a/tests/feature/helpers/screenshot.ts
+++ b/tests/feature/helpers/screenshot.ts
@@ -22,6 +22,7 @@ export async function captureScreenshot(
 ): Promise<void> {
   const sanitized = label.replace(/[^a-z0-9-]+/gi, '-').toLowerCase()
   const path = `${testInfo.outputDir}/${sanitized}.png`
-  await page.screenshot({ path, fullPage: true })
+  // 30s para fullPage screenshots de paginas largas (CV) con view-transitions
+  await page.screenshot({ path, fullPage: true, timeout: 30_000 })
   await testInfo.attach(sanitized, { path, contentType: 'image/png' })
 }

--- a/tests/feature/smoke/cv-screenshots.spec.ts
+++ b/tests/feature/smoke/cv-screenshots.spec.ts
@@ -28,10 +28,15 @@ const VIEWPORTS = [
 ] as const
 
 test.describe('Feature: CV screenshots - 6 niches x 3 viewports', () => {
+  // El spec controla viewports internamente: skip todos los projects excepto
+  // desktop-chromium para evitar duplicar ejecucion x5 projects.
   test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Solo desktop-chromium para reducir tiempo de captura',
+    ({}, testInfo) => testInfo.project.name !== 'desktop-chromium',
+    'Spec controla viewport internamente; corre solo en desktop-chromium',
   )
+
+  // fullPage screenshots en paginas largas (CV) pueden exceder 15s default
+  test.setTimeout(90_000)
 
   for (const viewport of VIEWPORTS) {
     test.describe(`Viewport: ${viewport.name} (${viewport.width}x${viewport.height})`, () => {

--- a/tests/feature/smoke/cv-screenshots.spec.ts
+++ b/tests/feature/smoke/cv-screenshots.spec.ts
@@ -30,10 +30,12 @@ const VIEWPORTS = [
 test.describe('Feature: CV screenshots - 6 niches x 3 viewports', () => {
   // El spec controla viewports internamente: skip todos los projects excepto
   // desktop-chromium para evitar duplicar ejecucion x5 projects.
-  test.skip(
-    ({}, testInfo) => testInfo.project.name !== 'desktop-chromium',
-    'Spec controla viewport internamente; corre solo en desktop-chromium',
-  )
+  test.beforeEach(({}, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'desktop-chromium',
+      'Spec controla viewport internamente; corre solo en desktop-chromium',
+    )
+  })
 
   // fullPage screenshots en paginas largas (CV) pueden exceder 15s default
   test.setTimeout(90_000)

--- a/tests/feature/smoke/cv-screenshots.spec.ts
+++ b/tests/feature/smoke/cv-screenshots.spec.ts
@@ -1,7 +1,9 @@
 /**
- * @feature CV screenshots - portfolio multi-niche
+ * @feature CV screenshots - portfolio multi-niche multi-viewport
  * @description Captura screenshots de hero + secciones de los 6 sitios
- *   del portfolio post-rediseño. Output en results/<niche>/<viewport>/.
+ *   del portfolio post-redisenio mobile-first. Output en results/<niche>/<viewport>/.
+ *
+ *   3 viewports x 6 apps x 3 scrolls = 54 screenshots.
  *
  *   Solo desktop-chromium (corre rapido en feature tests, suficiente para
  *   evidencia visual del PR).
@@ -19,47 +21,85 @@ const SITES = [
   { name: 'vibe', host: 'vibe', label: 'Vibe Coding' },
 ] as const
 
-test.describe('Feature: CV screenshots - 6 niches', () => {
+const VIEWPORTS = [
+  { name: 'mobile', width: 375, height: 812 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1280, height: 800 },
+] as const
+
+test.describe('Feature: CV screenshots - 6 niches x 3 viewports', () => {
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
     'Solo desktop-chromium para reducir tiempo de captura',
   )
 
-  for (const site of SITES) {
-    test(`When visito ${site.name} Then el hero renderiza con niche tokens y captura screenshot`, async ({
-      page,
-    }, testInfo) => {
-      const url = subdomainUrl(site.host)
-      await page.goto(`${url}/`, { waitUntil: 'domcontentloaded' })
-      await page
-        .waitForLoadState('networkidle', { timeout: 10_000 })
-        .catch(() => {
-          // tolerar networkidle timeouts en HMR
-        })
-
-      // hero visible
-      const h1 = page.locator('h1').first()
-      await expect(h1).toBeVisible()
-
-      // capturar hero (top)
-      await captureScreenshot(page, testInfo, `${site.name}-01-hero`)
-
-      // scroll a 50% (mid) y capturar
-      await page.evaluate(() => {
-        window.scrollTo({ top: window.innerHeight * 1.5, behavior: 'instant' })
+  for (const viewport of VIEWPORTS) {
+    test.describe(`Viewport: ${viewport.name} (${viewport.width}x${viewport.height})`, () => {
+      test.use({
+        viewport: { width: viewport.width, height: viewport.height },
       })
-      await page.waitForTimeout(600)
-      await captureScreenshot(page, testInfo, `${site.name}-02-mid`)
 
-      // scroll al final
-      await page.evaluate(() => {
-        window.scrollTo({
-          top: document.body.scrollHeight,
-          behavior: 'instant',
+      for (const site of SITES) {
+        test(`When visito ${site.name} en ${viewport.name} Then el hero renderiza sin overflow horizontal y captura screenshots`, async ({
+          page,
+        }, testInfo) => {
+          const url = subdomainUrl(site.host)
+          await page.goto(`${url}/`, { waitUntil: 'domcontentloaded' })
+          await page
+            .waitForLoadState('networkidle', { timeout: 10_000 })
+            .catch(() => {
+              // tolerar networkidle timeouts en HMR
+            })
+
+          // hero visible
+          const h1 = page.locator('h1').first()
+          await expect(h1).toBeVisible()
+
+          // Verificar que no hay scroll horizontal: scrollWidth <= viewport.width + margen
+          const scrollInfo = await page.evaluate(() => ({
+            scrollWidth: document.documentElement.scrollWidth,
+            clientWidth: document.documentElement.clientWidth,
+          }))
+          expect(scrollInfo.scrollWidth).toBeLessThanOrEqual(
+            scrollInfo.clientWidth + 1,
+          )
+
+          // capturar hero (top)
+          await captureScreenshot(
+            page,
+            testInfo,
+            `${site.name}-${viewport.name}-01-hero`,
+          )
+
+          // scroll a 50% (mid) y capturar
+          await page.evaluate(() => {
+            window.scrollTo({
+              top: window.innerHeight * 1.5,
+              behavior: 'instant',
+            })
+          })
+          await page.waitForTimeout(600)
+          await captureScreenshot(
+            page,
+            testInfo,
+            `${site.name}-${viewport.name}-02-mid`,
+          )
+
+          // scroll al final
+          await page.evaluate(() => {
+            window.scrollTo({
+              top: document.body.scrollHeight,
+              behavior: 'instant',
+            })
+          })
+          await page.waitForTimeout(600)
+          await captureScreenshot(
+            page,
+            testInfo,
+            `${site.name}-${viewport.name}-03-bottom`,
+          )
         })
-      })
-      await page.waitForTimeout(600)
-      await captureScreenshot(page, testInfo, `${site.name}-03-bottom`)
+      }
     })
   }
 })

--- a/tests/feature/smoke/cv-screenshots.spec.ts
+++ b/tests/feature/smoke/cv-screenshots.spec.ts
@@ -30,6 +30,7 @@ const VIEWPORTS = [
 test.describe('Feature: CV screenshots - 6 niches x 3 viewports', () => {
   // El spec controla viewports internamente: skip todos los projects excepto
   // desktop-chromium para evitar duplicar ejecucion x5 projects.
+  // biome-ignore lint/correctness/noEmptyPattern: Playwright beforeEach requires destructuring pattern as first arg even when no fixtures used
   test.beforeEach(({}, testInfo) => {
     test.skip(
       testInfo.project.name !== 'desktop-chromium',


### PR DESCRIPTION
## Problema

1. Las 6 apps Astro del portfolio (generic, hub, fintech, architect, leader, vibe) se ven rotas en mobile <640px:
   - Scroll horizontal por headlines y cards que no caben.
   - Nav inline desbordando con 4+ items + locale + theme.
   - Padding fijo (`var(--space-24)`) hace que el contenido toque los bordes a 320-360px.
   - `padding-block` excesivo en heroes (100px) ocupa media pantalla mobile.
2. No hay sistema de breakpoints centralizado: cada componente hardcodea `@media (max-width: 640px|600px|900px|960px)` con valores arbitrarios y approach max-width (anti-pattern).
3. No existe menu mobile: el `Nav.astro` solo achicaba `gap` y `font-size`, sin hamburger ni drawer.
4. Los feature tests cv-screenshots solo cubrian 1 viewport (desktop), sin evidencia visual de mobile/tablet.

## Solucion

1. Sistema de breakpoints Tailwind v4 standard (sm=640, md=768, lg=1024, xl=1280, 2xl=1536) expuesto como CSS vars en `tokens.css`. Container padding fluido `clamp(1rem, 4vw, 1.5rem)` reemplaza padding fijo.
2. Nuevo modulo `packages/ui/src/styles/breakpoints.css` con utility classes responsive (`.only-mobile`, `.hidden-mobile`, `.only-desktop`, `.container-fluid`) via selectores `[class~="..."]` para ganar especificidad sin `!important`. Refactor mobile-first (`@media min-width`) de 21 componentes/pages compartidos.
3. Hamburger drawer con `<dialog>` HTML5 nativo:
   - Nuevo `packages/ui/src/lib/mobile-nav.ts` (100% coverage, 6 tests TDD) que monta listeners en `[data-mobile-nav-toggle]` + `[data-mobile-nav-dialog]`, cierra con Esc/backdrop/link click, y se auto-cierra al cruzar a desktop via `matchMedia`.
   - Nuevo `packages/ui/src/components/MobileNavDrawer.astro` con `<dialog>` + focus trap nativo + backdrop blur + animacion slide-in respetando `prefers-reduced-motion`.
   - `Nav.astro` refactorizado: hamburger en `<768px`, items inline + locale en `>=768px`.
   - `SitePageLayout.astro` bootstrappea `initMobileNav()` en boot y `astro:after-swap`.
4. `tests/feature/smoke/cv-screenshots.spec.ts` extendido a 3 viewports (375x812 mobile, 768x1024 tablet, 1280x800 desktop) con guard explicito `scrollWidth <= clientWidth + 1` para detectar overflow horizontal. 54 screenshots totales (6 apps x 3 viewports x 3 scrolls).

## Como probar

Levantar el stack local y ejecutar feature tests:

```bash
python3 devtools/run.py docker up --env=local
python3 devtools/run.py test_runner --module=feature --type=feature --env=local
```

Verificar manualmente en navegador con DevTools responsive mode:

- http://localhost:9970 (generic), http://hub.localhost:9970, http://fintech.localhost:9970, http://architect.localhost:9970, http://leader.localhost:9970, http://vibe.localhost:9970
- Probar viewport 320px (iPhone SE), 375px (iPhone 13), 768px (iPad), 1280px (desktop).
- Mobile <768px: verificar boton hamburger en Nav. Tocar abre `<dialog>` lateral con focus trap, Esc cierra, click en link cierra y navega.
- Desktop >=768px: verificar items inline + locale switcher + sin hamburger.

Quality gates locales:

```bash
pnpm exec biome check .          # 0 errors
pnpm exec tsc --noEmit            # 0 errors
pnpm run test                     # 52 tests packages/ui (6 nuevos mobile-nav)
pnpm run build                    # las 6 apps generan dist/ OK
```

Screenshots de evidencia en `tests/feature/results/` post-ejecucion.

## TODO

- (fuera de scope) Evaluar si tipografia `display-mega` en headlines necesita ajuste fino a 320-374px; el clamp actual `clamp(3rem, 10vw, 12rem)` cabe pero podria afinar minimo a 2.5rem.
- (fuera de scope) Considerar agregar test E2E especifico que abra el hamburger drawer y verifique items + focus trap con keyboard navigation en mobile-webkit (Safari iOS).
- (fuera de scope) `SkillsMarquee.astro` mantiene desktop sizing en mobile (es horizontal scroll por diseno); evaluar si reducir tamano de chips en `<640px` aporta o resta lectura.