### PR TITLE
fix(cors): permite localhost en preflight API GW dev + expone PUBLIC_ vars al container

### DIFF
--- a/docker/docker-compose/dev.yml
+++ b/docker/docker-compose/dev.yml
@@ -4,6 +4,10 @@ x-app-environment: &app-environment
   BASE_DOMAIN: ${BASE_DOMAIN:-localhost}
   BASE_SCHEME: ${BASE_SCHEME:-http}
   BASE_PORT: ${BASE_PORT:-9971}
+  # Backend serverless (vienen de docker/env/.dev). Astro los lee
+  # como import.meta.env.PUBLIC_* y los inlinea en el bundle del browser.
+  PUBLIC_API_ENDPOINT: ${PUBLIC_API_ENDPOINT:-}
+  PUBLIC_TURNSTILE_SITEKEY: ${PUBLIC_TURNSTILE_SITEKEY:-}
 
 services:
   nginx:

--- a/docker/docker-compose/local.yml
+++ b/docker/docker-compose/local.yml
@@ -6,6 +6,10 @@ x-app-environment: &app-environment
   BASE_DOMAIN: ${BASE_DOMAIN:-localhost}
   BASE_SCHEME: ${BASE_SCHEME:-http}
   BASE_PORT: ${BASE_PORT:-9970}
+  # Backend serverless (vienen de docker/env/.local). Astro los lee
+  # como import.meta.env.PUBLIC_* y los inlinea en el bundle del browser.
+  PUBLIC_API_ENDPOINT: ${PUBLIC_API_ENDPOINT:-}
+  PUBLIC_TURNSTILE_SITEKEY: ${PUBLIC_TURNSTILE_SITEKEY:-}
 
 services:
   nginx:

--- a/docker/docker-compose/prod.yml
+++ b/docker/docker-compose/prod.yml
@@ -5,6 +5,10 @@ x-app-environment: &app-environment
   BASE_DOMAIN: ${BASE_DOMAIN:-the-full-stack.com}
   BASE_SCHEME: ${BASE_SCHEME:-https}
   BASE_PORT: ${BASE_PORT-}
+  # Backend serverless (vienen de docker/env/.prod). Astro los lee
+  # como import.meta.env.PUBLIC_* y los inlinea en el bundle del browser.
+  PUBLIC_API_ENDPOINT: ${PUBLIC_API_ENDPOINT:-}
+  PUBLIC_TURNSTILE_SITEKEY: ${PUBLIC_TURNSTILE_SITEKEY:-}
 
 services:
   nginx:

--- a/docker/docker-compose/test.yml
+++ b/docker/docker-compose/test.yml
@@ -4,6 +4,10 @@ x-app-environment: &app-environment
   BASE_DOMAIN: ${BASE_DOMAIN:-localhost}
   BASE_SCHEME: ${BASE_SCHEME:-http}
   BASE_PORT: ${BASE_PORT:-9972}
+  # Backend serverless (vienen de docker/env/.test). Astro los lee
+  # como import.meta.env.PUBLIC_* y los inlinea en el bundle del browser.
+  PUBLIC_API_ENDPOINT: ${PUBLIC_API_ENDPOINT:-}
+  PUBLIC_TURNSTILE_SITEKEY: ${PUBLIC_TURNSTILE_SITEKEY:-}
 
 services:
   nginx:

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -88,6 +88,17 @@ Globals:
   # metodos (HandlerErrorCode: InvalidRequest "REST API doesn't contain any
   # methods"). El API se materializa cuando aparece el primer endpoint.
 
+# ============================================================================
+# Conditions: stage-based behavior
+# ============================================================================
+# IsDev: en dev permitimos CORS '*' en preflight para poder testear desde
+# localhost:9970-9973 (Docker stack del frontend). Prod mantiene whitelist
+# estricta. La Lambda igual valida Turnstile token, asi que '*' en preflight
+# no permite enviar form sin captcha resuelto.
+# ============================================================================
+Conditions:
+  IsDev: !Equals [!Ref Stage, 'dev']
+
 Resources:
   # ==========================================================================
   # Lambda Layer compartido: Powertools v3 + httpx + pydantic
@@ -167,7 +178,13 @@ Resources:
           "integrationLatency":"$context.integrationLatency",
           "latency":"$context.responseLatency"}
       Cors:
-        AllowOrigin: "'https://the-full-stack.com'"
+        # En dev permitimos '*' para testear desde localhost:9970-9973 (Docker
+        # stack). En prod mantenemos whitelist estricta (apex). La Lambda igual
+        # valida Turnstile token: '*' en preflight no permite spammear sin captcha.
+        AllowOrigin: !If
+          - IsDev
+          - "'*'"
+          - "'https://the-full-stack.com'"
         AllowHeaders: "'Content-Type,X-Turnstile-Token,X-Turnstile-Bypass-Secret'"
         AllowMethods: "'GET,POST,OPTIONS'"
         MaxAge: "'600'"


### PR DESCRIPTION
## Problema

1. El ContactForm renderizaba el fallback mailto en local porque PUBLIC_API_ENDPOINT y PUBLIC_TURNSTILE_SITEKEY vivian en docker/env/.local pero el compose file solo las usaba para interpolacion (--env-file), NO las inyectaba al container. Astro lee import.meta.env.PUBLIC_* al startup del dev server, sin las vars el condicional cae al fallback.
2. El API Gateway tenia Cors.AllowOrigin: https://the-full-stack.com hardcoded. Preflight OPTIONS /contact desde http://localhost:9970 fallaba en el browser con "The 'Access-Control-Allow-Origin' header has a value 'https://the-full-stack.com' that is not equal to the supplied origin".

## Solucion

1. docker/docker-compose/{local,dev,test,prod}.yml: agrega PUBLIC_API_ENDPOINT y PUBLIC_TURNSTILE_SITEKEY al bloque x-app-environment compartido. Asi compose toma el valor del --env-file y lo inyecta al container.
2. serverless/template.yaml: agrega Conditions.IsDev y usa !If en PortfolioApi.Cors.AllowOrigin para devolver '*' en stage dev. Prod mantiene whitelist estricta. La Lambda igual valida Turnstile token, asi que '*' en preflight no permite spammear sin captcha resuelto.

## Como probar

Backend: sam build + sam deploy --config-env dev + aws apigateway create-deployment.

Frontend: python3 devtools/run.py docker rebuild --env=local, luego abrir http://localhost:9970/contact, debe verse el form completo con widget Turnstile.

## TODO

Agregar localhost y *.localhost a Hostname Management del widget Turnstile en Cloudflare Dashboard, sino el widget no renderiza con error 110200.