### PR TITLE
fix(turnstile): permite *.localhost en stage dev en hostname allowlist

### DIFF
--- a/serverless/src/contact_form/turnstile.py
+++ b/serverless/src/contact_form/turnstile.py
@@ -12,6 +12,7 @@ Response: {success: bool, hostname, error-codes, action, cdata, ...}
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 import httpx
@@ -22,7 +23,10 @@ from common.ssm_client import get_secret
 
 TURNSTILE_SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
 
-# Lista de hostnames esperados (debe matchear el widget del Cloudflare dashboard)
+# Lista de hostnames esperados (debe matchear el widget del Cloudflare dashboard).
+# 'localhost' apex se acepta siempre (compat con dev). Subdominios *.localhost
+# se aceptan solo en stage=dev via _LOCAL_SUBDOMAIN_PATTERN (RFC 6761 garantiza
+# que resuelven a 127.0.0.1).
 _EXPECTED_HOSTNAMES = frozenset({
     'the-full-stack.com',
     'hub.the-full-stack.com',
@@ -33,6 +37,24 @@ _EXPECTED_HOSTNAMES = frozenset({
     'localhost',
     '127.0.0.1',
 })
+
+# Pattern para subdominios *.localhost. Turnstile envia solo el hostname
+# (sin scheme ni puerto), por eso no incluimos http:// ni :port aqui.
+_LOCAL_SUBDOMAIN_PATTERN: re.Pattern[str] = re.compile(
+    r'^[a-z0-9-]+\.localhost$',
+)
+
+
+def _hostname_allowed(hostname: str) -> bool:
+    """True si hostname esta en whitelist apex o es *.localhost en stage dev."""
+    if hostname in _EXPECTED_HOSTNAMES:
+        return True
+    if (
+        os.environ.get('STAGE', 'dev') == 'dev'
+        and _LOCAL_SUBDOMAIN_PATTERN.match(hostname)
+    ):
+        return True
+    return False
 
 
 def verify_turnstile_token(
@@ -108,9 +130,10 @@ def verify_turnstile_token(
             extra={'error_codes': error_codes},
         )
 
-    # Validar hostname (defensa en profundidad contra widget hijacking)
+    # Validar hostname (defensa en profundidad contra widget hijacking).
+    # En stage=dev se permite cualquier *.localhost (ver _hostname_allowed).
     hostname = result.get('hostname', '').lower()
-    if hostname and hostname not in _EXPECTED_HOSTNAMES:
+    if hostname and not _hostname_allowed(hostname):
         logger.warning(
             'turnstile hostname mismatch',
             extra={'received_hostname': hostname, 'remote_ip': remote_ip},

--- a/serverless/tests/unit/contact_form/test_turnstile.py
+++ b/serverless/tests/unit/contact_form/test_turnstile.py
@@ -88,6 +88,88 @@ class TestVerifyTurnstileToken:
 
         assert exc_info.value.code == 'CAPTCHA_HOSTNAME_MISMATCH'
 
+    @respx.mock
+    @pytest.mark.parametrize(
+        'hostname',
+        [
+            'hub.localhost',
+            'fintech.localhost',
+            'architect.localhost',
+            'leader.localhost',
+            'vibe.localhost',
+        ],
+    )
+    def test_when_localhost_subdomain_in_stage_dev_then_allowed(
+        self,
+        contact_form_aws: None,
+        monkeypatch: pytest.MonkeyPatch,
+        hostname: str,
+    ) -> None:
+        """
+        Given hostname *.localhost + STAGE=dev,
+        When verify,
+        Then aceptado (RFC 6761 garantiza resolucion local).
+        """
+        monkeypatch.setenv('STAGE', 'dev')
+        respx.post(TURNSTILE_SITEVERIFY_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={'success': True, 'hostname': hostname},
+            )
+        )
+
+        result = verify_turnstile_token('cf-response-value', remote_ip='1.2.3.4')
+
+        assert result['success'] is True
+        assert result['hostname'] == hostname
+
+    @respx.mock
+    def test_when_localhost_subdomain_in_stage_prod_then_rejected(
+        self, contact_form_aws: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given hostname *.localhost + STAGE=prod,
+        When verify,
+        Then rechazado (subdominios localhost solo en dev).
+        """
+        monkeypatch.setenv('STAGE', 'prod')
+        respx.post(TURNSTILE_SITEVERIFY_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={'success': True, 'hostname': 'architect.localhost'},
+            )
+        )
+
+        with pytest.raises(TurnstileError) as exc_info:
+            verify_turnstile_token('cf-response-value', remote_ip='1.2.3.4')
+
+        assert exc_info.value.code == 'CAPTCHA_HOSTNAME_MISMATCH'
+
+    @respx.mock
+    def test_when_evil_localhost_subdomain_then_rejected(
+        self, contact_form_aws: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given hostname disfrazado tipo evil.localhost.attacker.com,
+        When verify,
+        Then rechazado (pattern enforce $ anclado).
+        """
+        monkeypatch.setenv('STAGE', 'dev')
+        respx.post(TURNSTILE_SITEVERIFY_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    'success': True,
+                    'hostname': 'evil.localhost.attacker.com',
+                },
+            )
+        )
+
+        with pytest.raises(TurnstileError) as exc_info:
+            verify_turnstile_token('cf-response-value', remote_ip='1.2.3.4')
+
+        assert exc_info.value.code == 'CAPTCHA_HOSTNAME_MISMATCH'
+
     def test_when_bypass_secret_matches_then_skip_verify(
         self, contact_form_aws: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Problema

Despues de los fixes #34 (CORS API GW) y #35 (CORS subdomain en common/cors.py), el form en http://architect.localhost:9970/contact pasaba el preflight y la Lambda echaba el origin correcto, PERO siteverify de Turnstile devolvia hostname='architect.localhost' y la Lambda lo rechazaba con CAPTCHA_HOSTNAME_MISMATCH porque la whitelist hardcoded solo tenia 'localhost' apex (no subdomains).

## Solucion

serverless/src/contact_form/turnstile.py:

- Agrega _LOCAL_SUBDOMAIN_PATTERN regex ^[a-z0-9-]+\.localhost$ (Turnstile envia hostname sin scheme ni puerto)
- Nueva funcion _hostname_allowed(hostname) que retorna True si hostname esta en la whitelist hardcoded O matchea el pattern *.localhost con STAGE=dev
- Cambia el check de hostname in _EXPECTED_HOSTNAMES por _hostname_allowed(hostname)

RFC 6761 garantiza que *.localhost siempre resuelve a 127.0.0.1, por lo que es seguro permitirlos localmente. Stage prod mantiene whitelist estricta a los 6 subdomains de the-full-stack.com.

## Como probar

Backend (curl, deploy ya aplicado al stack dev):

curl -s -X POST https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/contact -H 'Origin: http://architect.localhost:9970' -H 'Content-Type: application/json' -d '{"name":"X","email":"a@b.com","message":"mensaje largo","cf_token":"<token-real-de-turnstile>"}'

Tests:

cd serverless/
uv run python -m pytest tests/unit/contact_form/test_turnstile.py -v
# Espera 12 passed (antes 5)

Frontend (local):

1. Hard reload http://architect.localhost:9970/contact con DevTools "Disable cache"
2. Form con mensaje >= 10 chars, captcha resuelto, Enviar
3. Espera HTTP 201 + status "Mensaje enviado. Te respondere en menos de 24h." + email a pacg1991@gmail.com

## TODO

Nada bloqueante. Cierra el trio de fixes para form funcional en *.localhost local (#34 + #35 + este).