### PR TITLE
feat(serverless): SPEC-008 Neon migrations + psycopg3 layer

### DIFF
--- a/serverless/layers/postgres_python/README.md
+++ b/serverless/layers/postgres_python/README.md
@@ -1,0 +1,37 @@
+# PostgresLayer
+
+> Lambda Layer con psycopg3 binary compilado para arm64 Graviton2.
+> Usado por las Lambdas `stream_processor` (SPEC-009) y `aggregator` (SPEC-010).
+
+## Por que un layer separado
+
+- psycopg[binary] pesa ~10MB. Si lo inlineamos en cada Lambda zip, cada
+  function crece y cold start sube.
+- Solo 2 Lambdas (stream_processor, aggregator) lo necesitan. El layer las
+  evita duplicar.
+- CommonLayer (SPEC-001) NO incluye psycopg para mantener el size bajo
+  para las 3 Lambdas hot path (contact_form, tracking_pixel, turnstile_validator)
+  que NO tocan PostgreSQL.
+
+## Rebuild
+
+```bash
+cd serverless
+make build  # o: sam build --use-container --cached
+```
+
+`--use-container` es OBLIGATORIO porque el binary de psycopg debe matchear
+linux/arm64 (no tu host x86_64). Sin esto, falla con
+`ImportError: cannot import name 'psycopg' from partially initialized module`.
+
+## Cuando agregar al template
+
+El layer se referencia en SPEC-009/010 con:
+
+```yaml
+Layers:
+  - !Ref CommonLayer
+  - !Ref PostgresLayer
+```
+
+NO referenciarlo en SPECs 005/006/007 (no tocan DB).

--- a/serverless/layers/postgres_python/requirements.txt
+++ b/serverless/layers/postgres_python/requirements.txt
@@ -1,0 +1,4 @@
+# Lambda Layer postgres_python (psycopg3 binary arm64)
+# Build: sam build --use-container (cross-platform compile a arm64)
+
+psycopg[binary]>=3.2,<4.0

--- a/serverless/migrations/001_init_schema.down.sql
+++ b/serverless/migrations/001_init_schema.down.sql
@@ -1,0 +1,6 @@
+-- Rollback de 001_init_schema.sql
+BEGIN;
+DROP TABLE IF EXISTS processed_stream_events CASCADE;
+DROP TABLE IF EXISTS tracking_events CASCADE;
+DROP TABLE IF EXISTS contacts CASCADE;
+COMMIT;

--- a/serverless/migrations/001_init_schema.sql
+++ b/serverless/migrations/001_init_schema.sql
@@ -1,0 +1,113 @@
+-- Migration 001: init schema
+-- Crea tablas contacts + tracking_events + processed_stream_events
+-- PG18 features: UUIDv7 nativo, GeneratedField virtual, GIN, BRIN
+--
+-- Idempotente: usa CREATE TABLE IF NOT EXISTS
+
+BEGIN;
+
+-- Extensions necesarias (deben crearse ANTES de las tablas que las usan)
+CREATE EXTENSION IF NOT EXISTS citext;
+
+-- =============================================================================
+-- contacts: replica de DynamoDB ContactsTable (form submissions)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS contacts (
+    -- PK: UUIDv7 generado por la Lambda al insert (no usamos uuidv7() de PG aqui
+    -- porque queremos que el id coincida con DynamoDB)
+    id UUID PRIMARY KEY,
+
+    -- Idempotency key del DynamoDB Stream event (evita doble insert)
+    stream_event_id TEXT UNIQUE,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- Form fields
+    name TEXT NOT NULL,
+    email CITEXT NOT NULL,  -- case-insensitive para CRM matching
+    message TEXT NOT NULL,
+    company TEXT,
+    role TEXT,
+    service_type TEXT CHECK (
+        service_type IN ('consulting', 'fulltime', 'contract', 'other')
+        OR service_type IS NULL
+    ),
+    budget TEXT,
+    timeline TEXT,
+    niche TEXT,
+
+    -- Request metadata
+    ip INET,
+    country CHAR(2),
+    user_agent TEXT,
+
+    -- Marketing/lifecycle (poblado manualmente por owner)
+    status TEXT DEFAULT 'new' CHECK (status IN ('new', 'contacted', 'qualified', 'converted', 'rejected')),
+    notes TEXT
+);
+
+-- =============================================================================
+-- tracking_events: replica de DynamoDB TrackingTable (partitioned por mes)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS tracking_events (
+    -- Composite PK como en DynamoDB
+    session_id TEXT NOT NULL,
+    page_id UUID NOT NULL,
+
+    -- Idempotency (sin UNIQUE constraint - PG no soporta UNIQUE en partitioned
+    -- table sin incluir partitioning column. Idempotency se enforce via
+    -- processed_stream_events PK)
+    stream_event_id TEXT,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ,  -- mirror del TTL de DynamoDB
+
+    -- Page metadata
+    page_url TEXT NOT NULL,
+    page_title TEXT,
+    page_path TEXT,
+    referrer TEXT,
+
+    -- UTM
+    utm_source TEXT,
+    utm_medium TEXT,
+    utm_campaign TEXT,
+    utm_content TEXT,
+    utm_term TEXT,
+
+    -- Viewport
+    viewport_width INT,
+    viewport_height INT,
+
+    -- Niche + enrichment
+    niche TEXT,
+    ip INET,
+    country CHAR(2),
+    user_agent TEXT,
+    browser TEXT,
+    browser_version TEXT,
+    os TEXT,
+    device_type TEXT
+) PARTITION BY RANGE (created_at);
+
+-- Particion default para que los inserts no fallen mientras pg_partman se setea
+CREATE TABLE IF NOT EXISTS tracking_events_default PARTITION OF tracking_events DEFAULT;
+
+-- =============================================================================
+-- processed_stream_events: idempotency log para el stream_processor
+-- =============================================================================
+-- Cada DynamoDB Stream record tiene un eventID unico. El stream_processor
+-- verifica este eventID antes de insertar en contacts/tracking_events.
+-- TTL implicito via cleanup nightly por aggregator (>30 dias).
+CREATE TABLE IF NOT EXISTS processed_stream_events (
+    event_id TEXT PRIMARY KEY,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    event_type TEXT,  -- 'INSERT' | 'MODIFY' | 'REMOVE'
+    table_name TEXT   -- 'contacts' | 'tracking'
+);
+
+COMMIT;

--- a/serverless/migrations/002_indexes.down.sql
+++ b/serverless/migrations/002_indexes.down.sql
@@ -1,0 +1,16 @@
+-- Rollback indexes
+BEGIN;
+DROP INDEX IF EXISTS idx_contacts_email;
+DROP INDEX IF EXISTS idx_contacts_created_at;
+DROP INDEX IF EXISTS idx_contacts_niche_created;
+DROP INDEX IF EXISTS idx_contacts_status;
+DROP INDEX IF EXISTS idx_contacts_message_fts;
+DROP INDEX IF EXISTS idx_tracking_session_created;
+DROP INDEX IF EXISTS idx_tracking_created_brin;
+DROP INDEX IF EXISTS idx_tracking_page_path;
+DROP INDEX IF EXISTS idx_tracking_referrer;
+DROP INDEX IF EXISTS idx_tracking_utm_source;
+DROP INDEX IF EXISTS idx_tracking_country;
+DROP INDEX IF EXISTS idx_tracking_device_type;
+DROP INDEX IF EXISTS idx_tracking_niche_created;
+COMMIT;

--- a/serverless/migrations/002_indexes.sql
+++ b/serverless/migrations/002_indexes.sql
@@ -1,0 +1,62 @@
+-- Migration 002: indexes
+-- Composite + partial + GIN + BRIN segun patrones de query del dashboard.
+
+BEGIN;
+
+-- =============================================================================
+-- contacts indexes
+-- =============================================================================
+
+-- Lookup por email (CRM filtering, case-insensitive ya por CITEXT)
+CREATE INDEX IF NOT EXISTS idx_contacts_email ON contacts (email);
+
+-- Lookup por created_at (rango temporal: "contactos de la ultima semana")
+CREATE INDEX IF NOT EXISTS idx_contacts_created_at ON contacts (created_at DESC);
+
+-- Lookup por niche + created_at (dashboard "contactos por niche este mes")
+CREATE INDEX IF NOT EXISTS idx_contacts_niche_created ON contacts (niche, created_at DESC);
+
+-- Lookup por status (CRM: "nuevos por contactar")
+CREATE INDEX IF NOT EXISTS idx_contacts_status ON contacts (status)
+    WHERE status IN ('new', 'contacted');  -- partial index
+
+-- Full-text search en messages (Spanish dictionary)
+CREATE INDEX IF NOT EXISTS idx_contacts_message_fts
+    ON contacts USING gin (to_tsvector('spanish', message));
+
+-- =============================================================================
+-- tracking_events indexes
+-- =============================================================================
+
+-- Session journey: WHERE session_id = X ORDER BY created_at
+CREATE INDEX IF NOT EXISTS idx_tracking_session_created
+    ON tracking_events (session_id, created_at);
+
+-- BRIN para created_at (gigantes time-series con escritura ordenada)
+CREATE INDEX IF NOT EXISTS idx_tracking_created_brin
+    ON tracking_events USING brin (created_at);
+
+-- Top landing pages: WHERE page_path = X
+CREATE INDEX IF NOT EXISTS idx_tracking_page_path ON tracking_events (page_path);
+
+-- Top referrers: WHERE referrer IS NOT NULL
+CREATE INDEX IF NOT EXISTS idx_tracking_referrer ON tracking_events (referrer)
+    WHERE referrer IS NOT NULL;  -- partial
+
+-- UTM source breakdown
+CREATE INDEX IF NOT EXISTS idx_tracking_utm_source ON tracking_events (utm_source)
+    WHERE utm_source IS NOT NULL;
+
+-- Country (geo breakdown)
+CREATE INDEX IF NOT EXISTS idx_tracking_country ON tracking_events (country)
+    WHERE country IS NOT NULL;
+
+-- Device type breakdown
+CREATE INDEX IF NOT EXISTS idx_tracking_device_type ON tracking_events (device_type);
+
+-- Niche + created (dashboard "tracking events por niche")
+CREATE INDEX IF NOT EXISTS idx_tracking_niche_created
+    ON tracking_events (niche, created_at DESC)
+    WHERE niche IS NOT NULL;
+
+COMMIT;

--- a/serverless/migrations/003_materialized_views.down.sql
+++ b/serverless/migrations/003_materialized_views.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP MATERIALIZED VIEW IF EXISTS mv_session_journey;
+DROP MATERIALIZED VIEW IF EXISTS mv_top_landing_pages;
+DROP MATERIALIZED VIEW IF EXISTS mv_contacts_by_month_niche;
+COMMIT;

--- a/serverless/migrations/003_materialized_views.sql
+++ b/serverless/migrations/003_materialized_views.sql
@@ -1,0 +1,60 @@
+-- Migration 003: materialized views
+-- MVs precomputadas + refresh nightly por aggregator.
+-- CONCURRENTLY no bloquea reads en refresh.
+
+BEGIN;
+
+-- =============================================================================
+-- mv_contacts_by_month_niche: contacts agrupados por mes + niche
+-- =============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_contacts_by_month_niche AS
+SELECT
+    DATE_TRUNC('month', created_at) AS month,
+    COALESCE(niche, 'unknown') AS niche,
+    COUNT(*) AS contact_count,
+    COUNT(*) FILTER (WHERE status = 'converted') AS converted_count
+FROM contacts
+GROUP BY 1, 2
+ORDER BY 1 DESC, 2;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_contacts_month_niche
+    ON mv_contacts_by_month_niche (month, niche);
+
+-- =============================================================================
+-- mv_top_landing_pages: top 100 paginas por visitas (ultimos 30 dias)
+-- =============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_top_landing_pages AS
+SELECT
+    page_path,
+    COUNT(*) AS visit_count,
+    COUNT(DISTINCT session_id) AS unique_sessions,
+    COUNT(*) FILTER (WHERE country IS NOT NULL) AS visits_with_country
+FROM tracking_events
+WHERE created_at >= NOW() - INTERVAL '30 days'
+    AND page_path IS NOT NULL
+GROUP BY page_path
+ORDER BY visit_count DESC
+LIMIT 100;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_top_landing_path
+    ON mv_top_landing_pages (page_path);
+
+-- =============================================================================
+-- mv_session_journey: paginas por sesion en orden temporal (LAG/LEAD)
+-- =============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_session_journey AS
+SELECT
+    session_id,
+    page_id,
+    page_path,
+    created_at,
+    LAG(page_path) OVER (PARTITION BY session_id ORDER BY created_at) AS prev_page,
+    LEAD(page_path) OVER (PARTITION BY session_id ORDER BY created_at) AS next_page,
+    ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY created_at) AS step_in_session
+FROM tracking_events
+WHERE created_at >= NOW() - INTERVAL '30 days';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_session_journey
+    ON mv_session_journey (session_id, page_id);
+
+COMMIT;

--- a/serverless/migrations/004_aggregates_tables.down.sql
+++ b/serverless/migrations/004_aggregates_tables.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+DROP TABLE IF EXISTS tracking_daily_aggregates;
+DROP TABLE IF EXISTS daily_metrics;
+COMMIT;

--- a/serverless/migrations/004_aggregates_tables.sql
+++ b/serverless/migrations/004_aggregates_tables.sql
@@ -1,0 +1,55 @@
+-- Migration 004: daily_metrics + tracking_daily_aggregates
+-- Tablas precomputadas que el aggregator Lambda popula cada noche.
+
+BEGIN;
+
+-- =============================================================================
+-- daily_metrics: KPIs del dashboard (1 row por dia)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS daily_metrics (
+    metric_date DATE PRIMARY KEY,
+
+    -- Volume
+    total_contacts INT NOT NULL DEFAULT 0,
+    total_tracking_events INT NOT NULL DEFAULT 0,
+    unique_sessions INT NOT NULL DEFAULT 0,
+
+    -- Conversion
+    new_contacts INT NOT NULL DEFAULT 0,
+    converted_contacts INT NOT NULL DEFAULT 0,
+    conversion_rate NUMERIC(5, 4) DEFAULT 0,  -- 0.0000 a 1.0000
+
+    -- Top breakdowns (JSON para flexibilidad)
+    contacts_by_niche JSONB,
+    contacts_by_service_type JSONB,
+    tracking_by_device JSONB,
+    tracking_by_country JSONB,
+
+    -- Computed_at
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_daily_metrics_date ON daily_metrics (metric_date DESC);
+
+-- =============================================================================
+-- tracking_daily_aggregates: pre-agrupado por dia + niche + device
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS tracking_daily_aggregates (
+    metric_date DATE NOT NULL,
+    niche TEXT NOT NULL DEFAULT 'unknown',
+    device_type TEXT NOT NULL DEFAULT 'unknown',
+
+    event_count INT NOT NULL DEFAULT 0,
+    unique_sessions INT NOT NULL DEFAULT 0,
+    countries JSONB,  -- {"US": 12, "MX": 5, ...}
+    top_pages JSONB,  -- [{"page_path": "/projects", "count": 10}, ...]
+
+    computed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (metric_date, niche, device_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tracking_daily_date_niche
+    ON tracking_daily_aggregates (metric_date DESC, niche);
+
+COMMIT;

--- a/serverless/migrations/005_migrations_log.down.sql
+++ b/serverless/migrations/005_migrations_log.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP TABLE IF EXISTS schema_migrations;
+COMMIT;

--- a/serverless/migrations/005_migrations_log.sql
+++ b/serverless/migrations/005_migrations_log.sql
@@ -1,0 +1,22 @@
+-- Migration 005: log de migraciones aplicadas
+-- Tabla para tracking de migrations corridas (pattern goose/sqlx/flyway)
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    checksum TEXT,
+    duration_ms INT
+);
+
+-- Auto-registrar las migrations corridas (idempotente: ON CONFLICT DO NOTHING)
+INSERT INTO schema_migrations (version) VALUES
+    ('001_init_schema'),
+    ('002_indexes'),
+    ('003_materialized_views'),
+    ('004_aggregates_tables'),
+    ('005_migrations_log')
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/serverless/scripts/migrate.py
+++ b/serverless/scripts/migrate.py
@@ -1,0 +1,169 @@
+"""
+Aplica migrations SQL contra Neon PostgreSQL.
+
+Lee DB_URL desde env (cargado por devtools desde docker/env/.{stage}).
+Itera migrations/*.sql en orden y aplica las que no esten en schema_migrations.
+
+Uso:
+    cd serverless
+    DB_URL=<...> python scripts/migrate.py [up|down] [--target=<version>]
+
+Default: `up` aplica todas las pending.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _connect():
+    """Lazy import psycopg para que el script funcione sin venv si solo lista."""
+    import psycopg  # noqa: PLC0415
+
+    db_url = os.environ.get('DB_URL')
+    if not db_url:
+        msg = 'DB_URL no esta seteada (esperado en docker/env/.{stage})'
+        raise SystemExit(msg)
+    return psycopg.connect(db_url)
+
+
+def _list_migrations(direction: str = 'up') -> list[tuple[str, Path]]:
+    """Retorna lista ordenada de (version, path) de migrations."""
+    migrations_dir = Path(__file__).parent.parent / 'migrations'
+    suffix = '.down.sql' if direction == 'down' else '.sql'
+    skip_suffix = '.sql' if direction == 'down' else '.down.sql'
+    files = []
+    for path in sorted(migrations_dir.iterdir()):
+        name = path.name
+        if not name.endswith(suffix):
+            continue
+        if direction == 'up' and name.endswith('.down.sql'):
+            continue
+        if direction == 'down' and not name.endswith('.down.sql'):
+            continue
+        version = name.replace(suffix, '').replace('.down', '')
+        files.append((version, path))
+    if direction == 'down':
+        files.reverse()
+    return files
+
+
+def _applied_versions(conn) -> set[str]:
+    """Retorna versiones ya aplicadas (lee schema_migrations)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations')"
+        )
+        exists = cur.fetchone()[0]
+        if not exists:
+            return set()
+        cur.execute('SELECT version FROM schema_migrations')
+        return {row[0] for row in cur.fetchall()}
+
+
+def _apply_migration(conn, version: str, path: Path) -> None:
+    """Aplica una migration (lee SQL + ejecuta + log en schema_migrations)."""
+    sql = path.read_text(encoding='utf-8')
+    checksum = hashlib.sha256(sql.encode()).hexdigest()[:16]
+
+    print(f'[migrate] applying {version}...')
+    start = time.time()
+
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        # Si la migration creo schema_migrations, registramos
+        # (si no existe la tabla aun, esta migration la creara - 005 case)
+        cur.execute(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'schema_migrations')"
+        )
+        if cur.fetchone()[0]:
+            cur.execute(
+                'INSERT INTO schema_migrations (version, checksum, duration_ms) '
+                'VALUES (%s, %s, %s) ON CONFLICT (version) DO NOTHING',
+                (version, checksum, int((time.time() - start) * 1000)),
+            )
+
+    duration_ms = int((time.time() - start) * 1000)
+    print(f'[migrate]   {version} applied in {duration_ms}ms')
+
+
+def up() -> int:
+    """Aplica migrations pendientes."""
+    with _connect() as conn:
+        conn.autocommit = False
+        applied = _applied_versions(conn)
+        pending = [
+            (v, p) for v, p in _list_migrations('up') if v not in applied
+        ]
+        if not pending:
+            print('[migrate] no pending migrations')
+            return 0
+        print(f'[migrate] {len(pending)} pending migration(s)')
+        for version, path in pending:
+            try:
+                _apply_migration(conn, version, path)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                print(f'[migrate]   FAILED {version} (rolled back)')
+                raise
+    print('[migrate] all migrations applied')
+    return 0
+
+
+def down(target: str | None = None) -> int:
+    """Rollback hasta version (o todas si target=None)."""
+    with _connect() as conn:
+        conn.autocommit = False
+        applied = _applied_versions(conn)
+        files = [(v, p) for v, p in _list_migrations('down') if v in applied]
+        if target:
+            files = [(v, p) for v, p in files if v >= target]
+        if not files:
+            print('[migrate] nothing to rollback')
+            return 0
+        print(f'[migrate] rolling back {len(files)} migration(s)')
+        for version, path in files:
+            print(f'[migrate] reverting {version}')
+            with conn.cursor() as cur:
+                cur.execute(path.read_text(encoding='utf-8'))
+                cur.execute(
+                    'DELETE FROM schema_migrations WHERE version = %s',
+                    (version,),
+                )
+            conn.commit()
+    return 0
+
+
+def status() -> int:
+    """Lista migrations + status (applied/pending)."""
+    with _connect() as conn:
+        applied = _applied_versions(conn)
+    for version, _ in _list_migrations('up'):
+        mark = '✓ applied' if version in applied else '· pending'
+        print(f'  {mark}  {version}')
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    cmd = argv[0] if argv else 'up'
+    if cmd == 'up':
+        return up()
+    if cmd == 'down':
+        target = None
+        for arg in argv[1:]:
+            if arg.startswith('--target='):
+                target = arg.split('=', 1)[1]
+        return down(target)
+    if cmd == 'status':
+        return status()
+    print(f'Usage: migrate.py [up|down|status]')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/serverless/specs/README.md
+++ b/serverless/specs/README.md
@@ -16,7 +16,7 @@
 | [SPEC-005](SPEC-005-contact-form-lambda.md) | Lambda `contact_form` (POST /contact + Turnstile + SES + rate-limit) | done | 1 dia | SPEC-002, SPEC-003, SPEC-004 |
 | [SPEC-006](SPEC-006-tracking-pixel-lambda.md) | Lambda `tracking_pixel` (POST /track + enrichment + rate-limit) | done | 0.5 dia | SPEC-002, SPEC-003, SPEC-004 |
 | [SPEC-007](SPEC-007-turnstile-validator-lambda.md) | Lambda `turnstile_validator` (POST /validate-turnstile) | done | 0.5 dia | SPEC-002, SPEC-003 |
-| [SPEC-008](SPEC-008-neon-setup-migrations.md) | Neon project + migrations SQL 001-005 + psycopg3 layer | draft | 1 dia | SPEC-001 |
+| [SPEC-008](SPEC-008-neon-setup-migrations.md) | Neon project + migrations SQL 001-005 + psycopg3 layer | done | 1 dia | SPEC-001 |
 | [SPEC-009](SPEC-009-stream-processor-lambda.md) | Lambda `stream_processor` (Streams -> Neon) + DLQ | draft | 1-2 dias | SPEC-005, SPEC-006, SPEC-008 |
 | [SPEC-010](SPEC-010-aggregator-lambda.md) | Lambda `aggregator` (cron 03:00 UTC) + materialized views | draft | 1-2 dias | SPEC-008, SPEC-009 |
 | [SPEC-011](SPEC-011-ses-dns-production.md) | SES domain verification (DKIM/SPF/DMARC) + production access | draft | 0.5 dia + 24-48h espera | SPEC-000 |

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -111,6 +111,22 @@ Resources:
       BuildMethod: python3.13
       BuildArchitecture: arm64
 
+  # Layer separado para psycopg3 (Lambdas que tocan Neon: SPEC-009/010)
+  PostgresLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: !Sub portfolio-postgres-${Stage}
+      Description: psycopg3 binary arm64 para Lambdas que tocan Neon PostgreSQL
+      ContentUri: layers/postgres_python/
+      CompatibleRuntimes:
+        - python3.13
+      CompatibleArchitectures:
+        - arm64
+      RetentionPolicy: Delete
+    Metadata:
+      BuildMethod: python3.13
+      BuildArchitecture: arm64
+
   # ==========================================================================
   # API Gateway REST + CloudWatch Access Log Group
   # ==========================================================================


### PR DESCRIPTION
5 migrations SQL aplicadas exitosamente contra Neon real:

- 001_init_schema: contacts + tracking_events (partitioned) + processed_stream_events
- 002_indexes: 13 indexes (B-tree, GIN FTS spanish, BRIN time-series, partial)
- 003_materialized_views: mv_contacts_by_month_niche + mv_top_landing_pages + mv_session_journey
- 004_aggregates_tables: daily_metrics + tracking_daily_aggregates
- 005_migrations_log: schema_migrations + auto-registro

template.yaml: PostgresLayer (psycopg[binary] arm64) separado del CommonLayer.

scripts/migrate.py: runner Python up/down/status.

Bugs encontrados:
- CREATE EXTENSION citext movido al top (debe ir antes de tablas que lo usan)
- Partitioned table no soporta UNIQUE constraint (quitado de stream_event_id en tracking_events; idempotency via processed_stream_events.PK)

Verificacion: migrate.py status -> 5/5 applied.