### PR TITLE
feat(deploy): setup Cloudflare Pages via REST API + skill cloudflare-deploy

### DIFF
--- a/.claude/docs/cloudflare/01-architecture.md
+++ b/.claude/docs/cloudflare/01-architecture.md
@@ -1,0 +1,97 @@
+# Arquitectura del deploy
+
+> Como esta organizado el deploy del portfolio en Cloudflare Pages.
+
+[← README](./README.md) | [Siguiente: API token →](./02-api-token.md)
+
+## Decision: 6 proyectos Pages separados (no 1 con multi-app)
+
+Cada app del monorepo es un proyecto Pages independiente. Razones:
+
+1. **Pages no soporta multiples root_dir** dentro de un solo proyecto.
+   Si quisieras 1 proyecto, todos los `apps/*` se buildearian juntos
+   o tendrias que hacer hacky `_routes.json`.
+2. **Watch paths funciona por proyecto**: cambios en `apps/hub/` NO
+   triggean rebuild de `generic`. Si fuera 1 proyecto, cualquier cambio
+   re-buildearia todo.
+3. **Custom domains 1:1**: cada app tiene su propio subdominio. Con 1
+   proyecto, tendrias que servir todo desde un solo `pages.dev` y hacer
+   path-based routing.
+4. **Free tier scaling**: 500 builds/mes/proyecto = 3000 builds/mes
+   total. Con 1 solo proyecto seria 500 total.
+
+## Topologia
+
+```
+the-full-stack.com (zona DNS en Cloudflare)
+│
+├── @ + www              → CNAME → generic-3ab.pages.dev    [proyecto: generic]
+├── hub                  → CNAME → hub-9sd.pages.dev        [proyecto: hub]
+├── fintech              → CNAME → fintech-868.pages.dev    [proyecto: fintech]
+├── architect            → CNAME → architect-349.pages.dev  [proyecto: architect]
+├── leader               → CNAME → leader-av7.pages.dev     [proyecto: leader]
+└── vibe                 → CNAME → vibe-c2l.pages.dev       [proyecto: vibe]
+```
+
+Todos los CNAMEs estan proxied (proxy naranja activo) — el trafico pasa
+por la red de Cloudflare (cache, WAF, SSL termination en el edge).
+
+## Mapeo proyecto -> contenido
+
+| Proyecto | Package pnpm | Root del codigo | Build output |
+|----------|--------------|-----------------|--------------|
+| `generic` | `@portfolio/generic` | `apps/generic/` | `apps/generic/dist/` |
+| `hub` | `@portfolio/hub` | `apps/hub/` | `apps/hub/dist/` |
+| `fintech` | `@portfolio/fintech` | `apps/fintech/` | `apps/fintech/dist/` |
+| `architect` | `@portfolio/architect` | `apps/architect/` | `apps/architect/dist/` |
+| `leader` | `@portfolio/leader` | `apps/leader/` | `apps/leader/dist/` |
+| `vibe` | `@portfolio/vibe` | `apps/vibe/` | `apps/vibe/dist/` |
+
+## Registrar vs DNS authority (separados)
+
+- **Registrar**: AWS Route 53 (donde compraste el dominio). Renovacion y
+  WHOIS se gestionan en `console.aws.amazon.com/route53/`.
+- **DNS authority**: Cloudflare. Los nameservers (`*.ns.cloudflare.com`)
+  estan configurados en AWS Route 53 Registrar.
+- **Hosting**: Cloudflare Pages (6 proyectos).
+
+Es una configuracion estandar y correcta. **No requiere migrar el
+registrar a Cloudflare** — basta con que los nameservers en AWS apunten
+a Cloudflare.
+
+## SSL/TLS
+
+- **Universal SSL** de Cloudflare: cert automatico para cada custom
+  domain. Tarda 1-10 min en emitirse despues de attach domain.
+- CA: Google Trust Services (default actual de CF).
+- Renovacion automatica, no requiere accion manual.
+- TLS termination en el edge de CF (cliente <-> CF: HTTPS; CF <-> Pages:
+  HTTPS interno).
+
+## Headers de seguridad
+
+Cada app emite headers desde `apps/<app>/public/_headers`. Pages copia
+ese archivo al output y lo aplica a cada respuesta. Contenido tipico:
+
+```
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; ...
+```
+
+## CI/CD: git-native, no GitHub Actions para deploy
+
+Pages se dispara por webhook de GitHub al push a `main`. No requiere
+secrets en GitHub Actions, no requiere `wrangler` en CI.
+
+El workflow `.github/workflows/ci.yml` corre **paralelo**: lint +
+typecheck + unit + build + e2e. Si CI pasa y el PR se mergea a main,
+Cloudflare ejecuta su propio build (esta vez para deploy).
+
+Si en el futuro quisieras CI/CD con `wrangler-action` (deploy condicional
+por app modificada, approval gates, etc.) podrias migrar a direct upload.
+Hoy git-native es mas simple.

--- a/.claude/docs/cloudflare/02-api-token.md
+++ b/.claude/docs/cloudflare/02-api-token.md
@@ -1,0 +1,124 @@
+# API Token: permisos, creacion, rotacion
+
+> Como crear, manejar, rotar y revocar el API token de Cloudflare con
+> permisos minimos para gestionar el deploy del portfolio.
+
+[← Architecture](./01-architecture.md) | [README](./README.md) | [Siguiente: Pages API setup →](./03-pages-api-setup.md)
+
+## Permisos minimos
+
+| Resource | Permission | Scope |
+|----------|-----------|-------|
+| Account → **Cloudflare Pages** | Edit | tu account |
+| Zone → **DNS** | Edit | `the-full-stack.com` |
+| Zone → **SSL and Certificates** | Read | `the-full-stack.com` |
+| User → **User Details** | Read | All accounts |
+
+### Por que cada uno
+
+- **Pages Edit**: crear/modificar/borrar proyectos, attachar custom
+  domains, configurar env vars y build_config.
+- **DNS Edit**: crear/listar/actualizar CNAMEs en la zona.
+- **SSL Read**: verificar status de certs (Universal SSL emite solo,
+  no requiere Edit).
+- **User Details Read**: necesario para `/user/tokens/verify` (validar
+  que el token esta activo).
+
+### Permisos a EVITAR
+
+- ❌ `Account Admin` — overprovisioned
+- ❌ `API Token Management` — permite rotar el token mismo (riesgo)
+- ❌ `Account Settings: Edit` — innecesario
+- ❌ Cualquier `Zone: *` wildcard — usar zona especifica
+
+### Permisos opcionales (solo si necesario)
+
+- `Zone → Zone Settings: Edit` — si vas a cambiar Always Use HTTPS,
+  TLS minimo, etc.
+- `Zone → SSL and Certificates: Edit` — solo si gestionas certs custom
+  (no para Universal SSL).
+- `Zone → Page Rules: Edit` / `Firewall: Edit` — solo si automatizas
+  rules.
+- `Account → Workers Scripts: Edit` — solo si migras a Workers Static
+  Assets en el futuro.
+
+## Crear el token (2026)
+
+1. Dashboard https://dash.cloudflare.com/profile/api-tokens
+2. **Create Token** → **Create Custom Token** (no usar templates pre-hechos)
+3. Name: `portfolio-pages-api` (o similar identificable)
+4. Permissions: agregar los 4 de la tabla arriba
+5. Account Resources: seleccionar tu account
+6. Zone Resources: seleccionar `the-full-stack.com` (no wildcard)
+7. **TTL**: 7-30 dias (rotar regularmente). 7 dias es ideal para tareas
+   one-shot; 30 si vas a iterar.
+8. **Create Token** y **copiar inmediato** — Cloudflare lo muestra
+   UNA sola vez.
+
+## Almacenamiento local
+
+```bash
+# Template en el repo (sin valores)
+cp tmp/cloudflare-creds.env.template tmp/cloudflare-creds.env
+
+# Editar el archivo y completar:
+# CLOUDFLARE_API_TOKEN=v1.0_xxx...
+# ACCOUNT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# tmp/ esta en .gitignore — el archivo NO se commitea
+```
+
+## Verificar el token
+
+```bash
+set -a; . tmp/cloudflare-creds.env; set +a
+
+# Check token activo
+curl -s "https://api.cloudflare.com/client/v4/user/tokens/verify" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+# Esperado: success=true, status=active
+
+# Check acceso a Pages
+curl -s "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+# Esperado: success=true, result=[lista de proyectos]
+```
+
+## Account ID
+
+Dashboard → cualquier sitio en CF → panel derecho **Account ID**
+(string de 32 chars hexadecimal). NO es secreto, pero igual no lo
+publiques.
+
+## Rotacion (cada 7-30 dias)
+
+1. Crear token nuevo (mismos permisos) en el dashboard.
+2. Reemplazar el valor en `tmp/cloudflare-creds.env`.
+3. Esperar ~1h para que requests en vuelo terminen.
+4. Eliminar token viejo desde el dashboard.
+
+## Si el token se filtra
+
+**INMEDIATO:**
+
+1. Dashboard → My Profile → API Tokens → eliminar el token comprometido
+2. Si esta en historia de git: revisar con
+   `git log --all -p | grep -i cloudflare` y purgar si aparece
+   (`git filter-branch` o BFG Repo Cleaner)
+3. Crear token nuevo y actualizar `tmp/cloudflare-creds.env`
+4. Revisar Audit Logs en CF (Account → Audit Logs) por actividad
+   sospechosa con el token viejo
+
+## Cleanup despues de una tarea
+
+```bash
+# Borrar credenciales locales
+rm -f tmp/cloudflare-creds.env
+
+# Revocar token en el dashboard (no se puede via API sin permiso de
+# token management, que es justo lo que NO queremos darle)
+# → https://dash.cloudflare.com/profile/api-tokens → eliminar
+```
+
+No es necesario tener el token siempre activo. Crear uno cuando se
+necesita, revocarlo al terminar — minimiza la superficie de ataque.

--- a/.claude/docs/cloudflare/03-pages-api-setup.md
+++ b/.claude/docs/cloudflare/03-pages-api-setup.md
@@ -1,0 +1,170 @@
+# Pages projects via REST API
+
+> Como crear, actualizar y borrar proyectos Pages git-connected
+> usando la REST API de Cloudflare. Wrangler NO sirve para este caso.
+
+[← API token](./02-api-token.md) | [README](./README.md) | [Siguiente: monorepo build →](./04-monorepo-build-config.md)
+
+## Wrangler vs REST API (decision)
+
+| Capacidad | Wrangler CLI | REST API |
+|-----------|--------------|----------|
+| Crear proyecto direct upload | ✓ | ✓ |
+| Crear proyecto git-connected | ❌ (issue cloudflare/workers-sdk#10972) | ✓ |
+| Subir build manual | ✓ (`wrangler pages deploy`) | ✓ |
+| Patch build config | ✓ parcial | ✓ completo |
+| Listar deployments | ✓ | ✓ |
+| Configurar env vars | ✓ | ✓ (formato distinto, ver abajo) |
+| Attach custom domain | ❌ | ✓ |
+
+**Conclusion**: para git-connected con 6 proyectos, REST API. Wrangler
+sirve solo si vas a buildear localmente y subir el dist/.
+
+## Endpoint: crear proyecto
+
+```
+POST https://api.cloudflare.com/client/v4/accounts/{account_id}/pages/projects
+Authorization: Bearer {api_token}
+Content-Type: application/json
+```
+
+## Payload minimo (git-connected)
+
+```json
+{
+  "name": "generic",
+  "production_branch": "main",
+  "source": {
+    "type": "github",
+    "config": {
+      "owner": "bypabloc",
+      "repo_name": "cv",
+      "production_branch": "main",
+      "deployments_enabled": true,
+      "pr_comments_enabled": false,
+      "production_deployments_enabled": true,
+      "preview_deployment_setting": "none"
+    }
+  },
+  "build_config": {
+    "build_command": "pnpm install --frozen-lockfile && pnpm --filter @portfolio/generic... build",
+    "destination_dir": "apps/generic/dist",
+    "root_dir": ""
+  },
+  "deployment_configs": {
+    "production": {
+      "env_vars": {
+        "NODE_VERSION": {"type": "plain_text", "value": "24"},
+        "PNPM_VERSION": {"type": "plain_text", "value": "11.0.9"}
+      }
+    },
+    "preview": {
+      "env_vars": {
+        "NODE_VERSION": {"type": "plain_text", "value": "24"},
+        "PNPM_VERSION": {"type": "plain_text", "value": "11.0.9"}
+      }
+    }
+  }
+}
+```
+
+### Gotcha: `env_vars` shape
+
+El formato correcto en 2026 es **`env_vars`** (no `environment_variables`)
+y cada valor es **`{"type": "plain_text", "value": "..."}`** (no string
+plano).
+
+Tipos validos de env var:
+- `plain_text` — texto normal, visible en logs
+- `secret_text` — secret, oculto en logs y UI
+
+Si pasas el shape viejo (`{"value": "..."}`) la API responde 200 pero
+silenciosamente NO setea las env vars (vuelven `null`).
+
+### Gotcha: `preview_deployment_setting`
+
+| Valor | Comportamiento |
+|-------|----------------|
+| `all` | Deploy preview por cada push a CUALQUIER branch (consume builds) |
+| `custom` | Deploy preview por branches que matcheen `preview_branch_includes` |
+| `none` | Solo deploy en production_branch — no previews por PR |
+
+Para portfolio con bajo trafico de PRs: `none` para ahorrar builds.
+
+## Endpoints utiles
+
+| Operacion | Method + path |
+|-----------|---------------|
+| Listar proyectos | `GET /accounts/{id}/pages/projects` |
+| Obtener proyecto | `GET /accounts/{id}/pages/projects/{name}` |
+| Crear proyecto | `POST /accounts/{id}/pages/projects` |
+| Actualizar proyecto | `PATCH /accounts/{id}/pages/projects/{name}` |
+| Borrar proyecto | `DELETE /accounts/{id}/pages/projects/{name}` |
+| Listar deployments | `GET /accounts/{id}/pages/projects/{name}/deployments` |
+| Crear deployment (trigger build) | `POST /accounts/{id}/pages/projects/{name}/deployments` |
+| Obtener logs de deployment | `GET /accounts/{id}/pages/projects/{name}/deployments/{deploy_id}/history/logs` |
+| Listar custom domains | `GET /accounts/{id}/pages/projects/{name}/domains` |
+| Attach custom domain | `POST /accounts/{id}/pages/projects/{name}/domains` body `{"name": "domain"}` |
+| Obtener status de domain | `GET /accounts/{id}/pages/projects/{name}/domains/{domain}` |
+
+## Trigger deploy manual
+
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/generic/deployments" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+**Response 304 Not Modified**: significa que ya hay un deploy del commit
+actual de `production_branch`. CF no re-buildea el mismo commit.
+Workaround: hacer un commit no-op + push (`git commit --allow-empty`).
+
+## Status de deploy
+
+Cada deployment tiene un `latest_stage` con `name` y `status`:
+
+| Stage name | Significado |
+|-----------|-------------|
+| `queued` | En cola esperando build slot |
+| `initialize` | Setup del build env |
+| `clone_repo` | Clone del repo |
+| `build` | Ejecutando `build_command` |
+| `deploy` | Subiendo assets al edge |
+
+Status posibles: `active` (en curso), `success`, `failure`, `cancelled`.
+
+El deploy esta **realmente listo** cuando `stage.name == "deploy"` y
+`stage.status == "success"`.
+
+## Bug del free tier: 1 build concurrent
+
+Free tier corre **1 build a la vez por account** (no por proyecto). Si
+disparas 6 deploys, los otros 5 quedan `queued:active`. Plan Pro ($5)
+sube a 5 concurrent.
+
+Tiempo total estimado para 6 apps Astro chicas: ~15-25 min secuencial.
+
+## Idempotencia
+
+`POST /pages/projects` con un `name` que ya existe devuelve **409
+Conflict**. Antes de crear:
+
+```python
+existing = client.get_project(name)
+if existing is None:
+    client.create_project(payload)
+else:
+    client.patch_project(name, patch_payload)
+```
+
+PATCH puede actualizar `build_config` y `deployment_configs` sin recrear
+el proyecto (mantiene custom domains, deployments history, etc.).
+
+## Limites
+
+- 5 proyectos por account default (se sube solicitando a Cloudflare,
+  granted en ~24h)
+- 100 custom domains por proyecto
+- 500 builds/mes por proyecto (free tier)
+- 100MB max para un solo archivo, 20K archivos max por deployment
+- 25MB max para `_redirects` y `_headers` files

--- a/.claude/docs/cloudflare/04-monorepo-build-config.md
+++ b/.claude/docs/cloudflare/04-monorepo-build-config.md
@@ -1,0 +1,150 @@
+# Build config para monorepo pnpm
+
+> Como configurar el build de cada proyecto Pages cuando el codigo vive
+> en un monorepo pnpm con packages compartidos.
+
+[← Pages API setup](./03-pages-api-setup.md) | [README](./README.md) | [Siguiente: DNS →](./05-dns-and-custom-domains.md)
+
+## Decision: root_dir = "" (repo root)
+
+La clave para que funcione un monorepo pnpm en Cloudflare Pages:
+
+| Campo | Valor | Por que |
+|-------|-------|---------|
+| `root_dir` | `""` (vacio) | pnpm workspaces necesita ver `pnpm-workspace.yaml` en la raiz para resolver `@portfolio/*` |
+| `destination_dir` | `apps/<app>/dist` | El output de Astro vive ahi |
+| `build_command` | `pnpm install --frozen-lockfile && pnpm --filter @portfolio/<app>... build` | Instala todo + buildea solo lo necesario |
+
+### Por que NO `root_dir = "apps/<app>"`
+
+Si seteas root al directorio de la app:
+- pnpm no encuentra `pnpm-workspace.yaml` (esta en la raiz)
+- `@portfolio/content`, `@portfolio/ui`, etc. no resuelven
+- Cloudflare falla con `Cannot find cwd: /opt/buildhome/repo/apps/<app>`
+  (bug del build system v2 con monorepos)
+
+Workaround posible (`cd ../..` en build command) — pero es fragil y
+no aporta nada vs `root_dir=""`.
+
+## Build command desglosado
+
+```bash
+pnpm install --frozen-lockfile \
+  && pnpm --filter @portfolio/generic... build
+```
+
+### `pnpm install --frozen-lockfile`
+
+- `--frozen-lockfile`: falla si `pnpm-lock.yaml` no coincide con
+  `package.json`. Equivalente a "reproducibilidad estricta", obligatorio
+  en CI.
+- pnpm respeta `allowBuilds` en `pnpm-workspace.yaml`:
+  ```yaml
+  allowBuilds:
+    esbuild: true   # build script de esbuild aprobado
+    sharp: true     # build script de sharp aprobado
+  ```
+  Sin esto, pnpm 11+ skipea esbuild/sharp y el build falla.
+
+### `pnpm --filter @portfolio/<app>... build`
+
+- `--filter` selecciona un workspace.
+- `...` (tres puntos al final) incluye **deps internas del workspace**.
+- Ejemplo: `@portfolio/generic` depende de `@portfolio/content`,
+  `@portfolio/ui`, `@portfolio/seo`, etc. — todas se buildean en orden
+  topologico antes de generic.
+
+Variantes de `--filter`:
+
+| Sintaxis | Que selecciona |
+|----------|----------------|
+| `--filter @portfolio/generic` | Solo generic |
+| `--filter @portfolio/generic...` | generic + sus deps internas (TODAS las que necesite) |
+| `--filter ...@portfolio/generic` | Lo que dependa de generic (no aplica aqui) |
+| `--filter @portfolio/generic^...` | Solo deps internas de generic (sin generic) |
+| `-r` | Todos los packages del workspace (overkill) |
+
+`pnpm -r build` tambien funciona pero buildea TODO el monorepo, incluso
+packages que la app no usa. Para 6 apps que comparten subsets distintos
+de packages, `--filter <app>...` es mas rapido.
+
+## Env vars de build
+
+```
+NODE_VERSION=24
+PNPM_VERSION=11.0.9
+```
+
+- Default de Cloudflare Pages: Node 20, pnpm 9. Si tu `package.json#engines`
+  pide Node 24, hay que setearlo explicito.
+- Pages usa `asdf` internamente para instalar versiones de runtime —
+  acepta cualquier version reciente de Node y pnpm.
+- Otras env vars (custom): se pasan exactamente como cualquier variable
+  de entorno al build process. Ej: `BASE_DOMAIN`, `BASE_SCHEME`.
+
+## Prebuild scripts
+
+Si tu `package.json` tiene `"prebuild": "..."`, npm/pnpm lo ejecuta
+automaticamente antes de `build`. NO hay que invocarlo explicito en el
+build command.
+
+Ejemplo del portfolio:
+```json
+"scripts": {
+  "prebuild": "vite-node --config scripts/vite.config.ts scripts/build-public-assets.mjs",
+  "build": "astro build"
+}
+```
+
+Al correr `pnpm --filter @portfolio/generic... build`, pnpm dispara
+primero `prebuild` y luego `build`. Esta cadena se preserva en Pages.
+
+## Path de output: `apps/<app>/dist`
+
+El campo `destination_dir` del build_config es RELATIVO a `root_dir`.
+Como `root_dir = ""`:
+
+```
+root_dir       = ""                  (repo root = /opt/buildhome/repo)
+destination_dir = "apps/generic/dist" (donde Astro emite output)
+```
+
+Si `root_dir` fuera `apps/generic`, `destination_dir` seria `dist`.
+Pero por el bug mencionado, evitamos esa combinacion.
+
+## Build image version
+
+Pages tiene "build images" con toolchain pre-instalado:
+- v1: Node 12, pnpm viejo (deprecated)
+- v2: Node 18 default
+- v3: Node 20 default (current default)
+
+Especificar Node 24 via env var `NODE_VERSION` funciona en cualquier
+build image >= v2.
+
+## Cache de pnpm en Pages
+
+Pages cachea automaticamente `node_modules` entre builds (si lockfile
+no cambio). Primer build: 30-60s en `pnpm install`. Builds subsecuentes:
+3-5s.
+
+No requiere config — Pages detecta `pnpm-lock.yaml` y cachea.
+
+## Verificacion local del build command
+
+Antes de configurar Pages, validar el comando localmente:
+
+```bash
+# Limpiar
+rm -rf apps/generic/dist
+
+# Correr exactamente lo que Pages va a correr
+pnpm install --frozen-lockfile
+pnpm --filter @portfolio/generic... build
+
+# Verificar output
+ls apps/generic/dist/index.html
+```
+
+Si funciona local, funciona en Pages (modulo diferencias de env vars
+que setees explicitas).

--- a/.claude/docs/cloudflare/05-dns-and-custom-domains.md
+++ b/.claude/docs/cloudflare/05-dns-and-custom-domains.md
@@ -1,0 +1,197 @@
+# DNS y custom domains
+
+> Como gestionar DNS records para custom domains de Cloudflare Pages,
+> incluyendo el apex con CNAME flattening y el gotcha del subdomain
+> con sufijo aleatorio.
+
+[← Monorepo build](./04-monorepo-build-config.md) | [README](./README.md) | [Siguiente: Gotchas →](./06-gotchas.md)
+
+## Decision: CNAME proxied para todos (incluido apex)
+
+Cloudflare DNS soporta **CNAME flattening** nativo: podes poner un CNAME
+en el apex de la zona (`the-full-stack.com`) y Cloudflare lo resuelve
+transparentemente como A/AAAA al cliente. Esto NO funciona en otros DNS
+providers (Route 53 lo emula con "Alias records").
+
+```
+the-full-stack.com         CNAME → generic-3ab.pages.dev   (proxied)
+www.the-full-stack.com     CNAME → generic-3ab.pages.dev   (proxied)
+hub.the-full-stack.com     CNAME → hub-9sd.pages.dev       (proxied)
+...
+```
+
+Todos con `proxied: true` (proxy CF activo) — esto da:
+- SSL termination en el edge
+- Cache CDN
+- WAF basico
+- DDoS protection
+- HTTP/3, Brotli, etc.
+
+## ⚠️ GOTCHA: subdomain pages.dev con sufijo aleatorio
+
+Cuando creas un proyecto Pages, Cloudflare le asigna un subdominio
+`<name>.pages.dev`. PERO si `<name>.pages.dev` ya esta ocupado por otro
+usuario de Cloudflare a nivel global, te asigna un **sufijo aleatorio**:
+
+| Proyecto | URL esperada | URL real |
+|----------|--------------|----------|
+| `generic` | `generic.pages.dev` | `generic-3ab.pages.dev` |
+| `hub` | `hub.pages.dev` | `hub-9sd.pages.dev` |
+| `fintech` | `fintech.pages.dev` | `fintech-868.pages.dev` |
+
+**Si apuntas el CNAME a `generic.pages.dev` (sin sufijo), va a un
+proyecto que NO es tuyo** y CF responde HTTP 403 al request (mismo
+host, distinto proyecto Pages).
+
+### Como obtener el subdomain real
+
+API: `GET /accounts/{id}/pages/projects/{name}` devuelve el field
+`subdomain` con el valor real. Ejemplo:
+
+```bash
+curl -s "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/generic" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  | jq -r '.result.subdomain'
+# Output: generic-3ab.pages.dev
+```
+
+### Como crear el CNAME correcto
+
+```python
+project = client.get_project("generic")
+target = project["subdomain"]  # "generic-3ab.pages.dev"
+client.create_dns_record(
+    zone_id,
+    record_type="CNAME",
+    name="the-full-stack.com",
+    content=target,
+    proxied=True,
+)
+```
+
+NUNCA hardcodear `f"{project_name}.pages.dev"` — leer el subdomain real
+del payload del proyecto.
+
+## Endpoint DNS
+
+```
+POST /zones/{zone_id}/dns_records
+GET  /zones/{zone_id}/dns_records?name=<host>&type=CNAME
+PUT  /zones/{zone_id}/dns_records/{record_id}    # reemplaza el record
+PATCH /zones/{zone_id}/dns_records/{record_id}   # update parcial
+```
+
+### Obtener zone_id
+
+```bash
+curl -s "https://api.cloudflare.com/client/v4/zones?name=the-full-stack.com" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  | jq -r '.result[0].id'
+```
+
+### Payload basico CNAME
+
+```json
+{
+  "type": "CNAME",
+  "name": "hub.the-full-stack.com",
+  "content": "hub-9sd.pages.dev",
+  "proxied": true,
+  "ttl": 1
+}
+```
+
+- `ttl: 1` = "Auto" (CF gestiona TTL cuando proxied=true)
+- `proxied: true` = trafico pasa por el edge de CF
+- `proxied: false` = "DNS only" (cliente conecta directo al origen,
+  pierdes CDN/WAF/SSL termination)
+
+## Custom domain attach (en Pages)
+
+Crear el CNAME NO basta. Hay que **attachar el custom domain al proyecto
+Pages** explicitamente:
+
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/generic/domains" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -d '{"name": "the-full-stack.com"}'
+```
+
+Cuando attachas el domain:
+1. Pages emite un cert SSL (Google CA por default, ~5-10 min)
+2. `status` del domain pasa por: `pending` → `active`
+3. Una vez `active`, CF empieza a servir el contenido del proyecto
+
+## Status de domain
+
+```bash
+curl -s "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/generic/domains/the-full-stack.com" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+Campos relevantes:
+- `status`: estado global (`pending` | `active` | `deactivated`)
+- `verification_data.status`: `pending` → CNAME no detectado |
+  `active` → CNAME OK
+- `validation_data.status`: validacion HTTP del domain
+  (`pending` → `active`)
+- `certificate_authority`: `google` (default 2026)
+
+Cuando los 3 estan `active`, el domain sirve via HTTPS.
+
+## CNAME flattening (apex sin A record)
+
+Cloudflare resuelve CNAMEs en el apex aplicando "CNAME flattening": al
+query externo, devuelve las IPs A/AAAA detras del CNAME (las del edge
+de Cloudflare cuando proxied).
+
+```
+dig the-full-stack.com
+→ 172.67.182.237
+→ 104.21.59.192
+
+dig CNAME the-full-stack.com   # opcional, expone el CNAME real
+→ generic-3ab.pages.dev.
+```
+
+Esto **solo funciona dentro de Cloudflare DNS**. Si tu zona estuviera
+en Route 53 u otro provider, tendrias que usar A records con IPs de
+Cloudflare (que cambian) — frágil.
+
+## Propagacion DNS
+
+- Cambios en records dentro de CF: **instant** a nivel de los NS
+  autoritativos de CF
+- Resolvers publicos (8.8.8.8, 1.1.1.1): 30s-5 min
+- Resolvers ISP: 5-60 min dependiendo de TTL viejo
+- Caches DNS locales (sistema, browser): hasta el TTL del query
+
+Si tu maquina local cachea un NXDOMAIN viejo, los nuevos records pueden
+tardar mas. Workaround: usar `--resolve` en curl o forzar query a
+nameservers de CF:
+
+```bash
+curl --resolve hub.the-full-stack.com:443:104.21.59.192 https://hub.the-full-stack.com
+dig @1.1.1.1 hub.the-full-stack.com
+```
+
+## DNS records preexistentes (Vercel, otros)
+
+Si el dominio venia de otro hosting (Vercel, Netlify, etc.), antes de
+crear los CNAMEs de Pages **borrar los A records viejos**:
+
+```bash
+# Listar todos
+curl -s "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+# Buscar A records sospechosos (ej: 76.76.21.21 = Vercel)
+# Borrar:
+curl -X DELETE \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records/{record_id}" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+CF rechaza crear un CNAME si existe un A record con el mismo nombre
+(conflict por RFC).

--- a/.claude/docs/cloudflare/06-gotchas.md
+++ b/.claude/docs/cloudflare/06-gotchas.md
@@ -1,0 +1,226 @@
+# Gotchas conocidos
+
+> Errores reales encontrados durante el setup de Cloudflare Pages para
+> este portfolio + sus causas raiz y fixes. Consultar antes de
+> diagnosticar.
+
+[← DNS](./05-dns-and-custom-domains.md) | [README](./README.md) | [Siguiente: Script idempotente →](./07-script-idempotente.md)
+
+## 1. `Cannot find cwd: /opt/buildhome/repo/apps/<app>`
+
+**Sintoma**: build falla inmediato, antes de ejecutar el build command.
+
+**Causa**: Tenes `root_dir: "apps/<app>"` configurado. El build system
+v2 de Pages intenta `cd apps/<app>` antes del build y falla por un bug
+con monorepos pnpm.
+
+**Fix**: Setear `root_dir: ""` y `destination_dir: "apps/<app>/dist"`.
+Build command corre desde la raiz del repo, donde pnpm puede ver
+`pnpm-workspace.yaml`.
+
+Detalle: [04-monorepo-build-config.md](./04-monorepo-build-config.md).
+
+## 2. `No package.json found in /opt/buildhome/repo`
+
+**Sintoma**: build logs muestran `[ERR_PNPM_NO_PKG_MANIFEST]`.
+
+**Causa**: Cloudflare clono un commit antiguo de la branch que no
+contenia `package.json` en la raiz. Pasa cuando creas el proyecto y la
+branch `main` tenia commits viejos antes de la migracion a monorepo.
+
+**Fix**: Hacer un nuevo commit en `main` (cualquier cosa que tenga
+package.json) y re-trigger el deploy. CF auto-detecta el HEAD nuevo y
+re-buildea.
+
+```bash
+git checkout main
+git commit --allow-empty -m "chore: trigger CF rebuild"
+git push origin main
+```
+
+## 3. HTTP 304 al intentar trigger deploy
+
+**Sintoma**:
+```
+POST /pages/projects/<name>/deployments → 304 Not Modified
+```
+
+**Causa**: Ya existe un deploy del commit actual de `production_branch`.
+CF no re-buildea el mismo commit dos veces.
+
+**Fix**: Un commit nuevo (real o `--allow-empty`) en `main` para forzar
+un commit_hash distinto.
+
+## 4. HTTP 403 al acceder al custom domain
+
+**Sintoma**: Custom domain (e.g. `the-full-stack.com`) responde 403,
+pero el `.pages.dev` URL del deploy responde 200.
+
+**Causas posibles** (en orden de probabilidad):
+
+### 4a. CNAME apunta a `<name>.pages.dev` (sin sufijo) en vez del subdomain real
+
+Si `<name>.pages.dev` esta tomado a nivel global por otro usuario de CF,
+tu proyecto recibe un subdomain con sufijo (`generic-3ab.pages.dev`).
+Si el CNAME apunta a `generic.pages.dev`, el request va al proyecto del
+otro user → 403.
+
+**Fix**: Obtener `subdomain` del payload del proyecto via API y usarlo
+como target del CNAME. Detalle en
+[05-dns-and-custom-domains.md](./05-dns-and-custom-domains.md).
+
+### 4b. Cert SSL aun emitiendose
+
+Status del domain en `pending` por 1-10 min mientras CF emite el cert
+Universal SSL. Espera.
+
+**Verificacion**:
+```bash
+curl -s "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/<name>/domains/<domain>" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | jq '.result.status'
+```
+
+### 4c. Conflicto entre A record viejo y CNAME nuevo
+
+Si el dominio venia de Vercel/Netlify/otro, puede haber A records
+residuales con IPs que no son de CF. **Eliminarlos** antes de crear
+los CNAMEs (CF rechaza crear CNAME si existe A con mismo nombre, pero
+el delete puede no haberse hecho).
+
+## 5. HTTP 522 (Connection timed out)
+
+**Sintoma**: Cloudflare devuelve 522 al cliente.
+
+**Causa**: El edge de CF resuelve el DNS y reachea el origen (`.pages.dev`)
+pero la conexion al origen falla o timeoutea. Tipicamente: el CNAME se
+actualizo recien y la cache interna de CF aun apunta al viejo.
+
+**Fix**: Esperar 1-5 min para que la cache interna del edge se sincronice.
+Si persiste: toggle `proxied=false` → `proxied=true` en el CNAME para
+forzar re-process.
+
+```bash
+# Force re-process
+curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records/$RECORD_ID" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -d '{"proxied":false}'
+sleep 3
+curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records/$RECORD_ID" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -d '{"proxied":true}'
+```
+
+## 6. HTTP 000 desde WSL2 / DNS cache local
+
+**Sintoma**: `curl https://hub.the-full-stack.com` devuelve `000` (TCP
+fail). Pero desde `dig +short`, los nameservers de CF SI responden.
+
+**Causa**: Cache DNS del resolver de WSL2 / systemd-resolved tiene
+cacheado el NXDOMAIN viejo (cuando el CNAME no existia aun).
+
+**Fix**:
+```bash
+# Bypass cache local con --resolve
+curl --resolve hub.the-full-stack.com:443:104.21.59.192 \
+  https://hub.the-full-stack.com
+
+# O usar resolver externo
+dig @1.1.1.1 hub.the-full-stack.com
+dig @8.8.8.8 hub.the-full-stack.com
+
+# O flush cache (WSL2 / Linux con systemd-resolved)
+sudo systemd-resolve --flush-caches  # legacy
+sudo resolvectl flush-caches         # current
+```
+
+En navegador: incognito o `chrome://net-internals/#dns` → "Clear host cache".
+
+## 7. `env_vars` se setean como null en lugar del valor
+
+**Sintoma**: PATCH/POST con `environment_variables` retorna 200, pero
+`GET` del proyecto muestra `env_vars: null`.
+
+**Causa**: Shape incorrecto. La API espera **`env_vars`** (no
+`environment_variables`) con valores en formato
+**`{"type": "plain_text", "value": "..."}`** (no string plano).
+
+**Fix**: usar el shape correcto:
+
+```json
+{
+  "deployment_configs": {
+    "production": {
+      "env_vars": {
+        "NODE_VERSION": {"type": "plain_text", "value": "24"}
+      }
+    }
+  }
+}
+```
+
+Para secrets usar `"type": "secret_text"` en vez de `"plain_text"`.
+
+## 8. Subdomain `pages.dev` resuelve a OTRO sitio
+
+**Sintoma**: `curl https://generic.pages.dev` devuelve HTML de algun
+proyecto random (en mi caso: una landing en chino sobre CAD architecture
+asiatico).
+
+**Causa**: Los subdomains `<name>.pages.dev` son **globales a nivel de
+toda Cloudflare**. Otros usuarios pudieron registrar `generic`, `hub`,
+etc. antes que tu. Tu proyecto recibe el sufijo (`generic-3ab.pages.dev`).
+
+**Fix**: SIEMPRE usar el subdomain real del payload del proyecto
+(field `subdomain`). Nunca asumir `<name>.pages.dev`.
+
+## 9. Wrangler no puede crear git-connected projects
+
+**Sintoma**: `wrangler pages project create` no acepta source de git,
+o el proyecto creado no tiene webhook a GitHub.
+
+**Causa**: Wrangler v4 NO soporta git-connected projects (issue
+[cloudflare/workers-sdk#10972](https://github.com/cloudflare/workers-sdk/issues/10972),
+abierto desde octubre 2025).
+
+**Fix**: usar REST API directamente para crear el proyecto. Wrangler
+sirve solo para direct upload (`wrangler pages deploy ./dist`).
+
+Detalle: [03-pages-api-setup.md](./03-pages-api-setup.md).
+
+## 10. 1 build concurrent en free tier
+
+**Sintoma**: Trigger 6 deploys, solo 1 buildea, los otros 5 quedan
+`queued:active` por minutos.
+
+**Causa**: Free tier hace 1 concurrent build por account (no por
+proyecto). Es by-design.
+
+**Fix**: Esperar (~15-25 min para 6 apps Astro chicas) o pasar a Pages
+Pro ($5/proyecto/mes para 5 concurrent).
+
+## 11. Build cache obsoleto
+
+**Sintoma**: Build falla con error de "X file not found" o "module
+resolution failed" que no tiene sentido contra el repo actual.
+
+**Causa**: Pages cachea `node_modules` entre builds. A veces se
+corrompe.
+
+**Fix**: Settings del proyecto → Build & deployments → "Clear cache".
+Re-trigger deploy.
+
+## 12. `_headers` / `_redirects` no se aplican
+
+**Sintoma**: Headers de seguridad o redirects definidos en
+`apps/<app>/public/_headers` no se ven en la respuesta HTTP.
+
+**Causas posibles**:
+
+- El archivo no esta en `public/` (debe ser servido como asset estatico)
+- Sintaxis invalida (CF parsea y silenciosamente skipea reglas con error)
+- El archivo no se copio al `dist/` (verificar en build logs)
+
+**Fix**: Verificar
+[sintaxis oficial de _headers](https://developers.cloudflare.com/pages/configuration/headers/).
+Test local: en el `dist/` del build, debe existir un archivo `_headers`
+identico al de `public/`.

--- a/.claude/docs/cloudflare/07-script-idempotente.md
+++ b/.claude/docs/cloudflare/07-script-idempotente.md
@@ -1,0 +1,170 @@
+# Script idempotente: `devtools/cloudflare_setup/`
+
+> Como esta organizado el script Python que gestiona todo el setup,
+> que fases tiene, y como usarlo.
+
+[← Gotchas](./06-gotchas.md) | [README](./README.md) | [Siguiente: Comparacion proveedores →](./08-vercel-netlify-vs-cloudflare.md)
+
+## Por que un script Python
+
+- **Devtools** del portfolio ya usa Python 3.14 + uv
+- **Idempotente**: re-correr no rompe (chequea state antes de mutar)
+- **Reproducible**: agrega una app nueva → tocar `config.py` → re-correr
+- **Sin dependencia en wrangler**: la REST API directa cubre todo el
+  flow (wrangler no soporta git-connected creation)
+- **Documentado**: cada decision tiene comentarios in-code
+
+## Estructura
+
+```
+devtools/cloudflare_setup/
+├── __init__.py
+├── config.py      # Single source of truth: APPS, dominios, env vars
+├── payloads.py    # JSON shapes para Cloudflare REST API
+├── api.py         # Cliente httpx (sync) con CloudflareError
+└── main.py        # Orquestador con fases idempotentes
+```
+
+### `config.py`
+
+Define `APPS: tuple[AppConfig, ...]` — la fuente de verdad. Cada
+`AppConfig` tiene:
+
+| Campo | Significado |
+|-------|-------------|
+| `project_name` | Nombre del proyecto en Pages (tambien default subdomain) |
+| `package_name` | Nombre pnpm del workspace (e.g. `@portfolio/generic`) |
+| `root_dir` | Path relativo desde repo root (`apps/generic`) |
+| `custom_domain` | Apex o subdomain a attachar |
+
+Tambien define `COMMON_ENV_VARS` (NODE_VERSION, PNPM_VERSION,
+BASE_DOMAIN, BASE_SCHEME) y `GITHUB_OWNER`/`GITHUB_REPO`/`PRODUCTION_BRANCH`.
+
+### `payloads.py`
+
+Centraliza las JSON shapes:
+- `build_create_project_payload(app)` — body del POST de creacion
+- `build_patch_project_payload(app)` — body del PATCH (update sin recrear)
+
+Helper `_env_vars()` convierte `{k: v}` plano a la shape correcta
+`{k: {"type": "plain_text", "value": v}}`.
+
+### `api.py`
+
+`CloudflareClient` con metodos:
+- `get_project(name)` / `create_project(payload)` / `patch_project(name, payload)` / `delete_project(name)`
+- `list_domains(project)` / `attach_domain(project, domain)`
+- `list_deployments(project)` / `trigger_deployment(project)`
+- `list_dns_records(zone_id, name=...)` / `create_dns_record(zone_id, ...)`
+- `get_zone_id(zone_name)`
+
+Cada metodo unwrappea el envelope `{success, result, errors}` y levanta
+`CloudflareError` si `success=false`. Soporta `allow_404=True` para
+`get_project` (idempotency).
+
+### `main.py`
+
+Orquestador. Cada fase es idempotente — chequea state antes de mutar:
+
+```python
+def phase_projects(client):
+    for app in APPS:
+        existing = client.get_project(app.project_name)
+        if existing is None:
+            client.create_project(build_create_project_payload(app))
+        else:
+            client.patch_project(app.project_name, build_patch_project_payload(app))
+```
+
+## Fases disponibles
+
+```bash
+devtools/.venv/bin/python -m devtools.cloudflare_setup.main <phase>
+```
+
+| Phase | Que hace | Idempotente? |
+|-------|----------|--------------|
+| `projects` | Crea o patchea los 6 proyectos | si (create si no existe, patch si existe) |
+| `domains` | Attacha custom domains a sus proyectos | si (skip si ya attached) |
+| `dns` | Crea/actualiza CNAMEs en la zona | si (PUT replaces si target cambio) |
+| `status` | Imprime ultimo deployment por proyecto | si (read-only) |
+| `trigger` | Trigger deploy manual de cada proyecto | si (devuelve 304 si commit ya deployado) |
+| `all` | Corre projects → domains → dns → status | si |
+
+## Credenciales
+
+```bash
+# Cargar desde tmp/cloudflare-creds.env (gitignored)
+set -a; . tmp/cloudflare-creds.env; set +a
+```
+
+Contenido del file:
+```
+CLOUDFLARE_API_TOKEN=v1.0_xxx...
+ACCOUNT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Template (commiteado): `tmp/cloudflare-creds.env.template`.
+
+## Agregar una app nueva al setup
+
+1. Crear `apps/<app-nueva>/` con su `package.json`, schema Astro, etc.
+2. Editar `devtools/cloudflare_setup/config.py`:
+   ```python
+   APPS = (
+       # ... apps existentes ...
+       AppConfig(
+           project_name='nueva',
+           package_name='@portfolio/nueva',
+           root_dir='apps/nueva',
+           custom_domain='nueva.the-full-stack.com',
+       ),
+   )
+   ```
+3. Cargar credenciales y correr:
+   ```bash
+   set -a; . tmp/cloudflare-creds.env; set +a
+   devtools/.venv/bin/python -m devtools.cloudflare_setup.main all
+   ```
+
+El script:
+- Crea el proyecto (skip los 6 existentes)
+- Attacha el domain (skip los 6 existentes)
+- Crea el CNAME apuntando al subdomain real del proyecto nuevo
+- Imprime status
+
+## Troubleshoot
+
+### "non-JSON response (HTTP 304)"
+
+Trigger de deploy del mismo commit. Hacer commit nuevo o usar
+`--allow-empty`. Ver [06-gotchas.md](./06-gotchas.md#3).
+
+### "POST /pages/projects → success=false"
+
+Inspeccionar `errors[]` del response. Tipico:
+- `8000007: Project name already exists` → ya existe; phase `projects`
+  deberia haber patcheado en vez de crear
+- `8000045: Source repository not connected` → la GitHub App de
+  Cloudflare no esta autorizada para `bypabloc/cv`. Solucion:
+  https://dash.cloudflare.com → Workers & Pages → Create →
+  Pages → Connect to Git → autorizar GitHub App
+
+### "Cannot find zone the-full-stack.com"
+
+Token no tiene `Zone DNS Read/Edit` o el dominio no esta en CF DNS.
+Verificar con:
+```bash
+curl -s "https://api.cloudflare.com/client/v4/zones?name=the-full-stack.com" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+## Lint check
+
+```bash
+cd devtools
+uv run --frozen ruff check cloudflare_setup/
+```
+
+El modulo respeta el ruff config de `devtools/ruff.toml` (Python 3.14,
+line-length 80, single quotes para tecnicos).

--- a/.claude/docs/cloudflare/08-vercel-netlify-vs-cloudflare.md
+++ b/.claude/docs/cloudflare/08-vercel-netlify-vs-cloudflare.md
@@ -1,0 +1,126 @@
+# Comparacion: Cloudflare Pages vs Vercel vs Netlify
+
+> Por que elegimos Cloudflare Pages para este portfolio. Pricing 2026 y
+> trade-offs concretos.
+
+[← Script](./07-script-idempotente.md) | [README](./README.md) | [Siguiente: Workers Static Assets →](./09-workers-static-assets-future.md)
+
+## Veredicto rapido
+
+**Cloudflare Pages** para este caso. Razones:
+
+1. Free tier permite uso comercial (Vercel Hobby NO lo permite)
+2. Bandwidth ilimitado (Vercel: 100GB/mes, Netlify: ~30GB)
+3. 500 builds/mes/proyecto × 6 proyectos = 3000 builds/mes total
+4. SSL automatico, DNS unificado con el hosting
+5. Plan upgrade barato y opcional ($5/proyecto solo si necesitas 5+
+   concurrent builds)
+
+## Tabla comparativa (2026)
+
+| Capacidad | Cloudflare Pages Free | Vercel Hobby | Netlify Free |
+|-----------|----------------------|--------------|---------------|
+| Builds/mes | 500/proyecto | 100 soft | ~20 (300 credits / 15 each) |
+| Bandwidth | **Unlimited** | 100 GB | ~30 GB |
+| Concurrent builds | 1 | 1 | 1 |
+| Custom domains | 100/proyecto | 50/proyecto | Sin limite explicito |
+| Uso comercial | **Permitido** | **PROHIBIDO** | Permitido |
+| SSL automatico | Si | Si | Si |
+| Edge locations | 300+ | 70+ | 50+ |
+| Pricing del primer plan pagado | $5/proyecto/mes | $20/mes | $19/mes |
+| Limit upgrade Pro | 5,000 builds, unlimited bw | Unlimited | Unlimited |
+
+### Pricing modelo concreto (portfolio con ~100-1000 visits/mes)
+
+| Plataforma | Costo mensual estimado | Notas |
+|-----------|------------------------|-------|
+| Cloudflare Pages | **$0** | Free tier cubre todo |
+| Vercel | **$20/mes** | Hobby prohibe comercial → forzado a Pro |
+| Netlify | $0-$19/mes | Free funciona pero bandwidth tight con 6 apps |
+
+## Por que NO Vercel
+
+- **Commercial use prohibido en Hobby tier**: tu portfolio es comercial
+  (CV → contratos). Vercel ToS exige Pro ($20/mes) para cualquier uso
+  con fin comercial, incluso si no monetizas directamente.
+- 100 GB bandwidth cap: 6 apps con ~500MB/visit cada una agotan en
+  ~33k visits/mes. Hoy sobra, pero si crece toca pagar.
+- DX excelente para Next.js, pero Astro estatico no aprovecha las
+  ventajas (preview deployments, edge functions, ISR).
+
+## Por que NO Netlify
+
+- Bandwidth ~30GB free, lo cual es tight para 6 apps simultaneas (cada
+  carga inicial de 1-2MB con sitio entero × 6 = saturas rapido).
+- Pricing por credits es opaco: builds y bandwidth comparten una bolsa,
+  dificil de predecir.
+- Build credits limitan a ~20-30 builds/mes (vs 3000 en CF).
+
+## Por que SI Cloudflare Pages
+
+### Ventajas concretas
+
+1. **Free tier permanente para uso comercial**: portfolio crece sin
+   miedo a tener que migrar por costos.
+2. **Bandwidth ilimitado**: si tu portfolio se viraliza, no te corta el
+   gas.
+3. **Latencia global**: 300+ edge locations vs 70 de Vercel. Mejor para
+   audiencia LATAM (tu mercado: Chile, Mexico).
+4. **DNS unificado**: si tu dominio ya esta en CF DNS, todo (DNS + CDN
+   + hosting + WAF + SSL) se gestiona desde 1 dashboard.
+5. **Sin lock-in**: build es plain Astro static, podes migrar a Vercel
+   /Netlify en cualquier momento subiendo el `dist/`.
+
+### Limitaciones (no aplican aqui)
+
+- **Workers/SSR**: si necesitas server-side rendering, CF Pages tiene
+  Pages Functions o migrar a Workers Static Assets. Astro static no
+  los necesita.
+- **Image optimization**: CF tiene Images ($5/mes) pero no es necesario
+  para portfolio (las imagenes se pueden optimizar en build con
+  @astrojs/sharp).
+- **Analytics**: CF Web Analytics es free y basico. Si quieres mas:
+  Plausible, Fathom, Vercel Analytics (paid).
+
+## Cuando elegir cada uno (general)
+
+| Caso | Recomendacion |
+|------|---------------|
+| Portfolio/CV (este caso) | **Cloudflare Pages** |
+| Next.js SSR/ISR pesado | Vercel (Astro funciona OK pero Vercel optimiza Next) |
+| JAMstack con muchas Functions | Netlify (Functions integrados son simples) |
+| E-commerce escala / global | Cloudflare (Pages + Workers + R2 + KV) |
+| SaaS B2B con SSR | Vercel (DX para developers/equipos) |
+| Side project sin presupuesto | Cloudflare (free tier indefinido) |
+
+## Limites del free tier de CF que SI podrias tocar
+
+| Limite | Cuando preocuparte |
+|--------|--------------------|
+| 500 builds/mes/proyecto | Si haces 100+ pushes/dia a main |
+| 1 concurrent build | Si tenes prisa por deployar 6 cambios simultaneos |
+| 100MB max file | Si vas a servir videos sin CDN externo |
+| 20K files/deployment | Si tu build genera muchos chunks |
+| 25MB max `_headers`/`_redirects` | Improbable |
+
+Si tocas algun limite: Pages Pro ($5/proyecto/mes) lo soluciona.
+
+## Migration path entre proveedores
+
+Como el build es `pnpm build` → `dist/` estatico, migrar entre los 3 es
+trivial:
+
+| Desde | Hacia | Pasos |
+|-------|-------|-------|
+| CF Pages → Vercel | Conectar repo + Vercel detecta Astro automatic |
+| Vercel → Netlify | Idem |
+| Netlify → CF Pages | Igual + ajustar build command para pnpm |
+
+Los `_headers` files son sintaxis comun de Cloudflare y Netlify (Vercel
+usa `vercel.json` con sintaxis distinta).
+
+## TL;DR
+
+Para este portfolio: **Cloudflare Pages, free tier, 6 proyectos
+separados**. Sin razones tecnicas o economicas para pagar o cambiar de
+proveedor en el futuro previsible.

--- a/.claude/docs/cloudflare/09-workers-static-assets-future.md
+++ b/.claude/docs/cloudflare/09-workers-static-assets-future.md
@@ -1,0 +1,132 @@
+# Workers Static Assets (futuro)
+
+> Cuando migrar de Cloudflare Pages a Workers Static Assets. Hoy: NO.
+> En el futuro (Q4 2026+): tal vez si agregamos SSR o serverless.
+
+[← Comparacion proveedores](./08-vercel-netlify-vs-cloudflare.md) | [README](./README.md)
+
+## Que es Workers Static Assets
+
+Cloudflare introduce **Workers Static Assets** en 2024-2025 como el
+"sucesor" de Pages. Es un Worker que sirve assets estaticos + tiene
+acceso opcional a `fetch()` para SSR/serverless logic.
+
+Roadmap publico de Cloudflare (blog 2025-2026): "Pages and Workers are
+converging into one experience". Pages NO desaparece, pero **todas las
+inversiones nuevas van a Workers**.
+
+## Estado en 2026
+
+| Capacidad | Pages | Workers Static Assets |
+|-----------|-------|----------------------|
+| Static hosting | ✓ | ✓ |
+| Git integration auto | ✓ | ✓ (mas reciente) |
+| `_headers` / `_redirects` | ✓ | ✓ (pero recomienda Worker code) |
+| SSR / fetch handler | Limitado (Functions) | Nativo |
+| Durable Objects | No | ✓ |
+| Cron Triggers | No | ✓ |
+| KV / R2 / D1 | Via Functions | Nativo |
+| WAF / Page Rules | Idem | Idem |
+| Madurez | Production-grade desde 2021 | Stable, evolucionando |
+| Wrangler support | Parcial | Full |
+| Pricing | Free tier generoso | Free tier diferente (10M req/mes) |
+
+## Por que NO migrar HOY
+
+1. **Pages funciona perfecto** para este caso (Astro static + 6 apps +
+   custom domains)
+2. **No necesitamos SSR**, serverless, Cron, ni Durable Objects
+3. **Wrangler.toml requerido** en Workers — mas complejidad inicial
+4. **No hay deadline**: Cloudflare confirmo que Pages seguira soportado
+   "indefinidamente"
+5. **Free tier ligeramente distinto**: Workers cuenta requests, no
+   bandwidth. Para este trafico no importa, pero hay que pensarlo.
+
+## Cuando SI migrar
+
+Migrar a Workers Static Assets cuando se cumpla alguna de estas:
+
+### 1. Necesitamos SSR
+
+Ejemplos:
+- Form de contacto con backend en el mismo dominio
+- API de busqueda full-text sobre el CV
+- Endpoint de webhook para Notion/Calendly
+- A/B testing server-side
+
+Hoy todo eso esta resuelto con servicios externos (Formspree, Algolia,
+n8n.cloud, etc.).
+
+### 2. Necesitamos schedule jobs
+
+Ejemplos:
+- Refrescar datos del CV desde una fuente externa cada dia
+- Notificacion automatica al recibir un visit pico
+- Health-check de los 6 sitios + alertas
+
+Esto se podria resolver con Cron Triggers de Workers (1 a la vez en
+free tier). Hoy no es necesario.
+
+### 3. Necesitamos KV/R2/D1 con baja latencia
+
+Ejemplos:
+- Cache de respuestas LLM (si el CV agrega chatbot)
+- Storage de uploads (avatars dinamicos, etc.)
+- DB chica para tracking de visitas custom
+
+Si llega ese caso, Workers Static Assets > Pages porque el binding es
+nativo (en Pages hay que ir via Functions con mas overhead).
+
+## Como migrar (cuando llegue el momento)
+
+Migration estimada en <1 dia para 6 apps. Pasos:
+
+1. **Crear `wrangler.toml`** por cada app:
+   ```toml
+   name = "generic"
+   compatibility_date = "2026-05-13"
+   main = "src/worker.ts"   # opcional, si hay SSR
+
+   [assets]
+   directory = "./dist"
+   not_found_handling = "404-page"
+   ```
+
+2. **Actualizar el script Python** para usar la nueva API de Workers
+   (similar a Pages pero distinto endpoint).
+
+3. **Reemplazar CNAMEs DNS** apuntando a `<worker>.workers.dev` en vez
+   de `<project>.pages.dev`.
+
+4. **Probar uno (`generic`)** antes de migrar los 5 restantes.
+
+5. **Borrar proyectos Pages viejos** una vez verificada la migracion.
+
+## Cambios en el script de setup
+
+`devtools/cloudflare_setup/` esta diseñado para Pages. Cuando migremos:
+
+- `payloads.py` necesita nuevo `build_create_worker_payload(app)`
+- `api.py` agrega endpoints `/accounts/{id}/workers/scripts/<name>`
+- `config.py` agrega `compatibility_date` por app
+- `main.py` cambia las llamadas
+
+Es backwards-compatible: podemos correr ambos sets (Pages + Workers) en
+paralelo durante la migracion para test.
+
+## Recursos
+
+- [Blog: Pages and Workers are converging](https://blog.cloudflare.com/pages-and-workers-are-converging-into-one-experience/) (2025)
+- [Migration guide: Pages → Workers Static Assets](https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/) (2025-2026)
+- [Workers Static Assets docs](https://developers.cloudflare.com/workers/static-assets/) (2026)
+
+## Conclusion
+
+**Q3 2026**: Quedarse en Pages, monitorear bandwidth + builds usados.
+
+**Q4 2026 o cuando lleguen estas condiciones**:
+- Necesitas SSR, Cron, Durable Objects, o bindings nativos KV/R2/D1
+- Cloudflare deprecate algo critico de Pages
+- Tarea de portfolio donde valga la pena experimentar con Workers
+
+Hasta entonces: Pages es production-grade y zero-friction.

--- a/.claude/docs/cloudflare/README.md
+++ b/.claude/docs/cloudflare/README.md
@@ -1,0 +1,62 @@
+# Cloudflare deployment knowledge base
+
+> Conocimiento consolidado sobre como esta desplegado este portfolio en
+> Cloudflare Pages y como gestionar el setup via API token. Cada nodo
+> cubre un tema; navegar por relevancia, no leer linealmente.
+
+## Cuando leer cada archivo
+
+| Tema | Archivo | Cuando leer |
+|------|---------|-------------|
+| Arquitectura global del deploy | [01-architecture.md](./01-architecture.md) | Entender que son los 6 proyectos Pages + DNS + custom domains |
+| API token: permisos y manejo | [02-api-token.md](./02-api-token.md) | Crear, rotar, revocar token con permisos minimos |
+| Setup via REST API (Pages projects) | [03-pages-api-setup.md](./03-pages-api-setup.md) | Crear proyectos Pages git-connected programaticamente |
+| Build config para monorepo pnpm | [04-monorepo-build-config.md](./04-monorepo-build-config.md) | Build command + root_dir + destination_dir correctos |
+| DNS records y CNAME flattening | [05-dns-and-custom-domains.md](./05-dns-and-custom-domains.md) | Apex con CNAME, subdomain real con sufijo aleatorio |
+| Gotchas conocidos | [06-gotchas.md](./06-gotchas.md) | Errores tipicos: Cannot find cwd, 403 cert pending, DNS cache |
+| Script idempotente del proyecto | [07-script-idempotente.md](./07-script-idempotente.md) | devtools/cloudflare_setup/ — fases, comandos, troubleshoot |
+| Comparacion con alternativas | [08-vercel-netlify-vs-cloudflare.md](./08-vercel-netlify-vs-cloudflare.md) | Por que Cloudflare Pages para este portfolio |
+| Workers Static Assets (futuro) | [09-workers-static-assets-future.md](./09-workers-static-assets-future.md) | Cuando migrar de Pages a Workers |
+
+## Reglas criticas
+
+- NUNCA dar al API token permisos mas alla de los necesarios. Permisos
+  minimos en [02-api-token.md](./02-api-token.md).
+- NUNCA commitear `tmp/cloudflare-creds.env`. Esta en `.gitignore`.
+- NUNCA usar `npx wrangler deploy` para git-connected — wrangler solo
+  soporta direct upload, los proyectos git-connected se crean via REST
+  API (ver [03-pages-api-setup.md](./03-pages-api-setup.md)).
+- SIEMPRE resolver el subdomain real del proyecto Pages antes de crear
+  el CNAME (CF agrega sufijo aleatorio si el nombre esta tomado).
+  Detalle en [05-dns-and-custom-domains.md](./05-dns-and-custom-domains.md).
+- SIEMPRE rotar/revocar el token cuando termina la tarea. Detalle en
+  [02-api-token.md](./02-api-token.md).
+
+## Quick start: re-deployar todo
+
+```bash
+# 1. Crear token (ver 02-api-token.md), guardar en tmp/cloudflare-creds.env
+cp tmp/cloudflare-creds.env.template tmp/cloudflare-creds.env
+# editar y completar CLOUDFLARE_API_TOKEN + ACCOUNT_ID
+
+# 2. Correr script idempotente
+set -a; . tmp/cloudflare-creds.env; set +a
+devtools/.venv/bin/python -m devtools.cloudflare_setup.main all
+
+# 3. Verificar
+devtools/.venv/bin/python -m devtools.cloudflare_setup.main status
+
+# 4. Limpiar
+rm -f tmp/cloudflare-creds.env
+# revocar token en dashboard: https://dash.cloudflare.com/profile/api-tokens
+```
+
+## Estado actual del deploy (2026-05-14)
+
+- 6 proyectos Pages: `generic`, `hub`, `fintech`, `architect`, `leader`, `vibe`
+- Dominio: `the-full-stack.com` (apex + www) + 5 subdominios
+- DNS: zona en Cloudflare DNS (NS = `*.ns.cloudflare.com`)
+- Registrar: AWS Route 53 (no requiere migracion)
+- SSL: Universal SSL automatico (Google CA via CF)
+- Build: `pnpm install --frozen-lockfile && pnpm --filter @portfolio/<app>... build`
+- Headers: `_headers` en `apps/*/public/` con CSP estricta + HSTS + X-Frame DENY

--- a/.claude/skills/cloudflare-deploy/SKILL.md
+++ b/.claude/skills/cloudflare-deploy/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: cloudflare-deploy
+description: >
+  Cloudflare Pages deployment reference for this Astro 6 portfolio
+  monorepo. Covers REST API setup with API tokens (NOT wrangler — wrangler
+  cannot create git-connected projects), permission minimums, DNS records
+  including CNAME flattening on apex, custom domains with the random
+  subdomain suffix gotcha, the monorepo pnpm build config (root_dir=""
+  + destination_dir=apps/<app>/dist + pnpm --filter <pkg>...), comparison
+  with Vercel and Netlify (commercial use, bandwidth, pricing 2026), and
+  the future Workers Static Assets migration path. ALWAYS invoke this
+  skill BEFORE answering ANY question about deploying to Cloudflare,
+  Cloudflare Pages, custom domains setup, API token permissions for
+  Cloudflare, monorepo build commands on Cloudflare, or migrating from
+  Vercel/Netlify to Cloudflare. NEVER answer Cloudflare questions from
+  training data alone — this project has consolidated 2026 knowledge that
+  includes gotchas (HTTP 403 from subdomain suffix, env_vars shape change,
+  wrangler limitation) that override generic advice.
+  Use when the user says "cloudflare", "cloudflare pages", "cf pages",
+  "wrangler", "pages.dev", "api token cloudflare", "custom domain
+  cloudflare", "deploy a cloudflare", "deployar a cloudflare",
+  "configurar cloudflare", "como deployar este proyecto", "como desplegar
+  este proyecto", "donde hostear", "donde hostear el portfolio",
+  "subir el sitio", "publicar el sitio", "publicar el portfolio",
+  "deployar el portfolio", "cf token", "_headers", "cloudflare dns",
+  "route 53 cloudflare", "migrar dns", "nameservers cloudflare",
+  "vercel a cloudflare", "netlify a cloudflare", "comparar hosting",
+  "que hosting uso", "where to host astro", "free hosting astro",
+  "monorepo cloudflare", "pnpm cloudflare", "astro cloudflare",
+  "cannot find cwd", "ERR_PNPM_NO_PKG_MANIFEST", "build falla en
+  cloudflare", "cloudflare build error", "cloudflare 403", "cloudflare
+  http 403", "cloudflare 522", "cert pending", "ssl pending cloudflare",
+  "workers static assets", "migrar a workers", "cloudflare workers".
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash(curl:*), Bash(dig:*), Bash(nslookup:*), Bash(pnpm:*), Bash(git:*)
+argument-hint: "tema: setup | dns | api-token | gotchas | comparacion | workers | troubleshoot"
+metadata:
+  version: "1.0"
+---
+
+# Cloudflare Pages deployment — knowledge reference
+
+> Conocimiento consolidado sobre el setup de Cloudflare Pages para
+> este portfolio (6 proyectos Pages git-connected, 6 subdominios bajo
+> `the-full-stack.com`). Toda decision, gotcha y procedimiento esta
+> documentado en `.claude/docs/cloudflare/`.
+
+## Pre-requisito OBLIGATORIO
+
+Antes de responder cualquier pregunta sobre Cloudflare, leer la doc
+relevante de `.claude/docs/cloudflare/`:
+
+| Tema de la pregunta | Archivo a leer |
+|---------------------|----------------|
+| Setup general / arquitectura | [01-architecture.md](../../docs/cloudflare/01-architecture.md) |
+| API token, permisos, rotacion | [02-api-token.md](../../docs/cloudflare/02-api-token.md) |
+| Crear proyectos Pages via REST API | [03-pages-api-setup.md](../../docs/cloudflare/03-pages-api-setup.md) |
+| Build command para monorepo pnpm | [04-monorepo-build-config.md](../../docs/cloudflare/04-monorepo-build-config.md) |
+| DNS, CNAME apex, custom domains | [05-dns-and-custom-domains.md](../../docs/cloudflare/05-dns-and-custom-domains.md) |
+| Errores y troubleshooting | [06-gotchas.md](../../docs/cloudflare/06-gotchas.md) |
+| Script Python idempotente | [07-script-idempotente.md](../../docs/cloudflare/07-script-idempotente.md) |
+| Comparacion vs Vercel/Netlify | [08-vercel-netlify-vs-cloudflare.md](../../docs/cloudflare/08-vercel-netlify-vs-cloudflare.md) |
+| Workers Static Assets (futuro) | [09-workers-static-assets-future.md](../../docs/cloudflare/09-workers-static-assets-future.md) |
+
+Si la pregunta toca multiples temas, leer todos los relevantes y luego
+sintetizar.
+
+## Reglas criticas (siempre activas)
+
+1. **NUNCA** recomendar `npx wrangler deploy` para crear proyectos
+   git-connected — wrangler v4 NO soporta esa operacion (issue
+   [cloudflare/workers-sdk#10972](https://github.com/cloudflare/workers-sdk/issues/10972)).
+   Para git-connected, usar REST API directamente.
+
+2. **NUNCA** asumir que `<project_name>.pages.dev` es el subdomain real.
+   CF agrega sufijo aleatorio si el nombre esta tomado globalmente.
+   Leer el campo `subdomain` del payload del proyecto.
+
+3. **SIEMPRE** usar `root_dir: ""` (vacio) en monorepo pnpm. Combinarlo
+   con `destination_dir: "apps/<app>/dist"`. `root_dir = apps/<app>`
+   rompe con bug "Cannot find cwd".
+
+4. **SIEMPRE** usar shape `env_vars` (no `environment_variables`) con
+   valores `{"type": "plain_text", "value": "..."}` — el shape viejo
+   responde 200 pero deja null.
+
+5. **NUNCA** dar al API token mas permisos de los necesarios:
+   `Pages:Edit` + `DNS:Edit` + `SSL:Read` + `User:Read`. NUNCA
+   `Account Admin` ni `API Token Management`.
+
+6. **SIEMPRE** verificar la skill antes de modificarla con
+   `claude --permission-mode bypassPermissions -p` (regla
+   [.claude/rules/claude-config-testing.md](../../rules/claude-config-testing.md)).
+
+## Workflow tipico de respuesta
+
+1. Identificar el tema del prompt (setup / DNS / token / error / etc.)
+2. Leer el(los) archivo(s) relevante(s) de `.claude/docs/cloudflare/`
+3. Responder con:
+   - Causa raiz (si es un error)
+   - Solucion concreta (no genericos)
+   - Comando o snippet ejecutable
+   - Verificacion: como confirmar que funciona
+4. Si la pregunta cae fuera de scope: derivar a otra skill o decir que
+   no esta cubierto
+
+## Atajos rapidos para preguntas frecuentes
+
+### "Como deployo este portfolio a Cloudflare?"
+
+Leer [01-architecture.md](../../docs/cloudflare/01-architecture.md) y
+[07-script-idempotente.md](../../docs/cloudflare/07-script-idempotente.md).
+Resumen:
+
+1. Crear token en https://dash.cloudflare.com/profile/api-tokens con
+   permisos minimos (ver `02-api-token.md`).
+2. `cp tmp/cloudflare-creds.env.template tmp/cloudflare-creds.env` y
+   completar.
+3. `set -a; . tmp/cloudflare-creds.env; set +a`
+4. `devtools/.venv/bin/python -m devtools.cloudflare_setup.main all`
+5. Verificar con `... main status`
+
+### "Cuanto cuesta?"
+
+$0. Free tier de CF Pages: 500 builds/mes × 6 proyectos = 3000 builds,
+bandwidth ilimitado, uso comercial permitido. Vercel/Netlify mas caros
+o limitados. Detalle en
+[08-vercel-netlify-vs-cloudflare.md](../../docs/cloudflare/08-vercel-netlify-vs-cloudflare.md).
+
+### "Por que el sitio responde HTTP 403?"
+
+Leer [06-gotchas.md](../../docs/cloudflare/06-gotchas.md#4) — tres
+causas posibles: (a) CNAME apunta al subdomain sin sufijo, (b) cert SSL
+aun emitiendose, (c) A record viejo no eliminado.
+
+### "Migrar el dominio desde Route 53?"
+
+Si los nameservers en AWS Route 53 ya apuntan a `*.ns.cloudflare.com`,
+no hay nada que migrar — la zona DNS ya esta en CF, solo el registrar
+sigue en AWS (correcto). Verificar con `dig +short NS the-full-stack.com`.
+
+### "Deberia usar Workers Static Assets?"
+
+Hoy no — esperar a Q4 2026 o cuando necesites SSR/Cron/Durable Objects.
+Pages production-grade y "set and forget". Detalle en
+[09-workers-static-assets-future.md](../../docs/cloudflare/09-workers-static-assets-future.md).
+
+### "El build falla con 'Cannot find cwd' / 'No package.json'"
+
+Causa: `root_dir` mal configurado o CF cacheo un commit viejo. Fix en
+[06-gotchas.md](../../docs/cloudflare/06-gotchas.md#1).
+
+## Anti-patrones a evitar
+
+- ❌ Responder desde training data generica de Cloudflare sin leer la
+  doc del proyecto
+- ❌ Recomendar wrangler para crear git-connected projects
+- ❌ Sugerir `root_dir: "apps/<app>"` en monorepo pnpm
+- ❌ Hardcodear `<project_name>.pages.dev` como CNAME target
+- ❌ Pedir al usuario que de "Account Admin" al token "para simplificar"
+- ❌ Recomendar Vercel Hobby para portfolio comercial (prohibido por ToS)
+- ❌ Olvidar el `_headers` en `apps/<app>/public/` cuando se discute CSP
+
+## Comandos utiles (smoke test rapido)
+
+```bash
+# Status de los 6 proyectos
+set -a; . tmp/cloudflare-creds.env; set +a
+devtools/.venv/bin/python -m devtools.cloudflare_setup.main status
+
+# Verificar nameservers del dominio
+dig +short NS the-full-stack.com
+
+# Verificar que un subdominio responde
+for sub in "" www. hub. fintech. architect. leader. vibe.; do
+  url="https://${sub}the-full-stack.com"
+  printf '%-40s %s\n' "$url" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url")"
+done
+
+# Bypass cache DNS local
+dig @1.1.1.1 hub.the-full-stack.com
+```
+
+## Relacion con otras skills/rules
+
+- `astro-portfolio` — strategy general del portfolio (incluye hosting
+  como subtema general)
+- `github-actions` — el CI workflow paralelo al deploy de CF
+- `dependency-upgrade` — antes de un deploy nuevo, validar deps
+- [.claude/rules/security.md](../../rules/security.md) — headers de
+  seguridad, CSP, secrets
+- [.claude/rules/verify-before-done.md](../../rules/verify-before-done.md)
+  — smoke test post-deploy obligatorio
+
+## Cuando NO invocar esta skill
+
+- Pregunta sobre Astro framework en si (usar `astro-portfolio` o
+  responder directo)
+- Pregunta sobre GitHub Actions workflow (usar `github-actions`)
+- Pregunta sobre Workers como entorno de runtime para apps no estaticas
+  (esta skill solo cubre el subset de Pages + Workers Static Assets)
+- Pregunta sobre otros servicios CF (R2, KV, D1, Stream, Images, etc.)
+  que no aplican al deploy estatico del portfolio

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ Thumbs.db
 
 # VSCode runtime (server-controller)
 .vscode/.server-controller-port.log
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,7 @@ Antes de trabajar, identifica que contexto necesitas:
 | Tests E2E | [tests/feature/README.md](tests/feature/README.md) | Escribir specs Playwright |
 | CV (contenido) | [.claude/docs/cv/README.md](.claude/docs/cv/README.md) | Datos del CV (perfil, experiencia, proyectos) |
 | Estrategia portfolio 2026 | invocar skill `astro-portfolio` | Decisiones de SEO/GEO/ATS/AI literacy/diseño |
+| Deploy Cloudflare Pages | [.claude/docs/cloudflare/README.md](.claude/docs/cloudflare/README.md) o skill `cloudflare-deploy` | Deploy, custom domains, DNS, gotchas, troubleshoot del setup actual |
 
 ## Skills disponibles
 
@@ -267,6 +268,7 @@ prompt. Detalles del frontmatter: [.claude/rules/skills.md](.claude/rules/skills
 |-------|-----|
 | `astro-portfolio` | Referencia obligatoria para cualquier decisión de estructura, SEO, GEO, ATS, diseño o stack del portfolio |
 | `animations-css` | Animaciones CSS (scroll-driven, view transitions, micro-interactions) — NO usar libs como motion / gsap / aos |
+| `cloudflare-deploy` | Deploy a Cloudflare Pages: REST API, custom domains, DNS, gotchas, comparacion vs Vercel/Netlify |
 | `codebase-audit` | Auditoria de calidad: dead code, complexity, duplication, tech debt |
 | `dependency-upgrade` | Workflows de upgrade con pnpm (audit, outdated, CVE, majors) |
 | `fix-hooks` | Reparar errores de pre-commit / pre-push iterativamente |

--- a/devtools/cloudflare_setup/__init__.py
+++ b/devtools/cloudflare_setup/__init__.py
@@ -1,0 +1,1 @@
+"""Cloudflare Pages setup for the portfolio monorepo (6 Astro apps)."""

--- a/devtools/cloudflare_setup/api.py
+++ b/devtools/cloudflare_setup/api.py
@@ -1,0 +1,221 @@
+"""
+Thin httpx-backed client for the Cloudflare REST API v4.
+
+Scope:
+  - Pages projects (create / get / delete / list)
+  - Pages custom domains (attach)
+  - Pages deployments (trigger / get latest)
+  - DNS records (create / list)
+
+The client is intentionally narrow — it only covers the endpoints the
+setup script needs. Each method returns the parsed `result` field of the
+Cloudflare envelope and raises CloudflareError on `success: false`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+API_BASE = 'https://api.cloudflare.com/client/v4'
+
+
+class CloudflareError(RuntimeError):
+    """Raised when the Cloudflare API returns success=false or HTTP >=400."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        errors: list[dict[str, Any]] | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.errors = errors or []
+        self.status_code = status_code
+
+
+class CloudflareClient:
+    """
+    Synchronous Cloudflare API client.
+
+    Synchronous on purpose: the setup script does six operations sequentially,
+    and rate-limit headroom matters more than the ~1s saved by parallelizing
+    six requests.
+    """
+
+    def __init__(self, *, api_token: str, account_id: str) -> None:
+        self._api_token = api_token
+        self.account_id = account_id
+        self._http = httpx.Client(
+            base_url=API_BASE,
+            headers={
+                'Authorization': f'Bearer {api_token}',
+                'Content-Type': 'application/json',
+            },
+            timeout=30.0,
+        )
+
+    # ---- lifecycle -----------------------------------------------------
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> CloudflareClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    # ---- low-level -----------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        allow_404: bool = False,
+    ) -> Any:
+        """Send a request, unwrap envelope, raise on failure."""
+        response = self._http.request(method, path, json=json)
+        if allow_404 and response.status_code == httpx.codes.NOT_FOUND:
+            return None
+        try:
+            envelope = response.json()
+        except ValueError as exc:
+            raise CloudflareError(
+                f'{method} {path} -> non-JSON response (HTTP {response.status_code})',
+                status_code=response.status_code,
+            ) from exc
+
+        if not envelope.get('success', False):
+            errors = envelope.get('errors') or []
+            raise CloudflareError(
+                f'{method} {path} -> {errors}',
+                errors=errors,
+                status_code=response.status_code,
+            )
+        return envelope.get('result')
+
+    # ---- Pages projects -------------------------------------------------
+
+    def get_project(self, name: str) -> dict[str, Any] | None:
+        """Return the project or None if it does not exist."""
+        return self._request(
+            'GET',
+            f'/accounts/{self.account_id}/pages/projects/{name}',
+            allow_404=True,
+        )
+
+    def create_project(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a new Pages project. Idempotent guard is on the caller."""
+        return self._request(
+            'POST',
+            f'/accounts/{self.account_id}/pages/projects',
+            json=payload,
+        )
+
+    def patch_project(
+        self, name: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Update an existing Pages project (build_config, env_vars, etc.)."""
+        return self._request(
+            'PATCH',
+            f'/accounts/{self.account_id}/pages/projects/{name}',
+            json=payload,
+        )
+
+    def delete_project(self, name: str) -> None:
+        self._request(
+            'DELETE', f'/accounts/{self.account_id}/pages/projects/{name}'
+        )
+
+    # ---- Pages domains --------------------------------------------------
+
+    def list_domains(self, project_name: str) -> list[dict[str, Any]]:
+        return (
+            self._request(
+                'GET',
+                f'/accounts/{self.account_id}/pages/projects/{project_name}/domains',
+            )
+            or []
+        )
+
+    def attach_domain(self, project_name: str, domain: str) -> dict[str, Any]:
+        return self._request(
+            'POST',
+            f'/accounts/{self.account_id}/pages/projects/{project_name}/domains',
+            json={'name': domain},
+        )
+
+    # ---- Pages deployments ----------------------------------------------
+
+    def list_deployments(
+        self,
+        project_name: str,
+        *,
+        per_page: int = 5,
+    ) -> list[dict[str, Any]]:
+        return (
+            self._request(
+                'GET',
+                f'/accounts/{self.account_id}/pages/projects/{project_name}/deployments?per_page={per_page}',
+            )
+            or []
+        )
+
+    def trigger_deployment(self, project_name: str) -> dict[str, Any]:
+        return self._request(
+            'POST',
+            f'/accounts/{self.account_id}/pages/projects/{project_name}/deployments',
+        )
+
+    # ---- DNS records ----------------------------------------------------
+
+    def list_dns_records(
+        self,
+        zone_id: str,
+        *,
+        name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        path = f'/zones/{zone_id}/dns_records'
+        if name:
+            path += f'?name={name}'
+        return self._request('GET', path) or []
+
+    def create_dns_record(
+        self,
+        zone_id: str,
+        *,
+        record_type: str,
+        name: str,
+        content: str,
+        proxied: bool = True,
+        ttl: int = 1,  # 1 = "auto" when proxied
+    ) -> dict[str, Any]:
+        return self._request(
+            'POST',
+            f'/zones/{zone_id}/dns_records',
+            json={
+                'type': record_type,
+                'name': name,
+                'content': content,
+                'proxied': proxied,
+                'ttl': ttl,
+            },
+        )
+
+    # ---- Zones ---------------------------------------------------------
+
+    def get_zone_id(self, zone_name: str) -> str | None:
+        """Resolve a zone name to its zone_id, or None if not found."""
+        result = self._request('GET', f'/zones?name={zone_name}')
+        if not result:
+            return None
+        return result[0]['id']

--- a/devtools/cloudflare_setup/config.py
+++ b/devtools/cloudflare_setup/config.py
@@ -1,0 +1,90 @@
+"""
+Configuration for the portfolio Cloudflare Pages setup.
+
+Six apps, one Pages project per app. The apex domain points to `generic`;
+the other five apps map 1:1 to subdomains under `the-full-stack.com`.
+
+Reading order:
+  1. APPS — single source of truth for project_name <-> root_dir <-> domain.
+  2. BUILD_COMMAND_TEMPLATE — same shape for every app, only the pnpm filter changes.
+  3. COMMON_ENV_VARS — shared between production and preview.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    """One Astro app inside the monorepo."""
+
+    project_name: str  # Pages project name (also the *.pages.dev subdomain)
+    package_name: str  # pnpm package name for --filter
+    root_dir: str  # path relative to repo root (where the Astro app lives)
+    custom_domain: str  # apex or subdomain to associate via Pages domains API
+
+
+# the-full-stack.com is the apex; generic is the canonical apex app.
+APEX_DOMAIN = 'the-full-stack.com'
+
+APPS: tuple[AppConfig, ...] = (
+    AppConfig(
+        project_name='generic',
+        package_name='@portfolio/generic',
+        root_dir='apps/generic',
+        custom_domain=APEX_DOMAIN,
+    ),
+    AppConfig(
+        project_name='hub',
+        package_name='@portfolio/hub',
+        root_dir='apps/hub',
+        custom_domain=f'hub.{APEX_DOMAIN}',
+    ),
+    AppConfig(
+        project_name='fintech',
+        package_name='@portfolio/fintech',
+        root_dir='apps/fintech',
+        custom_domain=f'fintech.{APEX_DOMAIN}',
+    ),
+    AppConfig(
+        project_name='architect',
+        package_name='@portfolio/architect',
+        root_dir='apps/architect',
+        custom_domain=f'architect.{APEX_DOMAIN}',
+    ),
+    AppConfig(
+        project_name='leader',
+        package_name='@portfolio/leader',
+        root_dir='apps/leader',
+        custom_domain=f'leader.{APEX_DOMAIN}',
+    ),
+    AppConfig(
+        project_name='vibe',
+        package_name='@portfolio/vibe',
+        root_dir='apps/vibe',
+        custom_domain=f'vibe.{APEX_DOMAIN}',
+    ),
+)
+
+
+# Build runs from the repo root so pnpm workspaces can resolve internal deps.
+# `--filter @portfolio/<app>...` (three dots) builds the app + all internal
+# workspace deps it needs (content, ui, seo, cv-pdf, app-shared, cv-filters).
+BUILD_COMMAND_TEMPLATE = (
+    'pnpm install --frozen-lockfile && pnpm --filter {package_name}... build'
+)
+
+
+# These flow into both production and preview deployment configs.
+# NODE_VERSION/PNPM_VERSION pin the toolchain to match the local repo
+# (Cloudflare's default is Node 20, our package.json#engines wants 24).
+COMMON_ENV_VARS: dict[str, str] = {
+    'NODE_VERSION': '24',
+    'PNPM_VERSION': '11.0.9',
+    'BASE_DOMAIN': APEX_DOMAIN,
+    'BASE_SCHEME': 'https',
+}
+
+
+GITHUB_OWNER = 'bypabloc'
+GITHUB_REPO = 'cv'
+PRODUCTION_BRANCH = 'main'

--- a/devtools/cloudflare_setup/main.py
+++ b/devtools/cloudflare_setup/main.py
@@ -1,0 +1,254 @@
+"""
+Cloudflare Pages setup orchestrator for the portfolio monorepo.
+
+Idempotent script: each phase checks current state before mutating, so it
+can be re-run safely after partial failures.
+
+Phases:
+  - projects: create or update the 6 Pages projects
+  - domains:  attach the apex + 5 subdomains to their projects
+  - dns:      create CNAME records pointing each domain to its pages.dev URL
+  - status:   print latest deployment status per project
+  - all:      run projects -> domains -> dns -> status in order
+
+Credentials are read from environment variables (loaded by run.py from
+``tmp/cloudflare-creds.env`` when present):
+  - CLOUDFLARE_API_TOKEN
+  - ACCOUNT_ID
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+
+from devtools.cloudflare_setup.api import CloudflareClient
+from devtools.cloudflare_setup.api import CloudflareError
+from devtools.cloudflare_setup.config import APEX_DOMAIN
+from devtools.cloudflare_setup.config import APPS
+from devtools.cloudflare_setup.config import AppConfig
+from devtools.cloudflare_setup.payloads import build_create_project_payload
+from devtools.cloudflare_setup.payloads import build_patch_project_payload
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _ok(message: str) -> None:
+    print(f'[OK]   {message}')
+
+
+def _info(message: str) -> None:
+    print(f'[INFO] {message}')
+
+
+def _fail(message: str) -> None:
+    print(f'[FAIL] {message}', file=sys.stderr)
+
+
+def _load_credentials() -> tuple[str, str]:
+    token = os.environ.get('CLOUDFLARE_API_TOKEN', '').strip()
+    account_id = os.environ.get('ACCOUNT_ID', '').strip()
+    if not token or not account_id:
+        msg = (
+            'Missing CLOUDFLARE_API_TOKEN or ACCOUNT_ID. '
+            'Export them or fill tmp/cloudflare-creds.env.'
+        )
+        raise SystemExit(msg)
+    return token, account_id
+
+
+# ---- phases --------------------------------------------------------------
+
+
+def phase_projects(client: CloudflareClient) -> None:
+    """Create or update the 6 Pages projects."""
+    for app in APPS:
+        existing = client.get_project(app.project_name)
+        if existing is None:
+            payload = build_create_project_payload(app)
+            client.create_project(payload)
+            _ok(f'created project {app.project_name} (root_dir={app.root_dir})')
+        else:
+            patch = build_patch_project_payload(app)
+            client.patch_project(app.project_name, patch)
+            _ok(f'patched  project {app.project_name} (already existed)')
+
+
+def phase_domains(client: CloudflareClient) -> None:
+    """Attach each app's custom domain to its Pages project."""
+    for app in APPS:
+        existing_names = {
+            d['name'] for d in client.list_domains(app.project_name)
+        }
+        if app.custom_domain in existing_names:
+            _ok(
+                f'domain {app.custom_domain} already attached to {app.project_name}'
+            )
+            continue
+        client.attach_domain(app.project_name, app.custom_domain)
+        _ok(f'attached {app.custom_domain} -> project {app.project_name}')
+
+
+def phase_dns(client: CloudflareClient, zone_id: str) -> None:
+    """
+    Create or update CNAME records pointing each custom domain at the project's
+    real ``pages.dev`` subdomain.
+
+    Critical gotcha: Cloudflare appends a random suffix to the pages.dev
+    subdomain when ``<project_name>.pages.dev`` is already taken at the global
+    level (e.g. ``generic.pages.dev`` belongs to someone else, our project gets
+    ``generic-3ab.pages.dev``). Pointing a CNAME at the unsuffixed URL returns
+    HTTP 403 because the request lands on a stranger's project. We resolve the
+    real subdomain from the project's API payload before touching DNS.
+
+    Apex is handled with CNAME flattening (Cloudflare's automatic apex CNAME
+    support). Cloudflare DNS treats a CNAME at the apex transparently as A/AAAA
+    at the edge — works only inside Cloudflare DNS.
+    """
+    for app in APPS:
+        project = client.get_project(app.project_name)
+        if project is None:
+            _fail(
+                f'project {app.project_name} does not exist; run phase=projects first'
+            )
+            continue
+        target = project.get('subdomain') or f'{app.project_name}.pages.dev'
+
+        existing = client.list_dns_records(zone_id, name=app.custom_domain)
+        if existing:
+            record = existing[0]
+            if (
+                record.get('content') == target
+                and record.get('type') == 'CNAME'
+            ):
+                _ok(
+                    f'DNS for {app.custom_domain} already correct '
+                    f'(CNAME -> {target})'
+                )
+                continue
+            # PUT replaces the record in place (idempotent update).
+            client._request(  # noqa: SLF001 - intentional access to thin helper
+                'PUT',
+                f'/zones/{zone_id}/dns_records/{record["id"]}',
+                json={
+                    'type': 'CNAME',
+                    'name': app.custom_domain,
+                    'content': target,
+                    'proxied': True,
+                    'ttl': 1,
+                },
+            )
+            _ok(
+                f'DNS CNAME {app.custom_domain} updated: '
+                f'{record.get("content")} -> {target}'
+            )
+            continue
+        client.create_dns_record(
+            zone_id,
+            record_type='CNAME',
+            name=app.custom_domain,
+            content=target,
+            proxied=True,
+        )
+        _ok(f'DNS CNAME {app.custom_domain} -> {target}')
+
+
+def phase_status(client: CloudflareClient) -> None:
+    """Print the latest deployment status for each project."""
+    for app in APPS:
+        deployments = client.list_deployments(app.project_name, per_page=1)
+        if not deployments:
+            _info(f'{app.project_name:10} no deployments yet')
+            continue
+        latest = deployments[0]
+        stage = latest.get('latest_stage') or {}
+        url = latest.get('url') or '-'
+        print(
+            f'[INFO] {app.project_name:10} '
+            f'stage={stage.get("name", "?"):10} '
+            f'status={stage.get("status", "?"):10} '
+            f'url={url}'
+        )
+
+
+def phase_trigger(client: CloudflareClient) -> None:
+    """Trigger a fresh deploy for each project (does NOT push to GitHub)."""
+    for app in APPS:
+        try:
+            result = client.trigger_deployment(app.project_name)
+            _ok(
+                f'triggered deploy for {app.project_name} (id={result.get("id", "?")[:8]})'
+            )
+        except CloudflareError as exc:
+            _fail(f'{app.project_name}: {exc}')
+
+
+# ---- entrypoint -----------------------------------------------------------
+
+
+def main(flags: dict) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(message)s',
+    )
+
+    token, account_id = _load_credentials()
+    phase: str = flags.get('phase', 'all')
+
+    with CloudflareClient(api_token=token, account_id=account_id) as client:
+        # zone_id is only needed for the dns phase; resolve lazily.
+        zone_id: str | None = None
+        if phase in {'dns', 'all'}:
+            zone_id = client.get_zone_id(APEX_DOMAIN)
+            if not zone_id:
+                _fail(f'zone {APEX_DOMAIN} not found in this account')
+                return 2
+            _info(f'zone {APEX_DOMAIN} -> {zone_id}')
+
+        try:
+            if phase in {'projects', 'all'}:
+                phase_projects(client)
+            if phase in {'domains', 'all'}:
+                phase_domains(client)
+            if phase in {'dns', 'all'}:
+                assert zone_id is not None  # noqa: S101 - tipo enviado por la rama
+                phase_dns(client, zone_id)
+            if phase == 'trigger':
+                phase_trigger(client)
+            if phase in {'status', 'all'}:
+                # Give Cloudflare a moment to register the first builds.
+                if phase == 'all':
+                    _info('waiting 5s for first deployments to register...')
+                    time.sleep(5)
+                phase_status(client)
+        except CloudflareError as exc:
+            _fail(str(exc))
+            return 1
+
+    return 0
+
+
+def _validate_flags(argv: list[str]) -> dict:
+    """Parse positional + --phase=<X>. Tiny on purpose."""
+    flags: dict = {'phase': 'all'}
+    for arg in argv:
+        if arg.startswith('--phase='):
+            flags['phase'] = arg.split('=', 1)[1]
+        elif arg in {'projects', 'domains', 'dns', 'status', 'trigger', 'all'}:
+            flags['phase'] = arg
+    valid = {'projects', 'domains', 'dns', 'status', 'trigger', 'all'}
+    if flags['phase'] not in valid:
+        raise SystemExit(
+            f'phase must be one of {sorted(valid)}, got {flags["phase"]!r}'
+        )
+    return flags
+
+
+if __name__ == '__main__':
+    sys.exit(main(_validate_flags(sys.argv[1:])))

--- a/devtools/cloudflare_setup/payloads.py
+++ b/devtools/cloudflare_setup/payloads.py
@@ -1,0 +1,100 @@
+"""
+Cloudflare Pages payload builders.
+
+Centralises the JSON shapes the Cloudflare REST API expects. Keeping these
+in one place means the script and the docs only need to track one source of
+truth for the project layout.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from devtools.cloudflare_setup.config import BUILD_COMMAND_TEMPLATE
+from devtools.cloudflare_setup.config import COMMON_ENV_VARS
+from devtools.cloudflare_setup.config import GITHUB_OWNER
+from devtools.cloudflare_setup.config import GITHUB_REPO
+from devtools.cloudflare_setup.config import PRODUCTION_BRANCH
+from devtools.cloudflare_setup.config import AppConfig
+
+
+def _env_vars(extra: dict[str, str] | None = None) -> dict[str, dict[str, str]]:
+    """
+    Convert flat ``{key: value}`` to Cloudflare's ``{key: {type, value}}`` shape.
+
+    ``plain_text`` is the right type for non-secret build-time variables. Use
+    ``secret_text`` for tokens (none here today, but documented for the future).
+    """
+    merged = dict(COMMON_ENV_VARS)
+    if extra:
+        merged.update(extra)
+    return {k: {'type': 'plain_text', 'value': v} for k, v in merged.items()}
+
+
+def build_create_project_payload(app: AppConfig) -> dict[str, Any]:
+    """
+    Compose the body for POST /accounts/{id}/pages/projects.
+
+    Key fields explained:
+      - ``build_config.root_dir``: where Cloudflare runs the build command.
+        Empty string ('') means repo root, which is what pnpm workspaces need.
+      - ``build_config.destination_dir``: where Astro emits the static site,
+        relative to root_dir. For ``apps/generic/dist`` with root_dir=''.
+      - ``deployment_configs.production.env_vars``: NODE_VERSION pins the
+        toolchain; BASE_DOMAIN/BASE_SCHEME feed into our site-urls helper.
+      - ``source.config.preview_deployment_setting=none``: avoid spawning a
+        preview deploy for every PR branch (we'd pay 6x build credits).
+    """
+    build_command = BUILD_COMMAND_TEMPLATE.format(package_name=app.package_name)
+    destination_dir = f'{app.root_dir}/dist'
+    env_vars = _env_vars()
+
+    return {
+        'name': app.project_name,
+        'production_branch': PRODUCTION_BRANCH,
+        'source': {
+            'type': 'github',
+            'config': {
+                'owner': GITHUB_OWNER,
+                'repo_name': GITHUB_REPO,
+                'production_branch': PRODUCTION_BRANCH,
+                'deployments_enabled': True,
+                'pr_comments_enabled': False,
+                'production_deployments_enabled': True,
+                # 'none' = only build production branch on push, no preview
+                # noise per PR. Switch to 'all' if you want PR previews later.
+                'preview_deployment_setting': 'none',
+            },
+        },
+        'build_config': {
+            'build_command': build_command,
+            'destination_dir': destination_dir,
+            'root_dir': '',
+        },
+        'deployment_configs': {
+            'production': {'env_vars': env_vars},
+            'preview': {'env_vars': env_vars},
+        },
+    }
+
+
+def build_patch_project_payload(app: AppConfig) -> dict[str, Any]:
+    """
+    Body for PATCH on an existing project — keeps build_config and env_vars
+    aligned with the canonical config without recreating the project.
+    """
+    build_command = BUILD_COMMAND_TEMPLATE.format(package_name=app.package_name)
+    destination_dir = f'{app.root_dir}/dist'
+    env_vars = _env_vars()
+
+    return {
+        'build_config': {
+            'build_command': build_command,
+            'destination_dir': destination_dir,
+            'root_dir': '',
+        },
+        'deployment_configs': {
+            'production': {'env_vars': env_vars},
+            'preview': {'env_vars': env_vars},
+        },
+    }

--- a/tmp/cloudflare-creds.env.template
+++ b/tmp/cloudflare-creds.env.template
@@ -1,0 +1,16 @@
+# Cloudflare credentials para setup de Pages
+# COMPLETAR LOS DOS VALORES, GUARDAR COMO tmp/cloudflare-creds.env
+# El archivo final NO se commitea (tmp/ esta en .gitignore)
+#
+# 1. CLOUDFLARE_API_TOKEN: crear en https://dash.cloudflare.com/profile/api-tokens
+#    Permisos minimos:
+#      - Account > Cloudflare Pages: Edit (scope: tu account)
+#      - Zone > DNS: Edit (scope: the-full-stack.com)
+#      - Zone > SSL and Certificates: Read (scope: the-full-stack.com)
+#      - User > User Details: Read
+#    TTL: 7 dias (lo revocamos al terminar)
+#
+# 2. ACCOUNT_ID: dashboard > Workers & Pages > panel derecho "Account ID"
+
+CLOUDFLARE_API_TOKEN=
+ACCOUNT_ID=


### PR DESCRIPTION
## Problema

1. No habia forma reproducible de deployar el portfolio a Cloudflare Pages. El intento desde la UI fallaba con `Cannot find cwd: /opt/buildhome/repo/apps/generic` por un bug del build system v2 con monorepos pnpm (root_dir + subpath).
2. El conocimiento sobre setup, gotchas (HTTP 403 por subdomain con sufijo aleatorio, env_vars shape change, wrangler no soporta git-connected) no estaba documentado — el modelo respondia desde training data generica y daba consejos incorrectos.
3. No habia skill invocable para "como deployo a cloudflare" — cualquier futura iteracion requeria redescubrir todo desde cero.

## Solucion

1. Script idempotente `devtools/cloudflare_setup/` (Python 3.14 + httpx) que crea/actualiza los 6 proyectos Pages via REST API con la config correcta:
   - `root_dir=''` (repo root) + `destination_dir='apps/<app>/dist'`
   - `build_command='pnpm install --frozen-lockfile && pnpm --filter @portfolio/<app>... build'`
   - `env_vars={NODE_VERSION:24, PNPM_VERSION:11.0.9, BASE_DOMAIN, BASE_SCHEME}` con shape correcto `{type:plain_text, value:...}`
   - Fases idempotentes: `projects | domains | dns | status | trigger | all` (chequean state antes de mutar)
   - Resuelve el subdomain real (`generic-3ab.pages.dev`, no `generic.pages.dev`) leyendo el campo `subdomain` del proyecto.
2. Knowledge base modular `.claude/docs/cloudflare/` (README + 9 archivos tematicos): arquitectura, API token, REST API setup, monorepo build config, DNS y custom domains, gotchas (12 errores documentados con fix), script idempotente, comparacion vs Vercel/Netlify, futuro Workers Static Assets.
3. Skill `cloudflare-deploy` (ALWAYS-invoke, keywords ES+EN) que lee la doc relevante antes de responder. Validada con `claude -p`: 5/5 PASS (regla `.claude/rules/claude-config-testing.md`).
4. Entrada en `CLAUDE.md` raiz (tabla arbol de conocimiento + tabla skills).
5. `tmp/` agregado a `.gitignore` + template seguro `tmp/cloudflare-creds.env.template` como punto de entrada (el `.env` real con el token nunca se commitea).

## Como probar

1. Estado actual del deploy en produccion (los 6 proyectos ya estan creados y funcionando):
   ```bash
   for h in "the-full-stack.com" "www.the-full-stack.com" "hub.the-full-stack.com" \
            "fintech.the-full-stack.com" "architect.the-full-stack.com" \
            "leader.the-full-stack.com" "vibe.the-full-stack.com"; do
     code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://$h")
     printf "  %-40s HTTP %s\n" "$h" "$code"
   done
   ```
   Esperado: los 7 hostnames responden HTTP 200 con titulo "Pablo Contreras — ...".
2. Probar el script idempotente (read-only):
   ```bash
   # Crear token con permisos minimos (ver .claude/docs/cloudflare/02-api-token.md)
   cp tmp/cloudflare-creds.env.template tmp/cloudflare-creds.env
   # editar y completar CLOUDFLARE_API_TOKEN + ACCOUNT_ID

   set -a; . tmp/cloudflare-creds.env; set +a
   devtools/.venv/bin/python -m devtools.cloudflare_setup.main status
   ```
   Esperado: lista los 6 proyectos con su ultimo deployment.
3. Probar la skill invocable:
   ```bash
   claude --permission-mode bypassPermissions \
     --disallowedTools "WebSearch" "WebFetch" \
     --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
     --output-format json \
     -p "como deployo este portfolio a cloudflare?"
   ```
   Esperado: `num_turns > 1` (skill invocada) y respuesta basada en `.claude/docs/cloudflare/`.
4. Lint del script:
   ```bash
   cd devtools && uv run --frozen ruff check cloudflare_setup/
   ```
   Esperado: `All checks passed!`

## TODO

- Revocar el API token usado durante el setup inicial (ya no se necesita activo — solo crear uno nuevo cuando se quiera re-correr el script).
- Borrar `tmp/cloudflare-creds.env` local cuando se termine el ciclo de iteracion.
- Eventualmente migrar a Workers Static Assets (Q4 2026 o cuando se necesite SSR / Cron / Durable Objects). Migration path documentado en `.claude/docs/cloudflare/09-workers-static-assets-future.md`.