### PR TITLE
docs(subdomain-standard): agrega convencion canonica para subdominios

### DIFF
--- a/.claude/docs/subdomain-standard/01-pattern.md
+++ b/.claude/docs/subdomain-standard/01-pattern.md
@@ -1,0 +1,118 @@
+# 01 - Patron canonico
+
+> [<- README](./README.md) | [02-naming-rules ->](./02-naming-rules.md)
+
+## Definicion formal
+
+```text
+[{component}.]{product}.{env}.{domain}
+```
+
+| Label | Obligatorio | Valores |
+|-------|-------------|---------|
+| `{domain}` | Si | `the-full-stack.com` |
+| `{env}` | Solo si NO es prod | `dev` \| `stage` |
+| `{product}` | Si (excepto excepciones) | slug kebab-case |
+| `{component}` | Opcional | slug kebab-case |
+
+Prod NO lleva label de env. Eso significa que prod tiene 1 label menos
+que dev/stage. Es la unica asimetria del patron y es intencional para
+mantener URLs de prod cortas (marketing / SEO).
+
+## Lectura right-to-left
+
+Leer de derecha a izquierda da el nivel de detalle creciente:
+
+```text
+api.faststruct.dev.the-full-stack.com
+                  └────────────────── dominio
+              └────────────────────── environment (no prod)
+   └─────────────────────────────────── producto
+└──────────────────────────────────── componente
+```
+
+## Casos posibles por nivel
+
+### Producto sin componente (1 sub-label + opcional env)
+
+Cuando el producto expone una sola cosa (landing + app monolitica):
+
+```text
+prod    faststruct.the-full-stack.com
+stage   faststruct.stage.the-full-stack.com
+dev     faststruct.dev.the-full-stack.com
+```
+
+### Producto con componentes (2 sub-labels + opcional env)
+
+Cuando el producto separa frontend / backend / admin en hostnames distintos:
+
+```text
+prod    app.faststruct.the-full-stack.com
+        api.faststruct.the-full-stack.com
+        admin.faststruct.the-full-stack.com
+stage   app.faststruct.stage.the-full-stack.com
+        api.faststruct.stage.the-full-stack.com
+dev     app.faststruct.dev.the-full-stack.com
+        api.faststruct.dev.the-full-stack.com
+```
+
+### Servicio de infra (product = servicio)
+
+Para servicios cross-cutting (status, mail, monitor), el nombre del
+servicio actua como `{product}`:
+
+```text
+prod    status.the-full-stack.com
+        mail.the-full-stack.com
+        monitor.the-full-stack.com
+dev     status.dev.the-full-stack.com
+```
+
+No suelen tener componentes (`{component}` se omite). Si en algun
+momento el servicio crece y se parte (ej. `monitor` con UI + API), se
+introduce componente normal: `ui.monitor.the-full-stack.com`.
+
+## Ejemplo completo de un producto
+
+Producto hipotetico `faststruct` con landing + app + api + admin + docs,
+en los 3 environments:
+
+| Env | URL |
+|-----|-----|
+| prod | `faststruct.the-full-stack.com` (landing) |
+| prod | `app.faststruct.the-full-stack.com` |
+| prod | `api.faststruct.the-full-stack.com` |
+| prod | `admin.faststruct.the-full-stack.com` |
+| prod | `docs.faststruct.the-full-stack.com` |
+| stage | `faststruct.stage.the-full-stack.com` |
+| stage | `app.faststruct.stage.the-full-stack.com` |
+| stage | `api.faststruct.stage.the-full-stack.com` |
+| stage | `admin.faststruct.stage.the-full-stack.com` |
+| dev | `faststruct.dev.the-full-stack.com` |
+| dev | `app.faststruct.dev.the-full-stack.com` |
+| dev | `api.faststruct.dev.the-full-stack.com` |
+| dev | `admin.faststruct.dev.the-full-stack.com` |
+
+## Por que este orden y no otro
+
+Se considero `{env}.{product}.{domain}` (dev primero). Se descarto porque:
+
+1. Wildcards por env son mas valiosos: `*.dev.the-full-stack.com` cubre
+   todos los products en dev con un cert wildcard de 1 nivel (cubre
+   Universal SSL de Cloudflare).
+2. CI/CD pipelines comparten env entre products (`deploy-all-dev`,
+   `smoke-test-stage`), mas que pipelines compartidos por product.
+3. Listados DNS agrupan por env (todos los `.dev.` juntos), facil de
+   auditar que esta vivo en cada ambiente.
+
+## Notas de implementacion
+
+- Component como sub-label (no como sufijo `-component`) permite usar
+  un cert wildcard `*.faststruct.the-full-stack.com` que cubra todos los
+  components en prod. Detalles en [05-wildcards-and-certs.md](./05-wildcards-and-certs.md).
+- DNS TTL recomendado: 300s para dev/stage (rotacion frecuente), 3600s
+  para prod (estable).
+- Proxied vs DNS-only en Cloudflare: proxied para todo lo HTTP
+  (productos, components), DNS-only para records de verificacion
+  (DKIM, SPF, DMARC, atproto, etc.).

--- a/.claude/docs/subdomain-standard/02-naming-rules.md
+++ b/.claude/docs/subdomain-standard/02-naming-rules.md
@@ -1,0 +1,141 @@
+# 02 - Reglas de naming + reservados
+
+> [<- 01-pattern](./01-pattern.md) | [03-environments ->](./03-environments.md)
+
+## Reglas para `{product}`
+
+1. **kebab-case obligatorio** si son 2+ palabras: `practical-exercises`,
+   `join-files`. Sin camelCase, sin snake_case.
+2. **Single-word preferido** cuando sea natural y reconocible:
+   `faststruct` mejor que `fast-struct`. Solo aplica si la palabra
+   completa es la marca real del producto.
+3. **ASCII lowercase**. Sin acentos (`á`), sin diacriticos (`ñ`), sin
+   caracteres especiales. Compatible con RFC 1035 + RFC 1123.
+4. **Longitud**: minimo 3, maximo 30 caracteres.
+5. **Sin guion al inicio o final** (`-foo`, `foo-`). Sin doble guion
+   (`foo--bar`).
+6. **Inmutable una vez lanzado**: una vez que un product tiene trafico,
+   renombrar requiere redirects + SEO migration. Pensar antes.
+
+## Reglas para `{component}`
+
+1. kebab-case + ASCII lowercase (idem).
+2. Nombres bien conocidos (preferidos, no obligatorios):
+   - `app` — SPA / web app principal
+   - `api` — backend HTTP / GraphQL / REST
+   - `admin` — panel admin separado
+   - `docs` — documentacion publica
+   - `cdn` — assets estaticos
+   - `auth` — IdP / SSO si aplica
+   - `ws` — WebSocket si separado
+   - `webhook` — receptores de webhooks
+3. Si el producto tiene un solo "thing" publico, **omitir component**.
+   La landing del producto vive en el slug del producto solo
+   (`faststruct.the-full-stack.com`).
+
+## Reglas para `{env}`
+
+Solo 3 valores formales:
+
+| Env | Label | Que es |
+|-----|-------|--------|
+| prod | (vacio) | Production estable, publica |
+| stage | `stage` | Release candidate, mirror de prod con datos de prueba |
+| dev | `dev` | Branch dev / trunk, expuesto publicamente con auth si aplica |
+
+Para previews por PR, ver [03-environments.md](./03-environments.md) —
+NO se extiende el patron con `preview`, `pr-123`, etc.
+
+## Reservados — PROHIBIDOS como `{product}`
+
+Estos nombres NO pueden usarse como nombre de un product propio porque
+ya tienen significado en el patron o en convenciones de internet:
+
+### Componentes reservados
+
+```text
+www, api, app, admin, mail, status, auth, cdn, assets, static
+```
+
+Razon: son nombres de `{component}` esperados. Si los usas como product,
+generan colisiones (`www.www.the-full-stack.com`? `api.api.the-full-stack.com`?).
+
+### Environments reservados
+
+```text
+dev, stage, staging, prod, production, test, qa, uat, local, localhost
+```
+
+Razon: son labels de `{env}` o variantes. Confundirian la lectura del
+patron.
+
+### Infra reservada
+
+```text
+infra, internal, private, vpn, tunnel
+```
+
+Razon: convencion para servicios cross-cutting. Si necesitas un product
+con uno de estos nombres, elegir un nombre mas especifico.
+
+### Portfolio nichos reservados
+
+```text
+hub, fintech, architect, leader, vibe, generic
+```
+
+Razon: son los 5 nichos del portfolio personal + el sitio generic. Ver
+[04-portfolio-exception.md](./04-portfolio-exception.md).
+
+## Reservados — PERMITIDOS como `{component}`
+
+Los nombres bien conocidos (`api`, `app`, `admin`, etc.) son
+**reservados como product** pero **permitidos como component**.
+Ejemplos:
+
+- ✅ `api.faststruct.the-full-stack.com` — `api` es component de
+  `faststruct` (product). Valido.
+- ❌ `api.the-full-stack.com` (directo, sin product padre) — sin
+  product, `api` queda como product. PROHIBIDO.
+
+## Validacion practica (regex)
+
+Para un product:
+
+```regex
+^[a-z](?:[a-z0-9]|-(?=[a-z0-9])){1,28}[a-z0-9]$
+```
+
+- Empieza y termina con [a-z0-9]
+- Solo letras minusculas, digitos, guiones
+- Sin guion doble
+- Longitud total entre 3 y 30
+
+Para un component: mismo regex.
+
+Para una URL completa (sin protocolo):
+
+```regex
+^(?:[a-z][a-z0-9-]*\.)?[a-z][a-z0-9-]*(?:\.(?:dev|stage))?\.the-full-stack\.com$
+```
+
+## Casos limite
+
+### Producto con 1 palabra que tambien es reservado
+
+Ejemplo: si tu producto se llama `Status` (nombre comercial). NO podes
+usar `status.the-full-stack.com` como product propio porque colisiona
+con el servicio de infra reservado.
+
+Soluciones:
+1. Renombrar el product comercialmente (`statusly`, `statuspulse`).
+2. Usar un nombre interno distinto del comercial (`spulse.the-full-stack.com`
+   con redirect/canonical desde el dominio publico real).
+3. Comprar dominio propio para ese product.
+
+### Producto con marca multi-palabra unica
+
+Ejemplo: `Visual Studio Marketplace`. NO usar `vsm` (siglas dificiles).
+NO usar `visual-studio-marketplace` (excesivo, 32 chars). Solucion: usar
+el slug corto que ya usás en otros lados (`vs-marketplace`,
+`vscodemkt`, etc.) y documentarlo.

--- a/.claude/docs/subdomain-standard/03-environments.md
+++ b/.claude/docs/subdomain-standard/03-environments.md
@@ -1,0 +1,145 @@
+# 03 - Environments (dev / stage / prod)
+
+> [<- 02-naming-rules](./02-naming-rules.md) | [04-portfolio-exception ->](./04-portfolio-exception.md)
+
+## 3 environments formales
+
+| Env | Label en URL | Proposito | Datos | Acceso |
+|-----|--------------|-----------|-------|--------|
+| **prod** | (vacio) | Production estable, publica | Reales | Publico |
+| **stage** | `.stage.` | Release candidate antes de prod | Mirror de prod (datos de prueba) | Publico con BasicAuth o token |
+| **dev** | `.dev.` | Trabajo en curso (branch dev / trunk) | Synthetic / mock | Publico con BasicAuth o token |
+
+## Asimetria prod
+
+Prod NO lleva label de env. La regla es:
+
+> Si NO hay label `.dev.` ni `.stage.` antes de `the-full-stack.com`, es prod.
+
+Razones:
+1. URLs de prod limpias para marketing / SEO.
+2. Diferencia visual inmediata en logs / monitoring (`*.dev.*` y
+   `*.stage.*` saltan a la vista).
+3. Coherente con SaaS modernos (`linear.app`, no `prod.linear.app`).
+
+## Ejemplos completos
+
+### Producto faststruct con 3 envs
+
+```text
+prod    faststruct.the-full-stack.com
+        app.faststruct.the-full-stack.com
+        api.faststruct.the-full-stack.com
+
+stage   faststruct.stage.the-full-stack.com
+        app.faststruct.stage.the-full-stack.com
+        api.faststruct.stage.the-full-stack.com
+
+dev     faststruct.dev.the-full-stack.com
+        app.faststruct.dev.the-full-stack.com
+        api.faststruct.dev.the-full-stack.com
+```
+
+### Servicio infra status con 2 envs (dev + prod)
+
+```text
+prod    status.the-full-stack.com
+dev     status.dev.the-full-stack.com
+```
+
+Stage es opcional en servicios infra — depende de criticidad.
+
+## Previews por PR — NO extender el patron
+
+Cloudflare Pages crea automaticamente preview URLs por commit / PR:
+
+```text
+<commit-hash>.<project>.pages.dev
+```
+
+Ejemplo: `a1b2c3d.faststruct.pages.dev`.
+
+**NO crear records DNS custom para previews**. NO inventar
+`pr-123.faststruct.dev.the-full-stack.com` ni similar. Razones:
+
+1. Los previews son efimeros (segundos de vida util). Crear DNS records
+   es overhead innecesario.
+2. Cloudflare Pages ya gestiona el certificado SSL automatico.
+3. Si se necesita URL "linda" para compartir un preview en PR review,
+   usar la `pages.dev` directa.
+
+## Flujo dev -> stage -> prod
+
+```text
+1. Branch feature -> merge a dev -> deploy automatico a *.dev.*
+2. Cuando dev esta estable -> merge dev a release branch -> deploy a *.stage.*
+3. QA + smoke test en stage -> tag release -> deploy a prod (sin label)
+```
+
+Si tu flujo no necesita stage (proyectos chicos), omitir el ambiente.
+Pero NO inventar variantes (`pre-prod`, `release-candidate`, `beta`).
+Las 3 etiquetas (dev/stage/prod) son la lista cerrada.
+
+## Acceso restringido en no-prod
+
+Recomendado para dev y stage:
+
+| Mecanismo | Cuando usar |
+|-----------|-------------|
+| HTTP Basic Auth via Cloudflare Worker | Mas simple, sin cambiar la app |
+| Cloudflare Access (zero trust) | Si tenes equipo, sso integrado |
+| IP allowlist | Si trabajas siempre desde IPs conocidas |
+| Robot.txt + noindex | SIEMPRE (evitar indexacion en Google) |
+
+`robots.txt` en dev/stage debe tener:
+
+```text
+User-agent: *
+Disallow: /
+```
+
+Servido condicionalmente segun hostname (detectar `.dev.` o `.stage.`).
+
+## Que NO usar
+
+```text
+❌ qa.faststruct.the-full-stack.com       — usa stage
+❌ uat.faststruct.the-full-stack.com      — usa stage
+❌ preview.faststruct.the-full-stack.com  — usa default pages.dev
+❌ beta.faststruct.the-full-stack.com     — releases en prod con feature flags
+❌ test.faststruct.the-full-stack.com     — tests corren en CI, no necesitan URL
+❌ feature-x.faststruct.the-full-stack.com — usa flag o branch preview pages.dev
+❌ prod.faststruct.the-full-stack.com     — prod va sin label
+```
+
+## Variables de entorno asociadas
+
+Sugerencia para mantener consistencia con `docker/env/.{local,dev,test,prod}`:
+
+```bash
+# .dev
+BASE_DOMAIN=the-full-stack.com
+BASE_SCHEME=https
+ENV_LABEL=dev          # se inserta entre product y domain
+# Resultado: api.faststruct.dev.the-full-stack.com
+
+# .prod
+BASE_DOMAIN=the-full-stack.com
+BASE_SCHEME=https
+ENV_LABEL=              # vacio -> prod
+# Resultado: api.faststruct.the-full-stack.com
+```
+
+Helper TypeScript / Python para construir la URL:
+
+```python
+def build_url(component: str | None, product: str, env_label: str, domain: str) -> str:
+    parts = []
+    if component:
+        parts.append(component)
+    parts.append(product)
+    if env_label:  # vacio -> prod, no agregar
+        parts.append(env_label)
+    parts.append(domain)
+    return '.'.join(parts)
+```

--- a/.claude/docs/subdomain-standard/04-portfolio-exception.md
+++ b/.claude/docs/subdomain-standard/04-portfolio-exception.md
@@ -1,0 +1,99 @@
+# 04 - Excepcion del portfolio personal
+
+> [<- 03-environments](./03-environments.md) | [05-wildcards-and-certs ->](./05-wildcards-and-certs.md)
+
+## Por que es excepcion
+
+El portfolio personal (`the-full-stack.com`) precede al estandar y es
+parte del branding del owner. Migrarlo bajo el patron
+`portfolio.the-full-stack.com` o `cv.the-full-stack.com` rompe SEO,
+links externos y la narrativa del dominio (que ES el portfolio).
+
+Decision: dejarlo como excepcion permanente. El estandar aplica solo
+a productos y servicios NUEVOS bajo el dominio.
+
+## Subdominios reservados por el portfolio
+
+Estos 7 hostnames NO siguen el patron y NO pueden reusarse para otros
+productos:
+
+| Hostname | Que es |
+|----------|--------|
+| `the-full-stack.com` | Apex — portfolio generic (full stack senior) |
+| `www.the-full-stack.com` | Alias del apex |
+| `hub.the-full-stack.com` | Selector multi-niche con cards |
+| `fintech.the-full-stack.com` | Niche fintech LATAM |
+| `architect.the-full-stack.com` | Niche frontend architect |
+| `leader.the-full-stack.com` | Niche tech lead / engineering manager |
+| `vibe.the-full-stack.com` | Niche vibe coding / Claude Code |
+
+Adicionalmente, los nichos como words (`hub`, `fintech`, `architect`,
+`leader`, `vibe`, `generic`) estan reservados como product names
+(ver [02-naming-rules.md](./02-naming-rules.md)) para evitar
+colisiones futuras.
+
+## Como interactua con el estandar
+
+### Apex / www
+
+`the-full-stack.com` y `www.the-full-stack.com` apuntan al sitio
+portfolio generic. El apex NO esta disponible para `{product}` propio.
+
+Si en algun momento se quiere un sitio "raiz" del dominio que no sea el
+portfolio, opciones:
+
+1. Rediseñar el portfolio como hub/landing y mover el niche generic a
+   `generic.the-full-stack.com` (rompe el modelo actual).
+2. Mantener el portfolio en el apex y poner el nuevo sitio en un
+   subdomain coherente con el estandar.
+
+### Backend del portfolio
+
+El backend serverless del portfolio (form de contacto, tracking pixel)
+debe migrarse al estandar como product `portfolio`:
+
+```text
+prod    api.portfolio.the-full-stack.com
+dev     api.portfolio.dev.the-full-stack.com
+```
+
+Ver [06-migration-backend-api.md](./06-migration-backend-api.md) para
+el plan concreto.
+
+Notar que `portfolio.the-full-stack.com` (sin component) NO se crea —
+el portfolio "es" el dominio, no necesita una landing dedicada bajo
+ese slug.
+
+## Que pasa si quiero un product que choca con un nicho
+
+Ejemplo: quiero lanzar un product comercial llamado `fintech`.
+
+NO podes usar `fintech.the-full-stack.com` (ya es el niche fintech del
+portfolio). Opciones:
+
+1. Renombrar el product comercialmente.
+2. Comprar otro dominio para ese product.
+3. Renombrar el niche del portfolio (rompe SEO + branding actual).
+
+La opcion 1 es la recomendada. El portfolio gana en branding y los
+products pueden tener nombres distintivos.
+
+## Resumen visual
+
+```text
+EXCEPCION (portfolio):
+  the-full-stack.com               ← portfolio generic
+  www.the-full-stack.com           ← alias apex
+  hub.the-full-stack.com           ← niche hub
+  fintech.the-full-stack.com       ← niche fintech
+  architect.the-full-stack.com     ← niche architect
+  leader.the-full-stack.com        ← niche leader
+  vibe.the-full-stack.com          ← niche vibe
+
+ESTANDAR (todo lo demas):
+  faststruct.the-full-stack.com    ← product faststruct prod
+  api.portfolio.the-full-stack.com ← backend portfolio prod
+  status.the-full-stack.com        ← servicio infra prod
+  faststruct.dev.the-full-stack.com ← product faststruct dev
+  ...
+```

--- a/.claude/docs/subdomain-standard/05-wildcards-and-certs.md
+++ b/.claude/docs/subdomain-standard/05-wildcards-and-certs.md
@@ -1,0 +1,126 @@
+# 05 - Wildcards y certificados
+
+> [<- 04-portfolio-exception](./04-portfolio-exception.md) | [06-migration-backend-api ->](./06-migration-backend-api.md)
+
+## Wildcards strategicos que el patron permite
+
+| Wildcard | Cubre | Util para |
+|----------|-------|-----------|
+| `*.the-full-stack.com` | Cualquier subdomain de 1 nivel: `faststruct`, `hub`, `status`, etc. | Universal SSL de Cloudflare (default) |
+| `*.dev.the-full-stack.com` | Products en dev: `faststruct.dev`, `proyectoX.dev`, etc. | Cert wildcard 1-nivel por env dev |
+| `*.stage.the-full-stack.com` | Products en stage | Cert wildcard 1-nivel por env stage |
+| `*.faststruct.the-full-stack.com` | Components de faststruct prod: `app`, `api`, `admin`, etc. | Cert wildcard 1-nivel por product prod |
+| `*.faststruct.dev.the-full-stack.com` | Components de faststruct dev | Cert wildcard 1-nivel por product+env dev |
+
+## Limitacion de wildcards SSL
+
+**Un wildcard SSL cubre solo UN nivel de label**. Esto significa:
+
+- `*.the-full-stack.com` cubre `faststruct.the-full-stack.com` ✅
+- `*.the-full-stack.com` NO cubre `api.faststruct.the-full-stack.com` ❌
+  (2 niveles)
+- `*.faststruct.the-full-stack.com` cubre `api.faststruct.the-full-stack.com` ✅
+
+Por eso el patron usa `{component}` como sub-label (no como sufijo del
+slug del product). Eso permite que un solo cert wildcard cubra todos los
+components.
+
+## Estrategias practicas
+
+### Estrategia A — Cloudflare Pages auto-cert por hostname (DEFAULT, RECOMENDADO)
+
+Cada Pages project agrega su custom domain via UI o API y Cloudflare
+emite un cert SAN especifico para ese hostname (via Google Trust Services
+o similar). Ventajas:
+
+- Cero gestion manual de certs.
+- Renovacion automatica antes de expiracion.
+- Funciona para products y components individuales.
+
+Desventajas:
+
+- Cada cert es por hostname (no wildcard). Si tenes 30 hostnames, son 30
+  certs.
+- Lleva ~5-15min para emitir cada cert nuevo.
+
+**Cuando usar**: 95% de los casos. Por default, dejar que Cloudflare
+maneje el SSL.
+
+### Estrategia B — Universal SSL de Cloudflare (gratis)
+
+Cloudflare emite automaticamente un cert wildcard `*.the-full-stack.com`
++ `the-full-stack.com`. Cubre todos los hostnames de **1 nivel**:
+
+- `faststruct.the-full-stack.com` ✅
+- `status.the-full-stack.com` ✅
+- `hub.the-full-stack.com` ✅
+- `api.faststruct.the-full-stack.com` ❌ (2 niveles)
+
+**Cuando usar**: ya esta activo por default. Cubre los products sin
+component automaticamente. No requiere nada.
+
+### Estrategia C — Cloudflare Advanced Certificate (pago, ~$10/mes/cert)
+
+Cert wildcard custom para 2 niveles:
+
+- `*.faststruct.the-full-stack.com` cubre app, api, admin, docs, etc.
+- `*.dev.the-full-stack.com` cubre cualquier product en dev.
+
+**Cuando usar**: si gestiones >10 hostnames bajo un product/env y queres
+1 solo cert. En la escala actual del proyecto (<20 hostnames), Pages
+auto-cert (estrategia A) es mas simple y gratis.
+
+### Estrategia D — ACM cert custom (para API Gateway de AWS)
+
+API Gateway requiere un cert ACM en la misma region. Para el backend
+serverless del portfolio:
+
+```bash
+# Cert SAN cubriendo prod + dev del backend portfolio
+aws acm request-certificate \
+  --domain-name api.portfolio.the-full-stack.com \
+  --subject-alternative-names api.portfolio.dev.the-full-stack.com \
+  --validation-method DNS \
+  --region us-east-1
+```
+
+Despues, agregar los CNAMEs de validacion en Cloudflare. Detalle en
+[06-migration-backend-api.md](./06-migration-backend-api.md).
+
+## Decision flow para SSL
+
+```text
+1. Product en Cloudflare Pages? -> Estrategia A (auto-cert por hostname)
+2. Product sin component (1 nivel)? -> Estrategia B cubre auto via Universal SSL
+3. Product con 5+ components y queres 1 cert? -> Estrategia C (Advanced Cert pago)
+4. API Gateway de AWS? -> Estrategia D (ACM cert)
+5. Otro hosting? -> revisar capabilities del hosting
+```
+
+## CAA records
+
+Recomendado tener CAA records en la zona para limitar que CAs pueden
+emitir certs:
+
+```text
+CAA  the-full-stack.com  0 issue "letsencrypt.org"
+CAA  the-full-stack.com  0 issue "pki.goog"
+CAA  the-full-stack.com  0 issue "amazon.com"
+CAA  the-full-stack.com  0 issuewild "letsencrypt.org"
+CAA  the-full-stack.com  0 issuewild "pki.goog"
+CAA  the-full-stack.com  0 iodef "mailto:pacg1991@gmail.com"
+```
+
+Esto evita que un atacante emita un cert con otra CA si compromete una
+parte del DNS. Cloudflare por default emite con `pki.goog` (Google Trust
+Services) o `letsencrypt.org`.
+
+## TTL recomendado
+
+| Tipo de record | TTL |
+|----------------|-----|
+| Apex / www (estable) | 3600s (1h) |
+| Products en prod (estables) | 3600s |
+| Products en dev/stage (rotacion frecuente) | 300s (5min) |
+| Records de verificacion (DKIM, SPF, DMARC, atproto) | 3600s |
+| Validacion ACM/Let's Encrypt (temporales) | 300s |

--- a/.claude/docs/subdomain-standard/06-migration-backend-api.md
+++ b/.claude/docs/subdomain-standard/06-migration-backend-api.md
@@ -1,0 +1,192 @@
+# 06 - Migracion del backend serverless al estandar
+
+> [<- 05-wildcards-and-certs](./05-wildcards-and-certs.md) | [07-anti-patterns ->](./07-anti-patterns.md)
+
+## Estado actual (2026-05-15)
+
+El backend serverless del portfolio usa los hostnames raw de API Gateway:
+
+```text
+prod   https://332ivhahf2.execute-api.us-east-1.amazonaws.com/prod
+dev    https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev
+```
+
+Frontend lo consume via `PUBLIC_API_ENDPOINT` en `docker/env/.{dev,prod}`.
+
+## Estado objetivo
+
+Aplicando el estandar (product = `portfolio`, component = `api`):
+
+```text
+prod   https://api.portfolio.the-full-stack.com
+dev    https://api.portfolio.dev.the-full-stack.com
+```
+
+## Plan de migracion
+
+### Paso 1 — Cert ACM en us-east-1
+
+API Gateway REST API requiere cert ACM en la misma region (us-east-1).
+
+```bash
+aws acm request-certificate \
+  --domain-name api.portfolio.the-full-stack.com \
+  --subject-alternative-names api.portfolio.dev.the-full-stack.com \
+  --validation-method DNS \
+  --region us-east-1 \
+  --output json
+```
+
+Anotar el `CertificateArn` retornado.
+
+### Paso 2 — Validacion via DNS en Cloudflare
+
+ACM devuelve 2 records CNAME (1 por hostname) que hay que crear en
+Cloudflare como **DNS only** (no proxied):
+
+```bash
+aws acm describe-certificate \
+  --certificate-arn <ARN> \
+  --region us-east-1 \
+  --query 'Certificate.DomainValidationOptions[*].[DomainName,ResourceRecord]' \
+  --output json
+```
+
+Crear en Cloudflare los 2 CNAMEs con `proxied: false` y TTL 300.
+
+Esperar el `Status: ISSUED` del cert (~5-30min).
+
+### Paso 3 — Custom Domain Names en API Gateway
+
+Crear 2 entries (prod + dev):
+
+```bash
+# prod
+aws apigateway create-domain-name \
+  --domain-name api.portfolio.the-full-stack.com \
+  --certificate-arn <ARN> \
+  --endpoint-configuration types=REGIONAL \
+  --security-policy TLS_1_2 \
+  --region us-east-1
+
+# dev
+aws apigateway create-domain-name \
+  --domain-name api.portfolio.dev.the-full-stack.com \
+  --certificate-arn <ARN> \
+  --endpoint-configuration types=REGIONAL \
+  --security-policy TLS_1_2 \
+  --region us-east-1
+```
+
+Cada uno devuelve un `regionalDomainName` (algo como
+`d-abc123.execute-api.us-east-1.amazonaws.com`).
+
+### Paso 4 — Base Path Mapping
+
+Mapear cada custom domain al stage correspondiente:
+
+```bash
+# prod -> stage prod del REST API 332ivhahf2
+aws apigateway create-base-path-mapping \
+  --domain-name api.portfolio.the-full-stack.com \
+  --rest-api-id 332ivhahf2 \
+  --stage prod \
+  --region us-east-1
+
+# dev -> stage dev del REST API ssnj6odx7l
+aws apigateway create-base-path-mapping \
+  --domain-name api.portfolio.dev.the-full-stack.com \
+  --rest-api-id ssnj6odx7l \
+  --stage dev \
+  --region us-east-1
+```
+
+### Paso 5 — CNAMEs en Cloudflare apuntando a API Gateway
+
+Crear CNAMEs **proxied** (recomendado para tener WAF + cache) o
+**DNS only** (mas simple):
+
+```text
+CNAME  api.portfolio.the-full-stack.com         -> d-abc123.execute-api.us-east-1.amazonaws.com  (proxied)
+CNAME  api.portfolio.dev.the-full-stack.com     -> d-xyz789.execute-api.us-east-1.amazonaws.com  (proxied)
+```
+
+Con proxied: Cloudflare termina TLS en su edge + reencripta hacia API
+Gateway. Hay un small overhead pero gana WAF + DDoS + rate limit en el edge.
+
+### Paso 6 — Actualizar frontend
+
+Editar `docker/env/.dev`:
+
+```bash
+PUBLIC_API_ENDPOINT=https://api.portfolio.dev.the-full-stack.com
+```
+
+Editar `docker/env/.prod`:
+
+```bash
+PUBLIC_API_ENDPOINT=https://api.portfolio.the-full-stack.com
+```
+
+Redeploy del frontend (Cloudflare Pages rebuild de las 6 apps).
+
+### Paso 7 — Verificacion
+
+```bash
+# Verificar resolucion DNS
+dig api.portfolio.the-full-stack.com +short
+dig api.portfolio.dev.the-full-stack.com +short
+
+# Verificar cert
+echo | openssl s_client -servername api.portfolio.the-full-stack.com \
+  -connect api.portfolio.the-full-stack.com:443 2>/dev/null \
+  | openssl x509 -noout -dates -subject
+
+# Verificar endpoint funcional
+curl -i https://api.portfolio.the-full-stack.com/health
+curl -i https://api.portfolio.dev.the-full-stack.com/health
+```
+
+### Paso 8 — Soft-rollback period
+
+Mantener URLs raw `execute-api.amazonaws.com` operativas por **30 dias**.
+NO eliminar nada de API Gateway. Solo el frontend deja de apuntar ahi.
+
+Despues de 30 dias sin issues:
+- Confirmar que ningun cliente externo usa la URL raw.
+- Documentar la URL raw como deprecated en INTEGRATION.md.
+
+### Paso 9 — Eventual cleanup (opcional, post-validacion)
+
+Si en 60+ dias nadie consume las URLs raw, se pueden desactivar pero
+NO es necesario — API Gateway no cobra por hostname raw inactivo.
+
+## Costos esperados
+
+| Item | Costo mensual |
+|------|---------------|
+| Custom Domain Names (2 entries) | $0 (no charge per domain) |
+| ACM cert (regional) | $0 (free) |
+| API Gateway requests (1M free tier + $3.50/M) | igual que antes |
+| Cloudflare DNS records (2 CNAMEs proxied) | $0 (free plan) |
+| Cloudflare proxied requests | $0 (free plan, 100k/dia) |
+
+**Cost delta: ~$0/mes.**
+
+## Riesgos
+
+1. **DNS propagation**: cambio de PUBLIC_API_ENDPOINT puede tardar ~5min
+   en propagarse a usuarios via cache CDN del frontend.
+2. **CORS**: si la app tiene CORS estricto whitelisting el hostname raw,
+   actualizar la config para incluir el nuevo hostname antes del cutover.
+3. **Hard-coded URLs**: buscar en codigo y docs por `execute-api` antes
+   del cutover.
+
+## Comandos de busqueda pre-migracion
+
+```bash
+# Buscar referencias hardcoded
+grep -rn "execute-api.us-east-1.amazonaws.com" \
+  --include="*.ts" --include="*.astro" --include="*.md" \
+  --include="*.py" --include="*.json" --exclude-dir=node_modules .
+```

--- a/.claude/docs/subdomain-standard/07-anti-patterns.md
+++ b/.claude/docs/subdomain-standard/07-anti-patterns.md
@@ -1,0 +1,128 @@
+# 07 - Anti-patterns
+
+> [<- 06-migration-backend-api](./06-migration-backend-api.md) | [README ->](./README.md)
+
+## Lista de formas prohibidas con razon
+
+### Forma del subdomain
+
+| Prohibido | Por que | Correcto |
+|-----------|---------|----------|
+| `prod.faststruct.the-full-stack.com` | Prod va sin label de env (asimetria intencional) | `faststruct.the-full-stack.com` |
+| `dev-faststruct.the-full-stack.com` | Env como sufijo flat rompe el patron `{env}` como label | `faststruct.dev.the-full-stack.com` |
+| `faststruct-dev.the-full-stack.com` | Env como sufijo flat invertido | `faststruct.dev.the-full-stack.com` |
+| `faststruct-api.the-full-stack.com` | Component como sufijo slug compuesto rompe wildcards | `api.faststruct.the-full-stack.com` |
+| `dev.the-full-stack.com` | Falta product, queda env solo | nunca usar — env siempre con product |
+| `stage.the-full-stack.com` | Idem dev | nunca usar |
+| `Faststruct.the-full-stack.com` | Mayusculas violan RFC 1035 | `faststruct.the-full-stack.com` |
+| `faststruct_api.the-full-stack.com` | Underscore prohibido en hostnames | `api.faststruct.the-full-stack.com` |
+| `faststruct.com.the-full-stack.com` | Punto extra en slug, parece TLD pegado | usar slug propio |
+
+### Naming de products
+
+| Prohibido | Por que | Correcto |
+|-----------|---------|----------|
+| `api.the-full-stack.com` | `api` es reservado como product (es component) | usar como component de algo: `api.{product}.the-full-stack.com` |
+| `app.the-full-stack.com` | `app` es reservado como product | `app.{product}.the-full-stack.com` |
+| `admin.the-full-stack.com` | `admin` es reservado como product | `admin.{product}.the-full-stack.com` |
+| `dev.the-full-stack.com` como product propio | `dev` reservado para env | usar otro nombre |
+| `prod.the-full-stack.com` como product propio | `prod` reservado para env | usar otro nombre |
+| `fintech.the-full-stack.com` como product propio | reservado para portfolio niche | usar otro nombre |
+| `tunnel.the-full-stack.com` como product propio | reservado para infra | si es CF tunnel, scope a env: `vpn.{env}.the-full-stack.com` |
+| Product `Status` | colision con servicio infra `status` | renombrar comercialmente |
+
+### Environments
+
+| Prohibido | Por que | Correcto |
+|-----------|---------|----------|
+| `qa.faststruct.the-full-stack.com` | `qa` no esta en la lista cerrada | usar `stage` |
+| `uat.faststruct.the-full-stack.com` | idem | usar `stage` |
+| `preview.faststruct.the-full-stack.com` | extender el patron para previews | usar default `<hash>.<project>.pages.dev` |
+| `beta.faststruct.the-full-stack.com` | sub-env post-prod no formal | usar feature flags + prod URL |
+| `test.faststruct.the-full-stack.com` | tests corren en CI, no necesitan URL | usar CI / local |
+| `feature-x.faststruct.the-full-stack.com` | env temporal por feature | usar default pages.dev |
+| `release-candidate.faststruct.the-full-stack.com` | sub-env informal | usar `stage` |
+
+### Multiples envs en un slug
+
+| Prohibido | Por que | Correcto |
+|-----------|---------|----------|
+| `faststruct.dev-stage.the-full-stack.com` | dos envs combinados sin sentido | uno o el otro |
+| `faststruct.dev.stage.the-full-stack.com` | 2 labels env, ambigüo | uno solo |
+
+## Anti-patterns por motivo
+
+### Marketing-driven (ceder al impulso de URLs "lindas")
+
+```text
+❌ get.faststruct.com  ← punto entry de marketing, separa del estandar
+✅ faststruct.the-full-stack.com  ← prod simple cumple ese rol
+```
+
+Si necesitas un CTA muy corto, comprar un dominio dedicado (`fstr.io`)
+en lugar de inventar un subdomain del estandar.
+
+### "Solo por esta vez"
+
+```text
+❌ demo-cliente-acme.the-full-stack.com  ← deploy one-off para un demo
+✅ demo.{product}.dev.the-full-stack.com con feature flag
+✅ usar URL pages.dev directa
+```
+
+Los demos one-off acumulan DNS huerfanos rapido. Limitar al patron o
+usar pages.dev efimero.
+
+### Acronimos crypticos como product
+
+```text
+❌ vsm.the-full-stack.com (que es vsm?)
+✅ vscodemkt.the-full-stack.com (autodescriptivo)
+```
+
+Reglas: si un dev nuevo no entiende que es el product por el nombre,
+el nombre es malo.
+
+### Sufijos para evitar el patron
+
+```text
+❌ api-v2.faststruct.the-full-stack.com  ← versioning en subdomain
+✅ api.faststruct.the-full-stack.com con /v2 path-based versioning
+✅ api.faststruct-v2.the-full-stack.com solo si v2 es un product propio
+```
+
+## Cuando una excepcion es valida
+
+Casos donde se puede romper el estandar conscientemente:
+
+1. **Migracion temporal**: subdomain legacy durante transicion (max 90 dias).
+2. **Constraint externo**: proveedor SaaS requiere un CNAME especifico
+   (ej. `auto-detect.fly.dev`).
+3. **Verificacion de identidad**: CNAMEs `*._domainkey` (DKIM),
+   `_dmarc`, `_atproto` etc. no son del trafico HTTP — siguen reglas
+   propias del protocolo.
+
+Documentar excepciones en `docs/cv/` o en un `EXCEPTIONS.md` de la zona
+para que esten visibles en review.
+
+## Como auditar la zona
+
+Script de auditoria sugerido:
+
+```bash
+#!/usr/bin/env bash
+# Lista records de Cloudflare + Route 53 y marca los que rompen el estandar.
+
+# 1. Leer todos los hostnames
+# 2. Filtrar los que apuntan a hosting (excluir DKIM/SPF/DMARC/atproto)
+# 3. Para cada uno, validar contra regex del estandar
+# 4. Reportar los que no matchean + razon
+```
+
+Regex del estandar (para validacion):
+
+```regex
+^(?:[a-z][a-z0-9-]*\.)?[a-z][a-z0-9-]*(?:\.(?:dev|stage))?\.the-full-stack\.com$
+```
+
+Reservados a excluir adicionalmente: el conjunto del portfolio (apex, www, hub, fintech, architect, leader, vibe).

--- a/.claude/docs/subdomain-standard/README.md
+++ b/.claude/docs/subdomain-standard/README.md
@@ -1,0 +1,83 @@
+# Estandar de subdominios — `the-full-stack.com`
+
+> Convencion canonica para nombrar subdominios bajo `the-full-stack.com`,
+> cubriendo productos, servicios de infra y multiples environments
+> (`dev`, `stage`, `prod`). Aplicable a todo lo que viva en el dominio
+> excepto el portfolio personal (excepcion permanente).
+
+## Patron canonico
+
+```text
+[{component}.]{product}.{env}.{domain}
+```
+
+Reglas de presencia:
+
+- `{domain}` — siempre `the-full-stack.com`.
+- `{env}` — opcional; presente solo cuando NO es prod. Valores: `dev`, `stage`.
+- `{product}` — slug del producto. Obligatorio salvo apex/www del portfolio.
+- `{component}` — opcional, identifica componentes dentro del producto.
+
+### Forma reducida por env
+
+```text
+prod    [{component}.]{product}.the-full-stack.com
+stage   [{component}.]{product}.stage.the-full-stack.com
+dev     [{component}.]{product}.dev.the-full-stack.com
+```
+
+## Cuando leer cada archivo
+
+| Tema | Archivo | Cuando leer |
+|------|---------|-------------|
+| Patron canonico + ejemplos | [01-pattern.md](./01-pattern.md) | Entender la forma `[{component}.]{product}.{env}.{domain}` |
+| Reglas de naming + reservados | [02-naming-rules.md](./02-naming-rules.md) | Antes de elegir nombre de producto o componente |
+| Environments (dev/stage/prod) | [03-environments.md](./03-environments.md) | Definir flujo dev/stage/prod, decision sobre previews por PR |
+| Excepcion del portfolio personal | [04-portfolio-exception.md](./04-portfolio-exception.md) | Por que `fintech.the-full-stack.com` no sigue el patron |
+| Wildcards y certificados | [05-wildcards-and-certs.md](./05-wildcards-and-certs.md) | Planear SSL: por hostname, wildcard 1-nivel, Advanced Cert |
+| Migracion backend serverless | [06-migration-backend-api.md](./06-migration-backend-api.md) | Plan concreto para migrar `execute-api.amazonaws.com` |
+| Anti-patterns | [07-anti-patterns.md](./07-anti-patterns.md) | Lista de formas prohibidas con razones |
+
+## Reglas criticas
+
+- SIEMPRE prod va SIN label de env (`faststruct.the-full-stack.com`, no
+  `prod.faststruct.the-full-stack.com`).
+- SIEMPRE `dev` y `stage` van como label intermedio
+  (`faststruct.dev.the-full-stack.com`, no `dev-faststruct.the-full-stack.com`).
+- NUNCA usar nombres reservados como `{product}` — ver
+  [02-naming-rules.md](./02-naming-rules.md) para la lista completa.
+- NUNCA inventar un 4to environment (`qa`, `uat`, `preview-N`). Para
+  previews por PR usar el default de Cloudflare Pages
+  (`<hash>.<project>.pages.dev`) — ver [03-environments.md](./03-environments.md).
+- El portfolio (`the-full-stack.com`, `www`, `hub`, `fintech`,
+  `architect`, `leader`, `vibe`) es excepcion permanente. Ver
+  [04-portfolio-exception.md](./04-portfolio-exception.md).
+
+## Decision flow rapida
+
+```text
+1. Es portfolio personal? -> usar nicho existente (excepcion)
+2. Es servicio de infra atomico? -> {service}.{env}.{domain}
+3. Es product con un solo frontend? -> {product}.{env}.{domain}
+4. Es product con varios components? -> {component}.{product}.{env}.{domain}
+5. Es env temporal de PR? -> default pages.dev (no extender el estandar)
+```
+
+## Ejemplos rapidos
+
+```text
+# Producto faststruct (varios components)
+faststruct.the-full-stack.com               (prod, landing)
+app.faststruct.the-full-stack.com           (prod, app)
+api.faststruct.the-full-stack.com           (prod, api)
+api.faststruct.dev.the-full-stack.com       (dev, api)
+api.faststruct.stage.the-full-stack.com     (stage, api)
+
+# Producto portfolio-backend (despues de migrar execute-api)
+api.portfolio.the-full-stack.com            (prod)
+api.portfolio.dev.the-full-stack.com        (dev)
+
+# Servicio infra status page
+status.the-full-stack.com                   (prod)
+status.dev.the-full-stack.com               (dev)
+```

--- a/.claude/skills/subdomain-standard/SKILL.md
+++ b/.claude/skills/subdomain-standard/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: subdomain-standard
+description: >
+  Subdomain naming standard for the-full-stack.com — canonical pattern
+  [{component}.]{product}.{env}.{domain} with prod implicit (no env
+  label), dev and stage as middle labels. Covers naming rules (kebab-case,
+  ASCII lowercase, reserved names: www/api/app/admin/mail/status/dev/stage/
+  prod/test/localhost/infra/internal/private/vpn/tunnel + portfolio niches
+  hub/fintech/architect/leader/vibe/generic), environment conventions
+  (dev/stage/prod only — qa/uat/beta/preview prohibited, use stage or
+  pages.dev), portfolio personal exception (apex + www + 5 niches are
+  permanent exception that does NOT follow the pattern), wildcard SSL
+  strategies (1-level limit, Universal SSL covers *.the-full-stack.com,
+  Pages auto-cert per hostname, ACM cert for API Gateway, Advanced
+  Certificate for 2-level wildcards), migration plan for the current
+  backend serverless (from execute-api.us-east-1.amazonaws.com to
+  api.portfolio.the-full-stack.com / api.portfolio.dev.the-full-stack.com)
+  and anti-patterns (env as flat suffix dev-faststruct, slug composition
+  faststruct-api, qa/uat/beta envs, uppercase, underscores in hostnames).
+  ALWAYS invoke this skill BEFORE answering ANY question about subdomain
+  naming, hostname structure, environment URL patterns, new product
+  hostname, where to put a new service, how to name dev/stage URL,
+  reserved hostnames, wildcard SSL planning, or migrating the API Gateway
+  custom domain for this portfolio. NEVER answer subdomain naming
+  questions from training data alone — this project has a consolidated
+  standard with specific reserved words and a portfolio exception that
+  overrides generic advice.
+  Use when the user says "subdomain standard", "estandar subdominios",
+  "convencion subdominios", "naming subdominios", "nombrar subdominio",
+  "como nombrar subdominio", "como llamo el subdominio", "patron
+  subdominios", "subdomain pattern", "subdomain naming convention",
+  "subdomain structure", "new product subdomain", "agregar subdominio",
+  "nuevo subdominio", "como crear subdominio nuevo", "donde pongo este
+  servicio", "que url uso para", "como llamo la api", "como llamo el
+  admin", "subdominio dev", "subdominio stage", "subdominio prod",
+  "subdominio environment", "url por ambiente", "dev stage prod url",
+  "url dev stage prod", "wildcard ssl", "wildcard cert", "cert wildcard",
+  "wildcard *.the-full-stack.com", "ssl multi nivel", "ssl multinivel",
+  "advanced cert cloudflare", "acm cert api gateway", "cert para api
+  gateway", "custom domain api gateway", "migrar execute-api",
+  "ejecute-api a custom domain", "api gateway custom domain", "the
+  full stack subdomain", "reserved hostnames", "reservados", "nombres
+  reservados", "prohibidos", "que no usar como subdominio", "antipattern
+  subdominio", "anti pattern subdomain", "como migrar al estandar",
+  "migracion subdomain", "qa subdomain", "uat subdomain", "preview
+  subdomain", "beta subdomain", "release candidate url".
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash(curl:*), Bash(dig:*), Bash(nslookup:*)
+argument-hint: "tema: pattern | naming | environments | portfolio | wildcards | migration | anti-patterns"
+metadata:
+  version: "1.0"
+---
+
+# Subdomain naming standard — knowledge reference
+
+> Conocimiento consolidado sobre la convencion de subdominios bajo
+> `the-full-stack.com`. Toda decision, regla, reserva y plan de
+> migracion esta documentado en `.claude/docs/subdomain-standard/`.
+
+## Pre-requisito OBLIGATORIO
+
+Antes de responder cualquier pregunta sobre subdominios, leer la doc
+relevante:
+
+| Pregunta del usuario | Leer |
+|----------------------|------|
+| Que patron uso? Como armo la URL? | `.claude/docs/subdomain-standard/01-pattern.md` |
+| Como nombro el product? Que palabras estan reservadas? | `.claude/docs/subdomain-standard/02-naming-rules.md` |
+| Como manejo dev/stage/prod? Que pasa con QA/UAT/beta? | `.claude/docs/subdomain-standard/03-environments.md` |
+| Por que el portfolio no sigue el patron? Puedo nombrar mi product como un niche? | `.claude/docs/subdomain-standard/04-portfolio-exception.md` |
+| Como configuro SSL wildcard? Necesito Advanced Cert? | `.claude/docs/subdomain-standard/05-wildcards-and-certs.md` |
+| Como migro el backend de execute-api a custom domain? | `.claude/docs/subdomain-standard/06-migration-backend-api.md` |
+| Que NO puedo hacer? Que es anti-pattern? | `.claude/docs/subdomain-standard/07-anti-patterns.md` |
+
+Para preguntas genericas (cualquier mencion del estandar sin tema
+especifico), leer primero `README.md` del directorio docs.
+
+## Patron canonico (resumen)
+
+```text
+[{component}.]{product}.{env}.{domain}
+
+prod    [{component}.]{product}.the-full-stack.com
+stage   [{component}.]{product}.stage.the-full-stack.com
+dev     [{component}.]{product}.dev.the-full-stack.com
+```
+
+## Reglas criticas
+
+- NUNCA prod lleva label de env (`prod.faststruct.the-full-stack.com`
+  PROHIBIDO).
+- NUNCA env como sufijo flat (`dev-faststruct.the-full-stack.com`
+  PROHIBIDO).
+- NUNCA usar reservados como product propio: `api`, `app`, `admin`,
+  `mail`, `status`, `auth`, `cdn`, `assets`, `static`, `dev`, `stage`,
+  `staging`, `prod`, `production`, `test`, `qa`, `uat`, `local`,
+  `localhost`, `infra`, `internal`, `private`, `vpn`, `tunnel`, `hub`,
+  `fintech`, `architect`, `leader`, `vibe`, `generic`.
+- SIEMPRE el portfolio (apex + www + 5 niches) es excepcion permanente.
+  El estandar aplica solo a products + servicios NUEVOS.
+- SIEMPRE solo 3 envs formales: `dev`, `stage`, prod. Previews por PR
+  usan default `<hash>.<project>.pages.dev`.
+
+## Quick decision flow
+
+```text
+1. Es portfolio personal? -> usar nicho existente (excepcion)
+2. Es servicio de infra atomico? -> {service}.{env}.{domain}
+3. Es product con 1 frontend? -> {product}.{env}.{domain}
+4. Es product con varios components? -> {component}.{product}.{env}.{domain}
+5. Es env temporal de PR? -> default pages.dev (NO extender estandar)
+```
+
+## Ejemplos clave
+
+```text
+# Producto faststruct
+faststruct.the-full-stack.com               (prod, landing)
+api.faststruct.the-full-stack.com           (prod, component api)
+api.faststruct.dev.the-full-stack.com       (dev, component api)
+app.faststruct.stage.the-full-stack.com     (stage, component app)
+
+# Backend portfolio (post-migracion)
+api.portfolio.the-full-stack.com            (prod)
+api.portfolio.dev.the-full-stack.com        (dev)
+
+# Servicio infra
+status.the-full-stack.com                   (prod)
+status.dev.the-full-stack.com               (dev)
+```
+
+## Validacion regex
+
+```regex
+^(?:[a-z][a-z0-9-]*\.)?[a-z][a-z0-9-]*(?:\.(?:dev|stage))?\.the-full-stack\.com$
+```
+
+Mas: nombres reservados a rechazar adicionalmente segun
+[02-naming-rules.md](../../docs/subdomain-standard/02-naming-rules.md).
+
+## Estado del estandar
+
+- **Adopcion**: 2026-05-15
+- **Excepciones existentes**: portfolio (7 hostnames: apex + www + 5
+  niches) — permanente.
+- **Migraciones pendientes**: backend serverless
+  (`execute-api.amazonaws.com` -> `api.portfolio.{env}.the-full-stack.com`).
+  Plan en [06-migration-backend-api.md](../../docs/subdomain-standard/06-migration-backend-api.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ Antes de trabajar, identifica que contexto necesitas:
 | CV (contenido) | [.claude/docs/cv/README.md](.claude/docs/cv/README.md) | Datos del CV (perfil, experiencia, proyectos) |
 | Estrategia portfolio 2026 | invocar skill `astro-portfolio` | Decisiones de SEO/GEO/ATS/AI literacy/diseño |
 | Deploy Cloudflare Pages | [.claude/docs/cloudflare/README.md](.claude/docs/cloudflare/README.md) o skill `cloudflare-deploy` | Deploy, custom domains, DNS, gotchas, troubleshoot del setup actual |
+| Estandar subdominios | [.claude/docs/subdomain-standard/README.md](.claude/docs/subdomain-standard/README.md) o skill `subdomain-standard` | Patron `[{component}.]{product}.{env}.{domain}` para products, components y envs (dev/stage/prod) bajo the-full-stack.com. Reservados, wildcards SSL, plan de migracion del backend |
 | AWS Lambda Python 3.13 | [.claude/docs/aws-lambda/README.md](.claude/docs/aws-lambda/README.md) o skill `aws-lambda-python` | Backend serverless: runtime, Powertools v3, cold start, SAM deploy, IAM, costs |
 | AWS API Gateway | [.claude/docs/aws-api-gateway/README.md](.claude/docs/aws-api-gateway/README.md) o skill `aws-api-gateway` | REST vs HTTP, throttling per-IP via WAF, CORS, request validation, deploy |
 | AWS DynamoDB | [.claude/docs/aws-dynamodb/README.md](.claude/docs/aws-dynamodb/README.md) o skill `aws-dynamodb` | On-demand, TTL, boto3, single-table, GSI, pricing 2026 |


### PR DESCRIPTION
## Problema

El proyecto no tenia un estandar formal para nombrar subdominios bajo `the-full-stack.com`. A medida que crece el alcance (productos, infra, environments dev/stage/prod), aparecen ambigüedades:

- Como nombrar un product nuevo (formato? reservados? colision con nichos del portfolio?).
- Donde poner los components de un product (api, app, admin, docs).
- Como manejar el env (sufijo? prefijo? que pasa con QA/UAT/beta?).
- Que strategy de SSL aplicar (wildcard 1-nivel? Advanced Cert? per-hostname?).
- Como migrar el backend serverless actual (`execute-api.us-east-1.amazonaws.com`) a un custom domain coherente.

Sin estandar, cada decision se toma ad-hoc y acumula inconsistencias (ej. `tunnel-app`, `tunnel-server`, `tunnel` apuntando al mismo Cloudflare Tunnel — ya limpiado).

## Solucion

Estandar canonico:

```
[{component}.]{product}.{env}.{domain}
```

- prod implicito (sin label de env).
- dev y stage como label intermedio.
- Solo 3 envs formales (dev/stage/prod) — qa/uat/beta/preview prohibidos.
- Portfolio personal (apex + www + 5 niches) es excepcion permanente.

Documentado en `.claude/docs/subdomain-standard/` (8 archivos modulares siguiendo el patron del Knowledge Tree del proyecto) + skill invocable `subdomain-standard` con keywords ES+EN.

Estructura:

- `README.md` — indice + decision flow + reglas criticas.
- `01-pattern.md` — patron canonico, lectura right-to-left, ejemplos por nivel.
- `02-naming-rules.md` — kebab-case, ASCII lowercase, regex, reservados (componentes + envs + infra + nichos).
- `03-environments.md` — dev/stage/prod, asimetria prod sin label, robots.txt en no-prod.
- `04-portfolio-exception.md` — por que apex + 5 niches no siguen el patron.
- `05-wildcards-and-certs.md` — Universal SSL vs Pages auto-cert vs Advanced Cert vs ACM.
- `06-migration-backend-api.md` — plan 9 pasos para migrar `execute-api` -> `api.portfolio.{env}.the-full-stack.com`.
- `07-anti-patterns.md` — formas prohibidas con razon.

Validado 5/5 angulos con `claude -p`:

| Test | num_turns | Resultado |
|---|---|---|
| 1. Producto nuevo + componente api | 3 | URLs prod/stage/dev correctas + asimetria prod |
| 2. Puedo usar qa.miproducto? | 4 | Rechaza, propone stage |
| 3. Como migrar execute-api? | 4 | Plan 9 pasos exacto |
| 4. Puedo nombrar mi product fintech? | 4 | Rechaza por colision con niche |
| 5. faststruct-api vs api.faststruct? | 10 | Distingue anti-pattern vs canonico |

## Como probar

1. Verificar que la skill esta registrada:
   ```bash
   ls .claude/skills/subdomain-standard/SKILL.md
   ls .claude/docs/subdomain-standard/
   ```

2. Verificar entry en CLAUDE.md (linea 259):
   ```bash
   grep -n "subdomain-standard" CLAUDE.md
   ```

3. Invocar la skill con un caso real:
   ```bash
   claude --permission-mode bypassPermissions \
     --disallowedTools "WebSearch" "WebFetch" \
     --output-format json \
     -p "Necesito agregar un nuevo product faststruct con componente api. Que URLs uso para prod, stage y dev?"
   ```
   Esperado: `num_turns >= 3`, devuelve `api.faststruct.the-full-stack.com` (prod), `api.faststruct.stage.the-full-stack.com` (stage), `api.faststruct.dev.the-full-stack.com` (dev).

4. Caso negativo (env prohibido):
   ```bash
   claude --permission-mode bypassPermissions \
     --disallowedTools "WebSearch" "WebFetch" \
     --output-format json \
     -p "Puedo crear qa.miproducto.the-full-stack.com?"
   ```
   Esperado: rechaza y propone `stage`.

5. Lectura humana: abrir `.claude/docs/subdomain-standard/README.md` y seguir el decision flow.

## TODO

- [ ] Migrar el backend serverless del portfolio al estandar (`api.portfolio.{env}.the-full-stack.com`) — ver plan en `06-migration-backend-api.md`. Requiere cert ACM en us-east-1 + Custom Domain Names en API Gateway + actualizar `PUBLIC_API_ENDPOINT` en `docker/env/.{dev,prod}`. Fuera de scope de este PR.
- [ ] Auditar zona Cloudflare actual para verificar que todos los hostnames cumplen el estandar o estan en la lista de excepciones del portfolio. Fuera de scope.
- [ ] Considerar agregar un script de validacion en `devtools/` que parsee DNS records de Cloudflare y los compare contra el regex del estandar. Fuera de scope.