### PR TITLE
feat(serverless): SPEC-007 Lambda turnstile_validator deployed

### DIFF
--- a/serverless/specs/README.md
+++ b/serverless/specs/README.md
@@ -15,7 +15,7 @@
 | [SPEC-004](SPEC-004-rate-limit-module.md) | Rate-limit module en `common/rate_limit/` + 2 tablas | done | 1 dia | SPEC-002, SPEC-003 |
 | [SPEC-005](SPEC-005-contact-form-lambda.md) | Lambda `contact_form` (POST /contact + Turnstile + SES + rate-limit) | done | 1 dia | SPEC-002, SPEC-003, SPEC-004 |
 | [SPEC-006](SPEC-006-tracking-pixel-lambda.md) | Lambda `tracking_pixel` (POST /track + enrichment + rate-limit) | done | 0.5 dia | SPEC-002, SPEC-003, SPEC-004 |
-| [SPEC-007](SPEC-007-turnstile-validator-lambda.md) | Lambda `turnstile_validator` (POST /validate-turnstile) | draft | 0.5 dia | SPEC-002, SPEC-003 |
+| [SPEC-007](SPEC-007-turnstile-validator-lambda.md) | Lambda `turnstile_validator` (POST /validate-turnstile) | done | 0.5 dia | SPEC-002, SPEC-003 |
 | [SPEC-008](SPEC-008-neon-setup-migrations.md) | Neon project + migrations SQL 001-005 + psycopg3 layer | draft | 1 dia | SPEC-001 |
 | [SPEC-009](SPEC-009-stream-processor-lambda.md) | Lambda `stream_processor` (Streams -> Neon) + DLQ | draft | 1-2 dias | SPEC-005, SPEC-006, SPEC-008 |
 | [SPEC-010](SPEC-010-aggregator-lambda.md) | Lambda `aggregator` (cron 03:00 UTC) + materialized views | draft | 1-2 dias | SPEC-008, SPEC-009 |

--- a/serverless/src/turnstile_validator/__init__.py
+++ b/serverless/src/turnstile_validator/__init__.py
@@ -1,0 +1,1 @@
+"""turnstile_validator: endpoint interno para validar tokens (reutilizable)."""

--- a/serverless/src/turnstile_validator/handler.py
+++ b/serverless/src/turnstile_validator/handler.py
@@ -1,0 +1,114 @@
+"""
+Lambda handler: POST /validate-turnstile
+
+Endpoint interno para validar tokens Cloudflare Turnstile sin persistir nada.
+Util para flujos en multiples pasos donde el validate ocurre antes que el
+save (ej: validar al type del email, no al submit completo del form).
+
+Reutiliza la funcion verify_turnstile_token de contact_form/turnstile.py.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from aws_lambda_powertools.metrics import MetricUnit
+from pydantic import BaseModel, Field
+from pydantic import ValidationError as PydanticValidationError
+
+from common.cors import resolve_origin
+from common.exceptions import ApplicationError, ValidationError
+from common.ip_extractor import extract_ip
+from common.logger import logger
+from common.metrics import metrics
+from common.rate_limit import check_or_raise
+from common.responses import error_response, json_response
+from common.tracer import tracer
+
+# Reutilizamos la funcion del contact_form module (Lambda comparte common
+# pero contact_form NO esta en el deploy zip de turnstile_validator).
+# Para evitar acoplamiento, copiamos solo la funcion verify aqui en service.
+from turnstile_validator.service import verify_token_only
+
+
+class ValidateTokenInput(BaseModel):
+    """Body schema POST /validate-turnstile."""
+
+    cf_token: str = Field(..., min_length=20, max_length=2048)
+    action: str | None = Field(default=None, max_length=100)
+
+
+class ValidateTokenOutput(BaseModel):
+    """Respuesta 200 si el token es valido."""
+
+    valid: bool
+    hostname: str
+    challenge_ts: str | None = None
+
+
+@logger.inject_lambda_context(log_event=False, correlation_id_path='requestContext.requestId')
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Entry point Lambda turnstile_validator."""
+    headers = event.get('headers') or {}
+    origin = resolve_origin(headers)
+    ip = extract_ip(event)
+    bypass_secret = next(
+        (v for k, v in headers.items() if k.lower() == 'x-turnstile-bypass-secret'),
+        None,
+    )
+
+    try:
+        body_raw = event.get('body') or ''
+        try:
+            body_dict = json.loads(body_raw) if body_raw else {}
+        except json.JSONDecodeError as e:
+            msg = 'Invalid JSON body'
+            raise ValidationError(msg, code='INVALID_JSON') from e
+
+        try:
+            parsed = ValidateTokenInput(**body_dict)
+        except PydanticValidationError as e:
+            raise ValidationError(
+                'Validation failed',
+                code='INVALID_INPUT',
+                extra={'errors': e.errors(include_url=False)},
+            ) from e
+
+        # Rate-limit estricto (5/min) por ser endpoint reusable
+        check_or_raise(
+            ip=ip,
+            endpoint='/validate-turnstile',
+            country=None,
+            turnstile_validated=False,
+        )
+
+        result = verify_token_only(
+            parsed.cf_token,
+            remote_ip=ip,
+            bypass_secret=bypass_secret,
+        )
+
+        metrics.add_metric(name='TurnstileValidated', unit=MetricUnit.Count, value=1)
+
+        output = ValidateTokenOutput(
+            valid=True,
+            hostname=result.get('hostname', ''),
+            challenge_ts=result.get('challenge_ts'),
+        )
+        return json_response(200, output.model_dump(), origin=origin)
+
+    except ApplicationError as e:
+        logger.warning(
+            'turnstile validation rejected',
+            extra={'code': e.code, 'reason': e.message, 'ip': ip},
+        )
+        metrics.add_metric(name='TurnstileRejected', unit=MetricUnit.Count, value=1)
+        return error_response(e, origin=origin)
+
+    except Exception:
+        logger.exception('unhandled error in turnstile_validator')
+        metrics.add_metric(name='TurnstileError', unit=MetricUnit.Count, value=1)
+        return error_response(Exception('internal'), origin=origin)

--- a/serverless/src/turnstile_validator/requirements.txt
+++ b/serverless/src/turnstile_validator/requirements.txt
@@ -1,0 +1,1 @@
+# turnstile_validator: no requiere deps adicionales al CommonLayer.

--- a/serverless/src/turnstile_validator/service.py
+++ b/serverless/src/turnstile_validator/service.py
@@ -1,0 +1,98 @@
+"""
+Validacion Turnstile reutilizable (sin persistencia, sin email).
+
+Copia minimal de la logica de contact_form/turnstile.py para evitar
+acoplamiento entre Lambdas. Si la logica diverge en el futuro, mantener
+sincronizado o extraer a common/.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from common.exceptions import TurnstileError
+from common.logger import logger
+from common.ssm_client import get_secret
+
+TURNSTILE_SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+_EXPECTED_HOSTNAMES = frozenset({
+    'the-full-stack.com',
+    'hub.the-full-stack.com',
+    'fintech.the-full-stack.com',
+    'architect.the-full-stack.com',
+    'leader.the-full-stack.com',
+    'vibe.the-full-stack.com',
+    'localhost',
+    '127.0.0.1',
+})
+
+
+def verify_token_only(
+    cf_response: str,
+    *,
+    remote_ip: str | None = None,
+    bypass_secret: str | None = None,
+) -> dict[str, Any]:
+    """
+    Valida un Turnstile cf_response. Retorna el dict si success, raise si no.
+
+    Args:
+        cf_response: token de Turnstile del frontend.
+        remote_ip: IP del cliente.
+        bypass_secret: si matchea TURNSTILE_BYPASS_SECRET, skip.
+
+    Returns:
+        Dict con la respuesta de Cloudflare siteverify.
+
+    Raises:
+        TurnstileError: si la validacion falla.
+    """
+    expected_bypass = os.environ.get('TURNSTILE_BYPASS_SECRET', '')
+    if bypass_secret and expected_bypass and bypass_secret == expected_bypass:
+        return {'success': True, 'hostname': 'bypass', 'bypassed': True}
+
+    secret_path = os.environ.get(
+        'SSM_TURNSTILE_SECRET_PATH', '/portfolio/turnstile-secret'
+    )
+    secret = get_secret(secret_path)
+
+    payload: dict[str, str] = {'secret': secret, 'response': cf_response}
+    if remote_ip:
+        payload['remoteip'] = remote_ip
+
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            response = client.post(TURNSTILE_SITEVERIFY_URL, data=payload)
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+    except (httpx.HTTPError, ValueError) as e:
+        msg = f'Turnstile siteverify failed: {e}'
+        raise TurnstileError(msg, code='CAPTCHA_FAILED') from e
+
+    if not result.get('success'):
+        error_codes = result.get('error-codes', [])
+        logger.warning(
+            'turnstile verify failed',
+            extra={'error_codes': error_codes, 'remote_ip': remote_ip},
+        )
+        msg = f'Turnstile verify failed: {error_codes}'
+        raise TurnstileError(
+            msg,
+            code='CAPTCHA_INVALID',
+            extra={'error_codes': error_codes},
+        )
+
+    hostname = result.get('hostname', '').lower()
+    if hostname and hostname not in _EXPECTED_HOSTNAMES:
+        msg = f'Hostname mismatch: {hostname!r}'
+        raise TurnstileError(
+            msg,
+            code='CAPTCHA_HOSTNAME_MISMATCH',
+            extra={'hostname': hostname},
+        )
+
+    return result

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -233,6 +233,53 @@ Resources:
         Stage: !Ref Stage
 
   # ==========================================================================
+  # Lambda: turnstile_validator (POST /validate-turnstile, SPEC-007)
+  # ==========================================================================
+  TurnstileValidatorFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: python3.13
+      BuildArchitecture: arm64
+    Properties:
+      FunctionName: !Sub portfolio-turnstile-validator-${Stage}
+      CodeUri: src/
+      Handler: turnstile_validator.handler.lambda_handler
+      Layers:
+        - !Ref CommonLayer
+      MemorySize: 256
+      Timeout: 10
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: turnstile-validator
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CacheTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref RateLimitRulesTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref RateLimitBucketsTable
+        - SSMParameterReadPolicy:
+            ParameterName: 'portfolio/turnstile-secret'
+        - Statement:
+            - Effect: Allow
+              Action: kms:Decrypt
+              Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+              Condition:
+                StringEquals:
+                  kms:ViaService: !Sub ssm.${AWS::Region}.amazonaws.com
+      Events:
+        PostValidateTurnstile:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PortfolioApi
+            Path: /validate-turnstile
+            Method: POST
+      Tags:
+        Project: portfolio
+        ManagedBy: SAM
+        Stage: !Ref Stage
+
+  # ==========================================================================
   # Lambda: tracking_pixel (POST /track, SPEC-006)
   # ==========================================================================
   TrackingPixelFunction:

--- a/serverless/tests/unit/turnstile_validator/conftest.py
+++ b/serverless/tests/unit/turnstile_validator/conftest.py
@@ -1,0 +1,55 @@
+"""Fixtures para turnstile_validator tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+@pytest.fixture
+def turnstile_aws(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
+    monkeypatch.setenv('CACHE_TABLE_NAME', 'portfolio-cache-test')
+    monkeypatch.setenv(
+        'RATE_LIMIT_RULES_TABLE_NAME', 'portfolio-rate-limit-rules-test'
+    )
+    monkeypatch.setenv(
+        'RATE_LIMIT_BUCKETS_TABLE_NAME', 'portfolio-rate-limit-buckets-test'
+    )
+    monkeypatch.setenv(
+        'SSM_TURNSTILE_SECRET_PATH', '/portfolio-test/turnstile-secret'
+    )
+
+    with mock_aws():
+        ddb = boto3.client('dynamodb', region_name='us-east-1')
+        for table_name, keys in [
+            ('portfolio-cache-test', [('cache_key', 'HASH')]),
+            (
+                'portfolio-rate-limit-rules-test',
+                [('rule_key', 'HASH'), ('kind', 'RANGE')],
+            ),
+            (
+                'portfolio-rate-limit-buckets-test',
+                [('bucket_key', 'HASH')],
+            ),
+        ]:
+            ddb.create_table(
+                TableName=table_name,
+                AttributeDefinitions=[
+                    {'AttributeName': k[0], 'AttributeType': 'S'} for k in keys
+                ],
+                KeySchema=[
+                    {'AttributeName': k[0], 'KeyType': k[1]} for k in keys
+                ],
+                BillingMode='PAY_PER_REQUEST',
+            )
+
+        ssm = boto3.client('ssm', region_name='us-east-1')
+        ssm.put_parameter(
+            Name='/portfolio-test/turnstile-secret',
+            Value='test-secret',
+            Type='SecureString',
+        )
+        yield

--- a/serverless/tests/unit/turnstile_validator/test_handler.py
+++ b/serverless/tests/unit/turnstile_validator/test_handler.py
@@ -1,0 +1,103 @@
+"""Tests del handler turnstile_validator."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from turnstile_validator.handler import lambda_handler
+from turnstile_validator.service import TURNSTILE_SITEVERIFY_URL
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class MockLambdaContext:
+    function_name: str = 'test-validator'
+    memory_limit_in_mb: int = 256
+    invoked_function_arn: str = 'arn:aws:lambda:us-east-1:000000000000:function:t'
+    aws_request_id: str = 'req-id'
+
+    def get_remaining_time_in_millis(self) -> int:
+        return 10000
+
+
+def _ctx() -> Any:
+    return MockLambdaContext()
+
+
+def _build_event(*, body: dict | None = None, ip: str = '1.2.3.4') -> dict:
+    return {
+        'httpMethod': 'POST',
+        'path': '/validate-turnstile',
+        'headers': {
+            'Content-Type': 'application/json',
+            'Origin': 'https://the-full-stack.com',
+            'CF-Connecting-IP': ip,
+        },
+        'body': json.dumps(body) if body else '',
+        'requestContext': {
+            'identity': {'sourceIp': ip},
+            'requestId': 'req-id',
+            'stage': 'test',
+        },
+    }
+
+
+class TestValidatorHandler:
+    @respx.mock
+    def test_when_valid_token_then_200_with_valid_true(
+        self, turnstile_aws: None
+    ) -> None:
+        """
+        Given Turnstile siteverify success,
+        When invoke /validate-turnstile,
+        Then 200 con {valid: true, hostname}.
+        """
+        respx.post(TURNSTILE_SITEVERIFY_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={'success': True, 'hostname': 'the-full-stack.com'},
+            )
+        )
+
+        event = _build_event(body={'cf_token': 'x' * 30})
+        response = lambda_handler(event, _ctx())
+
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['valid'] is True
+        assert body['hostname'] == 'the-full-stack.com'
+
+    def test_when_missing_token_then_400(
+        self, turnstile_aws: None
+    ) -> None:
+        """Given sin cf_token, When invoke, Then 400 INVALID_INPUT."""
+        event = _build_event(body={})
+
+        response = lambda_handler(event, _ctx())
+
+        assert response['statusCode'] == 400
+        assert json.loads(response['body'])['code'] == 'INVALID_INPUT'
+
+    def test_when_bypass_secret_then_200(
+        self,
+        turnstile_aws: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Given bypass_secret matchea, When invoke, Then 200 sin CF call."""
+        monkeypatch.setenv('TURNSTILE_BYPASS_SECRET', 'bypass-123')
+
+        event = _build_event(body={'cf_token': 'x' * 30})
+        event['headers']['X-Turnstile-Bypass-Secret'] = 'bypass-123'
+
+        response = lambda_handler(event, _ctx())
+
+        assert response['statusCode'] == 200
+        body = json.loads(response['body'])
+        assert body['valid'] is True


### PR DESCRIPTION
Endpoint POST /validate-turnstile interno deployed dev+prod. Reusable. 4 archivos + 3 tests. Smoke test verifica 400 sin token. Pendiente test con token real (se hace en frontend SPEC-012).

Endpoints: 
- dev: https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/validate-turnstile
- prod: https://332ivhahf2.execute-api.us-east-1.amazonaws.com/prod/validate-turnstile