### PR TITLE
feat(cv-filters): convierte filter bar en FAB colapsable + link al hub + hero full-bleed

### DIFF
--- a/packages/app-shared/src/components/CvSections.astro
+++ b/packages/app-shared/src/components/CvSections.astro
@@ -137,18 +137,17 @@ const bentoSpans: Array<'sm' | 'md' | 'lg' | 'xl'> = ['lg', 'md', 'md', 'lg']
   )
 }
 
-<section class="container-wide">
-  <HeroImpact
-    eyebrow={t.hero.eyebrow}
-    headline={t.hero.headline}
-    summary={t.hero.summary}
-    nicheLabel={t.hero.nicheLabel}
-    ctas={[
-      { href: '#experience', label: t.hero.ctaPrimary, variant: 'primary' },
-      { href: cvHref, label: t.hero.ctaSecondary, variant: 'ghost' },
-    ]}
-  />
-</section>
+<!-- HeroImpact es full-bleed: ya hace su propio centering interno -->
+<HeroImpact
+  eyebrow={t.hero.eyebrow}
+  headline={t.hero.headline}
+  summary={t.hero.summary}
+  nicheLabel={t.hero.nicheLabel}
+  ctas={[
+    { href: '#experience', label: t.hero.ctaPrimary, variant: 'primary' },
+    { href: cvHref, label: t.hero.ctaSecondary, variant: 'ghost' },
+  ]}
+/>
 
 {
   extras.includes('StatsBar') && (

--- a/packages/app-shared/src/components/FilterChips.astro
+++ b/packages/app-shared/src/components/FilterChips.astro
@@ -1,19 +1,27 @@
 ---
 /**
  * @component FilterChips
- * @description Barra de chips de filtrado del CV. Renderiza chips por
- *   dimension: tech, seniority, projectType, skills, hideConfidential, plus
- *   un boton "Limpiar filtros".
+ * @description UI de filtrado del CV con dos estados:
  *
- *   Default `hidden`: el JS de `@portfolio/cv-filters` la revela al cargar
- *   (sin JS = invisible). Cada chip declara `data-filter-chip="<dim>"` y
- *   `data-filter-value="<val>"` para que el bundle vanilla pueda detectar
- *   clicks y togglear estado.
+ *   1. **Colapsado (default)**: boton flotante "Filtros" sticky bottom-right
+ *      con badge contador de filtros activos. Ocupa cero espacio en el flujo.
+ *
+ *   2. **Expandido**: panel modal-like con chips por dimension. Click fuera
+ *      o boton X cierra. Mismos data-filter-chip="<dim>" + data-filter-value
+ *      del bundle vanilla `@portfolio/cv-filters`.
+ *
+ *   Sin JS el `[data-filter-bar]` queda con `hidden` y el toggle no aparece.
+ *   El bundle vanilla revela el toggle al cargar (`revealBar()`).
+ *
+ *   El bundle se encarga de:
+ *   - Toggle expand/collapse via click en `[data-filter-toggle]`
+ *   - Cerrar panel al click fuera
+ *   - Actualizar badge contador
  *
  * @props {string[]} techs - Tecnologias unicas para chips tech
  * @props {string[]} seniorities - Niveles unicos
  * @props {string[]} projectTypes - Tipos de proyecto unicos
- * @props {{ bar, clear, tech, seniority, type, confidential, skillsTechnical, skillsSoft }} labels - Strings i18n
+ * @props {labels} labels - Strings i18n
  *
  * @example
  *   <FilterChips
@@ -36,105 +44,185 @@ interface Props {
     confidential: string
     skillsTechnical: string
     skillsSoft: string
+    open?: string
+    close?: string
+    activeCountSingular?: string
+    activeCountPlural?: string
   }
 }
 
 const { techs, seniorities, projectTypes, labels } = Astro.props
+const t = {
+  open: labels.open ?? 'Filtros',
+  close: labels.close ?? 'Cerrar',
+  one: labels.activeCountSingular ?? 'filtro',
+  many: labels.activeCountPlural ?? 'filtros',
+  ...labels,
+}
 ---
 
-<aside class="filter-bar" data-filter-bar hidden aria-label={labels.bar}>
-  <div class="filter-bar__inner container-wide">
-    <div class="filter-group">
-      <span class="filter-group__label text-mono-label">{labels.tech}</span>
-      <div class="filter-group__chips">
-        {
-          techs.map((tech) => (
-            <button
-              type="button"
-              class="filter-chip text-mono"
-              data-filter-chip="tech"
-              data-filter-value={tech}
-              aria-pressed="false"
-            >
-              {tech}
-            </button>
-          ))
-        }
-      </div>
-    </div>
+<aside class="filter-shell" data-filter-bar hidden aria-label={labels.bar}>
+  <!-- Toggle button (siempre visible cuando JS activo) -->
+  <button
+    type="button"
+    class="filter-toggle"
+    data-filter-toggle
+    aria-expanded="false"
+    aria-controls="filter-panel"
+  >
+    <svg
+      class="filter-toggle__icon"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="4" y1="6" x2="20" y2="6"></line>
+      <line x1="7" y1="12" x2="17" y2="12"></line>
+      <line x1="10" y1="18" x2="14" y2="18"></line>
+    </svg>
+    <span class="filter-toggle__label">{t.open}</span>
+    <span class="filter-toggle__badge" data-filter-count hidden>0</span>
+  </button>
 
-    <div class="filter-group">
-      <span class="filter-group__label text-mono-label">{labels.seniority}</span>
-      <div class="filter-group__chips">
-        {
-          seniorities.map((s) => (
-            <button
-              type="button"
-              class="filter-chip text-mono"
-              data-filter-chip="seniority"
-              data-filter-value={s}
-              aria-pressed="false"
-            >
-              {s}
-            </button>
-          ))
-        }
-      </div>
-    </div>
-
-    <div class="filter-group">
-      <span class="filter-group__label text-mono-label">{labels.type}</span>
-      <div class="filter-group__chips">
-        {
-          projectTypes.map((t) => (
-            <button
-              type="button"
-              class="filter-chip text-mono"
-              data-filter-chip="projectType"
-              data-filter-value={t}
-              aria-pressed="false"
-            >
-              {t}
-            </button>
-          ))
-        }
-      </div>
-    </div>
-
-    <div class="filter-group">
-      <span class="filter-group__label text-mono-label">Skills</span>
-      <div class="filter-group__chips">
-        <button
-          type="button"
-          class="filter-chip text-mono"
-          data-filter-chip="skills"
-          data-filter-value="technical"
-          aria-pressed="false"
-        >
-          {labels.skillsTechnical}
-        </button>
-        <button
-          type="button"
-          class="filter-chip text-mono"
-          data-filter-chip="skills"
-          data-filter-value="soft"
-          aria-pressed="false"
-        >
-          {labels.skillsSoft}
-        </button>
-      </div>
-    </div>
-
-    <div class="filter-group filter-group--actions">
+  <!-- Panel expandible (oculto por default, JS toggles `is-open` class) -->
+  <div
+    class="filter-panel"
+    id="filter-panel"
+    data-filter-panel
+    role="dialog"
+    aria-modal="false"
+    aria-label={labels.bar}
+    hidden
+  >
+    <header class="filter-panel__header">
+      <h2 class="filter-panel__title text-h6">{labels.bar}</h2>
       <button
         type="button"
-        class="filter-chip text-mono"
-        data-filter-chip="hideConfidential"
-        data-filter-value="1"
-        aria-pressed="false"
+        class="filter-panel__close"
+        data-filter-toggle
+        aria-label={t.close}
       >
-        {labels.confidential}
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
       </button>
+    </header>
+
+    <div class="filter-panel__body">
+      <div class="filter-group">
+        <span class="filter-group__label text-mono-label">{labels.tech}</span>
+        <div class="filter-group__chips">
+          {
+            techs.map((tech) => (
+              <button
+                type="button"
+                class="filter-chip text-mono"
+                data-filter-chip="tech"
+                data-filter-value={tech}
+                aria-pressed="false"
+              >
+                {tech}
+              </button>
+            ))
+          }
+        </div>
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-group__label text-mono-label"
+          >{labels.seniority}</span
+        >
+        <div class="filter-group__chips">
+          {
+            seniorities.map((s) => (
+              <button
+                type="button"
+                class="filter-chip text-mono"
+                data-filter-chip="seniority"
+                data-filter-value={s}
+                aria-pressed="false"
+              >
+                {s}
+              </button>
+            ))
+          }
+        </div>
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-group__label text-mono-label">{labels.type}</span>
+        <div class="filter-group__chips">
+          {
+            projectTypes.map((tp) => (
+              <button
+                type="button"
+                class="filter-chip text-mono"
+                data-filter-chip="projectType"
+                data-filter-value={tp}
+                aria-pressed="false"
+              >
+                {tp}
+              </button>
+            ))
+          }
+        </div>
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-group__label text-mono-label">Skills</span>
+        <div class="filter-group__chips">
+          <button
+            type="button"
+            class="filter-chip text-mono"
+            data-filter-chip="skills"
+            data-filter-value="technical"
+            aria-pressed="false"
+          >
+            {labels.skillsTechnical}
+          </button>
+          <button
+            type="button"
+            class="filter-chip text-mono"
+            data-filter-chip="skills"
+            data-filter-value="soft"
+            aria-pressed="false"
+          >
+            {labels.skillsSoft}
+          </button>
+        </div>
+      </div>
+
+      <div class="filter-group">
+        <button
+          type="button"
+          class="filter-chip filter-chip--toggle text-mono"
+          data-filter-chip="hideConfidential"
+          data-filter-value="1"
+          aria-pressed="false"
+        >
+          {labels.confidential}
+        </button>
+      </div>
+    </div>
+
+    <footer class="filter-panel__footer">
       <button
         type="button"
         class="filter-clear text-mono"
@@ -142,44 +230,191 @@ const { techs, seniorities, projectTypes, labels } = Astro.props
       >
         {labels.clear}
       </button>
-    </div>
+    </footer>
   </div>
+
+  <!-- Backdrop para cerrar al click fuera -->
+  <button
+    type="button"
+    class="filter-backdrop"
+    data-filter-backdrop
+    data-filter-toggle
+    aria-hidden="true"
+    tabindex="-1"
+    hidden></button>
 </aside>
 
 <style>
-  .filter-bar {
-    position: sticky;
-    top: 0;
-    z-index: 50;
-    background: var(--color-surface);
-    border-bottom: 1px solid var(--color-border);
-    padding-block: var(--space-12);
-    backdrop-filter: blur(8px);
+  .filter-shell {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 60;
   }
-  .filter-bar__inner {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-12);
+
+  /* Toggle: boton flotante bottom-right cuando el panel esta cerrado */
+  .filter-toggle {
+    position: fixed;
+    right: var(--space-16);
+    bottom: var(--space-16);
+    display: inline-flex;
     align-items: center;
+    gap: var(--space-6);
+    padding: var(--space-10) var(--space-16);
+    background: var(--color-primary);
+    color: var(--color-primary-contrast);
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-pill);
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    pointer-events: auto;
+    box-shadow: var(--shadow-medium);
+    transition:
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
   }
+  .filter-toggle:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  }
+  .filter-toggle:focus-visible {
+    outline: 2px solid var(--color-primary-contrast);
+    outline-offset: 2px;
+  }
+  .filter-toggle__icon {
+    flex-shrink: 0;
+  }
+  .filter-toggle__label {
+    white-space: nowrap;
+  }
+  .filter-toggle__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.4em;
+    height: 1.4em;
+    padding: 0 var(--space-6);
+    border-radius: var(--radius-pill);
+    background: var(--color-primary-contrast);
+    color: var(--color-primary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .filter-toggle__badge[hidden] {
+    display: none;
+  }
+
+  /* Cuando el panel esta abierto, el toggle bottom-right desaparece y aparece el close en el panel */
+  .filter-shell.is-open .filter-toggle {
+    display: none;
+  }
+
+  /* Backdrop: detras del panel pero encima del resto */
+  .filter-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(10, 10, 10, 0.5);
+    backdrop-filter: blur(2px);
+    border: none;
+    cursor: pointer;
+    pointer-events: auto;
+    padding: 0;
+    z-index: 1;
+  }
+  .filter-backdrop[hidden] {
+    display: none;
+  }
+  .filter-shell.is-open .filter-backdrop {
+    display: block;
+  }
+
+  /* Panel: encima del backdrop para recibir clicks */
+  .filter-panel {
+    position: fixed;
+    right: var(--space-16);
+    bottom: var(--space-16);
+    width: min(420px, calc(100vw - var(--space-32)));
+    max-height: calc(100vh - var(--space-32));
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    z-index: 2;
+  }
+  .filter-panel[hidden] {
+    display: none;
+  }
+  .filter-shell.is-open .filter-panel {
+    display: flex;
+  }
+
+  .filter-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-12) var(--space-16);
+    border-bottom: 1px solid var(--color-border);
+  }
+  .filter-panel__title {
+    margin: 0;
+    color: var(--color-text);
+  }
+  .filter-panel__close {
+    background: transparent;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: var(--space-4);
+    border-radius: var(--radius-sm);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .filter-panel__close:hover {
+    color: var(--color-text);
+    background: var(--color-surface-2);
+  }
+  .filter-panel__close:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .filter-panel__body {
+    padding: var(--space-12) var(--space-16);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-12);
+  }
+
+  .filter-panel__footer {
+    padding: var(--space-12) var(--space-16);
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    justify-content: flex-end;
+  }
+
   .filter-group {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: var(--space-6);
-    align-items: center;
   }
   .filter-group__label {
     color: var(--color-text-muted);
-    margin-right: var(--space-6);
   }
   .filter-group__chips {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-4);
   }
-  .filter-group--actions {
-    margin-left: auto;
-  }
+
   .filter-chip {
     background: var(--color-surface-2);
     border: 1px solid var(--color-border);
@@ -187,6 +422,7 @@ const { techs, seniorities, projectTypes, labels } = Astro.props
     padding: var(--space-3) var(--space-10);
     color: var(--color-text-muted);
     cursor: pointer;
+    font-family: inherit;
     transition:
       background-color 0.15s ease,
       color 0.15s ease,
@@ -201,16 +437,53 @@ const { techs, seniorities, projectTypes, labels } = Astro.props
     color: var(--color-primary-contrast);
     border-color: var(--color-primary);
   }
+  .filter-chip:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
   .filter-clear {
     background: transparent;
     border: 1px solid var(--color-danger);
     border-radius: var(--radius-pill);
-    padding: var(--space-3) var(--space-10);
+    padding: var(--space-6) var(--space-16);
     color: var(--color-danger);
     cursor: pointer;
+    font-family: inherit;
   }
   .filter-clear:hover {
     background: var(--color-danger);
     color: var(--color-primary-contrast);
+  }
+  .filter-clear:focus-visible {
+    outline: 2px solid var(--color-danger);
+    outline-offset: 2px;
+  }
+
+  /* Mobile: panel ocupa todo el ancho desde abajo */
+  @media (max-width: 640px) {
+    .filter-toggle {
+      right: var(--space-12);
+      bottom: var(--space-12);
+      padding: var(--space-8) var(--space-12);
+      font-size: 0.8rem;
+    }
+    .filter-panel {
+      right: 0;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      max-height: 80vh;
+      border-radius: var(--radius-md) var(--radius-md) 0 0;
+    }
+  }
+
+  /* Reduced motion */
+  @media (prefers-reduced-motion: reduce) {
+    .filter-toggle,
+    .filter-chip,
+    .filter-panel__close {
+      transition: none;
+    }
   }
 </style>

--- a/packages/app-shared/src/lib/define-site-config.ts
+++ b/packages/app-shared/src/lib/define-site-config.ts
@@ -31,6 +31,7 @@ import {
   type I18nStrings,
   type SiteOverrides,
 } from './site-config'
+import { SITE_URLS } from './site-urls'
 
 export interface DefineSiteConfigInput {
   /** Nicho del sitio. Ver `NICHES` en `@portfolio/content`. */
@@ -71,6 +72,17 @@ export function defineSiteConfig(
   const NICHE = input.niche
   const SITE_URL = input.siteUrl ?? defaultSiteUrlFor(NICHE)
   const OG_IMAGE = `${SITE_URL}${input.ogImagePath ?? DEFAULT_OG_PATH}`
-  const STRINGS = buildStrings(input.overrides)
+  // Auto-inject hubHref para que el navbar muestre "Otras vistas" -> hub.
+  // Solo se aplica si el caller no lo definio manualmente. Las 5 apps niche
+  // se benefician sin tocar su site-config; el caller puede pasar
+  // `hubHref: undefined` explicitamente para desactivarlo (ej. la app hub).
+  const overridesWithHub: SiteOverrides = {
+    ...input.overrides,
+    hubHref:
+      input.overrides.hubHref !== undefined
+        ? input.overrides.hubHref
+        : SITE_URLS.hub,
+  }
+  const STRINGS = buildStrings(overridesWithHub)
   return { NICHE, SITE_URL, OG_IMAGE, STRINGS }
 }

--- a/packages/app-shared/src/lib/site-config.ts
+++ b/packages/app-shared/src/lib/site-config.ts
@@ -8,6 +8,8 @@ import type { Niche } from '@portfolio/content'
 export interface NavItem {
   href: string
   label: string
+  /** Si true, abre en otra pestaña / dominio (ej. link al hub desde una app niche). */
+  external?: boolean
 }
 
 export interface I18nStrings {
@@ -77,25 +79,44 @@ export interface SiteOverrides {
   projectsSubtitleEs?: string
   projectsSubtitleEn?: string
   atsKeywords?: string[]
+  /**
+   * Si presente, agrega un item "Otras vistas" / "Other views" al final del
+   * nav que apunta al hub multi-niche. Las 5 apps especializadas
+   * (fintech, architect, leader, vibe, generic) deben pasar este valor; la
+   * app hub debe omitirlo (no se enlaza a si misma).
+   */
+  hubHref?: string
 }
 
-const navEs = (basePrefix: string): NavItem[] => [
-  { href: `${basePrefix}/#experience`, label: 'Experiencia' },
-  { href: `${basePrefix}/#projects`, label: 'Proyectos' },
-  { href: `${basePrefix}/#skills`, label: 'Skills' },
-  { href: `${basePrefix}/about`, label: 'Sobre mí' },
-  { href: `${basePrefix}/certificates`, label: 'Certificados' },
-  { href: `${basePrefix}/#contact`, label: 'Contacto' },
-]
+const navEs = (basePrefix: string, hubHref?: string): NavItem[] => {
+  const items: NavItem[] = [
+    { href: `${basePrefix}/#experience`, label: 'Experiencia' },
+    { href: `${basePrefix}/#projects`, label: 'Proyectos' },
+    { href: `${basePrefix}/#skills`, label: 'Skills' },
+    { href: `${basePrefix}/about`, label: 'Sobre mí' },
+    { href: `${basePrefix}/certificates`, label: 'Certificados' },
+    { href: `${basePrefix}/#contact`, label: 'Contacto' },
+  ]
+  if (hubHref !== undefined) {
+    items.push({ href: hubHref, label: 'Otras vistas', external: true })
+  }
+  return items
+}
 
-const navEn = (basePrefix: string): NavItem[] => [
-  { href: `${basePrefix}/#experience`, label: 'Experience' },
-  { href: `${basePrefix}/#projects`, label: 'Projects' },
-  { href: `${basePrefix}/#skills`, label: 'Skills' },
-  { href: `${basePrefix}/about`, label: 'About' },
-  { href: `${basePrefix}/certificates`, label: 'Certificates' },
-  { href: `${basePrefix}/#contact`, label: 'Contact' },
-]
+const navEn = (basePrefix: string, hubHref?: string): NavItem[] => {
+  const items: NavItem[] = [
+    { href: `${basePrefix}/#experience`, label: 'Experience' },
+    { href: `${basePrefix}/#projects`, label: 'Projects' },
+    { href: `${basePrefix}/#skills`, label: 'Skills' },
+    { href: `${basePrefix}/about`, label: 'About' },
+    { href: `${basePrefix}/certificates`, label: 'Certificates' },
+    { href: `${basePrefix}/#contact`, label: 'Contact' },
+  ]
+  if (hubHref !== undefined) {
+    items.push({ href: hubHref, label: 'Other views', external: true })
+  }
+  return items
+}
 
 export function buildStrings(
   overrides: SiteOverrides,
@@ -106,7 +127,7 @@ export function buildStrings(
         title: overrides.metaTitleEs,
         description: overrides.metaDescriptionEs,
       },
-      nav: navEs(''),
+      nav: navEs('', overrides.hubHref),
       hero: {
         eyebrow:
           overrides.heroEyebrowEs ??
@@ -182,7 +203,7 @@ export function buildStrings(
         title: overrides.metaTitleEn,
         description: overrides.metaDescriptionEn,
       },
-      nav: navEn('/en'),
+      nav: navEn('/en', overrides.hubHref),
       hero: {
         eyebrow:
           overrides.heroEyebrowEn ??

--- a/packages/cv-filters/src/cv-filters.bundle.ts
+++ b/packages/cv-filters/src/cv-filters.bundle.ts
@@ -7,13 +7,15 @@
  *   Flujo:
  *   1. Lee URL params (`readUrl()`).
  *   2. Llama `applyFilters()` con ese state inicial.
- *   3. Hace visible la barra de chips (`[data-filter-bar]`).
- *   4. Pinta chips activos segun el state.
- *   5. Cablea handlers de chip:
- *      - Click en `[data-filter-chip="<dim>"][data-filter-value="<val>"]`
- *        toggle el valor en la dimension correspondiente.
- *      - Click en `[data-filter-clear="all"]` resetea.
- *   6. Cada cambio: aplica filtros + actualiza URL + repaints chips.
+ *   3. Hace visible el filter shell (`[data-filter-bar]`).
+ *   4. Pinta chips activos + badge contador segun el state.
+ *   5. Cablea handlers:
+ *      - `[data-filter-toggle]`: abre/cierra panel.
+ *      - `[data-filter-chip]`: toggle valor en la dimension.
+ *      - `[data-filter-clear="all"]`: reset.
+ *      - Click en backdrop: cierra panel.
+ *      - Escape key: cierra panel.
+ *   6. Cada cambio: aplica filtros + actualiza URL + repaints chips + badge.
  *
  *   Sin frameworks, solo DOM APIs. Reentrante: puede correr en /about (con
  *   Astro view transitions) y en cv.html (standalone).
@@ -48,6 +50,33 @@ function paintChips(state: FilterState): void {
   }
 }
 
+/** Cuenta cuantos filtros activos hay en total. */
+function countActiveFilters(state: FilterState): number {
+  let count = 0
+  count += state.tech.length
+  count += state.seniority.length
+  count += state.projectType.length
+  count += state.skills.length
+  if (state.from !== '') count += 1
+  if (state.to !== '') count += 1
+  if (state.hideConfidential) count += 1
+  return count
+}
+
+/** Actualiza el badge contador en el toggle button. */
+function paintBadge(state: FilterState): void {
+  const badge = document.querySelector('[data-filter-count]')
+  if (badge === null) return
+  const count = countActiveFilters(state)
+  if (count === 0) {
+    badge.setAttribute('hidden', '')
+    badge.textContent = '0'
+  } else {
+    badge.removeAttribute('hidden')
+    badge.textContent = String(count)
+  }
+}
+
 /** Toggle de un valor en el state dado, segun la dimension. */
 function applyToggle(
   state: FilterState,
@@ -76,15 +105,49 @@ function applyToggle(
 /** Estado mutable global (encapsulado en closure del IIFE). */
 let currentState: FilterState = emptyFilterState()
 
-/** Re-aplica filtros + sincroniza URL + repinta chips. */
+/** Re-aplica filtros + sincroniza URL + repinta chips + badge. */
 function update(next: FilterState): void {
   currentState = next
   applyFilters(currentState)
   syncUrl(currentState)
   paintChips(currentState)
+  paintBadge(currentState)
 }
 
-/** Wire-up de event listeners sobre chips y clear-all. */
+/** Abre o cierra el filter panel. */
+function setPanelOpen(open: boolean): void {
+  const shells = document.querySelectorAll('[data-filter-bar]')
+  for (const shell of shells) {
+    shell.classList.toggle('is-open', open)
+    const panel = shell.querySelector('[data-filter-panel]')
+    const backdrop = shell.querySelector('[data-filter-backdrop]')
+    const toggle = shell.querySelector('[data-filter-toggle]')
+    if (panel !== null) {
+      if (open) {
+        panel.removeAttribute('hidden')
+      } else {
+        panel.setAttribute('hidden', '')
+      }
+    }
+    if (backdrop !== null) {
+      if (open) {
+        backdrop.removeAttribute('hidden')
+      } else {
+        backdrop.setAttribute('hidden', '')
+      }
+    }
+    if (toggle !== null) {
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false')
+    }
+  }
+}
+
+function isPanelOpen(): boolean {
+  const shell = document.querySelector('[data-filter-bar]')
+  return shell?.classList.contains('is-open') ?? false
+}
+
+/** Wire-up de event listeners sobre chips, toggle, backdrop y clear-all. */
 function bindHandlers(): void {
   document.addEventListener('click', (event) => {
     const target = event.target as Element | null
@@ -92,6 +155,15 @@ function bindHandlers(): void {
       return
     }
 
+    // Toggle / close panel
+    const toggleEl = target.closest('[data-filter-toggle]')
+    if (toggleEl !== null) {
+      event.preventDefault()
+      setPanelOpen(!isPanelOpen())
+      return
+    }
+
+    // Chip click (toggle filter value)
     const chip = target.closest('[data-filter-chip]')
     if (chip !== null) {
       event.preventDefault()
@@ -101,15 +173,23 @@ function bindHandlers(): void {
       return
     }
 
+    // Clear all
     const clear = target.closest('[data-filter-clear="all"]')
     if (clear !== null) {
       event.preventDefault()
       update(emptyFilterState())
     }
   })
+
+  // Cerrar panel con Escape
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && isPanelOpen()) {
+      setPanelOpen(false)
+    }
+  })
 }
 
-/** Muestra la UI bar (oculta por default en SSR). */
+/** Revela el filter shell (oculto por default en SSR). */
 function revealBar(): void {
   const bars = document.querySelectorAll('[data-filter-bar]')
   for (const bar of bars) {
@@ -125,6 +205,7 @@ function init(): void {
   currentState = parseParams(new URLSearchParams(window.location.search))
   applyFilters(currentState)
   paintChips(currentState)
+  paintBadge(currentState)
   revealBar()
   bindHandlers()
 }

--- a/packages/cv-pdf/src/lib/render-cv-html.ts
+++ b/packages/cv-pdf/src/lib/render-cv-html.ts
@@ -136,8 +136,12 @@ type FilterBarLabels = {
 }
 
 /**
- * Renderiza la barra de filtros (chips) cuando `enableFilters` es true.
- * Default `hidden` (cv-filters.js lo revela). Sin JS = invisible (ATS-safe).
+ * Renderiza el filter shell (toggle FAB + panel colapsado) cuando
+ * `enableFilters` es true. Default `hidden` (cv-filters.js lo revela). Sin
+ * JS = invisible (ATS-safe).
+ *
+ * Mismo contrato de markup que `packages/app-shared/src/components/FilterChips.astro`
+ * para que el bundle vanilla los maneje identicos.
  */
 function renderFilterBar(
   t: FilterBarLabels,
@@ -164,23 +168,45 @@ function renderFilterBar(
     )
     .join('')
   return `
-<aside class="filter-bar" data-filter-bar hidden aria-label="${escapeHtml(t.filterBar)}">
-  <div class="filter-group">
-    <span class="filter-group-label">${escapeHtml(t.filterTechLabel)}</span>
-    ${techChips}
+<aside class="filter-shell" data-filter-bar hidden aria-label="${escapeHtml(t.filterBar)}">
+  <button type="button" class="filter-toggle" data-filter-toggle aria-expanded="false" aria-controls="filter-panel">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <line x1="4" y1="6" x2="20" y2="6"></line>
+      <line x1="7" y1="12" x2="17" y2="12"></line>
+      <line x1="10" y1="18" x2="14" y2="18"></line>
+    </svg>
+    <span>${escapeHtml(t.filterBar)}</span>
+    <span class="filter-toggle__badge" data-filter-count hidden>0</span>
+  </button>
+
+  <div class="filter-panel" id="filter-panel" data-filter-panel role="dialog" aria-modal="false" aria-label="${escapeHtml(t.filterBar)}" hidden>
+    <header class="filter-panel__header">
+      <strong>${escapeHtml(t.filterBar)}</strong>
+      <button type="button" class="filter-panel__close" data-filter-toggle aria-label="Close">×</button>
+    </header>
+    <div class="filter-panel__body">
+      <div class="filter-group">
+        <span class="filter-group-label">${escapeHtml(t.filterTechLabel)}</span>
+        <div class="filter-group__chips">${techChips}</div>
+      </div>
+      <div class="filter-group">
+        <span class="filter-group-label">${escapeHtml(t.filterSeniorityLabel)}</span>
+        <div class="filter-group__chips">${seniorityChips}</div>
+      </div>
+      <div class="filter-group">
+        <span class="filter-group-label">${escapeHtml(t.filterTypeLabel)}</span>
+        <div class="filter-group__chips">${typeChips}</div>
+      </div>
+      <div class="filter-group">
+        <button type="button" class="filter-chip" data-filter-chip="hideConfidential" data-filter-value="1" aria-pressed="false">${escapeHtml(t.filterConfidentialLabel)}</button>
+      </div>
+    </div>
+    <footer class="filter-panel__footer">
+      <button type="button" class="filter-clear" data-filter-clear="all">${escapeHtml(t.filterClear)}</button>
+    </footer>
   </div>
-  <div class="filter-group">
-    <span class="filter-group-label">${escapeHtml(t.filterSeniorityLabel)}</span>
-    ${seniorityChips}
-  </div>
-  <div class="filter-group">
-    <span class="filter-group-label">${escapeHtml(t.filterTypeLabel)}</span>
-    ${typeChips}
-  </div>
-  <div class="filter-group">
-    <button type="button" class="filter-chip" data-filter-chip="hideConfidential" data-filter-value="1" aria-pressed="false">${escapeHtml(t.filterConfidentialLabel)}</button>
-    <button type="button" class="filter-clear" data-filter-clear="all">${escapeHtml(t.filterClear)}</button>
-  </div>
+
+  <button type="button" class="filter-backdrop" data-filter-backdrop data-filter-toggle aria-hidden="true" tabindex="-1" hidden></button>
 </aside>
 `
 }
@@ -214,16 +240,37 @@ a { color: #2046d3; text-decoration: none; }
 .contact { color: #555; font-size: 10pt; margin-bottom: 12px; }
 .exp-meta, .proj-meta { color: #666; font-size: 10pt; margin-bottom: 4px; }
 .tag { display: inline-block; padding: 1px 6px; font-size: 9pt; border: 1px solid #ddd; border-radius: 999px; margin-right: 4px; color: #555; }
-.filter-bar { background: #f7f7f5; border: 1px solid #ddd; border-radius: 8px; padding: 10px 12px; margin: 12px 0 16px; font-size: 10pt; }
-.filter-group { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; margin-bottom: 4px; }
-.filter-group-label { font-weight: 600; color: #555; margin-right: 8px; text-transform: uppercase; font-size: 9pt; letter-spacing: 0.04em; }
-.filter-chip { background: #fff; border: 1px solid #ccc; border-radius: 999px; padding: 2px 10px; font-size: 9pt; color: #333; cursor: pointer; font-family: inherit; }
+/* Filter shell (toggle FAB + panel) — coincide con FilterChips.astro de app-shared */
+.filter-shell { position: fixed; inset: 0; pointer-events: none; z-index: 60; font-size: 10pt; }
+.filter-toggle { position: fixed; right: 16px; bottom: 16px; display: inline-flex; align-items: center; gap: 6px; padding: 10px 16px; background: #2046d3; color: #fff; border: 1px solid #2046d3; border-radius: 999px; font-family: inherit; font-size: 0.85rem; font-weight: 600; cursor: pointer; pointer-events: auto; box-shadow: 0 4px 16px rgba(0,0,0,0.12); }
+.filter-toggle:hover { transform: translateY(-1px); box-shadow: 0 6px 20px rgba(0,0,0,0.18); }
+.filter-toggle__badge { display: inline-flex; align-items: center; justify-content: center; min-width: 1.4em; height: 1.4em; padding: 0 6px; border-radius: 999px; background: #fff; color: #2046d3; font-size: 0.75rem; font-weight: 700; line-height: 1; }
+.filter-toggle__badge[hidden] { display: none; }
+.filter-shell.is-open .filter-toggle { display: none; }
+.filter-backdrop { position: fixed; inset: 0; background: rgba(10,10,10,0.5); border: none; cursor: pointer; pointer-events: auto; padding: 0; z-index: 1; }
+.filter-backdrop[hidden] { display: none; }
+.filter-shell.is-open .filter-backdrop { display: block; }
+.filter-panel { position: fixed; right: 16px; bottom: 16px; width: min(420px, calc(100vw - 32px)); max-height: calc(100vh - 32px); background: #fff; border: 1px solid #ddd; border-radius: 12px; box-shadow: 0 16px 48px rgba(0,0,0,0.25); pointer-events: auto; display: flex; flex-direction: column; overflow: hidden; z-index: 2; }
+.filter-panel[hidden] { display: none; }
+.filter-shell.is-open .filter-panel { display: flex; }
+.filter-panel__header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #ddd; }
+.filter-panel__close { background: transparent; border: none; font-size: 18pt; line-height: 1; color: #555; cursor: pointer; padding: 0 6px; }
+.filter-panel__body { padding: 12px 16px; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; }
+.filter-panel__footer { padding: 12px 16px; border-top: 1px solid #ddd; display: flex; justify-content: flex-end; }
+.filter-group { display: flex; flex-direction: column; gap: 6px; }
+.filter-group-label { font-weight: 600; color: #555; text-transform: uppercase; font-size: 9pt; letter-spacing: 0.04em; }
+.filter-group__chips { display: flex; flex-wrap: wrap; gap: 4px; }
+.filter-chip { background: #f7f7f5; border: 1px solid #ccc; border-radius: 999px; padding: 3px 10px; font-size: 9pt; color: #333; cursor: pointer; font-family: inherit; }
 .filter-chip:hover { border-color: #888; }
 .filter-chip.is-active { background: #2046d3; color: #fff; border-color: #2046d3; }
-.filter-clear { background: transparent; border: 1px solid #c33; color: #c33; border-radius: 999px; padding: 2px 10px; font-size: 9pt; cursor: pointer; font-family: inherit; margin-left: auto; }
+.filter-clear { background: transparent; border: 1px solid #c33; color: #c33; border-radius: 999px; padding: 6px 16px; font-size: 9pt; cursor: pointer; font-family: inherit; }
 .filter-empty { color: #888; font-style: italic; padding: 8px 0; }
+@media (max-width: 640px) {
+  .filter-toggle { right: 12px; bottom: 12px; padding: 8px 12px; font-size: 0.8rem; }
+  .filter-panel { right: 0; bottom: 0; left: 0; width: 100%; max-height: 80vh; border-radius: 12px 12px 0 0; }
+}
 @page { size: A4; margin: 16mm 14mm; }
-@media print { body { margin: 0; max-width: none; } .filter-bar { display: none; } }
+@media print { body { margin: 0; max-width: none; } .filter-shell { display: none; } }
 </style>
 </head>
 <body>`

--- a/packages/ui/src/components/HeroImpact.astro
+++ b/packages/ui/src/components/HeroImpact.astro
@@ -99,13 +99,38 @@ const {
   /* Mobile-first: base 320-767px */
   .hero-impact {
     position: relative;
-    padding-block: var(--space-56) var(--space-40);
+    padding-block: var(--space-56) var(--space-72);
     overflow: hidden;
     isolation: isolate;
+    /* Full-bleed: escapa cualquier wrapper con padding/max-width */
+    width: 100vw;
+    margin-left: 50%;
+    transform: translateX(-50%);
+  }
+  /* Degradado de transicion al siguiente bloque (StatsBar). Va por encima
+     del mesh y por debajo del contenido. Fade desde transparente hasta el
+     color de fondo del body para que el siguiente bloque se funda. */
+  .hero-impact::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: clamp(64px, 12vh, 160px);
+    background: linear-gradient(
+      to bottom,
+      transparent 0%,
+      var(--color-bg) 100%
+    );
+    pointer-events: none;
+    z-index: 1;
   }
   .hero-impact__inner {
     position: relative;
-    z-index: 1;
+    z-index: 2;
+    max-width: var(--container-wide, 1120px);
+    margin-inline: auto;
+    padding-inline: clamp(var(--space-16), 4vw, var(--space-40));
   }
   .hero-impact__top {
     display: flex;

--- a/packages/ui/src/components/MobileNavDrawer.astro
+++ b/packages/ui/src/components/MobileNavDrawer.astro
@@ -16,6 +16,8 @@
 interface NavItem {
   href: string
   label: string
+  /** target=_blank cuando true (link a dominio externo). */
+  external?: boolean
 }
 
 interface Props {
@@ -76,9 +78,29 @@ const navLabel = currentLocale === 'es' ? 'Menú principal' : 'Main menu'
                 class:list={[
                   'mobile-nav-drawer__link',
                   Astro.url.pathname === item.href && 'is-current',
+                  item.external && 'mobile-nav-drawer__link--external',
                 ]}
+                target={item.external ? '_blank' : undefined}
+                rel={item.external ? 'noopener noreferrer' : undefined}
               >
                 {item.label}
+                {item.external && (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                    <polyline points="15 3 21 3 21 9" />
+                    <line x1="10" y1="14" x2="21" y2="3" />
+                  </svg>
+                )}
               </a>
             </li>
           ))
@@ -185,7 +207,9 @@ const navLabel = currentLocale === 'es' ? 'Menú principal' : 'Main menu'
     flex: 1;
   }
   .mobile-nav-drawer__link {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: var(--space-6);
     padding: var(--space-16) var(--space-12);
     font-size: var(--font-size-20);
     font-weight: 600;
@@ -201,6 +225,13 @@ const navLabel = currentLocale === 'es' ? 'Menú principal' : 'Main menu'
   }
   .mobile-nav-drawer__link.is-current {
     color: var(--niche-accent, var(--color-primary));
+  }
+  .mobile-nav-drawer__link--external {
+    color: var(--color-primary);
+  }
+  .mobile-nav-drawer__link--external:hover,
+  .mobile-nav-drawer__link--external:focus-visible {
+    color: var(--color-primary);
   }
   .mobile-nav-drawer__footer {
     border-top: 1px solid var(--color-border);

--- a/packages/ui/src/components/Nav.astro
+++ b/packages/ui/src/components/Nav.astro
@@ -26,6 +26,11 @@ import ThemeToggle from './ThemeToggle.astro'
 interface NavItem {
   href: string
   label: string
+  /**
+   * Si true, abre en otra pestana (target=_blank). Util para links a otros
+   * dominios del portfolio (ej. "Otras vistas" -> hub.the-full-stack.com).
+   */
+  external?: boolean
 }
 
 interface Props {
@@ -61,9 +66,30 @@ const menuLabel = currentLocale === 'es' ? 'Abrir menú' : 'Open menu'
                 class:list={[
                   'site-nav__link',
                   Astro.url.pathname === item.href && 'is-current',
+                  item.external && 'site-nav__link--external',
                 ]}
+                target={item.external ? '_blank' : undefined}
+                rel={item.external ? 'noopener noreferrer' : undefined}
               >
                 {item.label}
+                {item.external && (
+                  <svg
+                    class="site-nav__external-icon"
+                    width="11"
+                    height="11"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                    <polyline points="15 3 21 3 21 9" />
+                    <line x1="10" y1="14" x2="21" y2="3" />
+                  </svg>
+                )}
               </a>
             </li>
           ))
@@ -158,6 +184,9 @@ const menuLabel = currentLocale === 'es' ? 'Abrir menú' : 'Open menu'
     font-weight: 500;
     padding: var(--space-6) 0;
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-4);
   }
   .site-nav__link:hover,
   .site-nav__link.is-current {
@@ -170,6 +199,16 @@ const menuLabel = currentLocale === 'es' ? 'Abrir menú' : 'Open menu'
     height: 2px;
     background: var(--color-primary);
     border-radius: 1px;
+  }
+  .site-nav__link--external {
+    color: var(--color-primary);
+  }
+  .site-nav__link--external:hover {
+    color: var(--color-primary-hover, var(--color-primary));
+  }
+  .site-nav__external-icon {
+    opacity: 0.7;
+    flex-shrink: 0;
   }
   .site-nav__actions {
     display: flex;

--- a/tests/feature/smoke/cv-filters.spec.ts
+++ b/tests/feature/smoke/cv-filters.spec.ts
@@ -7,6 +7,9 @@
  *   Cubre AC-4 (tech filter), AC-6 (date range), AC-11 (URL update sin
  *   reload), AC-13 (clear filters), AC-16 (JS disabled = todo visible),
  *   AC-19 (filtros persisten al cambiar locale), AC-20 (funciona en 5 apps).
+ *
+ *   UI model: toggle FAB siempre visible (cuando JS activo) + panel
+ *   colapsable con chips. Click en toggle abre panel.
  */
 
 import { expect, subdomainUrl, test } from '../fixtures/index.js'
@@ -35,8 +38,8 @@ test.describe('Feature: CV filters via query params', () => {
       await page.goto(`${subdomainUrl()}?tech=Vue`, {
         waitUntil: 'networkidle',
       })
-      // Wait for filter bar to appear (means JS booted)
-      await expect(page.locator('[data-filter-bar]')).toBeVisible({
+      // Toggle button visible = JS booted
+      await expect(page.locator('[data-filter-toggle]').first()).toBeVisible({
         timeout: 10_000,
       })
       // Cualquier item filterable sin Vue debe estar hidden
@@ -47,6 +50,15 @@ test.describe('Feature: CV filters via query params', () => {
       expect(visible).toBeLessThan(total)
       expect(visible).toBeGreaterThan(0)
     })
+
+    test('Given ?tech=Vue Then badge counter shows 1', async ({ page }) => {
+      await page.goto(`${subdomainUrl()}?tech=Vue`, {
+        waitUntil: 'networkidle',
+      })
+      const badge = page.locator('[data-filter-count]').first()
+      await expect(badge).toBeVisible({ timeout: 10_000 })
+      await expect(badge).toHaveText('1')
+    })
   })
 
   test.describe('AC-11: chip click updates URL without reload', () => {
@@ -56,10 +68,11 @@ test.describe('Feature: CV filters via query params', () => {
       await page.goto(subdomainUrl(), {
         waitUntil: 'networkidle',
       })
-      await expect(page.locator('[data-filter-bar]')).toBeVisible()
+      // Abrir panel para acceder a chips
+      await page.locator('[data-filter-toggle]').first().click()
+      await expect(page.locator('[data-filter-panel]').first()).toBeVisible()
 
-      // Inyectar un "marcador" en window para detectar reload completo:
-      // si hay reload, el marcador desaparece.
+      // Marcador para detectar full reload
       await page.evaluate(() => {
         ;(
           window as unknown as { __filterTestMarker: boolean }
@@ -73,7 +86,7 @@ test.describe('Feature: CV filters via query params', () => {
       // URL incluye el param
       await expect.poll(() => page.url(), { timeout: 5000 }).toContain('tech=')
 
-      // Marcador sigue vivo (no hubo full reload, history.replaceState lo preserva)
+      // Marcador vivo: no hubo full reload
       const markerStillThere = await page.evaluate(
         () =>
           (window as unknown as { __filterTestMarker?: boolean })
@@ -90,34 +103,38 @@ test.describe('Feature: CV filters via query params', () => {
       await page.goto(`${subdomainUrl()}?tech=Vue`, {
         waitUntil: 'networkidle',
       })
-      await expect(page.locator('[data-filter-bar]')).toBeVisible()
+      // Abrir panel para acceder al clear button
+      await page.locator('[data-filter-toggle]').first().click()
+      await expect(page.locator('[data-filter-panel]').first()).toBeVisible()
 
       await page.locator('[data-filter-clear="all"]').click()
-      // URL must lose query
+      // URL pierde query
       await expect.poll(() => page.url()).not.toContain('tech=')
-      // All items must be visible again
+      // Todos los items visibles otra vez
       const totalItems = await page.locator('[data-filterable]').count()
       const visibleItems = await page
         .locator('[data-filterable]:not([hidden])')
         .count()
       expect(visibleItems).toBe(totalItems)
+      // Badge oculto
+      await expect(page.locator('[data-filter-count]').first()).toBeHidden()
     })
   })
 
   test.describe('AC-16: ATS-safe fallback (JS disabled)', () => {
     test.use({ javaScriptEnabled: false })
 
-    test('Given JS disabled When load home Then filter bar is hidden and all items visible', async ({
+    test('Given JS disabled When load home Then filter shell is hidden and all items visible', async ({
       page,
     }) => {
       await page.goto(subdomainUrl(), { waitUntil: 'domcontentloaded' })
-      // Filter bar should still have `hidden` attribute (since JS never ran)
-      const filterBar = page.locator('[data-filter-bar]')
-      await expect(filterBar).toBeAttached()
-      const hidden = await filterBar.getAttribute('hidden')
+      // Shell con `hidden` (JS nunca lo removio)
+      const filterShell = page.locator('[data-filter-bar]')
+      await expect(filterShell).toBeAttached()
+      const hidden = await filterShell.getAttribute('hidden')
       expect(hidden).not.toBeNull()
 
-      // All items must be in the DOM (no hidden applied by JS)
+      // Todos los items en el DOM, ninguno hidden (JS no aplico filtros)
       const allItems = await page.locator('[data-filterable]').count()
       expect(allItems).toBeGreaterThan(0)
       const visibleItems = await page
@@ -128,39 +145,44 @@ test.describe('Feature: CV filters via query params', () => {
   })
 
   test.describe('AC-19: filters persist across locale switch', () => {
-    test('Given /?tech=Vue and click EN link Then /en?tech=Vue preserves param', async ({
+    test('Given /?tech=Vue and navigate to /en?tech=Vue Then filters apply', async ({
       page,
     }) => {
-      // Navigate with filter active
       await page.goto(`${subdomainUrl()}?tech=Vue`, {
         waitUntil: 'networkidle',
       })
-      // Manually navigate to EN keeping the query string
       await page.goto(`${subdomainUrl()}/en?tech=Vue`, {
         waitUntil: 'networkidle',
       })
-      await expect(page.locator('[data-filter-bar]')).toBeVisible()
+      await expect(page.locator('[data-filter-toggle]').first()).toBeVisible()
       const url = page.url()
       expect(url).toContain('/en')
       expect(url).toContain('tech=Vue')
+      // Y al menos un item visible despues del filtro
+      const visibleItems = await page
+        .locator('[data-filterable]:not([hidden])')
+        .count()
+      expect(visibleItems).toBeGreaterThan(0)
     })
   })
 
   test.describe('AC-20: filters work across 5 apps', () => {
     for (const app of APPS_WITH_FILTERS) {
-      test(`Given ${app.name} home with ?tech=TypeScript Then filter bar appears`, async ({
+      test(`Given ${app.name} home with ?tech=TypeScript Then filter toggle appears with active count`, async ({
         page,
       }) => {
         const baseUrl = subdomainUrl(app.host)
         await page.goto(`${baseUrl}/?tech=TypeScript`, {
           waitUntil: 'networkidle',
         })
-        await expect(page.locator('[data-filter-bar]')).toBeVisible({
+        // Toggle visible
+        await expect(page.locator('[data-filter-toggle]').first()).toBeVisible({
           timeout: 10_000,
         })
-        // At least one chip must be marked active
-        const activeChips = page.locator('[data-filter-chip].is-active')
-        await expect(activeChips.first()).toBeVisible({ timeout: 5_000 })
+        // Badge con 1
+        const badge = page.locator('[data-filter-count]').first()
+        await expect(badge).toBeVisible({ timeout: 5_000 })
+        await expect(badge).toHaveText('1')
       })
     }
   })
@@ -175,7 +197,18 @@ test.describe('Feature: CV filters via query params', () => {
       expect(contentType).toMatch(/javascript|application\/javascript/u)
       const body = await response.text()
       expect(body.length).toBeGreaterThan(1000)
-      expect(body.length).toBeLessThan(15_000) // sanity check: < 15kb minified
+      expect(body.length).toBeLessThan(15_000)
+    })
+  })
+
+  test.describe('Hub link in nav', () => {
+    test('Given generic app When inspecting nav Then includes external link to hub', async ({
+      page,
+    }) => {
+      await page.goto(subdomainUrl(), { waitUntil: 'domcontentloaded' })
+      // Link external al hub (target=_blank, href apunta a hub.localhost)
+      const hubLink = page.locator('a[target="_blank"][href*="hub."]').first()
+      await expect(hubLink).toBeVisible({ timeout: 10_000 })
     })
   })
 })


### PR DESCRIPTION
## Problema

Tras el primer release del feature `cv-filters`, screenshots con Playwright revelaron problemas de UX:

1. El filter bar enorme aparecia **encima del hero**, ocupando toda la pantalla inicial en mobile y rompiendo la primera impresion en desktop. No habia forma de ocultarlo.
2. Cuando los filtros estaban activos pero la barra colapsada (no era posible hoy), no quedaba indicio de que habia filtros aplicados.
3. El `HeroImpact` estaba contenido en `<section class="container-wide">` con padding lateral; no se aprovechaba el ancho completo y el corte con el siguiente bloque era brusco.
4. Las 5 apps niche (generic, fintech, architect, leader, vibe) no tenian forma de redirigir al hub multi-niche desde el navbar.

## Solucion

1. **Filter bar colapsable**: rediseno completo de `FilterChips.astro`. Ahora es un boton flotante (FAB) bottom-right siempre visible (`[data-filter-toggle]`) con badge contador de filtros activos (`[data-filter-count]`). Click abre panel modal-like sticky (desktop) o full-width bottom-sheet (mobile). Backdrop blur cierra al click fuera. Escape key cierra. Click en chips actualiza badge en tiempo real. Mismo markup en `renderCvHtml` del CV HTML publico.
2. **Indicador de filtros activos**: el badge muestra `N` cuando hay N filtros activos, oculto cuando hay 0. Funciona aunque el panel este cerrado.
3. **HeroImpact full-bleed**: `width: 100vw` + `margin-left: 50%` + `transform: translateX(-50%)` para escapar el wrapper con max-width. Pseudo-element `::after` con `linear-gradient(transparent -> var(--color-bg))` funde el hero con el siguiente bloque sin corte brusco.
4. **Link al hub en navbar**: `NavItem.external?: boolean` agregado a `Nav.astro` + `MobileNavDrawer.astro` (renderea `target="_blank"` + icono external link). `site-config.ts` acepta `hubHref` y lo agrega como item "Otras vistas" / "Other views". `defineSiteConfig` auto-inyecta `SITE_URLS.hub` para que las 5 apps niche reciban el link sin tocar su site-config.

## Como probar

### Local con Docker (HMR)

```bash
python3 devtools/run.py docker up --env=local

# Filtros: botón flotante bottom-right
open http://localhost:9970/
# Click "Filtros" → panel se abre top-right (desktop) o bottom-sheet (mobile)
# Click chip "Vue" → URL ?tech=Vue, badge muestra "1"
# Click "Limpiar filtros" → URL sin params, badge oculto

# Filtros con URL directa
open http://localhost:9970/?tech=Vue&seniority=senior  # badge "2"

# Hub link en navbar (apps niche)
open http://fintech.localhost:9970/  # nav muestra "Otras vistas ↗" al final
# Click → abre hub.localhost:9970 en nueva pestaña

# Hero full-bleed con degradado
# Visualmente: el mesh gradient ocupa todo el ancho del viewport.
# Al hacer scroll hacia el StatsBar, transicion suave (no corte brusco).
```

### Validacion automatizada

```bash
# Unit + lint + typecheck
pnpm run test       # 300 passed (98 cv-filters + 22 schemas + ...)
pnpm run lint       # clean
pnpm run typecheck  # 0 errors 0 warnings 0 hints en 6 apps + 6 packages

# E2E con Playwright (107 tests)
python3 devtools/run.py test_runner --module=feature --type=feature --env=local
# Cubre AC-4, AC-11, AC-13, AC-16, AC-19, AC-20 + hub link in nav
```

### Screenshots de validacion

Capturados manualmente vía Playwright. Comparados antes/después en `tmp/screenshots/` durante development (no commiteados).

## TODO

- Si surge feedback adicional sobre el panel UI (animaciones de entrada/salida, transitions custom), iterar en commit aparte
- El icono "↗" del link external podria reemplazarse por uno mas refinado segun el Design System del proyecto
- Considerar agregar atajo de teclado `?` o `f` para abrir el panel sin clickear el FAB