### PR TITLE
feat(serverless): SPEC-010 aggregator + SPEC-011 SES DNS doc

### DIFF
--- a/serverless/docs/ses-setup.md
+++ b/serverless/docs/ses-setup.md
@@ -1,0 +1,81 @@
+# SES setup - the-full-stack.com
+
+> Estado actual: **production access GRANTED en us-east-1** (case `173472640000887`).
+> Esta spec quedo casi vacia porque la configuracion DKIM/SPF/DMARC se hizo
+> previamente. Este documento es para referencia + verificacion.
+
+## Resumen
+
+| Item | Valor | Estado |
+|------|-------|--------|
+| Region | `us-east-1` | ✅ |
+| Account | `637423614564` | ✅ |
+| Domain identity | `the-full-stack.com` | ✅ Verified |
+| Email identity | `the.full.stack.tech@gmail.com` | ✅ Verified (legacy) |
+| Production access | Case `173472640000887` | ✅ GRANTED |
+| Daily quota | 50,000 emails/day | ✅ |
+| Send rate | 14 emails/seg | ✅ |
+| Enforcement status | HEALTHY | ✅ |
+| Mail type | TRANSACTIONAL | ✅ |
+| Dedicated IP auto-warmup | Enabled | ✅ |
+| Suppression list | BOUNCE + COMPLAINT auto-managed | ✅ |
+
+## Verificacion (idempotente)
+
+```bash
+# Identidades verificadas
+aws sesv2 list-email-identities --region us-east-1 \
+  --query 'EmailIdentities[*].[IdentityName,VerificationStatus,SendingEnabled]'
+
+# Account-level (sandbox, production, quota)
+aws sesv2 get-account --region us-east-1
+
+# Send quota actual
+aws sesv2 get-account --region us-east-1 \
+  --query 'SendQuota.[Max24HourSend,MaxSendRate,SentLast24Hours]'
+```
+
+## DKIM (Cloudflare DNS)
+
+3 CNAMEs del DKIM autogenerados por SES estan en Cloudflare DNS para
+`the-full-stack.com`. Para verificar:
+
+```bash
+# Inspeccionar DKIM tokens en SES
+aws sesv2 get-email-identity --email-identity the-full-stack.com \
+  --region us-east-1 --query 'DkimAttributes'
+```
+
+Si vieras `Status: SUCCESS` y `Tokens` no vacios -> DKIM esta OK en Cloudflare.
+
+## SPF + DMARC
+
+SPF TXT (`v=spf1 include:amazonses.com -all`) y DMARC TXT
+(`v=DMARC1; p=quarantine; rua=mailto:...`) ya estan en Cloudflare DNS
+desde antes (no es parte de esta spec).
+
+## Email sender (configurado)
+
+| Variable | Valor |
+|----------|-------|
+| `EMAIL_FROM` (SSM `/portfolio/ses-from-address`) | `no-reply@the-full-stack.com` |
+| `OWNER_EMAIL` (SSM `/portfolio/owner-email`) | `pacg1991@gmail.com` |
+
+Configurados en SPEC-000 + verificados como SES identities en us-east-1.
+
+## Mail Tester (validacion deliverability futura)
+
+Cuando el frontend este live y se envie el primer email real:
+
+1. Ir a https://www.mail-tester.com/
+2. Copiar el email destinatario generado
+3. Enviar un contact_form desde el portfolio apuntando a ese email
+4. Ver el score. Objetivo: >= 8/10
+
+NO disponible en esta spec (requiere SPEC-012 + frontend live).
+
+## SES Bounce/Complaint handling (futuro, no en MVP)
+
+Para limit increase >100k emails/day, configurar SNS topic + Lambda que
+escuche bounces/complaints y popule supresion. NO necesario para portfolio
+volumen actual (~200 emails/mes).

--- a/serverless/specs/README.md
+++ b/serverless/specs/README.md
@@ -18,8 +18,8 @@
 | [SPEC-007](SPEC-007-turnstile-validator-lambda.md) | Lambda `turnstile_validator` (POST /validate-turnstile) | done | 0.5 dia | SPEC-002, SPEC-003 |
 | [SPEC-008](SPEC-008-neon-setup-migrations.md) | Neon project + migrations SQL 001-005 + psycopg3 layer | done | 1 dia | SPEC-001 |
 | [SPEC-009](SPEC-009-stream-processor-lambda.md) | Lambda `stream_processor` (Streams -> Neon) + DLQ | done | 1-2 dias | SPEC-005, SPEC-006, SPEC-008 |
-| [SPEC-010](SPEC-010-aggregator-lambda.md) | Lambda `aggregator` (cron 03:00 UTC) + materialized views | draft | 1-2 dias | SPEC-008, SPEC-009 |
-| [SPEC-011](SPEC-011-ses-dns-production.md) | SES domain verification (DKIM/SPF/DMARC) + production access | draft | 0.5 dia + 24-48h espera | SPEC-000 |
+| [SPEC-010](SPEC-010-aggregator-lambda.md) | Lambda `aggregator` (cron 03:00 UTC) + materialized views | done | 1-2 dias | SPEC-008, SPEC-009 |
+| [SPEC-011](SPEC-011-ses-dns-production.md) | SES domain verification (DKIM/SPF/DMARC) + production access | done | 0.5 dia + 24-48h espera | SPEC-000 |
 | [SPEC-012](SPEC-012-frontend-contact-form.md) | Componente `ContactForm.astro` en `packages/ui` + integracion 6 apps | draft | 1 dia | SPEC-005 |
 | [SPEC-013](SPEC-013-frontend-tracking-pixel.md) | Componentes `TrackingPixel.astro` + `CookieBanner.astro` + GDPR opt-in | draft | 1 dia | SPEC-006, SPEC-012 |
 | [SPEC-014](SPEC-014-dashboard-analytics.md) | Dashboard Astro protegido que consulta Neon (basic auth) | draft | 2-3 dias | SPEC-010 |

--- a/serverless/src/aggregator/__init__.py
+++ b/serverless/src/aggregator/__init__.py
@@ -1,0 +1,1 @@
+"""aggregator: cron nightly que computa daily_metrics + refresca MVs."""

--- a/serverless/src/aggregator/handler.py
+++ b/serverless/src/aggregator/handler.py
@@ -1,0 +1,89 @@
+"""
+Lambda handler: scheduled cron 03:00 UTC daily.
+
+Triggered por EventBridge Scheduled Rule. Computa daily_metrics para
+yesterday + refresca MVs + cleanup processed_stream_events.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aws_lambda_powertools.metrics import MetricUnit
+
+from common.logger import logger
+from common.metrics import metrics
+from common.tracer import tracer
+from aggregator.queries import (
+    CLEANUP_OLD_EVENTS,
+    COMPUTE_DAILY_METRICS,
+    REFRESH_MV_CONTACTS,
+    REFRESH_MV_JOURNEY,
+    REFRESH_MV_LANDING,
+)
+
+_conn: Any = None
+
+
+def _get_connection() -> Any:
+    """Lazy connection a Neon."""
+    global _conn  # noqa: PLW0603
+    if _conn is None or _conn.closed:
+        import psycopg  # noqa: PLC0415
+        from common.ssm_client import get_secret  # noqa: PLC0415
+
+        path = os.environ.get('SSM_NEON_URL_PATH', '/portfolio/neon-url')
+        _conn = psycopg.connect(get_secret(path), autocommit=True)
+    return _conn
+
+
+@logger.inject_lambda_context(log_event=False)
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Entry point del aggregator nightly."""
+    # Target: yesterday (UTC)
+    yesterday = (datetime.now(UTC) - timedelta(days=1)).date()
+    logger.info('aggregator starting', extra={'target_date': str(yesterday)})
+
+    conn = _get_connection()
+    results: dict[str, Any] = {'target_date': str(yesterday)}
+
+    # Step 1: compute daily_metrics
+    with conn.cursor() as cur:
+        cur.execute(COMPUTE_DAILY_METRICS, {'target_date': yesterday})
+    results['daily_metrics'] = 'ok'
+    metrics.add_metric(name='AggregatorDailyMetrics', unit=MetricUnit.Count, value=1)
+
+    # Step 2: refresh MVs (CONCURRENTLY, individually para que un fail no
+    # rompa los otros)
+    for mv_query, mv_name in [
+        (REFRESH_MV_CONTACTS, 'mv_contacts_by_month_niche'),
+        (REFRESH_MV_LANDING, 'mv_top_landing_pages'),
+        (REFRESH_MV_JOURNEY, 'mv_session_journey'),
+    ]:
+        try:
+            with conn.cursor() as cur:
+                cur.execute(mv_query)
+            results[mv_name] = 'refreshed'
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                'failed to refresh materialized view',
+                extra={'mv_name': mv_name},
+            )
+            results[mv_name] = 'failed'
+
+    # Step 3: cleanup processed_stream_events > 30d
+    with conn.cursor() as cur:
+        cur.execute(CLEANUP_OLD_EVENTS)
+        results['cleanup_rows'] = cur.rowcount
+    metrics.add_metric(
+        name='AggregatorEventsCleaned',
+        unit=MetricUnit.Count,
+        value=cur.rowcount or 0,
+    )
+
+    logger.info('aggregator completed', extra=results)
+    return results

--- a/serverless/src/aggregator/queries.py
+++ b/serverless/src/aggregator/queries.py
@@ -1,0 +1,99 @@
+"""SQL queries del aggregator. Constants para mantener sintaxis legible."""
+
+from __future__ import annotations
+
+# Compute daily_metrics para el dia anterior (ayer en UTC).
+COMPUTE_DAILY_METRICS = """
+INSERT INTO daily_metrics (
+    metric_date,
+    total_contacts,
+    total_tracking_events,
+    unique_sessions,
+    new_contacts,
+    converted_contacts,
+    conversion_rate,
+    contacts_by_niche,
+    contacts_by_service_type,
+    tracking_by_device,
+    tracking_by_country
+)
+SELECT
+    %(target_date)s::date,
+    -- Contacts del dia
+    (SELECT COUNT(*) FROM contacts
+     WHERE created_at::date = %(target_date)s::date),
+    -- Tracking events del dia
+    (SELECT COUNT(*) FROM tracking_events
+     WHERE created_at::date = %(target_date)s::date),
+    -- Unique sessions del dia
+    (SELECT COUNT(DISTINCT session_id) FROM tracking_events
+     WHERE created_at::date = %(target_date)s::date),
+    -- new_contacts (status='new')
+    (SELECT COUNT(*) FROM contacts
+     WHERE created_at::date = %(target_date)s::date AND status = 'new'),
+    -- converted_contacts (status='converted')
+    (SELECT COUNT(*) FROM contacts
+     WHERE created_at::date = %(target_date)s::date AND status = 'converted'),
+    -- conversion_rate
+    COALESCE(
+        (SELECT COUNT(*) FILTER (WHERE status = 'converted')::numeric
+         / NULLIF(COUNT(*), 0)
+         FROM contacts WHERE created_at::date = %(target_date)s::date),
+        0
+    ),
+    -- contacts_by_niche JSONB
+    COALESCE(
+        (SELECT jsonb_object_agg(COALESCE(niche, 'unknown'), cnt)
+         FROM (SELECT niche, COUNT(*) AS cnt FROM contacts
+               WHERE created_at::date = %(target_date)s::date
+               GROUP BY niche) q),
+        '{}'::jsonb
+    ),
+    -- contacts_by_service_type
+    COALESCE(
+        (SELECT jsonb_object_agg(COALESCE(service_type, 'unknown'), cnt)
+         FROM (SELECT service_type, COUNT(*) AS cnt FROM contacts
+               WHERE created_at::date = %(target_date)s::date
+               GROUP BY service_type) q),
+        '{}'::jsonb
+    ),
+    -- tracking_by_device
+    COALESCE(
+        (SELECT jsonb_object_agg(COALESCE(device_type, 'unknown'), cnt)
+         FROM (SELECT device_type, COUNT(*) AS cnt FROM tracking_events
+               WHERE created_at::date = %(target_date)s::date
+               GROUP BY device_type) q),
+        '{}'::jsonb
+    ),
+    -- tracking_by_country
+    COALESCE(
+        (SELECT jsonb_object_agg(COALESCE(country, 'unknown'), cnt)
+         FROM (SELECT country, COUNT(*) AS cnt FROM tracking_events
+               WHERE created_at::date = %(target_date)s::date
+               GROUP BY country) q),
+        '{}'::jsonb
+    )
+ON CONFLICT (metric_date) DO UPDATE SET
+    total_contacts = EXCLUDED.total_contacts,
+    total_tracking_events = EXCLUDED.total_tracking_events,
+    unique_sessions = EXCLUDED.unique_sessions,
+    new_contacts = EXCLUDED.new_contacts,
+    converted_contacts = EXCLUDED.converted_contacts,
+    conversion_rate = EXCLUDED.conversion_rate,
+    contacts_by_niche = EXCLUDED.contacts_by_niche,
+    contacts_by_service_type = EXCLUDED.contacts_by_service_type,
+    tracking_by_device = EXCLUDED.tracking_by_device,
+    tracking_by_country = EXCLUDED.tracking_by_country,
+    computed_at = now();
+"""
+
+# Refresh MVs (CONCURRENTLY no bloquea reads)
+REFRESH_MV_CONTACTS = 'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_contacts_by_month_niche'
+REFRESH_MV_LANDING = 'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_top_landing_pages'
+REFRESH_MV_JOURNEY = 'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_session_journey'
+
+# Cleanup processed_stream_events > 30 dias (anti-bloat)
+CLEANUP_OLD_EVENTS = """
+DELETE FROM processed_stream_events
+WHERE processed_at < NOW() - INTERVAL '30 days'
+"""

--- a/serverless/src/aggregator/requirements.txt
+++ b/serverless/src/aggregator/requirements.txt
@@ -1,0 +1,1 @@
+# aggregator: no requiere deps adicionales.

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -336,6 +336,49 @@ Resources:
         Stage: !Ref Stage
 
   # ==========================================================================
+  # Lambda: aggregator (cron 03:00 UTC daily, SPEC-010)
+  # ==========================================================================
+  AggregatorFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: python3.13
+      BuildArchitecture: arm64
+    Properties:
+      FunctionName: !Sub portfolio-aggregator-${Stage}
+      CodeUri: src/
+      Handler: aggregator.handler.lambda_handler
+      Layers:
+        - !Ref CommonLayer
+        - !Ref PostgresLayer
+      MemorySize: 1024
+      Timeout: 300
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: aggregator
+          SSM_NEON_URL_PATH: /portfolio/neon-url
+      Policies:
+        - SSMParameterReadPolicy:
+            ParameterName: 'portfolio/neon-url'
+        - Statement:
+            - Effect: Allow
+              Action: kms:Decrypt
+              Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+              Condition:
+                StringEquals:
+                  kms:ViaService: !Sub ssm.${AWS::Region}.amazonaws.com
+      Events:
+        Daily03UTC:
+          Type: Schedule
+          Properties:
+            Schedule: 'cron(0 3 * * ? *)'
+            Description: 'Aggregator nightly daily_metrics + MV refresh'
+            Enabled: true
+      Tags:
+        Project: portfolio
+        ManagedBy: SAM
+        Stage: !Ref Stage
+
+  # ==========================================================================
   # Lambda: stream_processor (DynamoDB Streams -> Neon, SPEC-009)
   # ==========================================================================
   StreamProcessorDLQ:


### PR DESCRIPTION
Lambda aggregator cron 03:00 UTC nightly: daily_metrics + refresh MVs + cleanup stream events > 30d. EventBridge Schedule + PostgresLayer + Neon connection via SSM.

SPEC-011 simplificada a doc (serverless/docs/ses-setup.md) porque SES production access ya GRANTED en us-east-1 (case 173472640000887). Domain identity, DKIM, SPF, DMARC configurados desde antes.

Stacks dev+prod CREATE_COMPLETE.