### PR TITLE
feat(profile): agrega availability bilingue + enriquece SEO con WorkLocation Remote

### DIFF
--- a/apps/architect/public/llms.txt
+++ b/apps/architect/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Frontend Architect with deep microservices and distributed systems experience. 12+ years designing scalable architectures: microfrontend (Vue/Nuxt) + 8+ Django microservices + AWS API Gateway + PostgreSQL/Redis/SQS + observability with CloudWatch/Sentry.
 
-Canonical URL: https://architect.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+Canonical URL: https://architect.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — architect
 

--- a/apps/architect/src/lib/site-config.ts
+++ b/apps/architect/src/lib/site-config.ts
@@ -15,8 +15,8 @@ export const { NICHE, SITE_URL, OG_IMAGE, STRINGS } = defineSiteConfig({
       'Arquitecto Frontend con experiencia en microservicios, microfrontends y sistemas escalables. Vue/Nuxt + Django + AWS. Decisiones de diseño y arquitectura documentadas.',
     metaDescriptionEn:
       'Frontend Architect experienced in microservices, microfrontends and scalable systems. Vue/Nuxt + Django + AWS. Documented design and architecture decisions.',
-    heroEyebrowEs: 'Pablo Contreras · Architect · Lima, Perú',
-    heroEyebrowEn: 'Pablo Contreras · Architect · Lima, Peru',
+    heroEyebrowEs: 'Pablo Contreras · Architect · Lima, Perú · Remoto LATAM/US',
+    heroEyebrowEn: 'Pablo Contreras · Architect · Lima, Peru · Remote LATAM/US',
     heroHeadlineEs: 'Frontend Architect & Microservicios',
     heroHeadlineEn: 'Frontend Architect & Microservices',
     heroSummaryEs:

--- a/apps/fintech/public/llms.txt
+++ b/apps/fintech/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Senior Full Stack engineer specialized in Latin American fintech (Chile, Mexico). 12+ years building credit, debt-settlement and payment products with Vue/Nuxt + Django + AWS microservices. Compliance-aware (PCI DSS, KYC, PII handling).
 
-Canonical URL: https://fintech.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+Canonical URL: https://fintech.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — fintech
 

--- a/apps/fintech/src/lib/site-config.ts
+++ b/apps/fintech/src/lib/site-config.ts
@@ -15,8 +15,10 @@ export const { NICHE, SITE_URL, OG_IMAGE, STRINGS } = defineSiteConfig({
       'Senior Full Stack especializado en fintech Chile/México. Saldar deudas, scoring crediticio, productos de crédito con Vue + Django + AWS. 8+ años entregando producto.',
     metaDescriptionEn:
       'Senior Full Stack specialized in LATAM fintech (Chile, Mexico). Debt settlement, credit scoring and credit products with Vue + Django + AWS. 8+ years shipping product.',
-    heroEyebrowEs: 'Pablo Contreras · Fintech LATAM · Lima, Perú',
-    heroEyebrowEn: 'Pablo Contreras · LATAM Fintech · Lima, Peru',
+    heroEyebrowEs:
+      'Pablo Contreras · Fintech LATAM · Lima, Perú · Remoto LATAM/US',
+    heroEyebrowEn:
+      'Pablo Contreras · LATAM Fintech · Lima, Peru · Remote LATAM/US',
     heroHeadlineEs: 'Senior Full Stack Fintech LATAM',
     heroHeadlineEn: 'Senior Full Stack LATAM Fintech',
     heroSummaryEs:

--- a/apps/generic/public/llms.txt
+++ b/apps/generic/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Senior Full Stack Engineer with 12+ years of experience in Vue/Nuxt, Django, AWS and LATAM fintech (Chile, Mexico). Cross-cutting expertise: fintech, architecture, tech leadership and vibe coding with Claude Code.
 
-Canonical URL: https://hub.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+Canonical URL: https://hub.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — generic
 

--- a/apps/hub/src/pages/en/index.astro
+++ b/apps/hub/src/pages/en/index.astro
@@ -51,7 +51,7 @@ const hubStyle = nicheTokensToCssVars('hub')
       <MeshGradientBg variant="vivid" aurora />
       <p class="text-mono-label hub-hero__eyebrow">
         <span class="hub-hero__dot" aria-hidden="true"></span>
-        Pablo Contreras · Lima, Peru
+        Pablo Contreras · Lima, Peru · Remote LATAM/US
       </p>
       <h1 class="text-display-mega hub-hero__title">
         <span class="gradient-text">Five</span><br />

--- a/apps/hub/src/pages/index.astro
+++ b/apps/hub/src/pages/index.astro
@@ -53,7 +53,7 @@ const hubStyle = nicheTokensToCssVars('hub')
       <MeshGradientBg variant="vivid" aurora />
       <p class="text-mono-label hub-hero__eyebrow">
         <span class="hub-hero__dot" aria-hidden="true"></span>
-        Pablo Contreras · Lima, Perú
+        Pablo Contreras · Lima, Perú · Remoto LATAM/US
       </p>
       <h1 class="text-display-mega hub-hero__title">
         <span class="gradient-text">Cinco</span><br />

--- a/apps/leader/public/llms.txt
+++ b/apps/leader/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Tech Lead and Engineering Manager. 4 leadership roles, 8 teams led, 11+ years shipping product. Innovator of the Year 2023 at Destacame for automating internal operations. Mentoring + delivery + organizational resilience during reorganizations.
 
-Canonical URL: https://leader.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+Canonical URL: https://leader.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — leader
 

--- a/apps/leader/src/lib/site-config.ts
+++ b/apps/leader/src/lib/site-config.ts
@@ -15,8 +15,8 @@ export const { NICHE, SITE_URL, OG_IMAGE, STRINGS } = defineSiteConfig({
       'Tech Lead con experiencia liderando equipos multidisciplinarios, mentoring y entrega de producto fintech a escala. Premio Innovador del Año en Destacame.',
     metaDescriptionEn:
       'Tech Lead experienced in leading cross-functional engineering teams, mentoring and shipping fintech products at scale. Innovator of the Year award at Destacame.',
-    heroEyebrowEs: 'Pablo Contreras · Tech Lead · Lima, Perú',
-    heroEyebrowEn: 'Pablo Contreras · Tech Lead · Lima, Peru',
+    heroEyebrowEs: 'Pablo Contreras · Tech Lead · Lima, Perú · Remoto LATAM/US',
+    heroEyebrowEn: 'Pablo Contreras · Tech Lead · Lima, Peru · Remote LATAM/US',
     heroHeadlineEs: 'Tech Lead & Engineering Manager',
     heroHeadlineEn: 'Tech Lead & Engineering Manager',
     heroSummaryEs:

--- a/apps/vibe/public/llms.txt
+++ b/apps/vibe/public/llms.txt
@@ -2,7 +2,7 @@
 
 > AI-Augmented Software Engineer. Using Claude Code since launch (May 2025), previously Claude web + my own FastStruct VS Code extension. Rolled out Claude Code at Destacame with standardized skills/rules/docs structure. Builds CLIs to centralize team processes. AI is a tool, not an author — all code is human-reviewed and tested.
 
-Canonical URL: https://vibe.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Contact: pacg1991@gmail.com.
+Canonical URL: https://vibe.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — vibe
 

--- a/apps/vibe/src/lib/site-config.ts
+++ b/apps/vibe/src/lib/site-config.ts
@@ -15,8 +15,10 @@ export const { NICHE, SITE_URL, OG_IMAGE, STRINGS } = defineSiteConfig({
       'Ingeniero que documenta workflows reales con Claude Code (desde el lanzamiento, mayo 2025) y antes Claude web + FastStruct. FastStruct (VS Code), monorepo Astro de este portfolio y un CV builder construido en una sola noche.',
     metaDescriptionEn:
       'Engineer documenting real workflows with Claude Code (since launch, May 2025) and previously Claude web + FastStruct. FastStruct (VS Code), Astro monorepo of this portfolio and a CV builder shipped in a single night.',
-    heroEyebrowEs: 'Pablo Contreras · Vibe Coding · Lima, Perú',
-    heroEyebrowEn: 'Pablo Contreras · Vibe Coding · Lima, Peru',
+    heroEyebrowEs:
+      'Pablo Contreras · Vibe Coding · Lima, Perú · Remoto LATAM/US',
+    heroEyebrowEn:
+      'Pablo Contreras · Vibe Coding · Lima, Peru · Remote LATAM/US',
     heroHeadlineEs: 'AI-Augmented Full Stack · Claude Code',
     heroHeadlineEn: 'AI-Augmented Full Stack · Claude Code',
     heroSummaryEs:

--- a/packages/app-shared/src/lib/site-config.ts
+++ b/packages/app-shared/src/lib/site-config.ts
@@ -108,7 +108,9 @@ export function buildStrings(
       },
       nav: navEs(''),
       hero: {
-        eyebrow: overrides.heroEyebrowEs ?? 'Pablo Contreras · Lima, Perú',
+        eyebrow:
+          overrides.heroEyebrowEs ??
+          'Pablo Contreras · Lima, Perú · Disponible remoto LATAM/US',
         headline: overrides.heroHeadlineEs ?? 'Senior Full Stack Engineer',
         summary:
           overrides.heroSummaryEs ??
@@ -182,7 +184,9 @@ export function buildStrings(
       },
       nav: navEn('/en'),
       hero: {
-        eyebrow: overrides.heroEyebrowEn ?? 'Pablo Contreras · Lima, Peru',
+        eyebrow:
+          overrides.heroEyebrowEn ??
+          'Pablo Contreras · Lima, Peru · Remote-friendly LATAM/US',
         headline: overrides.heroHeadlineEn ?? 'Senior Full Stack Engineer',
         summary:
           overrides.heroSummaryEn ??

--- a/packages/content/src/data/profile.ts
+++ b/packages/content/src/data/profile.ts
@@ -17,6 +17,10 @@ export const profile: Profile = ProfileSchema.parse({
     en: 'Software engineer with over 8 years of experience, specialized in Full Stack development with Python and JavaScript. Expert in building technology solutions with Vue, Django, microservices and AWS, I have successfully delivered and led the implementation of ERP systems and fintech platforms, significantly improving operational efficiency and user experience. Skilled in coordinating and motivating teams, I adapt easily to dynamic and challenging environments, always focused on quality and innovation.',
   },
   location: 'Lima, Perú',
+  availability: {
+    es: 'Disponible remoto · zona horaria LATAM/US',
+    en: 'Remote-friendly · LATAM/US timezone',
+  },
   contacts: {
     email: 'pacg1991@gmail.com',
     phone: '+51 918490148',

--- a/packages/content/src/schemas.ts
+++ b/packages/content/src/schemas.ts
@@ -109,7 +109,19 @@ export const ProfileSchema = z.object({
   handle: z.string().min(1),
   headline: BiLangSchema,
   summary: BiLangSchema,
+  /**
+   * Ciudad y pais en formato limpio (ej. "Lima, Perú"). Se usa tal cual en
+   * schema.org `PostalAddress.addressLocality` y en `llms.txt`. NO mezclar
+   * con marketing copy ("disponible remoto"); para eso usar `availability`.
+   */
   location: z.string().min(1),
+  /**
+   * Marketing copy bilingüe sobre disponibilidad (ej. "Disponible remoto
+   * · zona LATAM/US"). Opcional. Display-only: se concatena al
+   * `location` en hero/CV/about para señal ATS + GEO, pero NO se mete
+   * en JSON-LD ni en `llms.txt`.
+   */
+  availability: BiLangSchema.optional(),
   contacts: z.object({
     email: z.string().email(),
     phone: z.string().optional(),

--- a/packages/content/tests/fixtures/baseline/profile.json
+++ b/packages/content/tests/fixtures/baseline/profile.json
@@ -10,6 +10,10 @@
     "en": "Software engineer with over 8 years of experience, specialized in Full Stack development with Python and JavaScript. Expert in building technology solutions with Vue, Django, microservices and AWS, I have successfully delivered and led the implementation of ERP systems and fintech platforms, significantly improving operational efficiency and user experience. Skilled in coordinating and motivating teams, I adapt easily to dynamic and challenging environments, always focused on quality and innovation."
   },
   "location": "Lima, Perú",
+  "availability": {
+    "es": "Disponible remoto · zona horaria LATAM/US",
+    "en": "Remote-friendly · LATAM/US timezone"
+  },
   "contacts": {
     "email": "pacg1991@gmail.com",
     "phone": "+51 918490148",

--- a/packages/cv-pdf/src/lib/render-cv-html.ts
+++ b/packages/cv-pdf/src/lib/render-cv-html.ts
@@ -228,9 +228,12 @@ a { color: #2046d3; text-decoration: none; }
 </head>
 <body>`
 
+  const locationLine = profile.availability
+    ? `${escapeHtml(profile.location)} · ${escapeHtml(profile.availability[locale])}`
+    : escapeHtml(profile.location)
   const header = `
 <h1>${escapeHtml(profile.name)}</h1>
-<p class="contact">${escapeHtml(profile.headline[locale])} · ${escapeHtml(profile.location)}</p>
+<p class="contact">${escapeHtml(profile.headline[locale])} · ${locationLine}</p>
 <p class="contact">
   <a href="mailto:${escapeHtml(profile.contacts.email)}">${escapeHtml(profile.contacts.email)}</a>
   · <a href="${escapeHtml(profile.contacts.linkedin)}">LinkedIn</a>

--- a/packages/cv-pdf/tests/unit/render-cv-html.test.ts
+++ b/packages/cv-pdf/tests/unit/render-cv-html.test.ts
@@ -46,6 +46,18 @@ describe('renderCvHtml', () => {
     expect(html).toContain('github.com/bypabloc')
   })
 
+  it('Given locale es When render Then header shows location y availability ES concatenados', () => {
+    const html = renderCvHtml({ locale: 'es', niche: 'generic' })
+    expect(html).toContain(
+      'Lima, Perú · Disponible remoto · zona horaria LATAM/US',
+    )
+  })
+
+  it('Given locale en When render Then header shows location y availability EN concatenados', () => {
+    const html = renderCvHtml({ locale: 'en', niche: 'generic' })
+    expect(html).toContain('Lima, Perú · Remote-friendly · LATAM/US timezone')
+  })
+
   it('Given any input When render Then escapes potentially unsafe chars', () => {
     const html = renderCvHtml({ locale: 'es', niche: 'generic' })
     // No raw < or > that could break the HTML inside text nodes.

--- a/packages/seo/src/lib/build-llms-txt.ts
+++ b/packages/seo/src/lib/build-llms-txt.ts
@@ -74,8 +74,11 @@ export function buildLlmsTxt(input: BuildLlmsTxtInput): string {
   lines.push('')
   lines.push(`> ${NICHE_DESCRIPTION[niche]}`)
   lines.push('')
+  const availabilityFragment = profile.availability
+    ? ` Availability: ${profile.availability.en}.`
+    : ''
   lines.push(
-    `Canonical URL: ${siteUrl}. Author: ${profile.name} (${profile.handle}). Location: ${profile.location}. Contact: ${profile.contacts.email}.`,
+    `Canonical URL: ${siteUrl}. Author: ${profile.name} (${profile.handle}). Location: ${profile.location}.${availabilityFragment} Contact: ${profile.contacts.email}.`,
   )
   lines.push('')
 

--- a/packages/seo/src/lib/build-profile-page-schema.ts
+++ b/packages/seo/src/lib/build-profile-page-schema.ts
@@ -87,11 +87,27 @@ export function buildProfilePageSchema(
       hasOccupation: {
         '@type': 'Occupation',
         name: jobTitle,
-        occupationLocation: {
-          '@type': 'Country',
-          name: locale === 'es' ? 'Perú' : 'Peru',
-        },
+        occupationLocation: [
+          {
+            '@type': 'Country',
+            name: locale === 'es' ? 'Perú' : 'Peru',
+          },
+          {
+            '@type': 'VirtualLocation',
+            name:
+              locale === 'es'
+                ? 'Remoto · zona horaria LATAM/US'
+                : 'Remote · LATAM/US timezone',
+          },
+        ],
         skills: knowsAbout.join(', '),
+      },
+      seeks: {
+        '@type': 'Demand',
+        name:
+          locale === 'es'
+            ? 'Roles full stack senior remotos (LATAM/US)'
+            : 'Remote senior full stack roles (LATAM/US)',
       },
     },
   }

--- a/packages/seo/tests/unit/build-llms-txt.test.ts
+++ b/packages/seo/tests/unit/build-llms-txt.test.ts
@@ -67,4 +67,25 @@ describe('buildLlmsTxt', () => {
     })
     expect(out).not.toMatch(/Medium:/u)
   })
+
+  it('Given profile con availability When build Then incluye Availability en metadata header', () => {
+    const out = buildLlmsTxt({
+      siteUrl: 'https://x.example/',
+      profile,
+      niche: 'generic',
+      pages: [],
+    })
+    expect(out).toContain('Availability: Remote-friendly · LATAM/US timezone.')
+  })
+
+  it('Given profile sin availability When build Then omite Availability', () => {
+    const stripped = { ...profile, availability: undefined }
+    const out = buildLlmsTxt({
+      siteUrl: 'https://x.example/',
+      profile: stripped,
+      niche: 'generic',
+      pages: [],
+    })
+    expect(out).not.toMatch(/Availability:/u)
+  })
 })

--- a/packages/seo/tests/unit/build-profile-page-schema.test.ts
+++ b/packages/seo/tests/unit/build-profile-page-schema.test.ts
@@ -79,7 +79,7 @@ describe('buildProfilePageSchema', () => {
     expect(parsed.mainEntity.hasOccupation.skills).toBe('Vue, Django, AWS')
   })
 
-  it('Given locale es When build Then occupationLocation country es "Perú"', () => {
+  it('Given locale es When build Then occupationLocation incluye Country "Perú" y VirtualLocation remoto', () => {
     const ld = buildProfilePageSchema({
       profile,
       niche: 'generic',
@@ -88,10 +88,19 @@ describe('buildProfilePageSchema', () => {
       knowsAbout: [],
     })
     const parsed = JSON.parse(ld)
-    expect(parsed.mainEntity.hasOccupation.occupationLocation.name).toBe('Perú')
+    const loc = parsed.mainEntity.hasOccupation.occupationLocation as Array<{
+      '@type': string
+      name: string
+    }>
+    expect(loc).toHaveLength(2)
+    expect(loc[0]).toStrictEqual({ '@type': 'Country', name: 'Perú' })
+    expect(loc[1]).toStrictEqual({
+      '@type': 'VirtualLocation',
+      name: 'Remoto · zona horaria LATAM/US',
+    })
   })
 
-  it('Given locale en When build Then occupationLocation country es "Peru"', () => {
+  it('Given locale en When build Then occupationLocation incluye Country "Peru" y VirtualLocation remote', () => {
     const ld = buildProfilePageSchema({
       profile,
       niche: 'generic',
@@ -100,7 +109,46 @@ describe('buildProfilePageSchema', () => {
       knowsAbout: [],
     })
     const parsed = JSON.parse(ld)
-    expect(parsed.mainEntity.hasOccupation.occupationLocation.name).toBe('Peru')
+    const loc = parsed.mainEntity.hasOccupation.occupationLocation as Array<{
+      '@type': string
+      name: string
+    }>
+    expect(loc).toHaveLength(2)
+    expect(loc[0]).toStrictEqual({ '@type': 'Country', name: 'Peru' })
+    expect(loc[1]).toStrictEqual({
+      '@type': 'VirtualLocation',
+      name: 'Remote · LATAM/US timezone',
+    })
+  })
+
+  it('Given locale es When build Then mainEntity.seeks indica roles remotos LATAM/US en espanol', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'generic',
+      locale: 'es',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.seeks).toStrictEqual({
+      '@type': 'Demand',
+      name: 'Roles full stack senior remotos (LATAM/US)',
+    })
+  })
+
+  it('Given locale en When build Then mainEntity.seeks indica remote senior full stack en ingles', () => {
+    const ld = buildProfilePageSchema({
+      profile,
+      niche: 'generic',
+      locale: 'en',
+      canonicalUrl: 'https://x.example/',
+      knowsAbout: [],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.mainEntity.seeks).toStrictEqual({
+      '@type': 'Demand',
+      name: 'Remote senior full stack roles (LATAM/US)',
+    })
   })
 
   it('Given build Then sameAs contiene linkedin, github y medium', () => {


### PR DESCRIPTION
## Problema

1. La ubicacion del candidato ("Lima, Peru") solo aparecia en el header del CV HTML/PDF y en `addressLocality` del JSON-LD, pero NO se exponia en las 6 apps Astro (hero, about, eyebrow). Recruiters de US/EU que llegan via GEO/ATS no tenian senal de zona horaria ni disponibilidad para remoto.

2. El profile no diferenciaba entre **datos estructurados** (ciudad+pais para schema.org) y **marketing copy** (disponibilidad remoto, zona horaria). Mezclar ambos en `profile.location` habria ensuciado el `addressLocality` y el `llms.txt`.

3. El schema.org `ProfilePage` no senalaba disponibilidad para remoto. LLMs (Claude, ChatGPT, Perplexity) consultados por "developers en Lima disponibles remoto" no tenian senal explicita.

## Solucion

1. Nuevo campo `availability: BiLang` opcional en `ProfileSchema` (display-only). Se concatena al `location` en hero/CV/llms.txt pero NO contamina `addressLocality`. Eyebrow de las 6 apps ahora muestra `Pablo Contreras · [niche] · Lima, Peru · Remote LATAM/US` (es: `Remoto LATAM/US`). Header del CV concatena `location · availability[locale]`.

2. Separacion limpia:
   - `profile.location = 'Lima, Peru'` → schema.org `addressLocality`, `llms.txt` Location field
   - `profile.availability = { es, en }` → hero eyebrow, CV header, `llms.txt` Availability field (display-only)

3. `buildProfilePageSchema` enriquecido:
   - `occupationLocation` paso de objeto a **array** con `[Country, VirtualLocation]` donde `VirtualLocation.name` = "Remoto · zona horaria LATAM/US" / "Remote · LATAM/US timezone"
   - Nuevo campo `seeks: { @type: 'Demand', name: 'Roles full stack senior remotos (LATAM/US)' / 'Remote senior full stack roles (LATAM/US)' }` — senal directa para GEO
   - `buildLlmsTxt` agrega linea `Availability: Remote-friendly · LATAM/US timezone.` cuando profile.availability existe

## Como probar

Local (sin Docker):

```bash
pnpm install
pnpm run typecheck     # 0 errors en 6 apps + tsc
pnpm run test          # 150 tests pass (60 content + 22 cv-pdf + 26 seo + 43 app-shared)
pnpm run build         # 6 apps OK, 36 pages
```

Verificar render del CV:

```bash
grep -o "Lima, Perú · [^<]*" apps/generic/public/cv.html apps/generic/public/cv-es.html apps/generic/public/cv-en.html
# Esperado:
# cv-es.html:  Lima, Perú · Disponible remoto · zona horaria LATAM/US
# cv-en.html:  Lima, Perú · Remote-friendly · LATAM/US timezone
```

Verificar eyebrow en hero (preview):

```bash
pnpm run preview
# Visitar:
#   http://localhost:4321        -> generic       (eyebrow default con Remoto LATAM/US)
#   http://hub.localhost:4322    -> hub           (eyebrow hardcoded actualizado)
#   http://fintech.localhost:... -> fintech       (override + Remoto LATAM/US)
#   (idem leader, vibe, architect)
```

Verificar JSON-LD ProfilePage:

```bash
curl -s https://fintech.the-full-stack.com/ | grep -o '"ProfilePage"[^]]*' | head -1
# Debe contener: "occupationLocation":[{"@type":"Country","name":"Peru"},{"@type":"VirtualLocation","name":"Remote · LATAM/US timezone"}]
# Y: "seeks":{"@type":"Demand","name":"Remote senior full stack roles (LATAM/US)"}
```

Verificar llms.txt:

```bash
grep "Availability" apps/generic/public/llms.txt
# Esperado: ...Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
```

## TODO

Vacio.