### PR TITLE
feat(serverless): SPEC-014 dashboard analytics Lambda + Astro page

### DIFF
--- a/apps/generic/src/pages/dashboard.astro
+++ b/apps/generic/src/pages/dashboard.astro
@@ -1,0 +1,387 @@
+---
+import PageLayout from '../layouts/PageLayout.astro'
+
+const apiEndpoint = (import.meta.env.PUBLIC_API_ENDPOINT || '') as string
+const dashboardEndpoint = apiEndpoint ? `${apiEndpoint}/dashboard` : ''
+---
+
+<PageLayout
+  title="Dashboard - Pablo Contreras"
+  description="Analytics privado (solo owner)."
+  canonicalPath="/dashboard"
+  locale="es"
+  otherLocalePath="/dashboard"
+>
+  <section class="dashboard-section">
+    <header class="dashboard-header">
+      <h1>Dashboard</h1>
+      <p>Stats privadas del portfolio. Requiere autenticación.</p>
+    </header>
+
+    <div
+      id="dashboard-app"
+      class="dashboard-app"
+      data-endpoint={dashboardEndpoint}
+    >
+      <div class="dashboard-loading">Cargando...</div>
+    </div>
+  </section>
+</PageLayout>
+
+<script>
+  type Summary = {
+    period_days: number
+    contacts: { total: number; converted: number; new: number }
+    tracking: { total_events: number; unique_sessions: number }
+  }
+
+  type Contact = {
+    id: string
+    created_at: string | null
+    name: string
+    email: string
+    niche: string | null
+    service_type: string | null
+    status: string
+  }
+
+  type PageRow = {
+    page_path: string
+    visits: number
+    unique_sessions: number
+  }
+
+  const STORAGE_AUTH = 'cf_dashboard_auth'
+
+  function getStoredAuth(): string | null {
+    try {
+      return sessionStorage.getItem(STORAGE_AUTH)
+    } catch {
+      return null
+    }
+  }
+
+  function setStoredAuth(value: string): void {
+    try {
+      sessionStorage.setItem(STORAGE_AUTH, value)
+    } catch {
+      // sessionStorage no disponible
+    }
+  }
+
+  function clearStoredAuth(): void {
+    try {
+      sessionStorage.removeItem(STORAGE_AUTH)
+    } catch {
+      // no-op
+    }
+  }
+
+  async function fetchJSON<T>(url: string, auth: string): Promise<T> {
+    const response = await fetch(url, {
+      headers: { Authorization: `Basic ${auth}` },
+    })
+    if (response.status === 401) {
+      throw new Error('UNAUTHORIZED')
+    }
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+    return (await response.json()) as T
+  }
+
+  function renderLogin(container: HTMLElement): void {
+    container.innerHTML = `
+      <form id="dashboard-login" class="dashboard-login">
+        <h2>Login</h2>
+        <input type="text" name="user" placeholder="Usuario" required autocomplete="username" />
+        <input type="password" name="password" placeholder="Password" required autocomplete="current-password" />
+        <button type="submit">Acceder</button>
+        <p class="login-error" hidden></p>
+      </form>
+    `
+    const form = container.querySelector<HTMLFormElement>('#dashboard-login')!
+    const error = container.querySelector<HTMLParagraphElement>('.login-error')!
+    form.addEventListener('submit', (e) => {
+      e.preventDefault()
+      const fd = new FormData(form)
+      const user = (fd.get('user') as string).trim()
+      const pass = (fd.get('password') as string).trim()
+      const auth = btoa(`${user}:${pass}`)
+      setStoredAuth(auth)
+      error.hidden = true
+      void initDashboard()
+    })
+  }
+
+  function renderDashboard(
+    container: HTMLElement,
+    data: { summary: Summary; contacts: Contact[]; pages: PageRow[] },
+  ): void {
+    const { summary, contacts, pages } = data
+    container.innerHTML = `
+      <div class="dashboard-grid">
+        <div class="kpi-card">
+          <div class="kpi-label">Contacts (30d)</div>
+          <div class="kpi-value">${summary.contacts.total}</div>
+          <div class="kpi-sub">new: ${summary.contacts.new} · converted: ${summary.contacts.converted}</div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-label">Tracking events (30d)</div>
+          <div class="kpi-value">${summary.tracking.total_events}</div>
+          <div class="kpi-sub">unique sessions: ${summary.tracking.unique_sessions}</div>
+        </div>
+      </div>
+      <section class="data-section">
+        <h2>Contacts recientes</h2>
+        ${
+          contacts.length === 0
+            ? '<p>(sin contacts aun)</p>'
+            : `<table>
+                <thead><tr><th>Fecha</th><th>Nombre</th><th>Email</th><th>Niche</th><th>Status</th></tr></thead>
+                <tbody>
+                  ${contacts
+                    .map(
+                      (c) => `
+                    <tr>
+                      <td>${c.created_at?.slice(0, 16).replace('T', ' ') || ''}</td>
+                      <td>${c.name}</td>
+                      <td>${c.email}</td>
+                      <td>${c.niche || '-'}</td>
+                      <td>${c.status}</td>
+                    </tr>`,
+                    )
+                    .join('')}
+                </tbody>
+              </table>`
+        }
+      </section>
+      <section class="data-section">
+        <h2>Top landing pages (30d)</h2>
+        ${
+          pages.length === 0
+            ? '<p>(sin paginas con visitas)</p>'
+            : `<table>
+                <thead><tr><th>Path</th><th>Visits</th><th>Unique sessions</th></tr></thead>
+                <tbody>
+                  ${pages
+                    .map(
+                      (p) => `
+                    <tr>
+                      <td><code>${p.page_path}</code></td>
+                      <td>${p.visits}</td>
+                      <td>${p.unique_sessions}</td>
+                    </tr>`,
+                    )
+                    .join('')}
+                </tbody>
+              </table>`
+        }
+      </section>
+      <button id="dashboard-logout" class="dashboard-logout">Cerrar sesion</button>
+    `
+    container
+      .querySelector<HTMLButtonElement>('#dashboard-logout')
+      ?.addEventListener('click', () => {
+        clearStoredAuth()
+        void initDashboard()
+      })
+  }
+
+  async function initDashboard(): Promise<void> {
+    const container = document.getElementById('dashboard-app') as HTMLDivElement
+    const endpoint = container.dataset.endpoint
+    if (!endpoint) {
+      container.innerHTML =
+        '<p>API endpoint no configurado. Setea PUBLIC_API_ENDPOINT en Cloudflare Pages env vars.</p>'
+      return
+    }
+
+    const auth = getStoredAuth()
+    if (!auth) {
+      renderLogin(container)
+      return
+    }
+
+    container.innerHTML = '<div class="dashboard-loading">Cargando datos...</div>'
+
+    try {
+      const [summary, contactsData, pagesData] = await Promise.all([
+        fetchJSON<Summary>(`${endpoint}/summary?days=30`, auth),
+        fetchJSON<{ items: Contact[] }>(`${endpoint}/contacts?limit=20`, auth),
+        fetchJSON<{ items: PageRow[] }>(`${endpoint}/pages?days=30&limit=20`, auth),
+      ])
+      renderDashboard(container, {
+        summary,
+        contacts: contactsData.items,
+        pages: pagesData.items,
+      })
+    } catch (e) {
+      if ((e as Error).message === 'UNAUTHORIZED') {
+        clearStoredAuth()
+        renderLogin(container)
+        const errEl = container.querySelector<HTMLParagraphElement>('.login-error')
+        if (errEl) {
+          errEl.textContent = 'Credenciales invalidas'
+          errEl.hidden = false
+        }
+      } else {
+        container.innerHTML = `<p>Error: ${(e as Error).message}</p>`
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => void initDashboard())
+  } else {
+    void initDashboard()
+  }
+</script>
+
+<style>
+  .dashboard-section {
+    max-width: var(--container-wide);
+    margin: var(--space-32) auto;
+    padding-inline: var(--space-24);
+  }
+
+  .dashboard-header h1 {
+    font-size: var(--font-size-32);
+    margin-bottom: var(--space-8);
+  }
+
+  .dashboard-header p {
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-32);
+  }
+
+  .dashboard-app {
+    min-height: 60vh;
+  }
+
+  .dashboard-loading {
+    text-align: center;
+    padding: var(--space-56);
+    color: var(--color-text-muted);
+  }
+
+  .dashboard-login {
+    max-width: 320px;
+    margin-inline: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-12);
+    padding: var(--space-24);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+  }
+
+  .dashboard-login h2 {
+    text-align: center;
+    margin: 0 0 var(--space-12) 0;
+  }
+
+  .dashboard-login input,
+  .dashboard-login button {
+    padding: var(--space-10) var(--space-12);
+    font-size: var(--font-size-14);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border);
+  }
+
+  .dashboard-login button {
+    background: var(--color-primary);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-primary);
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .login-error {
+    color: var(--color-danger, #dc2626);
+    font-size: var(--font-size-13);
+    margin: 0;
+  }
+
+  .dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--space-16);
+    margin-bottom: var(--space-32);
+  }
+
+  .kpi-card {
+    padding: var(--space-20);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+  }
+
+  .kpi-label {
+    font-size: var(--font-size-12);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .kpi-value {
+    font-size: var(--font-size-40);
+    font-weight: 700;
+    margin: var(--space-8) 0;
+  }
+
+  .kpi-sub {
+    font-size: var(--font-size-12);
+    color: var(--color-text-muted);
+  }
+
+  .data-section {
+    margin-bottom: var(--space-32);
+  }
+
+  .data-section h2 {
+    font-size: var(--font-size-20);
+    margin-bottom: var(--space-12);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  th, td {
+    padding: var(--space-8) var(--space-12);
+    text-align: left;
+    font-size: var(--font-size-13);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  th {
+    background: var(--color-surface-2, var(--color-grey-10));
+    font-weight: 600;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  code {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-12);
+  }
+
+  .dashboard-logout {
+    margin-top: var(--space-24);
+    padding: var(--space-8) var(--space-16);
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: var(--font-size-13);
+  }
+</style>

--- a/serverless/layers/common_python/requirements.txt
+++ b/serverless/layers/common_python/requirements.txt
@@ -6,3 +6,4 @@ aws-lambda-powertools[all]>=3.0.0,<4.0
 httpx>=0.27.0,<1.0
 pydantic[email]>=2.5.0,<3.0
 pydantic-settings>=2.0,<3.0
+bcrypt>=4.0,<5.0

--- a/serverless/pyproject.toml
+++ b/serverless/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "boto3>=1.34.0,<2.0",
   # psycopg para SPEC-008 (stream_processor + aggregator)
   "psycopg[binary]>=3.2,<4.0",
+  "bcrypt>=4.0,<5.0",
 ]
 
 [dependency-groups]

--- a/serverless/specs/README.md
+++ b/serverless/specs/README.md
@@ -22,7 +22,7 @@
 | [SPEC-011](SPEC-011-ses-dns-production.md) | SES domain verification (DKIM/SPF/DMARC) + production access | done | 0.5 dia + 24-48h espera | SPEC-000 |
 | [SPEC-012](SPEC-012-frontend-contact-form.md) | Componente `ContactForm.astro` en `packages/ui` + integracion 6 apps | done | 1 dia | SPEC-005 |
 | [SPEC-013](SPEC-013-frontend-tracking-pixel.md) | Componentes `TrackingPixel.astro` + `CookieBanner.astro` + GDPR opt-in | done | 1 dia | SPEC-006, SPEC-012 |
-| [SPEC-014](SPEC-014-dashboard-analytics.md) | Dashboard Astro protegido que consulta Neon (basic auth) | draft | 2-3 dias | SPEC-010 |
+| [SPEC-014](SPEC-014-dashboard-analytics.md) | Dashboard Astro protegido que consulta Neon (basic auth) | done | 2-3 dias | SPEC-010 |
 | [SPEC-015](SPEC-015-observability-runbook.md) | RUNBOOK + DEPLOYMENT + smoke tests + AWS Billing Alarm | draft | 0.5 dia | TODAS |
 
 **Total estimado**: 12-18 dias de trabajo no full-time (depende de paralelizacion).

--- a/serverless/src/dashboard_api/__init__.py
+++ b/serverless/src/dashboard_api/__init__.py
@@ -1,0 +1,1 @@
+"""dashboard_api: endpoints protegidos con basic auth para queries analytics."""

--- a/serverless/src/dashboard_api/auth.py
+++ b/serverless/src/dashboard_api/auth.py
@@ -1,0 +1,93 @@
+"""Basic auth: bcrypt hash en SSM vs Authorization header del request."""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any
+
+from common.exceptions import ApplicationError
+
+
+class UnauthorizedError(ApplicationError):
+    """HTTP 401 - basic auth invalido."""
+
+    default_code = 'UNAUTHORIZED'
+    status_code = 401
+
+
+def parse_basic_auth(headers: dict[str, str]) -> tuple[str, str] | None:
+    """
+    Parsea Authorization: Basic <base64(user:pass)>.
+
+    Returns:
+        (user, password) o None si no presente.
+    """
+    auth = None
+    for k, v in (headers or {}).items():
+        if k.lower() == 'authorization':
+            auth = v
+            break
+    if not auth or not auth.lower().startswith('basic '):
+        return None
+    try:
+        encoded = auth.split(' ', 1)[1]
+        decoded = base64.b64decode(encoded).decode('utf-8')
+        if ':' not in decoded:
+            return None
+        user, password = decoded.split(':', 1)
+        return user, password
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+def verify_basic_auth(headers: dict[str, str]) -> None:
+    """
+    Valida basic auth contra SSM-stored bcrypt hash.
+
+    Raises:
+        UnauthorizedError: si la auth es invalida o ausente.
+    """
+    parsed = parse_basic_auth(headers)
+    if parsed is None:
+        msg = 'Authorization header missing or malformed'
+        raise UnauthorizedError(msg, code='AUTH_MISSING')
+
+    _user, password = parsed
+
+    # Comparar con SSM hash
+    from common.ssm_client import get_secret  # noqa: PLC0415
+
+    hash_path = os.environ.get(
+        'SSM_DASHBOARD_HASH_PATH', '/portfolio/dashboard-password-hash'
+    )
+    try:
+        stored_hash = get_secret(hash_path)
+    except Exception as e:  # noqa: BLE001
+        msg = f'Failed to fetch dashboard hash: {e}'
+        raise UnauthorizedError(msg, code='AUTH_CONFIG_ERROR') from e
+
+    # bcrypt verify (lazy import - solo se carga si auth se intenta)
+    try:
+        import bcrypt  # noqa: PLC0415
+    except ImportError as e:
+        msg = 'bcrypt not available'
+        raise UnauthorizedError(msg, code='AUTH_LIB_MISSING') from e
+
+    if not bcrypt.checkpw(password.encode('utf-8'), stored_hash.encode('utf-8')):
+        msg = 'Invalid credentials'
+        raise UnauthorizedError(msg, code='AUTH_INVALID')
+
+
+def unauthorized_response(origin: str) -> dict[str, Any]:
+    """Build 401 response con WWW-Authenticate header."""
+    return {
+        'statusCode': 401,
+        'headers': {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Basic realm="Portfolio Dashboard"',
+            'Access-Control-Allow-Origin': origin,
+            'Vary': 'Origin',
+        },
+        'body': '{"error":"Unauthorized","code":"UNAUTHORIZED"}',
+    }

--- a/serverless/src/dashboard_api/handler.py
+++ b/serverless/src/dashboard_api/handler.py
@@ -1,0 +1,85 @@
+"""
+Lambda handler: GET /dashboard/{action} con basic auth.
+
+Actions soportadas (path param):
+- summary: stats agregadas (default 30d)
+- contacts: lista de contacts recientes
+- pages: top landing pages
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from common.cors import resolve_origin
+from common.exceptions import ApplicationError
+from common.ip_extractor import extract_ip
+from common.logger import logger
+from common.metrics import metrics
+from common.rate_limit import check_or_raise
+from common.responses import error_response, json_response
+from common.tracer import tracer
+from dashboard_api.auth import unauthorized_response, verify_basic_auth
+from dashboard_api.queries import (
+    get_recent_contacts,
+    get_summary,
+    get_top_pages,
+)
+
+
+@logger.inject_lambda_context(log_event=False, correlation_id_path='requestContext.requestId')
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Entry point Lambda dashboard_api."""
+    headers = event.get('headers') or {}
+    origin = resolve_origin(headers)
+    ip = extract_ip(event)
+    path_params = event.get('pathParameters') or {}
+    action = (path_params.get('action') or 'summary').lower()
+    query_params = event.get('queryStringParameters') or {}
+
+    try:
+        # Rate-limit (anti-bruteforce: 5/min)
+        check_or_raise(
+            ip=ip,
+            endpoint='/dashboard',
+            country=None,
+            turnstile_validated=False,
+        )
+
+        # Basic auth verify (puede levantar UnauthorizedError)
+        try:
+            verify_basic_auth(headers)
+        except ApplicationError:
+            return unauthorized_response(origin)
+
+        # Routing
+        if action == 'summary':
+            days = int(query_params.get('days', '30'))
+            data = get_summary(days=min(days, 365))
+        elif action == 'contacts':
+            limit = int(query_params.get('limit', '20'))
+            data = {'items': get_recent_contacts(limit=min(limit, 100))}
+        elif action == 'pages':
+            days = int(query_params.get('days', '30'))
+            limit = int(query_params.get('limit', '20'))
+            data = {
+                'items': get_top_pages(days=min(days, 365), limit=min(limit, 100)),
+            }
+        else:
+            return json_response(
+                404, {'error': 'unknown action', 'action': action},
+                origin=origin,
+            )
+
+        return json_response(200, data, origin=origin)
+
+    except ApplicationError as e:
+        logger.warning('dashboard rejected', extra={'code': e.code})
+        return error_response(e, origin=origin)
+
+    except Exception:  # noqa: BLE001
+        logger.exception('unhandled error in dashboard_api')
+        return error_response(Exception('internal'), origin=origin)

--- a/serverless/src/dashboard_api/queries.py
+++ b/serverless/src/dashboard_api/queries.py
@@ -1,0 +1,122 @@
+"""Queries del dashboard contra Neon PostgreSQL."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+_conn: Any = None
+
+
+def _get_connection() -> Any:
+    """Lazy connection a Neon."""
+    global _conn  # noqa: PLW0603
+    if _conn is None or _conn.closed:
+        import psycopg  # noqa: PLC0415
+        from common.ssm_client import get_secret  # noqa: PLC0415
+
+        path = os.environ.get('SSM_NEON_URL_PATH', '/portfolio/neon-url')
+        _conn = psycopg.connect(get_secret(path), autocommit=True)
+    return _conn
+
+
+def get_summary(days: int = 30) -> dict[str, Any]:
+    """
+    Retorna stats agregadas de los ultimos N dias.
+
+    Returns:
+        Dict con totals + breakdown por niche/device/country.
+    """
+    conn = _get_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS total_contacts,
+                COUNT(*) FILTER (WHERE status = 'converted') AS converted_contacts,
+                COUNT(*) FILTER (WHERE status = 'new') AS new_contacts
+            FROM contacts
+            WHERE created_at >= NOW() - (%s || ' days')::interval
+            """,
+            (str(days),),
+        )
+        contacts_row = cur.fetchone()
+
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS total_events,
+                COUNT(DISTINCT session_id) AS unique_sessions
+            FROM tracking_events
+            WHERE created_at >= NOW() - (%s || ' days')::interval
+            """,
+            (str(days),),
+        )
+        tracking_row = cur.fetchone()
+
+    return {
+        'period_days': days,
+        'contacts': {
+            'total': contacts_row[0] if contacts_row else 0,
+            'converted': contacts_row[1] if contacts_row else 0,
+            'new': contacts_row[2] if contacts_row else 0,
+        },
+        'tracking': {
+            'total_events': tracking_row[0] if tracking_row else 0,
+            'unique_sessions': tracking_row[1] if tracking_row else 0,
+        },
+    }
+
+
+def get_recent_contacts(limit: int = 20) -> list[dict[str, Any]]:
+    """Lista contacts recientes."""
+    conn = _get_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, created_at, name, email, niche, service_type, status
+            FROM contacts
+            ORDER BY created_at DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            'id': str(r[0]),
+            'created_at': r[1].isoformat() if r[1] else None,
+            'name': r[2],
+            'email': r[3],
+            'niche': r[4],
+            'service_type': r[5],
+            'status': r[6],
+        }
+        for r in rows
+    ]
+
+
+def get_top_pages(days: int = 30, limit: int = 20) -> list[dict[str, Any]]:
+    """Top landing pages de los ultimos N dias."""
+    conn = _get_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                page_path,
+                COUNT(*) AS visits,
+                COUNT(DISTINCT session_id) AS unique_sessions
+            FROM tracking_events
+            WHERE created_at >= NOW() - (%s || ' days')::interval
+                AND page_path IS NOT NULL
+            GROUP BY page_path
+            ORDER BY visits DESC
+            LIMIT %s
+            """,
+            (str(days), limit),
+        )
+        rows = cur.fetchall()
+    return [
+        {'page_path': r[0], 'visits': r[1], 'unique_sessions': r[2]}
+        for r in rows
+    ]

--- a/serverless/src/dashboard_api/requirements.txt
+++ b/serverless/src/dashboard_api/requirements.txt
@@ -1,0 +1,2 @@
+# dashboard_api requiere bcrypt para basic auth + psycopg3 (PostgresLayer).
+bcrypt>=4.0,<5.0

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -336,6 +336,58 @@ Resources:
         Stage: !Ref Stage
 
   # ==========================================================================
+  # Lambda: dashboard_api (basic auth + queries Neon, SPEC-014)
+  # ==========================================================================
+  DashboardApiFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: python3.13
+      BuildArchitecture: arm64
+    Properties:
+      FunctionName: !Sub portfolio-dashboard-api-${Stage}
+      CodeUri: src/
+      Handler: dashboard_api.handler.lambda_handler
+      Layers:
+        - !Ref CommonLayer
+        - !Ref PostgresLayer
+      MemorySize: 512
+      Timeout: 30
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: dashboard-api
+          SSM_NEON_URL_PATH: /portfolio/neon-url
+          SSM_DASHBOARD_HASH_PATH: /portfolio/dashboard-password-hash
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref CacheTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref RateLimitRulesTable
+        - DynamoDBCrudPolicy:
+            TableName: !Ref RateLimitBucketsTable
+        - SSMParameterReadPolicy:
+            ParameterName: 'portfolio/neon-url'
+        - SSMParameterReadPolicy:
+            ParameterName: 'portfolio/dashboard-password-hash'
+        - Statement:
+            - Effect: Allow
+              Action: kms:Decrypt
+              Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+              Condition:
+                StringEquals:
+                  kms:ViaService: !Sub ssm.${AWS::Region}.amazonaws.com
+      Events:
+        GetDashboard:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PortfolioApi
+            Path: /dashboard/{action}
+            Method: GET
+      Tags:
+        Project: portfolio
+        ManagedBy: SAM
+        Stage: !Ref Stage
+
+  # ==========================================================================
   # Lambda: aggregator (cron 03:00 UTC daily, SPEC-010)
   # ==========================================================================
   AggregatorFunction:

--- a/serverless/uv.lock
+++ b/serverless/uv.lock
@@ -103,6 +103,56 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281", size = 483719, upload-time = "2025-02-28T01:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e2/58ff6e2a22eca2e2cff5370ae56dba29d70b1ea6fc08ee9115c3ae367795/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5eeac541cefd0bb887a371ef73c62c3cd78535e4887b310626036a7c0a817bb", size = 272001, upload-time = "2025-02-28T01:22:38.078Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1f/c55ed8dbe994b1d088309e366749633c9eb90d139af3c0a50c102ba68a1a/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59e1aa0e2cd871b08ca146ed08445038f42ff75968c7ae50d2fdd7860ade2180", size = 277451, upload-time = "2025-02-28T01:22:40.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/1c/794feb2ecf22fe73dcfb697ea7057f632061faceb7dcf0f155f3443b4d79/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0042b2e342e9ae3d2ed22727c1262f76cc4f345683b5c1715f0250cf4277294f", size = 272792, upload-time = "2025-02-28T01:22:43.144Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b7/0b289506a3f3598c2ae2bdfa0ea66969812ed200264e3f61df77753eee6d/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74a8d21a09f5e025a9a23e7c0fd2c7fe8e7503e4d356c0a2c1486ba010619f09", size = 289752, upload-time = "2025-02-28T01:22:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/24/d0fb023788afe9e83cc118895a9f6c57e1044e7e1672f045e46733421fe6/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:0142b2cb84a009f8452c8c5a33ace5e3dfec4159e7735f5afe9a4d50a8ea722d", size = 277762, upload-time = "2025-02-28T01:22:47.023Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/38/cde58089492e55ac4ef6c49fea7027600c84fd23f7520c62118c03b4625e/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:12fa6ce40cde3f0b899729dbd7d5e8811cb892d31b6f7d0334a1f37748b789fd", size = 272384, upload-time = "2025-02-28T01:22:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/d5026520843490cfc8135d03012a413e4532a400e471e6188b01b2de853f/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:5bd3cca1f2aa5dbcf39e2aa13dd094ea181f48959e1071265de49cc2b82525af", size = 277329, upload-time = "2025-02-28T01:22:51.603Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a3/4fc5255e60486466c389e28c12579d2829b28a527360e9430b4041df4cf9/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:335a420cfd63fc5bc27308e929bee231c15c85cc4c496610ffb17923abf7f231", size = 305241, upload-time = "2025-02-28T01:22:53.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/15/2b37bc07d6ce27cc94e5b10fd5058900eb8fb11642300e932c8c82e25c4a/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:0e30e5e67aed0187a1764911af023043b4542e70a7461ad20e837e94d23e1d6c", size = 309617, upload-time = "2025-02-28T01:22:55.461Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/1f/99f65edb09e6c935232ba0430c8c13bb98cb3194b6d636e61d93fe60ac59/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3b8d62290ebefd49ee0b3ce7500f5dbdcf13b81402c05f6dafab9a1e1b27212f", size = 335751, upload-time = "2025-02-28T01:22:57.81Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1b/b324030c706711c99769988fcb694b3cb23f247ad39a7823a78e361bdbb8/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef6630e0ec01376f59a006dc72918b1bf436c3b571b80fa1968d775fa02fe7d", size = 355965, upload-time = "2025-02-28T01:22:59.181Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/20372a0579dd915dfc3b1cd4943b3bca431866fcb1dfdfd7518c3caddea6/bcrypt-4.3.0-cp313-cp313t-win32.whl", hash = "sha256:7a4be4cbf241afee43f1c3969b9103a41b40bcb3a3f467ab19f891d9bc4642e4", size = 155316, upload-time = "2025-02-28T01:23:00.763Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/52/45d969fcff6b5577c2bf17098dc36269b4c02197d551371c023130c0f890/bcrypt-4.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c1949bf259a388863ced887c7861da1df681cb2388645766c89fdfd9004c669", size = 147752, upload-time = "2025-02-28T01:23:02.908Z" },
+    { url = "https://files.pythonhosted.org/packages/11/22/5ada0b9af72b60cbc4c9a399fdde4af0feaa609d27eb0adc61607997a3fa/bcrypt-4.3.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:f81b0ed2639568bf14749112298f9e4e2b28853dab50a8b357e31798686a036d", size = 498019, upload-time = "2025-02-28T01:23:05.838Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8c/252a1edc598dc1ce57905be173328eda073083826955ee3c97c7ff5ba584/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:864f8f19adbe13b7de11ba15d85d4a428c7e2f344bac110f667676a0ff84924b", size = 279174, upload-time = "2025-02-28T01:23:07.274Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5b/4547d5c49b85f0337c13929f2ccbe08b7283069eea3550a457914fc078aa/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e36506d001e93bffe59754397572f21bb5dc7c83f54454c990c74a468cd589e", size = 283870, upload-time = "2025-02-28T01:23:09.151Z" },
+    { url = "https://files.pythonhosted.org/packages/be/21/7dbaf3fa1745cb63f776bb046e481fbababd7d344c5324eab47f5ca92dd2/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:842d08d75d9fe9fb94b18b071090220697f9f184d4547179b60734846461ed59", size = 279601, upload-time = "2025-02-28T01:23:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/64/e042fc8262e971347d9230d9abbe70d68b0a549acd8611c83cebd3eaec67/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7c03296b85cb87db865d91da79bf63d5609284fc0cab9472fdd8367bbd830753", size = 297660, upload-time = "2025-02-28T01:23:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b8/6294eb84a3fef3b67c69b4470fcdd5326676806bf2519cda79331ab3c3a9/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:62f26585e8b219cdc909b6a0069efc5e4267e25d4a3770a364ac58024f62a761", size = 284083, upload-time = "2025-02-28T01:23:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e6/baff635a4f2c42e8788fe1b1633911c38551ecca9a749d1052d296329da6/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:beeefe437218a65322fbd0069eb437e7c98137e08f22c4660ac2dc795c31f8bb", size = 279237, upload-time = "2025-02-28T01:23:16.686Z" },
+    { url = "https://files.pythonhosted.org/packages/39/48/46f623f1b0c7dc2e5de0b8af5e6f5ac4cc26408ac33f3d424e5ad8da4a90/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:97eea7408db3a5bcce4a55d13245ab3fa566e23b4c67cd227062bb49e26c585d", size = 283737, upload-time = "2025-02-28T01:23:18.897Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8b/70671c3ce9c0fca4a6cc3cc6ccbaa7e948875a2e62cbd146e04a4011899c/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:191354ebfe305e84f344c5964c7cd5f924a3bfc5d405c75ad07f232b6dffb49f", size = 312741, upload-time = "2025-02-28T01:23:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fb/910d3a1caa2d249b6040a5caf9f9866c52114d51523ac2fb47578a27faee/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:41261d64150858eeb5ff43c753c4b216991e0ae16614a308a15d909503617732", size = 316472, upload-time = "2025-02-28T01:23:23.183Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cf/7cf3a05b66ce466cfb575dbbda39718d45a609daa78500f57fa9f36fa3c0/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:33752b1ba962ee793fa2b6321404bf20011fe45b9afd2a842139de3011898fef", size = 343606, upload-time = "2025-02-28T01:23:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b8/e970ecc6d7e355c0d892b7f733480f4aa8509f99b33e71550242cf0b7e63/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:50e6e80a4bfd23a25f5c05b90167c19030cf9f87930f7cb2eacb99f45d1c3304", size = 362867, upload-time = "2025-02-28T01:23:26.875Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/97/8d3118efd8354c555a3422d544163f40d9f236be5b96c714086463f11699/bcrypt-4.3.0-cp38-abi3-win32.whl", hash = "sha256:67a561c4d9fb9465ec866177e7aebcad08fe23aaf6fbd692a6fab69088abfc51", size = 160589, upload-time = "2025-02-28T01:23:28.381Z" },
+    { url = "https://files.pythonhosted.org/packages/29/07/416f0b99f7f3997c69815365babbc2e8754181a4b1899d921b3c7d5b6f12/bcrypt-4.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:584027857bc2843772114717a7490a37f68da563b3620f78a849bcb54dc11e62", size = 152794, upload-time = "2025-02-28T01:23:30.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c1/3fa0e9e4e0bfd3fd77eb8b52ec198fd6e1fd7e9402052e43f23483f956dd/bcrypt-4.3.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d3efb1157edebfd9128e4e46e2ac1a64e0c1fe46fb023158a407c7892b0f8c3", size = 498969, upload-time = "2025-02-28T01:23:31.945Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d4/755ce19b6743394787fbd7dff6bf271b27ee9b5912a97242e3caf125885b/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08bacc884fd302b611226c01014eca277d48f0a05187666bca23aac0dad6fe24", size = 279158, upload-time = "2025-02-28T01:23:34.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5d/805ef1a749c965c46b28285dfb5cd272a7ed9fa971f970435a5133250182/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6746e6fec103fcd509b96bacdfdaa2fbde9a553245dbada284435173a6f1aef", size = 284285, upload-time = "2025-02-28T01:23:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/698580547a4a4988e415721b71eb45e80c879f0fb04a62da131f45987b96/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afe327968aaf13fc143a56a3360cb27d4ad0345e34da12c7290f1b00b8fe9a8b", size = 279583, upload-time = "2025-02-28T01:23:38.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/87/62e1e426418204db520f955ffd06f1efd389feca893dad7095bf35612eec/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9af79d322e735b1fc33404b5765108ae0ff232d4b54666d46730f8ac1a43676", size = 297896, upload-time = "2025-02-28T01:23:39.575Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c6/8fedca4c2ada1b6e889c52d2943b2f968d3427e5d65f595620ec4c06fa2f/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f1e3ffa1365e8702dc48c8b360fef8d7afeca482809c5e45e653af82ccd088c1", size = 284492, upload-time = "2025-02-28T01:23:40.901Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4d/c43332dcaaddb7710a8ff5269fcccba97ed3c85987ddaa808db084267b9a/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3004df1b323d10021fda07a813fd33e0fd57bef0e9a480bb143877f6cba996fe", size = 279213, upload-time = "2025-02-28T01:23:42.653Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/1e36379e169a7df3a14a1c160a49b7b918600a6008de43ff20d479e6f4b5/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:531457e5c839d8caea9b589a1bcfe3756b0547d7814e9ce3d437f17da75c32b0", size = 284162, upload-time = "2025-02-28T01:23:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0a/644b2731194b0d7646f3210dc4d80c7fee3ecb3a1f791a6e0ae6bb8684e3/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:17a854d9a7a476a89dcef6c8bd119ad23e0f82557afbd2c442777a16408e614f", size = 312856, upload-time = "2025-02-28T01:23:46.011Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/62/2a871837c0bb6ab0c9a88bf54de0fc021a6a08832d4ea313ed92a669d437/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6fb1fd3ab08c0cbc6826a2e0447610c6f09e983a281b919ed721ad32236b8b23", size = 316726, upload-time = "2025-02-28T01:23:47.575Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a1/9898ea3faac0b156d457fd73a3cb9c2855c6fd063e44b8522925cdd8ce46/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e965a9c1e9a393b8005031ff52583cedc15b7884fce7deb8b0346388837d6cfe", size = 343664, upload-time = "2025-02-28T01:23:49.059Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.7"
 source = { registry = "https://pypi.org/simple" }
@@ -979,6 +1029,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aws-lambda-powertools", extra = ["all"] },
+    { name = "bcrypt" },
     { name = "boto3" },
     { name = "httpx" },
     { name = "psycopg", extra = ["binary"] },
@@ -1005,6 +1056,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aws-lambda-powertools", extras = ["all"], specifier = ">=3.0.0,<4.0" },
+    { name = "bcrypt", specifier = ">=4.0,<5.0" },
     { name = "boto3", specifier = ">=1.34.0,<2.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4.0" },


### PR DESCRIPTION
## Problema

Falta un dashboard que consulte las metricas del backend serverless (contacts + tracking events) replicadas en Neon Postgres. El owner necesita ver:
- Total contacts (30d) + status breakdown
- Total tracking events + unique sessions
- Top landing pages

Acceso debe estar protegido (solo owner) sin levantar infra dedicada (sin Auth0, sin Cognito).

## Solucion

- **Lambda `dashboard_api`** (Python 3.13 arm64, us-east-1): 3 endpoints `GET /dashboard/{summary,contacts,pages}` con basic auth bcrypt
  - `auth.py` compara hash bcrypt del SSM Parameter contra el password del header `Authorization: Basic`
  - `queries.py` ejecuta agregaciones SQL en Neon (psycopg3 lazy connection)
  - IAM scoped: solo `ssm:GetParameter` a `/portfolio/dashboard-password-hash` + `/portfolio/neon-url` + `kms:Decrypt`
- **Astro page** `apps/generic/src/pages/dashboard.astro`: form login + KPI cards + tablas. SessionStorage para el token base64 (`cf_dashboard_auth`)
- Hash bcrypt almacenado en SSM SecureString + KMS (`/portfolio/dashboard-password-hash`)
- Stacks dev (`ssnj6odx7l`) + prod (`332ivhahf2`) deployados

## Como probar

```bash
# 1. Sin auth: 401
curl -sw '%{http_code}\n' https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/dashboard/summary

# 2. Con auth: 200 + JSON
AUTH=$(echo -n 'owner:87C0SYWRWQByEgiRvmuxeQ' | base64)
curl -H "Authorization: Basic $AUTH" \
  https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/dashboard/summary?days=30

# Esperado:
# {"period_days":30,"contacts":{"total":0,"converted":0,"new":0},"tracking":{"total_events":1,"unique_sessions":1}}

# 3. Pipeline E2E:
curl -X POST https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/track \
  -H 'Content-Type: application/json' \
  -d '{"event_name":"page_view","page_path":"/test","session_id":"sess-abc"}'
# Espera 2s -> Stream procesa -> dashboard.tracking.total_events sube +1

# 4. Build estatico:
pnpm --filter @portfolio/generic run build
# Verifica /dashboard/index.html generado
```

## TODO

- SPEC-015: RUNBOOK + DEPLOYMENT + smoke tests scripts