### PR TITLE
feat(contact): ContactForm React 18 + Zod + bypass Turnstile

### DIFF
--- a/apps/architect/astro.config.ts
+++ b/apps/architect/astro.config.ts
@@ -2,6 +2,8 @@
  * @config astro
  * @description Astro config para apps/architect.
  */
+
+import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import yaml from '@modyfi/vite-plugin-yaml'
 import tailwindcss from '@tailwindcss/vite'
@@ -19,9 +21,18 @@ export default defineConfig({
     locales: ['es', 'en'],
     routing: { prefixDefaultLocale: false },
   },
-  integrations: [sitemap()],
+  integrations: [sitemap(), react()],
   vite: {
     plugins: [yaml({ schema: JSON_SCHEMA }), tailwindcss()],
+    optimizeDeps: {
+      include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+      ],
+    },
     ssr: {
       noExternal: [
         '@portfolio/app-shared',

--- a/apps/architect/package.json
+++ b/apps/architect/package.json
@@ -13,6 +13,7 @@
     "prebuild": "vite-node --config scripts/vite.config.ts scripts/build-public-assets.mjs"
   },
   "dependencies": {
+    "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.7.2",
     "@portfolio/app-shared": "workspace:*",
     "@portfolio/content": "workspace:*",
@@ -22,12 +23,16 @@
     "@portfolio/ui": "workspace:*",
     "@tailwindcss/vite": "^4.0.18",
     "astro": "^6.3.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "js-yaml": "^4.1.1",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",

--- a/apps/architect/src/pages/contact.astro
+++ b/apps/architect/src/pages/contact.astro
@@ -1,6 +1,6 @@
 ---
 import { profile } from '@portfolio/content'
-import ContactForm from '@portfolio/ui/components/ContactForm.astro'
+import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
 import PageLayout from '../layouts/PageLayout.astro'
 import { NICHE, STRINGS } from '../lib/site-config'

--- a/apps/fintech/astro.config.ts
+++ b/apps/fintech/astro.config.ts
@@ -2,6 +2,8 @@
  * @config astro
  * @description Astro config para apps/fintech.
  */
+
+import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import yaml from '@modyfi/vite-plugin-yaml'
 import tailwindcss from '@tailwindcss/vite'
@@ -19,9 +21,18 @@ export default defineConfig({
     locales: ['es', 'en'],
     routing: { prefixDefaultLocale: false },
   },
-  integrations: [sitemap()],
+  integrations: [sitemap(), react()],
   vite: {
     plugins: [yaml({ schema: JSON_SCHEMA }), tailwindcss()],
+    optimizeDeps: {
+      include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+      ],
+    },
     ssr: {
       noExternal: [
         '@portfolio/app-shared',

--- a/apps/fintech/package.json
+++ b/apps/fintech/package.json
@@ -13,6 +13,7 @@
     "prebuild": "vite-node --config scripts/vite.config.ts scripts/build-public-assets.mjs"
   },
   "dependencies": {
+    "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.7.2",
     "@portfolio/app-shared": "workspace:*",
     "@portfolio/content": "workspace:*",
@@ -22,12 +23,16 @@
     "@portfolio/ui": "workspace:*",
     "@tailwindcss/vite": "^4.0.18",
     "astro": "^6.3.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "js-yaml": "^4.1.1",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",

--- a/apps/fintech/src/pages/contact.astro
+++ b/apps/fintech/src/pages/contact.astro
@@ -1,6 +1,6 @@
 ---
 import { profile } from '@portfolio/content'
-import ContactForm from '@portfolio/ui/components/ContactForm.astro'
+import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
 import PageLayout from '../layouts/PageLayout.astro'
 import { NICHE, STRINGS } from '../lib/site-config'

--- a/apps/generic/astro.config.ts
+++ b/apps/generic/astro.config.ts
@@ -3,6 +3,8 @@
  * @description Astro config para apps/generic. Site URL, i18n (es default + en),
  *   sitemap integration, Tailwind v4 via @tailwindcss/vite.
  */
+
+import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import yaml from '@modyfi/vite-plugin-yaml'
 import tailwindcss from '@tailwindcss/vite'
@@ -22,9 +24,18 @@ export default defineConfig({
       prefixDefaultLocale: false,
     },
   },
-  integrations: [sitemap()],
+  integrations: [sitemap(), react()],
   vite: {
     plugins: [yaml({ schema: JSON_SCHEMA }), tailwindcss()],
+    optimizeDeps: {
+      include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+      ],
+    },
     ssr: {
       noExternal: [
         '@portfolio/app-shared',

--- a/apps/generic/package.json
+++ b/apps/generic/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Generic portfolio site \u2014 hub.the-full-stack.com",
+  "description": "Generic portfolio site — hub.the-full-stack.com",
   "scripts": {
     "dev": "astro dev --port 4321",
     "build": "astro build",
@@ -14,6 +14,7 @@
     "prebuild": "vite-node --config scripts/vite.config.ts scripts/build-public-assets.mjs"
   },
   "dependencies": {
+    "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.7.2",
     "@portfolio/app-shared": "workspace:*",
     "@portfolio/content": "workspace:*",
@@ -23,12 +24,16 @@
     "@portfolio/ui": "workspace:*",
     "@tailwindcss/vite": "^4.0.18",
     "astro": "^6.3.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "js-yaml": "^4.1.1",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",

--- a/apps/generic/src/pages/contact.astro
+++ b/apps/generic/src/pages/contact.astro
@@ -1,6 +1,6 @@
 ---
 import { profile } from '@portfolio/content'
-import ContactForm from '@portfolio/ui/components/ContactForm.astro'
+import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
 import PageLayout from '../layouts/PageLayout.astro'
 import { NICHE, STRINGS } from '../lib/site-config'

--- a/apps/hub/astro.config.ts
+++ b/apps/hub/astro.config.ts
@@ -2,6 +2,8 @@
  * @config astro
  * @description Astro config para apps/hub (landing selector en the-full-stack.com).
  */
+
+import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import yaml from '@modyfi/vite-plugin-yaml'
 import tailwindcss from '@tailwindcss/vite'
@@ -19,9 +21,18 @@ export default defineConfig({
     locales: ['es', 'en'],
     routing: { prefixDefaultLocale: false },
   },
-  integrations: [sitemap()],
+  integrations: [sitemap(), react()],
   vite: {
     plugins: [yaml({ schema: JSON_SCHEMA }), tailwindcss()],
+    optimizeDeps: {
+      include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+      ],
+    },
     ssr: {
       noExternal: [
         '@portfolio/app-shared',

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -12,6 +12,7 @@
     "typecheck": "astro check"
   },
   "dependencies": {
+    "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.7.2",
     "@portfolio/app-shared": "workspace:*",
     "@portfolio/content": "workspace:*",
@@ -19,12 +20,16 @@
     "@portfolio/ui": "workspace:*",
     "@tailwindcss/vite": "^4.0.18",
     "astro": "^6.3.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "js-yaml": "^4.1.1",
     "typescript": "^5.9.3",
     "vite": "^7.3.3",

--- a/apps/hub/src/pages/contact.astro
+++ b/apps/hub/src/pages/contact.astro
@@ -1,6 +1,6 @@
 ---
 import { profile } from '@portfolio/content'
-import ContactForm from '@portfolio/ui/components/ContactForm.astro'
+import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
 import BaseLayout from '@portfolio/ui/layouts/BaseLayout.astro'
 

--- a/apps/leader/astro.config.ts
+++ b/apps/leader/astro.config.ts
@@ -2,6 +2,8 @@
  * @config astro
  * @description Astro config para apps/leader.
  */
+
+import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import yaml from '@modyfi/vite-plugin-yaml'
 import tailwindcss from '@tailwindcss/vite'
@@ -19,9 +21,18 @@ export default defineConfig({
     locales: ['es', 'en'],
     routing: { prefixDefaultLocale: false },
   },
-  integrations: [sitemap()],
+  integrations: [sitemap(), react()],
   vite: {
     plugins: [yaml({ schema: JSON_SCHEMA }), tailwindcss()],
+    optimizeDeps: {
+      include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+      ],
+    },
     ssr: {
       noExternal: [
         '@portfolio/app-shared',

--- a/apps/leader/package.json
+++ b/apps/leader/package.json
@@ -13,6 +13,7 @@
     "prebuild": "vite-node --config scripts/vite.config.ts scripts/build-public-assets.mjs"
   },
   "dependencies": {
+    "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.7.2",
     "@portfolio/app-shared": "workspace:*",
     "@portfolio/content": "workspace:*",
@@ -22,12 +23,16 @@
     "@portfolio/ui": "workspace:*",
     "@tailwindcss/vite": "^4.0.18",
     "astro": "^6.3.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "js-yaml": "^4.1.1",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",

--- a/apps/leader/src/pages/contact.astro
+++ b/apps/leader/src/pages/contact.astro
@@ -1,6 +1,6 @@
 ---
 import { profile } from '@portfolio/content'
-import ContactForm from '@portfolio/ui/components/ContactForm.astro'
+import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
 import PageLayout from '../layouts/PageLayout.astro'
 import { NICHE, STRINGS } from '../lib/site-config'

--- a/apps/vibe/astro.config.ts
+++ b/apps/vibe/astro.config.ts
@@ -2,6 +2,8 @@
  * @config astro
  * @description Astro config para apps/vibe.
  */
+
+import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import yaml from '@modyfi/vite-plugin-yaml'
 import tailwindcss from '@tailwindcss/vite'
@@ -19,9 +21,18 @@ export default defineConfig({
     locales: ['es', 'en'],
     routing: { prefixDefaultLocale: false },
   },
-  integrations: [sitemap()],
+  integrations: [sitemap(), react()],
   vite: {
     plugins: [yaml({ schema: JSON_SCHEMA }), tailwindcss()],
+    optimizeDeps: {
+      include: [
+        'react',
+        'react-dom',
+        'react-dom/client',
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+      ],
+    },
     ssr: {
       noExternal: [
         '@portfolio/app-shared',

--- a/apps/vibe/package.json
+++ b/apps/vibe/package.json
@@ -13,6 +13,7 @@
     "prebuild": "vite-node --config scripts/vite.config.ts scripts/build-public-assets.mjs"
   },
   "dependencies": {
+    "@astrojs/react": "^4.4.2",
     "@astrojs/sitemap": "^3.7.2",
     "@portfolio/app-shared": "workspace:*",
     "@portfolio/content": "workspace:*",
@@ -22,12 +23,16 @@
     "@portfolio/ui": "workspace:*",
     "@tailwindcss/vite": "^4.0.18",
     "astro": "^6.3.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "js-yaml": "^4.1.1",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",

--- a/apps/vibe/src/pages/contact.astro
+++ b/apps/vibe/src/pages/contact.astro
@@ -1,6 +1,6 @@
 ---
 import { profile } from '@portfolio/content'
-import ContactForm from '@portfolio/ui/components/ContactForm.astro'
+import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
 import PageLayout from '../layouts/PageLayout.astro'
 import { NICHE, STRINGS } from '../lib/site-config'

--- a/devtools/serverless/flags.py
+++ b/devtools/serverless/flags.py
@@ -275,6 +275,34 @@ _DEFAULTS: dict[str, Any] = {
 }
 
 
+def _extract_positionals(flags_dict: dict[str, Any]) -> None:
+    """Extract positional args from sys.argv into flags_dict['subcommands'].
+
+    `flags_to_dict` solo parsea `--key=value`; los positionals (e.g.
+    `serverless build`, `serverless db-branch create --branch=X`) se
+    pierden. Este helper los reconstruye desde `sys.argv[2:]` (saltando
+    el nombre del script) tomando todo lo que NO arranque con `--`.
+
+    Mismo patron que `devtools/docker/flags.py::_extract_command`.
+    """
+    import sys as _sys
+
+    raw_args = _sys.argv[2:]
+    positionals: list[str] = []
+    for arg in raw_args:
+        if arg == '--':
+            break
+        if not arg.startswith('--'):
+            positionals.append(arg)
+
+    if positionals:
+        # Si `flags_dict['subcommands']` ya viene (e.g. de tests), lo
+        # respetamos; sino lo poblamos desde sys.argv.
+        existing = flags_dict.get('subcommands')
+        if not existing:
+            flags_dict['subcommands'] = positionals
+
+
 def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
     """Validate and normalize flags for serverless commands.
 
@@ -282,6 +310,8 @@ def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
     receives raw flags dict from flags_to_dict, returns normalized dict,
     raises ValueError on validation error (loader catches + prints).
     """
+    _extract_positionals(flags_dict)
+
     # Extraer comando posicional (primer token sin --) desde subcommands
     subcommands = flags_dict.get('subcommands', []) or []
     command = subcommands[0] if subcommands else 'help'

--- a/devtools/serverless/rate_limit_cmds.py
+++ b/devtools/serverless/rate_limit_cmds.py
@@ -43,8 +43,13 @@ from shared.console import _c
 from shared.console import _err
 
 
-_RULES_TABLE = 'rate_limit_rules'
-_BUCKETS_TABLE = 'rate_limit_buckets'
+# Las tablas DynamoDB siguen el patron `portfolio-<recurso>-<stage>` definido
+# en serverless/template.yaml. El stage por default es `dev` (lo unico que existe
+# hoy ademas de prod). Si se necesita gestionar otro stage, agregar flag --stage
+# y resolver el sufijo aqui.
+_STAGE = 'dev'
+_RULES_TABLE = f'portfolio-rate-limit-rules-{_STAGE}'
+_BUCKETS_TABLE = f'portfolio-rate-limit-buckets-{_STAGE}'
 _REGION = 'us-east-1'
 
 _VALID_ACTIONS = [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./components/*.astro": "./src/components/*.astro",
+    "./components/*.tsx": "./src/components/*.tsx",
     "./layouts/*.astro": "./src/layouts/*.astro",
     "./styles/*.css": "./src/styles/*.css",
     "./lib/*": "./src/lib/*.ts",
@@ -26,13 +27,18 @@
     "@fontsource-variable/space-grotesk": "^5.2.5",
     "@fontsource/space-grotesk": "^5.1.1",
     "@fontsource/space-mono": "^5.1.1",
-    "@portfolio/content": "workspace:*"
+    "@portfolio/content": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zod": "^3.25.76"
   },
   "peerDependencies": {
     "astro": "^6.0.0"
   },
   "devDependencies": {
     "@modyfi/vite-plugin-yaml": "^1.1.1",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
     "@vitest/coverage-v8": "^2.1.9",
     "happy-dom": "^15.11.7",
     "typescript": "^5.9.3",

--- a/packages/ui/src/components/ContactForm.astro
+++ b/packages/ui/src/components/ContactForm.astro
@@ -27,6 +27,26 @@ interface Props {
 const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
 ---
 
+<div class="contact-form-wrapper">
+  <!-- Card de confirmacion (oculta por default; el script la muestra si hay registro vivo) -->
+  <div class="contact-sent-card" data-contact-sent-card hidden>
+    <p class="contact-sent-card__title">Mensaje enviado</p>
+    <p class="contact-sent-card__body">
+      Ya enviaste un mensaje
+      <span data-contact-sent-date></span>. Te respondere en menos de 24h.
+    </p>
+    <p class="contact-sent-card__ref">
+      Ref: <code data-contact-sent-id></code>
+    </p>
+    <button
+      type="button"
+      class="contact-sent-card__resend"
+      data-contact-resend
+    >
+      Enviar otro mensaje
+    </button>
+  </div>
+
 <form
   class="contact-form"
   data-api-endpoint={apiEndpoint}
@@ -204,6 +224,7 @@ const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
 
   <p class="form-status" role="status" aria-live="polite"></p>
 </form>
+</div>
 
 <!-- Turnstile script (cargado async) -->
 <script
@@ -219,12 +240,26 @@ const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
    * NOTA: este script vive en module scope. Se ejecuta una sola vez por
    * pagina, registra event listeners en todos los <form.contact-form>.
    */
+  import {
+    clearContactRecord,
+    formatSentDate,
+    readContactRecord,
+    saveContactRecord,
+  } from '../lib/contact-storage'
 
   type ContactFormElements = {
     form: HTMLFormElement
     submit: HTMLButtonElement
     status: HTMLParagraphElement
     apiEndpoint: string
+  }
+
+  /**
+   * Body de respuesta 201 del Lambda contact_form.
+   */
+  type ContactSuccessBody = {
+    contact_id?: string
+    created_at?: string
   }
 
   /**
@@ -400,11 +435,14 @@ const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
         body: JSON.stringify(payload),
       })
 
-      // Body solo se intenta parsear si es JSON (los 4xx del Lambda lo son)
-      let body: ApiErrorBody | null = null
+      // Body solo se intenta parsear si es JSON (los 4xx del Lambda lo son
+      // y el 201 tambien)
+      let body: (ApiErrorBody & ContactSuccessBody) | null = null
       const contentType = response.headers.get('content-type') || ''
       if (contentType.includes('application/json')) {
-        body = (await response.json().catch(() => null)) as ApiErrorBody | null
+        body = (await response.json().catch(() => null)) as
+          | (ApiErrorBody & ContactSuccessBody)
+          | null
       }
 
       if (response.status === 201) {
@@ -418,6 +456,12 @@ const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
         const tsWidget = window.turnstile
         if (tsWidget && typeof tsWidget.reset === 'function') {
           tsWidget.reset(form.querySelector('.cf-turnstile'))
+        }
+        // Persistir contact_id + cookie compartida + ocultar form
+        const contactId = body?.contact_id
+        if (typeof contactId === 'string' && contactId.length > 0) {
+          const record = saveContactRecord(contactId)
+          renderSentCard(form, record.contactId, record.sentAt)
         }
       } else if (response.status === 400) {
         const errors = body?.extra?.errors ?? []
@@ -474,10 +518,70 @@ const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
     }
   }
 
+  /**
+   * Muestra la card de confirmacion y oculta el form.
+   */
+  function renderSentCard(
+    form: HTMLFormElement,
+    contactId: string,
+    sentAt: number,
+  ): void {
+    const wrapper = form.closest('.contact-form-wrapper')
+    if (!wrapper) return
+    const card = wrapper.querySelector<HTMLElement>('[data-contact-sent-card]')
+    if (!card) return
+
+    const dateEl = card.querySelector<HTMLElement>('[data-contact-sent-date]')
+    if (dateEl) {
+      const formatted = formatSentDate(sentAt)
+      dateEl.textContent = `el ${formatted}`
+    }
+    const idEl = card.querySelector<HTMLElement>('[data-contact-sent-id]')
+    if (idEl) idEl.textContent = contactId
+
+    form.hidden = true
+    card.hidden = false
+  }
+
+  /**
+   * Inversa: borra storage + cookie y vuelve a mostrar el form vacio.
+   */
+  function hideSentCard(form: HTMLFormElement): void {
+    const wrapper = form.closest('.contact-form-wrapper')
+    if (!wrapper) return
+    const card = wrapper.querySelector<HTMLElement>('[data-contact-sent-card]')
+    if (!card) return
+
+    clearContactRecord()
+    card.hidden = true
+    form.hidden = false
+
+    // Reset Turnstile para forzar nuevo challenge
+    const tsWidget = window.turnstile
+    if (tsWidget && typeof tsWidget.reset === 'function') {
+      tsWidget.reset(form.querySelector('.cf-turnstile'))
+    }
+  }
+
   function initContactForms(): void {
     const forms = document.querySelectorAll<HTMLFormElement>('.contact-form')
     forms.forEach((form) => {
       form.addEventListener('submit', handleSubmit as unknown as EventListener)
+
+      // Rehidratar UI desde localStorage/cookie si el user ya envio antes
+      const record = readContactRecord()
+      if (record) {
+        renderSentCard(form, record.contactId, record.sentAt)
+      }
+
+      // Wire del boton "Enviar otro mensaje" del card
+      const wrapper = form.closest('.contact-form-wrapper')
+      const resendBtn = wrapper?.querySelector<HTMLButtonElement>(
+        '[data-contact-resend]',
+      )
+      if (resendBtn) {
+        resendBtn.addEventListener('click', () => hideSentCard(form))
+      }
     })
   }
 
@@ -663,5 +767,72 @@ const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
     .submit-spinner {
       animation: none;
     }
+  }
+
+  .contact-form-wrapper {
+    width: 100%;
+  }
+
+  .contact-sent-card {
+    max-width: var(--container-narrow);
+    margin-inline: auto;
+    padding: var(--space-24);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-10);
+  }
+
+  .contact-sent-card[hidden] {
+    display: none;
+  }
+
+  .contact-sent-card__title {
+    margin: 0;
+    font-size: var(--font-size-20);
+    font-weight: 600;
+    color: var(--color-success, #16a34a);
+  }
+
+  .contact-sent-card__body {
+    margin: 0;
+    font-size: var(--font-size-14);
+    color: var(--color-text);
+    line-height: var(--line-height-base);
+  }
+
+  .contact-sent-card__ref {
+    margin: 0;
+    font-size: var(--font-size-12);
+    color: var(--color-text-muted);
+  }
+
+  .contact-sent-card__ref code {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-12);
+    color: var(--color-text-subtle);
+    word-break: break-all;
+  }
+
+  .contact-sent-card__resend {
+    align-self: flex-start;
+    margin-top: var(--space-6);
+    padding: var(--space-8) var(--space-16);
+    font-size: var(--font-size-13);
+    font-weight: 500;
+    color: var(--color-text);
+    background-color: transparent;
+    border: 1px solid var(--color-border-strong, var(--color-border));
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    transition: background-color 150ms ease, border-color 150ms ease;
+  }
+
+  .contact-sent-card__resend:hover {
+    background-color: var(--color-surface-2, var(--color-surface));
+    border-color: var(--color-primary);
   }
 </style>

--- a/packages/ui/src/components/ContactFormReact.astro
+++ b/packages/ui/src/components/ContactFormReact.astro
@@ -1,0 +1,215 @@
+---
+/**
+ * @component ContactFormReact (Astro wrapper)
+ * @description Monta ContactFormReact.tsx con `client:load`. Hidrata en el
+ *   cliente y comparte estilos globales del form (tokens del DS).
+ *
+ * @props {string} apiEndpoint - Full URL del POST /contact
+ * @props {string} turnstileSitekey - Sitekey publica del widget Turnstile
+ * @props {string} [niche] - Nicho del subdominio
+ */
+import ContactFormReact from './ContactFormReact.tsx'
+
+interface Props {
+  apiEndpoint: string
+  turnstileSitekey: string
+  niche?: string
+}
+const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
+---
+
+<ContactFormReact
+  apiEndpoint={apiEndpoint}
+  turnstileSitekey={turnstileSitekey}
+  niche={niche}
+  client:load
+/>
+
+<style is:global>
+  .contact-form-wrapper {
+    width: 100%;
+  }
+
+  .contact-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-12);
+    max-width: var(--container-narrow);
+    margin-inline: auto;
+  }
+
+  .contact-form .form-row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .contact-form .form-row label {
+    font-size: var(--font-size-13);
+    font-weight: 500;
+    color: var(--color-text);
+  }
+
+  .contact-form .form-row label span[aria-hidden] {
+    color: var(--color-primary);
+  }
+
+  .contact-form .form-row input,
+  .contact-form .form-row select,
+  .contact-form .form-row textarea {
+    padding: var(--space-10) var(--space-12);
+    font-size: var(--font-size-14);
+    font-family: var(--font-sans);
+    color: var(--color-text);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    transition: border-color 150ms ease;
+  }
+
+  .contact-form .form-row input:focus,
+  .contact-form .form-row select:focus,
+  .contact-form .form-row textarea:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+
+  .contact-form .form-row input[aria-invalid='true'],
+  .contact-form .form-row select[aria-invalid='true'],
+  .contact-form .form-row textarea[aria-invalid='true'] {
+    border-color: var(--color-danger, #dc2626);
+  }
+
+  .contact-form .form-row textarea {
+    resize: vertical;
+    min-height: 120px;
+  }
+
+  .contact-form .field-error {
+    display: block;
+    margin-top: var(--space-4);
+    color: var(--color-danger, #dc2626);
+    font-size: var(--font-size-12);
+    line-height: 1.4;
+  }
+
+  .contact-form .form-optional {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-12);
+  }
+
+  .contact-form .form-optional summary {
+    font-size: var(--font-size-13);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .contact-form .form-optional[open] summary {
+    margin-bottom: var(--space-12);
+  }
+
+  .contact-form .form-optional .form-row + .form-row {
+    margin-top: var(--space-12);
+  }
+
+  .contact-submit {
+    align-self: flex-start;
+    padding: var(--space-10) var(--space-24);
+    font-size: var(--font-size-14);
+    font-weight: 600;
+    color: var(--color-primary-contrast);
+    background-color: var(--color-primary);
+    border: none;
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    transition: background-color 150ms ease;
+  }
+
+  .contact-submit:hover:not(:disabled) {
+    background-color: var(--color-primary-hover);
+  }
+
+  .contact-submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .form-status {
+    min-height: 1.2em;
+    margin: 0;
+    font-size: var(--font-size-13);
+  }
+
+  .form-status[data-kind='success'] {
+    color: var(--color-success, #16a34a);
+  }
+
+  .form-status[data-kind='error'] {
+    color: var(--color-danger, #dc2626);
+  }
+
+  .form-status[data-kind='submitting'] {
+    color: var(--color-text-muted);
+  }
+
+  .contact-sent-card {
+    max-width: var(--container-narrow);
+    margin-inline: auto;
+    padding: var(--space-24);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-10);
+  }
+
+  .contact-sent-card__title {
+    margin: 0;
+    font-size: var(--font-size-20);
+    font-weight: 600;
+    color: var(--color-success, #16a34a);
+  }
+
+  .contact-sent-card__body {
+    margin: 0;
+    font-size: var(--font-size-14);
+    color: var(--color-text);
+    line-height: var(--line-height-base);
+  }
+
+  .contact-sent-card__ref {
+    margin: 0;
+    font-size: var(--font-size-12);
+    color: var(--color-text-muted);
+  }
+
+  .contact-sent-card__ref code {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-12);
+    color: var(--color-text-subtle);
+    word-break: break-all;
+  }
+
+  .contact-sent-card__resend {
+    align-self: flex-start;
+    margin-top: var(--space-6);
+    padding: var(--space-8) var(--space-16);
+    font-size: var(--font-size-13);
+    font-weight: 500;
+    color: var(--color-text);
+    background-color: transparent;
+    border: 1px solid var(--color-border-strong, var(--color-border));
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    transition: background-color 150ms ease, border-color 150ms ease;
+  }
+
+  .contact-sent-card__resend:hover {
+    background-color: var(--color-surface-2, var(--color-surface));
+    border-color: var(--color-primary);
+  }
+</style>

--- a/packages/ui/src/components/ContactFormReact.tsx
+++ b/packages/ui/src/components/ContactFormReact.tsx
@@ -1,0 +1,677 @@
+/**
+ * @component ContactFormReact
+ * @description Form de contacto React 18: validacion Zod dinamica + POST al
+ *   Lambda contact_form + persistencia (localStorage + cookie compartida) via
+ *   `contact-storage`. Muestra card "ya enviaste" tras exito.
+ *
+ *   Bypass Turnstile para tests: si `window.__playwrightTurnstileBypass`
+ *   es string, se envia como header `X-Turnstile-Bypass-Secret` y se omite
+ *   el widget Turnstile (el frontend Astro NUNCA setea esa variable; solo
+ *   Playwright via page.addInitScript en stage dev).
+ *
+ * @props {string} apiEndpoint - Full URL del POST /contact
+ * @props {string} turnstileSitekey - Sitekey publica del widget Turnstile
+ * @props {string} [niche] - Nicho del subdominio (generic | hub | fintech | ...)
+ */
+import {
+  type ChangeEvent,
+  type FocusEvent,
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react'
+import {
+  type ContactFieldErrors,
+  type ContactFormFieldName,
+  ContactFormSchema,
+  type ContactFormValues,
+  emptyValues,
+  getFieldErrors,
+} from '../lib/contact-form-schema'
+import {
+  type ContactRecord,
+  clearContactRecord,
+  formatSentDate,
+  readContactRecord,
+  saveContactRecord,
+} from '../lib/contact-storage'
+
+const TURNSTILE_SCRIPT_URL =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js'
+
+interface TurnstileGlobal {
+  render?: (
+    container: HTMLElement,
+    options: {
+      sitekey: string
+      callback: (token: string) => void
+      'error-callback'?: () => void
+      'expired-callback'?: () => void
+    },
+  ) => string
+  reset?: (widgetId?: string | Element | null) => void
+  remove?: (widgetId?: string) => void
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileGlobal
+    /**
+     * Bypass secret para tests E2E. SOLO seteado por Playwright via
+     * page.addInitScript. En produccion nunca llega al cliente.
+     */
+    __playwrightTurnstileBypass?: string
+  }
+}
+
+interface ContactFormReactProps {
+  apiEndpoint: string
+  turnstileSitekey: string
+  niche?: string
+}
+
+interface ApiErrorBody {
+  error?: string
+  code?: string
+  extra?: {
+    errors?: Array<{
+      type: string
+      loc: (string | number)[]
+      msg: string
+      ctx?: Record<string, unknown>
+    }>
+  }
+}
+
+interface ApiSuccessBody {
+  contact_id: string
+  created_at: string
+}
+
+type StatusKind = 'idle' | 'submitting' | 'success' | 'error'
+
+const ERROR_MESSAGES: Record<number | 'default', string> = {
+  403: 'Captcha invalido. Recarga la pagina e intenta nuevamente.',
+  429: 'Demasiados intentos. Espera unos minutos antes de reintentar.',
+  default: 'Error del servidor. Intenta nuevamente en unos minutos.',
+}
+
+function buildPayload(
+  data: ContactFormValues,
+  ctx: { niche: string; cfToken: string },
+): Record<string, string> {
+  const payload: Record<string, string> = {
+    niche: ctx.niche,
+    cf_token: ctx.cfToken,
+  }
+  for (const [key, raw] of Object.entries(data)) {
+    const value = typeof raw === 'string' ? raw.trim() : ''
+    if (value) payload[key] = value
+  }
+  return payload
+}
+
+function buildHeaders(bypassSecret: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (bypassSecret) headers['X-Turnstile-Bypass-Secret'] = bypassSecret
+  return headers
+}
+
+async function parseJsonSafe(
+  response: Response,
+): Promise<(ApiErrorBody & ApiSuccessBody) | null> {
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.includes('application/json')) return null
+  try {
+    return (await response.json()) as ApiErrorBody & ApiSuccessBody
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Mapea errores Pydantic del backend a `ContactFieldErrors`. Espejo del
+ * humanizeError() del componente Astro original.
+ */
+function mapPydanticErrors(
+  errors: NonNullable<NonNullable<ApiErrorBody['extra']>['errors']>,
+): ContactFieldErrors {
+  const result: ContactFieldErrors = {}
+  for (const err of errors) {
+    const field = [...err.loc]
+      .reverse()
+      .find((seg): seg is string => typeof seg === 'string')
+    if (!field) continue
+    if (result[field as ContactFormFieldName]) continue
+    const min = err.ctx?.min_length
+    const max = err.ctx?.max_length
+    let msg: string
+    switch (err.type) {
+      case 'missing':
+        msg = 'Este campo es obligatorio.'
+        break
+      case 'string_too_short':
+        msg = `Minimo ${min ?? '?'} caracteres.`
+        break
+      case 'string_too_long':
+        msg = `Maximo ${max ?? '?'} caracteres.`
+        break
+      case 'value_error':
+      case 'value_error.email':
+        msg = 'Email invalido. Revisa el formato.'
+        break
+      default:
+        msg = err.msg || 'Valor invalido.'
+    }
+    result[field as ContactFormFieldName] = msg
+  }
+  return result
+}
+
+export default function ContactFormReact({
+  apiEndpoint,
+  turnstileSitekey,
+  niche = 'generic',
+}: ContactFormReactProps) {
+  const reactId = useId()
+  const [values, setValues] = useState<ContactFormValues>(emptyValues)
+  const [errors, setErrors] = useState<ContactFieldErrors>({})
+  const [status, setStatus] = useState<StatusKind>('idle')
+  const [statusMessage, setStatusMessage] = useState<string>('')
+  const [sentRecord, setSentRecord] = useState<ContactRecord | null>(null)
+  const [turnstileToken, setTurnstileToken] = useState<string>('')
+  const turnstileContainerRef = useRef<HTMLDivElement | null>(null)
+  const widgetIdRef = useRef<string | null>(null)
+
+  // Detecta bypass de Playwright. Lo leemos una sola vez: el test lo inyecta
+  // con addInitScript ANTES de que la pagina cargue.
+  const bypassTokenRef = useRef<string>('')
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.__playwrightTurnstileBypass) {
+      bypassTokenRef.current = window.__playwrightTurnstileBypass
+    }
+  }, [])
+
+  // Rehidratar estado "ya envio" desde localStorage/cookie
+  useEffect(() => {
+    const record = readContactRecord()
+    if (record) setSentRecord(record)
+  }, [])
+
+  // Cargar script Turnstile + render widget (solo si NO hay bypass)
+  useEffect(() => {
+    if (bypassTokenRef.current) return
+    if (sentRecord) return
+    if (typeof window === 'undefined') return
+
+    let cancelled = false
+
+    function tryRender(): void {
+      if (cancelled) return
+      const t = window.turnstile
+      const container = turnstileContainerRef.current
+      if (!t?.render || !container) return
+      if (widgetIdRef.current) return
+      widgetIdRef.current = t.render(container, {
+        sitekey: turnstileSitekey,
+        callback: (token: string) => {
+          setTurnstileToken(token)
+        },
+        'error-callback': () => {
+          setTurnstileToken('')
+          setStatus('error')
+          setStatusMessage('Error cargando el captcha. Recarga la pagina.')
+        },
+        'expired-callback': () => {
+          setTurnstileToken('')
+        },
+      })
+    }
+
+    // Si el script ya esta en la pagina, render directo. Si no, inyectar.
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${TURNSTILE_SCRIPT_URL}"]`,
+    )
+    if (window.turnstile) {
+      tryRender()
+    } else if (existing) {
+      existing.addEventListener('load', tryRender, { once: true })
+    } else {
+      const script = document.createElement('script')
+      script.src = TURNSTILE_SCRIPT_URL
+      script.async = true
+      script.defer = true
+      script.addEventListener('load', tryRender, { once: true })
+      document.head.appendChild(script)
+    }
+
+    return () => {
+      cancelled = true
+      if (widgetIdRef.current && window.turnstile?.remove) {
+        try {
+          window.turnstile.remove(widgetIdRef.current)
+        } catch {
+          // ignorar
+        }
+        widgetIdRef.current = null
+      }
+    }
+  }, [sentRecord, turnstileSitekey])
+
+  /**
+   * Valida un solo campo y actualiza errors[field]. Se llama on blur o
+   * al detectar cambio en un campo que ya tenia error (UX progresiva).
+   */
+  const validateField = useCallback(
+    (field: ContactFormFieldName, nextValues: ContactFormValues): void => {
+      const fieldSchema = ContactFormSchema.shape[field]
+      const result = fieldSchema.safeParse(nextValues[field])
+      setErrors((prev) => {
+        const next = { ...prev }
+        if (result.success) {
+          delete next[field]
+        } else {
+          next[field] = result.error.issues[0]?.message ?? 'Valor invalido.'
+        }
+        return next
+      })
+    },
+    [],
+  )
+
+  const handleChange = useCallback(
+    (
+      e: ChangeEvent<
+        HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+      >,
+    ): void => {
+      const name = e.target.name as ContactFormFieldName
+      const value = e.target.value
+      setValues((prev) => {
+        const next = { ...prev, [name]: value }
+        // Si ya habia error en este campo, re-validar al tipear
+        if (errors[name]) {
+          // Schedule en microtask para usar el "next" estado
+          queueMicrotask(() => validateField(name, next))
+        }
+        return next
+      })
+    },
+    [errors, validateField],
+  )
+
+  const handleBlur = useCallback(
+    (
+      e: FocusEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+    ): void => {
+      const name = e.target.name as ContactFormFieldName
+      validateField(name, values)
+    },
+    [validateField, values],
+  )
+
+  function handleSuccess(contactId: string): void {
+    const record = saveContactRecord(contactId)
+    setSentRecord(record)
+    setValues(emptyValues())
+    setErrors({})
+    setStatus('success')
+    setStatusMessage('Mensaje enviado. Te respondere en menos de 24h.')
+    if (window.turnstile?.reset && widgetIdRef.current) {
+      try {
+        window.turnstile.reset(widgetIdRef.current)
+      } catch {
+        // ignorar
+      }
+    }
+  }
+
+  function handleApiError(
+    httpStatus: number,
+    body: (ApiErrorBody & ApiSuccessBody) | null,
+  ): void {
+    if (httpStatus === 400) {
+      const fieldErrors = mapPydanticErrors(body?.extra?.errors ?? [])
+      if (Object.keys(fieldErrors).length > 0) setErrors(fieldErrors)
+      setStatus('error')
+      setStatusMessage(
+        body?.error || 'Hay datos invalidos. Revisa los campos marcados.',
+      )
+      return
+    }
+    setStatus('error')
+    setStatusMessage(ERROR_MESSAGES[httpStatus] ?? ERROR_MESSAGES.default)
+  }
+
+  function preflightCheck():
+    | {
+        ok: true
+        data: ContactFormValues
+        bypassSecret: string
+        cfToken: string
+      }
+    | { ok: false } {
+    const parsed = ContactFormSchema.safeParse(values)
+    if (!parsed.success) {
+      setErrors(getFieldErrors(parsed.error))
+      setStatus('error')
+      setStatusMessage('Hay datos invalidos. Revisa los campos marcados.')
+      return { ok: false }
+    }
+    const bypassSecret = bypassTokenRef.current
+    const cfToken = bypassSecret ? '' : turnstileToken
+    if (!bypassSecret && !cfToken) {
+      setStatus('error')
+      setStatusMessage('Por favor completa el captcha antes de enviar.')
+      return { ok: false }
+    }
+    return { ok: true, data: parsed.data, bypassSecret, cfToken }
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    const pre = preflightCheck()
+    if (!pre.ok) return
+
+    setStatus('submitting')
+    setStatusMessage('Enviando...')
+
+    const payload = buildPayload(pre.data, { niche, cfToken: pre.cfToken })
+    const headers = buildHeaders(pre.bypassSecret)
+
+    try {
+      const response = await fetch(apiEndpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      })
+      const body = await parseJsonSafe(response)
+      if (response.status === 201 && body?.contact_id) {
+        handleSuccess(body.contact_id)
+        return
+      }
+      handleApiError(response.status, body)
+    } catch (_error) {
+      setStatus('error')
+      setStatusMessage('Error de red. Verifica tu conexion y reintenta.')
+    }
+  }
+
+  function handleResend(): void {
+    clearContactRecord()
+    setSentRecord(null)
+    setStatus('idle')
+    setStatusMessage('')
+    setTurnstileToken('')
+    setErrors({})
+  }
+
+  // Card de confirmacion: el form esta oculto
+  if (sentRecord) {
+    return (
+      <div className="contact-form-wrapper" data-testid="contact-sent-card">
+        <div className="contact-sent-card">
+          <p className="contact-sent-card__title">Mensaje enviado</p>
+          <p className="contact-sent-card__body">
+            Ya enviaste un mensaje el {formatSentDate(sentRecord.sentAt)}. Te
+            respondere en menos de 24h.
+          </p>
+          <p className="contact-sent-card__ref">
+            Ref:{' '}
+            <code data-testid="contact-sent-id">{sentRecord.contactId}</code>
+          </p>
+          <button
+            type="button"
+            className="contact-sent-card__resend"
+            data-testid="contact-resend-btn"
+            onClick={handleResend}
+          >
+            Enviar otro mensaje
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const idFor = (key: string) => `${reactId}-${key}`
+
+  return (
+    <div className="contact-form-wrapper">
+      <form
+        className="contact-form"
+        noValidate
+        onSubmit={handleSubmit}
+        data-testid="contact-form"
+        data-niche={niche}
+      >
+        <Field
+          id={idFor('name')}
+          label="Nombre"
+          required
+          name="name"
+          autoComplete="name"
+          value={values.name}
+          error={errors.name}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+
+        <Field
+          id={idFor('email')}
+          label="Email"
+          required
+          type="email"
+          name="email"
+          autoComplete="email"
+          value={values.email}
+          error={errors.email}
+          onChange={handleChange}
+          onBlur={handleBlur}
+        />
+
+        <details className="form-optional">
+          <summary>Datos opcionales (para conocerte mejor)</summary>
+
+          <Field
+            id={idFor('company')}
+            label="Empresa"
+            name="company"
+            autoComplete="organization"
+            value={values.company ?? ''}
+            error={errors.company}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+
+          <Field
+            id={idFor('role')}
+            label="Cargo / Rol"
+            name="role"
+            autoComplete="organization-title"
+            value={values.role ?? ''}
+            error={errors.role}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+
+          <div className="form-row">
+            <label htmlFor={idFor('service_type')}>Tipo de servicio</label>
+            <select
+              id={idFor('service_type')}
+              name="service_type"
+              value={values.service_type ?? ''}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              aria-describedby={`${idFor('service_type')}-error`}
+              aria-invalid={errors.service_type ? 'true' : undefined}
+            >
+              <option value="">(sin especificar)</option>
+              <option value="consulting">Consultoria</option>
+              <option value="fulltime">Full-time</option>
+              <option value="contract">Contrato / freelance</option>
+              <option value="other">Otro</option>
+            </select>
+            {errors.service_type && (
+              <small
+                className="field-error"
+                id={`${idFor('service_type')}-error`}
+                data-testid="error-service_type"
+              >
+                {errors.service_type}
+              </small>
+            )}
+          </div>
+
+          <Field
+            id={idFor('budget')}
+            label="Presupuesto"
+            name="budget"
+            placeholder="Ej: USD 5k-15k / mes"
+            value={values.budget ?? ''}
+            error={errors.budget}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+
+          <Field
+            id={idFor('timeline')}
+            label="Timeline"
+            name="timeline"
+            placeholder="Ej: empieza en 2 semanas"
+            value={values.timeline ?? ''}
+            error={errors.timeline}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+        </details>
+
+        <div className="form-row">
+          <label htmlFor={idFor('message')}>
+            Mensaje <span aria-hidden>*</span>
+          </label>
+          <textarea
+            id={idFor('message')}
+            name="message"
+            rows={6}
+            required
+            value={values.message}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            aria-describedby={`${idFor('message')}-error`}
+            aria-invalid={errors.message ? 'true' : undefined}
+          />
+          {errors.message && (
+            <small
+              className="field-error"
+              id={`${idFor('message')}-error`}
+              data-testid="error-message"
+            >
+              {errors.message}
+            </small>
+          )}
+        </div>
+
+        {/* Turnstile widget: solo se renderiza si NO hay bypass de tests */}
+        {!bypassTokenRef.current && (
+          <div
+            className="cf-turnstile"
+            ref={turnstileContainerRef}
+            data-testid="turnstile-container"
+          />
+        )}
+
+        <button
+          type="submit"
+          className="contact-submit"
+          disabled={status === 'submitting'}
+          data-testid="contact-submit"
+        >
+          <span className="submit-label">
+            {status === 'submitting' ? 'Enviando...' : 'Enviar'}
+          </span>
+        </button>
+
+        <p
+          className="form-status"
+          role="status"
+          aria-live="polite"
+          data-kind={status === 'idle' ? undefined : status}
+          data-testid="contact-status"
+        >
+          {statusMessage}
+        </p>
+      </form>
+    </div>
+  )
+}
+
+// ------- Subcomponentes -------
+
+interface FieldProps {
+  id: string
+  name: ContactFormFieldName
+  label: string
+  type?: string
+  required?: boolean
+  value: string
+  error?: string
+  autoComplete?: string
+  placeholder?: string
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+  onBlur: (e: FocusEvent<HTMLInputElement>) => void
+}
+
+function Field({
+  id,
+  name,
+  label,
+  type = 'text',
+  required = false,
+  value,
+  error,
+  autoComplete,
+  placeholder,
+  onChange,
+  onBlur,
+}: FieldProps) {
+  return (
+    <div className="form-row">
+      <label htmlFor={id}>
+        {label}
+        {required && (
+          <>
+            {' '}
+            <span aria-hidden>*</span>
+          </>
+        )}
+      </label>
+      <input
+        id={id}
+        name={name}
+        type={type}
+        value={value}
+        required={required}
+        autoComplete={autoComplete}
+        placeholder={placeholder}
+        onChange={onChange}
+        onBlur={onBlur}
+        aria-describedby={`${id}-error`}
+        aria-invalid={error ? 'true' : undefined}
+      />
+      {error && (
+        <small
+          className="field-error"
+          id={`${id}-error`}
+          data-testid={`error-${name}`}
+        >
+          {error}
+        </small>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/lib/contact-form-schema.ts
+++ b/packages/ui/src/lib/contact-form-schema.ts
@@ -1,0 +1,102 @@
+/**
+ * @module contact-form-schema
+ * @description Zod schema del form de contacto + helper para mapear errores
+ *   Zod a un dict `<field, message>` que renderiza el componente React.
+ *
+ *   Reglas espejo del Pydantic backend (serverless/src/contact_form/schemas.py):
+ *   - name: 2..200 chars
+ *   - email: formato email valido + max 254
+ *   - message: 10..5000 chars
+ *   - company/role/budget/timeline: opcionales con max length
+ *   - service_type: literal o vacio
+ */
+import { z } from 'zod'
+
+const SERVICE_TYPES = ['consulting', 'fulltime', 'contract', 'other'] as const
+
+export const ContactFormSchema = z.object({
+  name: z
+    .string({ required_error: 'El nombre es obligatorio.' })
+    .trim()
+    .min(2, 'Minimo 2 caracteres.')
+    .max(200, 'Maximo 200 caracteres.'),
+  email: z
+    .string({ required_error: 'El email es obligatorio.' })
+    .trim()
+    .min(1, 'El email es obligatorio.')
+    .max(254, 'Maximo 254 caracteres.')
+    .email('Email invalido. Revisa el formato.'),
+  message: z
+    .string({ required_error: 'El mensaje es obligatorio.' })
+    .trim()
+    .min(10, 'Minimo 10 caracteres.')
+    .max(5000, 'Maximo 5000 caracteres.'),
+  company: z
+    .string()
+    .trim()
+    .max(200, 'Maximo 200 caracteres.')
+    .optional()
+    .or(z.literal('')),
+  role: z
+    .string()
+    .trim()
+    .max(100, 'Maximo 100 caracteres.')
+    .optional()
+    .or(z.literal('')),
+  service_type: z
+    .enum(SERVICE_TYPES, {
+      errorMap: () => ({ message: 'Valor no permitido.' }),
+    })
+    .optional()
+    .or(z.literal('')),
+  budget: z
+    .string()
+    .trim()
+    .max(100, 'Maximo 100 caracteres.')
+    .optional()
+    .or(z.literal('')),
+  timeline: z
+    .string()
+    .trim()
+    .max(100, 'Maximo 100 caracteres.')
+    .optional()
+    .or(z.literal('')),
+})
+
+export type ContactFormValues = z.infer<typeof ContactFormSchema>
+
+export type ContactFormFieldName = keyof ContactFormValues
+
+export type ContactFieldErrors = Partial<Record<ContactFormFieldName, string>>
+
+/**
+ * @function getFieldErrors
+ * @description Convierte un ZodError a un dict `{field: firstMessage}`.
+ */
+export function getFieldErrors(error: z.ZodError): ContactFieldErrors {
+  const result: ContactFieldErrors = {}
+  for (const issue of error.issues) {
+    const field = issue.path[0]
+    if (typeof field !== 'string') continue
+    if (result[field as ContactFormFieldName]) continue
+    result[field as ContactFormFieldName] = issue.message
+  }
+  return result
+}
+
+/**
+ * @function emptyValues
+ * @description Estado inicial del form (todos los campos vacios).
+ */
+export function emptyValues(): ContactFormValues {
+  return {
+    name: '',
+    email: '',
+    message: '',
+    company: '',
+    role: '',
+    service_type: '',
+    budget: '',
+    timeline: '',
+  }
+}

--- a/packages/ui/src/lib/contact-storage.ts
+++ b/packages/ui/src/lib/contact-storage.ts
@@ -1,0 +1,256 @@
+/**
+ * @module contact-storage
+ * @description Persistencia del estado "ya envio el form de contacto" usando
+ *   localStorage (fuente de verdad) + cookie compartida entre subdominios
+ *   `.the-full-stack.com` (para que el estado se propague entre nichos).
+ *
+ *   localStorage es por subdominio (cada *.the-full-stack.com tiene su propio
+ *   storage), asi que la cookie compartida es la unica forma de evitar que el
+ *   user vea el form de nuevo al saltar entre nichos. Cuando otro subdominio
+ *   detecta la cookie pero no tiene localStorage, hace rehidratacion.
+ *
+ *   TTL: 7 dias.
+ */
+
+/**
+ * Estructura serializada del registro de contacto enviado.
+ */
+export interface ContactRecord {
+  contactId: string
+  /** Epoch ms del envio */
+  sentAt: number
+  /** Epoch ms en que expira el registro (sentAt + TTL_MS) */
+  expiresAt: number
+}
+
+const STORAGE_KEY = 'contact_sent'
+const COOKIE_NAME = 'contact_sent'
+export const TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Dominio raiz para la cookie compartida. Se calcula en runtime para que
+ * en `*.localhost` (dev) no se setee `Domain=` (los browsers no comparten
+ * cookies entre subdominios de `localhost` por especificacion).
+ */
+function getCookieDomain(hostname: string): string | null {
+  if (!hostname || hostname === 'localhost') return null
+  if (hostname.endsWith('.localhost')) return null
+  if (/^[\d.]+$/u.test(hostname)) return null
+  const parts = hostname.split('.')
+  if (parts.length < 2) return null
+  return `.${parts.slice(-2).join('.')}`
+}
+
+function isSecureProtocol(protocol: string): boolean {
+  return protocol === 'https:'
+}
+
+/**
+ * @function readCookie
+ * @description Lee el valor crudo de una cookie por nombre.
+ * @internal exportada solo para tests
+ */
+export function readCookie(name: string, cookieString: string): string | null {
+  if (!cookieString) return null
+  const pattern = new RegExp(
+    `(?:^|;\\s*)${name.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')}=([^;]*)`,
+    'u',
+  )
+  const match = cookieString.match(pattern)
+  if (!match?.[1]) return null
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @function buildCookieString
+ * @description Construye el string de cookie a setear via `document.cookie =`.
+ *   Exportado para tests.
+ */
+export function buildCookieString(
+  value: string,
+  options: {
+    maxAgeSeconds: number
+    hostname: string
+    protocol: string
+    path?: string
+  },
+): string {
+  const parts = [`${COOKIE_NAME}=${encodeURIComponent(value)}`]
+  parts.push(`Max-Age=${options.maxAgeSeconds}`)
+  parts.push(`Path=${options.path ?? '/'}`)
+  parts.push('SameSite=Lax')
+  const domain = getCookieDomain(options.hostname)
+  if (domain) parts.push(`Domain=${domain}`)
+  if (isSecureProtocol(options.protocol)) parts.push('Secure')
+  return parts.join('; ')
+}
+
+/**
+ * @function buildExpiredCookieString
+ * @description String para borrar la cookie (Max-Age=0). Mismo Domain/Path
+ *   que el setter, sino el browser no la elimina.
+ */
+export function buildExpiredCookieString(options: {
+  hostname: string
+  protocol: string
+  path?: string
+}): string {
+  const parts = [`${COOKIE_NAME}=`]
+  parts.push('Max-Age=0')
+  parts.push(`Path=${options.path ?? '/'}`)
+  parts.push('SameSite=Lax')
+  const domain = getCookieDomain(options.hostname)
+  if (domain) parts.push(`Domain=${domain}`)
+  if (isSecureProtocol(options.protocol)) parts.push('Secure')
+  return parts.join('; ')
+}
+
+/**
+ * @function parseRecord
+ * @description Valida y parsea un registro desde string JSON. Retorna `null`
+ *   si esta mal formado o expirado. Exportado para tests.
+ */
+export function parseRecord(
+  raw: string | null,
+  now: number,
+): ContactRecord | null {
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const obj = parsed as Record<string, unknown>
+  const contactId = obj.contactId
+  const sentAt = obj.sentAt
+  const expiresAt = obj.expiresAt
+  if (typeof contactId !== 'string' || contactId.length === 0) return null
+  if (typeof sentAt !== 'number' || !Number.isFinite(sentAt)) return null
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) return null
+  if (expiresAt <= now) return null
+  return { contactId, sentAt, expiresAt }
+}
+
+/**
+ * @function readContactRecord
+ * @description Lee el registro del contacto enviado, combinando localStorage
+ *   (rapido) + cookie (fallback cross-subdomain). Si la cookie tiene un
+ *   registro vivo pero localStorage no, rehidrata localStorage.
+ *
+ * @returns Registro vivo (no expirado) o `null`.
+ */
+export function readContactRecord(): ContactRecord | null {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null
+  }
+  const now = Date.now()
+
+  // 1. Intentar localStorage primero (fuente local de verdad)
+  let fromStorage: ContactRecord | null = null
+  try {
+    fromStorage = parseRecord(window.localStorage.getItem(STORAGE_KEY), now)
+  } catch {
+    // Safari private mode, etc. — silencioso, seguimos con cookie
+  }
+  if (fromStorage) return fromStorage
+
+  // 2. Fallback: cookie compartida
+  const fromCookie = parseRecord(readCookie(COOKIE_NAME, document.cookie), now)
+  if (fromCookie) {
+    // Rehidratar localStorage para evitar leer la cookie en cada nav
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(fromCookie))
+    } catch {
+      // ignorar
+    }
+    return fromCookie
+  }
+
+  return null
+}
+
+/**
+ * @function saveContactRecord
+ * @description Persiste el registro en localStorage + cookie compartida.
+ *
+ * @param contactId - UUID retornado por el Lambda (campo `contact_id`)
+ * @param now - Epoch ms del envio (default `Date.now()`). Inyectable para tests.
+ */
+export function saveContactRecord(
+  contactId: string,
+  now: number = Date.now(),
+): ContactRecord {
+  const record: ContactRecord = {
+    contactId,
+    sentAt: now,
+    expiresAt: now + TTL_MS,
+  }
+  const json = JSON.stringify(record)
+
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, json)
+    } catch {
+      // ignorar (private mode)
+    }
+  }
+
+  if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+    // Cookie Store API no esta disponible en Safari ni Firefox estables,
+    // por eso usamos la API legacy de document.cookie.
+    // biome-ignore lint/suspicious/noDocumentCookie: cross-browser fallback
+    document.cookie = buildCookieString(json, {
+      maxAgeSeconds: Math.floor(TTL_MS / 1000),
+      hostname: window.location.hostname,
+      protocol: window.location.protocol,
+    })
+  }
+
+  return record
+}
+
+/**
+ * @function clearContactRecord
+ * @description Borra el registro de localStorage + cookie. Se llama cuando el
+ *   user clickea "Enviar otro mensaje".
+ */
+export function clearContactRecord(): void {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // ignorar
+    }
+  }
+  if (typeof document !== 'undefined' && typeof window !== 'undefined') {
+    // biome-ignore lint/suspicious/noDocumentCookie: cross-browser fallback
+    document.cookie = buildExpiredCookieString({
+      hostname: window.location.hostname,
+      protocol: window.location.protocol,
+    })
+  }
+}
+
+/**
+ * @function formatSentDate
+ * @description Formatea el `sentAt` como fecha legible en es-CL (ej.
+ *   "15 de mayo de 2026"). Aislado en su propia funcion para facilitar
+ *   testing.
+ */
+export function formatSentDate(sentAt: number, locale = 'es-CL'): string {
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(new Date(sentAt))
+  } catch {
+    return new Date(sentAt).toISOString().slice(0, 10)
+  }
+}

--- a/packages/ui/tests/unit/contact-form-schema.test.ts
+++ b/packages/ui/tests/unit/contact-form-schema.test.ts
@@ -3,6 +3,7 @@
  *   errores. Refleja las mismas reglas del Pydantic backend.
  */
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 import {
   ContactFormSchema,
   emptyValues,
@@ -123,6 +124,40 @@ describe('ContactFormSchema', () => {
       expect(fieldErrors.email).toBe('Email invalido. Revisa el formato.')
       expect(fieldErrors.message).toBe('Minimo 10 caracteres.')
     }
+  })
+})
+
+describe('getFieldErrors', () => {
+  it('Given issue con path[0] no-string When mapeo Then se ignora', () => {
+    // ZodError con path no-string (e.g. raiz). Branch coverage de
+    // contact-form-schema.ts L80 (`if (typeof field !== 'string') continue`).
+    const error = z.ZodError.create([
+      {
+        code: 'custom',
+        path: [],
+        message: 'error en raiz',
+      },
+    ])
+    const result = getFieldErrors(error)
+    expect(result).toEqual({})
+  })
+
+  it('Given dos issues en mismo campo When mapeo Then se queda el primer mensaje', () => {
+    // Branch coverage de L81 (`if (result[field]) continue`).
+    const error = z.ZodError.create([
+      {
+        code: 'custom',
+        path: ['email'],
+        message: 'primer error',
+      },
+      {
+        code: 'custom',
+        path: ['email'],
+        message: 'segundo error',
+      },
+    ])
+    const result = getFieldErrors(error)
+    expect(result.email).toBe('primer error')
   })
 })
 

--- a/packages/ui/tests/unit/contact-form-schema.test.ts
+++ b/packages/ui/tests/unit/contact-form-schema.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @description Tests para contact-form-schema (Zod): validacion + mapeo de
+ *   errores. Refleja las mismas reglas del Pydantic backend.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  ContactFormSchema,
+  emptyValues,
+  getFieldErrors,
+} from '../../src/lib/contact-form-schema'
+
+describe('ContactFormSchema', () => {
+  it('Given valores validos minimos When parse Then success', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: 'Pablo',
+      email: 'pacg1991@gmail.com',
+      message: 'Hola, tengo un proyecto interesante para discutir.',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('Given name vacio When parse Then error en name', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: '',
+      email: 'a@b.com',
+      message: 'Mensaje suficientemente largo para pasar.',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fieldErrors = getFieldErrors(result.error)
+      expect(fieldErrors.name).toBe('Minimo 2 caracteres.')
+    }
+  })
+
+  it('Given email invalido When parse Then error en email', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: 'Pablo',
+      email: 'no-es-email',
+      message: 'Mensaje suficientemente largo para pasar.',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fieldErrors = getFieldErrors(result.error)
+      expect(fieldErrors.email).toBe('Email invalido. Revisa el formato.')
+    }
+  })
+
+  it('Given message muy corto When parse Then error de min 10', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: 'Pablo',
+      email: 'a@b.com',
+      message: 'corto',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fieldErrors = getFieldErrors(result.error)
+      expect(fieldErrors.message).toBe('Minimo 10 caracteres.')
+    }
+  })
+
+  it('Given message excede 5000 chars When parse Then error de max', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: 'Pablo',
+      email: 'a@b.com',
+      message: 'x'.repeat(5001),
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fieldErrors = getFieldErrors(result.error)
+      expect(fieldErrors.message).toBe('Maximo 5000 caracteres.')
+    }
+  })
+
+  it('Given service_type vacio When parse Then success (campo opcional)', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: 'Pablo',
+      email: 'a@b.com',
+      message: 'Mensaje suficientemente largo para pasar.',
+      service_type: '',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('Given service_type valido When parse Then success', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: 'Pablo',
+      email: 'a@b.com',
+      message: 'Mensaje suficientemente largo para pasar.',
+      service_type: 'consulting',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('Given service_type invalido When parse Then error', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: 'Pablo',
+      email: 'a@b.com',
+      message: 'Mensaje suficientemente largo para pasar.',
+      service_type: 'enterprise',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('Given multiples errores When getFieldErrors Then retorna primero por campo', () => {
+    const result = ContactFormSchema.safeParse({
+      ...emptyValues(),
+      name: '',
+      email: 'no-es-email',
+      message: 'corto',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const fieldErrors = getFieldErrors(result.error)
+      expect(fieldErrors.name).toBe('Minimo 2 caracteres.')
+      expect(fieldErrors.email).toBe('Email invalido. Revisa el formato.')
+      expect(fieldErrors.message).toBe('Minimo 10 caracteres.')
+    }
+  })
+})
+
+describe('emptyValues', () => {
+  it('When call Then returns all fields empty strings', () => {
+    const v = emptyValues()
+    expect(v).toEqual({
+      name: '',
+      email: '',
+      message: '',
+      company: '',
+      role: '',
+      service_type: '',
+      budget: '',
+      timeline: '',
+    })
+  })
+})

--- a/packages/ui/tests/unit/contact-storage.test.ts
+++ b/packages/ui/tests/unit/contact-storage.test.ts
@@ -1,0 +1,228 @@
+/**
+ * @description Tests para contact-storage: parseRecord, readCookie,
+ *   buildCookieString, save/read/clearContactRecord. Cubre flujo single-domain
+ *   (localStorage) y cross-subdomain (cookie compartida).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildCookieString,
+  buildExpiredCookieString,
+  clearContactRecord,
+  formatSentDate,
+  parseRecord,
+  readContactRecord,
+  readCookie,
+  saveContactRecord,
+  TTL_MS,
+} from '../../src/lib/contact-storage'
+
+const NOW = 1715731200000
+
+describe('parseRecord', () => {
+  it('Given null When parse Then returns null', () => {
+    expect(parseRecord(null, NOW)).toBe(null)
+  })
+
+  it('Given invalid JSON When parse Then returns null', () => {
+    expect(parseRecord('not-json', NOW)).toBe(null)
+  })
+
+  it('Given missing contactId When parse Then returns null', () => {
+    const raw = JSON.stringify({ sentAt: NOW, expiresAt: NOW + TTL_MS })
+    expect(parseRecord(raw, NOW)).toBe(null)
+  })
+
+  it('Given expired record When parse Then returns null', () => {
+    const raw = JSON.stringify({
+      contactId: 'abc',
+      sentAt: NOW - TTL_MS - 1,
+      expiresAt: NOW - 1,
+    })
+    expect(parseRecord(raw, NOW)).toBe(null)
+  })
+
+  it('Given valid record When parse Then returns parsed object', () => {
+    const raw = JSON.stringify({
+      contactId: 'abc-123',
+      sentAt: NOW,
+      expiresAt: NOW + TTL_MS,
+    })
+    const result = parseRecord(raw, NOW)
+    expect(result).toEqual({
+      contactId: 'abc-123',
+      sentAt: NOW,
+      expiresAt: NOW + TTL_MS,
+    })
+  })
+})
+
+describe('readCookie', () => {
+  it('Given empty cookie string When read Then returns null', () => {
+    expect(readCookie('contact_sent', '')).toBe(null)
+  })
+
+  it('Given cookie with target name When read Then returns decoded value', () => {
+    const value = encodeURIComponent('{"foo":"bar"}')
+    const cookieString = `other=1; contact_sent=${value}; another=2`
+    expect(readCookie('contact_sent', cookieString)).toBe('{"foo":"bar"}')
+  })
+
+  it('Given cookie without target name When read Then returns null', () => {
+    expect(readCookie('contact_sent', 'other=1; another=2')).toBe(null)
+  })
+
+  it('Given malformed URI encoding When read Then returns null', () => {
+    // %ZZ no es un escape valido -> decodeURIComponent lanza
+    expect(readCookie('contact_sent', 'contact_sent=%ZZ')).toBe(null)
+  })
+})
+
+describe('buildCookieString', () => {
+  it('Given the-full-stack.com hostname When build Then includes Domain=.the-full-stack.com', () => {
+    const result = buildCookieString('value-x', {
+      maxAgeSeconds: 604800,
+      hostname: 'fintech.the-full-stack.com',
+      protocol: 'https:',
+    })
+    expect(result).toBe(
+      'contact_sent=value-x; Max-Age=604800; Path=/; SameSite=Lax; Domain=.the-full-stack.com; Secure',
+    )
+  })
+
+  it('Given localhost When build Then omits Domain', () => {
+    const result = buildCookieString('v', {
+      maxAgeSeconds: 60,
+      hostname: 'localhost',
+      protocol: 'http:',
+    })
+    expect(result).toBe('contact_sent=v; Max-Age=60; Path=/; SameSite=Lax')
+  })
+
+  it('Given *.localhost When build Then omits Domain', () => {
+    const result = buildCookieString('v', {
+      maxAgeSeconds: 60,
+      hostname: 'fintech.localhost',
+      protocol: 'http:',
+    })
+    expect(result).toBe('contact_sent=v; Max-Age=60; Path=/; SameSite=Lax')
+  })
+
+  it('Given IP address When build Then omits Domain', () => {
+    const result = buildCookieString('v', {
+      maxAgeSeconds: 60,
+      hostname: '192.168.1.10',
+      protocol: 'http:',
+    })
+    expect(result).toBe('contact_sent=v; Max-Age=60; Path=/; SameSite=Lax')
+  })
+
+  it('Given value with special chars When build Then encodes value', () => {
+    const result = buildCookieString('a b;c', {
+      maxAgeSeconds: 60,
+      hostname: 'the-full-stack.com',
+      protocol: 'https:',
+    })
+    expect(result).toBe(
+      'contact_sent=a%20b%3Bc; Max-Age=60; Path=/; SameSite=Lax; Domain=.the-full-stack.com; Secure',
+    )
+  })
+})
+
+describe('buildExpiredCookieString', () => {
+  it('Given hostname When build expired Then uses Max-Age=0 and same Domain', () => {
+    const result = buildExpiredCookieString({
+      hostname: 'fintech.the-full-stack.com',
+      protocol: 'https:',
+    })
+    expect(result).toBe(
+      'contact_sent=; Max-Age=0; Path=/; SameSite=Lax; Domain=.the-full-stack.com; Secure',
+    )
+  })
+})
+
+describe('saveContactRecord + readContactRecord (jsdom)', () => {
+  let dateSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    // biome-ignore lint/suspicious/noDocumentCookie: test setup
+    document.cookie = 'contact_sent=; Max-Age=0; Path=/'
+    dateSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW)
+  })
+
+  afterEach(() => {
+    dateSpy.mockRestore()
+  })
+
+  it('Given saved record When read Then returns same record', () => {
+    saveContactRecord('019e28fc-b97d-7d79-91a5-44c9b19465b4', NOW)
+    const result = readContactRecord()
+    expect(result).toEqual({
+      contactId: '019e28fc-b97d-7d79-91a5-44c9b19465b4',
+      sentAt: NOW,
+      expiresAt: NOW + TTL_MS,
+    })
+  })
+
+  it('Given save Then localStorage has JSON record', () => {
+    saveContactRecord('test-id', NOW)
+    const raw = window.localStorage.getItem('contact_sent')
+    expect(raw).toBe(
+      JSON.stringify({
+        contactId: 'test-id',
+        sentAt: NOW,
+        expiresAt: NOW + TTL_MS,
+      }),
+    )
+  })
+
+  it('Given no record When read Then returns null', () => {
+    expect(readContactRecord()).toBe(null)
+  })
+
+  it('Given cleared record When read Then returns null', () => {
+    saveContactRecord('to-clear', NOW)
+    clearContactRecord()
+    expect(readContactRecord()).toBe(null)
+    expect(window.localStorage.getItem('contact_sent')).toBe(null)
+  })
+
+  it('Given only cookie present When read Then rehydrates localStorage', () => {
+    // Simular llegada cross-subdomain: cookie pero no localStorage
+    const record = JSON.stringify({
+      contactId: 'from-cookie',
+      sentAt: NOW,
+      expiresAt: NOW + TTL_MS,
+    })
+    // biome-ignore lint/suspicious/noDocumentCookie: test setup
+    document.cookie = `contact_sent=${encodeURIComponent(record)}; Path=/`
+    expect(window.localStorage.getItem('contact_sent')).toBe(null)
+
+    const result = readContactRecord()
+    expect(result).toEqual({
+      contactId: 'from-cookie',
+      sentAt: NOW,
+      expiresAt: NOW + TTL_MS,
+    })
+    expect(window.localStorage.getItem('contact_sent')).toBe(record)
+  })
+
+  it('Given expired localStorage record When read Then returns null', () => {
+    const expired = JSON.stringify({
+      contactId: 'old',
+      sentAt: NOW - TTL_MS - 1000,
+      expiresAt: NOW - 1000,
+    })
+    window.localStorage.setItem('contact_sent', expired)
+    expect(readContactRecord()).toBe(null)
+  })
+})
+
+describe('formatSentDate', () => {
+  it('Given epoch ms and es-CL When format Then returns Spanish long date', () => {
+    // 2026-05-15 (NOW=1715731200000 -> Tue May 14 2024 UTC; usamos un valor distinto)
+    const epoch = Date.UTC(2026, 4, 15, 12, 0, 0) // 15 may 2026
+    const formatted = formatSentDate(epoch, 'es-CL')
+    expect(formatted).toBe('15 de mayo de 2026')
+  })
+})

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -7,7 +7,7 @@
       "vite/client",
       "@modyfi/vite-plugin-yaml/modules"
     ],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "noEmit": true
   },
   "include": ["src/**/*", "tests/**/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   apps/architect:
     dependencies:
+      '@astrojs/react':
+        specifier: ^4.4.2
+        version: 4.4.2(@types/node@24.12.4)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.21.0)(yaml@2.9.0)
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -44,6 +47,12 @@ importers:
       astro:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^4.0.18
         version: 4.3.0
@@ -57,6 +66,12 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -75,6 +90,9 @@ importers:
 
   apps/fintech:
     dependencies:
+      '@astrojs/react':
+        specifier: ^4.4.2
+        version: 4.4.2(@types/node@24.12.4)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.21.0)(yaml@2.9.0)
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -102,6 +120,12 @@ importers:
       astro:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^4.0.18
         version: 4.3.0
@@ -115,6 +139,12 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -133,6 +163,9 @@ importers:
 
   apps/generic:
     dependencies:
+      '@astrojs/react':
+        specifier: ^4.4.2
+        version: 4.4.2(@types/node@24.12.4)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.21.0)(yaml@2.9.0)
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -160,6 +193,12 @@ importers:
       astro:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^4.0.18
         version: 4.3.0
@@ -173,6 +212,12 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -191,6 +236,9 @@ importers:
 
   apps/hub:
     dependencies:
+      '@astrojs/react':
+        specifier: ^4.4.2
+        version: 4.4.2(@types/node@24.12.4)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.21.0)(yaml@2.9.0)
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -212,6 +260,12 @@ importers:
       astro:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^4.0.18
         version: 4.3.0
@@ -225,6 +279,12 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -240,6 +300,9 @@ importers:
 
   apps/leader:
     dependencies:
+      '@astrojs/react':
+        specifier: ^4.4.2
+        version: 4.4.2(@types/node@24.12.4)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.21.0)(yaml@2.9.0)
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -267,6 +330,12 @@ importers:
       astro:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^4.0.18
         version: 4.3.0
@@ -280,6 +349,12 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -298,6 +373,9 @@ importers:
 
   apps/vibe:
     dependencies:
+      '@astrojs/react':
+        specifier: ^4.4.2
+        version: 4.4.2(@types/node@24.12.4)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.21.0)(yaml@2.9.0)
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -325,6 +403,12 @@ importers:
       astro:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^4.0.18
         version: 4.3.0
@@ -338,6 +422,12 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -529,10 +619,25 @@ importers:
       astro:
         specifier: ^6.0.0
         version: 6.3.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.9.0)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@modyfi/vite-plugin-yaml':
         specifier: ^1.1.1
         version: 1.1.1(rollup@4.60.3)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       '@vitest/coverage-v8':
         specifier: ^2.1.9
         version: 2.1.9(vitest@2.1.9(@types/node@24.12.4)(happy-dom@15.11.7)(lightningcss@1.32.0))
@@ -599,6 +704,15 @@ packages:
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
 
+  '@astrojs/react@4.4.2':
+    resolution: {integrity: sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
 
@@ -609,6 +723,44 @@ packages:
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -617,10 +769,38 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -728,6 +908,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -737,6 +923,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -752,6 +944,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.27.7':
     resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
@@ -761,6 +959,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -776,6 +980,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -785,6 +995,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -800,6 +1016,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -809,6 +1031,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -824,6 +1052,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -833,6 +1067,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -848,6 +1088,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -857,6 +1103,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -872,6 +1124,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -881,6 +1139,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -896,6 +1160,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -905,6 +1175,12 @@ packages:
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -920,11 +1196,23 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
@@ -938,11 +1226,23 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
@@ -956,11 +1256,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.27.7':
     resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
@@ -971,6 +1283,12 @@ packages:
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -986,6 +1304,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
@@ -998,6 +1322,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -1007,6 +1337,12 @@ packages:
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1216,6 +1552,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -1498,6 +1837,18 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1528,6 +1879,17 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -1536,6 +1898,12 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -1673,6 +2041,11 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1683,9 +2056,17 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1745,6 +2126,9 @@ packages:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
@@ -1777,6 +2161,9 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1838,6 +2225,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  electron-to-chromium@1.5.355:
+    resolution: {integrity: sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==}
+
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
 
@@ -1868,6 +2258,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.27.7:
@@ -1942,6 +2337,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -2074,6 +2473,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -2082,8 +2484,18 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonc-parser@2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
@@ -2172,6 +2584,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -2181,6 +2597,9 @@ packages:
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2367,6 +2786,9 @@ packages:
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -2464,6 +2886,19 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -2546,6 +2981,13 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
@@ -2814,6 +3256,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -2857,6 +3305,46 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vite@7.3.3:
@@ -3064,6 +3552,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
     hasBin: true
@@ -3218,6 +3709,29 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
+  '@astrojs/react@4.4.2(@types/node@24.12.4)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tsx@4.21.0)(yaml@2.9.0)':
+    dependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      ultrahtml: 1.6.0
+      vite: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@astrojs/sitemap@3.7.2':
     dependencies:
       sitemap: 9.0.1
@@ -3236,13 +3750,112 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -3333,10 +3946,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -3345,10 +3964,16 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -3357,10 +3982,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -3369,10 +4000,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -3381,10 +4018,16 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -3393,10 +4036,16 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -3405,10 +4054,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -3417,10 +4072,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -3429,7 +4090,13 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -3438,7 +4105,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
@@ -3447,7 +4120,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
@@ -3456,10 +4135,16 @@ snapshots:
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -3468,10 +4153,16 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -3634,6 +4325,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/pluginutils@5.1.0(rollup@4.60.3)':
     dependencies:
@@ -3834,6 +4527,27 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -3866,6 +4580,17 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 22.19.19
@@ -3873,6 +4598,18 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.19)(happy-dom@15.11.7)(lightningcss@1.32.0))':
     dependencies:
@@ -4238,6 +4975,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  baseline-browser-mapping@2.10.29: {}
+
   boolbase@1.0.0: {}
 
   brace-expansion@2.1.0:
@@ -4248,7 +4987,17 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.355
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001792: {}
 
   ccount@2.0.1: {}
 
@@ -4298,6 +5047,8 @@ snapshots:
 
   common-ancestor-path@2.0.0: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
@@ -4335,6 +5086,8 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -4384,6 +5137,8 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  electron-to-chromium@1.5.355: {}
+
   emmet@2.4.11:
     dependencies:
       '@emmetio/abbreviation': 2.3.3
@@ -4431,6 +5186,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -4512,6 +5296,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -4700,6 +5486,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -4708,7 +5496,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-schema-traverse@1.0.0: {}
+
+  json5@2.2.3: {}
 
   jsonc-parser@2.3.1: {}
 
@@ -4767,11 +5559,19 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
   lru-cache@11.3.6: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -5138,6 +5938,8 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
+  node-releases@2.0.44: {}
+
   normalize-path@3.0.0: {}
 
   nth-check@2.1.1:
@@ -5224,6 +6026,18 @@ snapshots:
   property-information@7.1.0: {}
 
   radix3@1.1.2: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   readdirp@4.1.2: {}
 
@@ -5372,6 +6186,12 @@ snapshots:
       fsevents: 2.3.3
 
   sax@1.6.0: {}
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
 
   semver@7.8.0: {}
 
@@ -5622,6 +6442,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   vfile-location@5.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -5692,6 +6518,22 @@ snapshots:
       '@types/node': 24.12.4
       fsevents: 2.3.3
       lightningcss: 1.32.0
+
+  vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.4
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.9.0
 
   vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
@@ -5930,6 +6772,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml-language-server@1.20.0:
     dependencies:

--- a/serverless/src/common/cache/serializers.py
+++ b/serverless/src/common/cache/serializers.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import base64
 import json
+from decimal import Decimal
 from typing import Any
 
 from common.cache.types import CacheEntry
@@ -25,12 +26,39 @@ class SerializationError(ValueError):
     """Raised cuando un valor no es serializable o decode falla."""
 
 
+class _CacheJSONEncoder(json.JSONEncoder):
+    """
+    JSON encoder que maneja tipos comunes de DynamoDB:
+
+    - `Decimal`: serializa a int si es entero, sino a float. DynamoDB siempre
+      retorna numericos como `Decimal` desde boto3 Resource. Convertir a tipo
+      Python nativo perdiendo precision esta OK aqui porque la cache es para
+      valores observables (counters, scores), no para money.
+    - `set` / `frozenset`: serializa a list (DynamoDB tiene tipo `SS`/`NS`/`BS`
+      pero al deserializar boto3 lo da como `set`).
+    - `bytes`: la rama bytes ya se cubre en `serialize()` antes de llegar a
+      JSON, pero un bytes anidado dentro de un dict tambien necesita un fallback
+      aqui (base64).
+    """
+
+    def default(self, o: Any) -> Any:  # noqa: D401 - JSONEncoder protocol
+        if isinstance(o, Decimal):
+            # Decimal('3') -> 3, Decimal('3.5') -> 3.5
+            return int(o) if o == o.to_integral_value() else float(o)
+        if isinstance(o, (set, frozenset)):
+            return list(o)
+        if isinstance(o, bytes):
+            return base64.b64encode(o).decode('ascii')
+        return super().default(o)
+
+
 def serialize(value: Any) -> tuple[str, str]:
     """
     Serializa value a (string_value, encoding).
 
     Args:
-        value: cualquier Python type JSON-serializable o bytes.
+        value: cualquier Python type JSON-serializable, bytes, Decimal, set o
+            dicts/lists anidados que contengan esos tipos.
 
     Returns:
         Tuple (string serializado, encoding marker).
@@ -42,7 +70,15 @@ def serialize(value: Any) -> tuple[str, str]:
         return base64.b64encode(value).decode('ascii'), 'bytes_b64'
 
     try:
-        return json.dumps(value, ensure_ascii=False, separators=(',', ':')), 'json'
+        return (
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                separators=(',', ':'),
+                cls=_CacheJSONEncoder,
+            ),
+            'json',
+        )
     except (TypeError, ValueError) as e:
         msg = f'Cannot serialize type {type(value).__name__}: {e}'
         raise SerializationError(msg) from e

--- a/serverless/src/contact_form/schemas.py
+++ b/serverless/src/contact_form/schemas.py
@@ -17,8 +17,11 @@ class ContactFormInput(BaseModel):
     email: EmailStr
     message: str = Field(..., min_length=10, max_length=5000)
 
-    # Captcha token (Cloudflare Turnstile)
-    cf_token: str = Field(..., min_length=20, max_length=2048)
+    # Captcha token (Cloudflare Turnstile).
+    # Opcional intencionalmente: si viene vacio, el handler de Turnstile evalua
+    # el header X-Turnstile-Bypass-Secret. Solo es valido en stage in {dev,local}.
+    # En stage/prod, vacio o invalido -> CAPTCHA_INVALID (Turnstile lo rechaza).
+    cf_token: str = Field(default='', max_length=2048)
 
     # Campos opcionales (form progresivo)
     company: str | None = Field(default=None, max_length=200)

--- a/serverless/src/contact_form/turnstile.py
+++ b/serverless/src/contact_form/turnstile.py
@@ -57,6 +57,63 @@ def _hostname_allowed(hostname: str) -> bool:
     return False
 
 
+_BYPASS_ALLOWED_STAGES = frozenset({'dev', 'local'})
+
+
+def _load_bypass_secret() -> str:
+    """
+    Resuelve el bypass secret desde SSM. Solo se llama si STAGE in {dev,local}.
+
+    Si el SSM_TURNSTILE_BYPASS_PATH no esta configurado o el param no existe,
+    retorna string vacio (bypass queda inerte, regla #2).
+    """
+    bypass_path = os.environ.get('SSM_TURNSTILE_BYPASS_PATH', '')
+    if not bypass_path:
+        return ''
+    try:
+        return get_secret(bypass_path)
+    except Exception:  # noqa: BLE001  (SSM ParameterNotFound, ClientError, etc.)
+        logger.info(
+            'bypass secret not configured in SSM; bypass disabled',
+            extra={'path': bypass_path},
+        )
+        return ''
+
+
+def _try_bypass_turnstile(bypass_secret: str | None) -> dict[str, Any] | None:
+    """
+    Intenta usar el bypass de Turnstile para tests E2E.
+
+    Reglas (defense-in-depth):
+    1. SOLO se considera si `cf_response` viene vacio (caller llama esto antes
+       de comparar con CF siteverify).
+    2. SOLO se activa en STAGE in {dev, local}. En stage/prod retorna None.
+    3. Requiere matchear el SSM param `/portfolio/dev/turnstile-bypass-secret`.
+       El secret nunca llega al frontend (lo inyecta Playwright via
+       page.addInitScript -> window.__playwright_turnstile_bypass).
+
+    Returns:
+        Dict con success=true si bypass aplica, `None` si no aplica
+        (el caller debe seguir con el flujo normal de Turnstile).
+    """
+    stage = os.environ.get('STAGE', 'prod').lower()
+    if stage not in _BYPASS_ALLOWED_STAGES:
+        return None
+    if not bypass_secret:
+        return None
+    expected_bypass = _load_bypass_secret()
+    if not expected_bypass:
+        return None
+    if bypass_secret != expected_bypass:
+        logger.warning(
+            'turnstile bypass attempted with invalid secret',
+            extra={'stage': stage},
+        )
+        return None
+    logger.info('turnstile bypassed via secret header', extra={'stage': stage})
+    return {'success': True, 'hostname': 'bypass', 'bypassed': True}
+
+
 def verify_turnstile_token(
     cf_response: str,
     *,
@@ -68,9 +125,10 @@ def verify_turnstile_token(
 
     Args:
         cf_response: valor del campo `cf-turnstile-response` del frontend.
+            Si viene vacio se considera bypass para tests (regla #1).
         remote_ip: IP del cliente (opcional pero recomendado).
-        bypass_secret: si matchea TURNSTILE_BYPASS_SECRET env var,
-                       skip la verificacion (para tests automatizados).
+        bypass_secret: header X-Turnstile-Bypass-Secret. Solo se evalua si
+            `cf_response` viene vacio Y STAGE esta en {dev, local}.
 
     Returns:
         Dict con la respuesta de siteverify si success=true.
@@ -78,11 +136,16 @@ def verify_turnstile_token(
     Raises:
         TurnstileError: si success=false, hostname inesperado, o timeout.
     """
-    # Bypass para tests
-    expected_bypass = os.environ.get('TURNSTILE_BYPASS_SECRET', '')
-    if bypass_secret and expected_bypass and bypass_secret == expected_bypass:
-        logger.info('turnstile bypassed via secret header')
-        return {'success': True, 'hostname': 'bypass', 'bypassed': True}
+    # Regla #1: bypass SOLO si cf_response viene vacio.
+    # Astro nunca envia cf_response vacio (el form requiere el widget Turnstile),
+    # asi que esta rama solo se activa desde tests automatizados.
+    if not cf_response or not cf_response.strip():
+        bypassed = _try_bypass_turnstile(bypass_secret)
+        if bypassed is not None:
+            return bypassed
+        # Sin bypass valido y sin cf_response real -> CAPTCHA_INVALID
+        msg = 'cf_token vacio y bypass no aplica'
+        raise TurnstileError(msg, code='CAPTCHA_INVALID')
 
     secret_path = os.environ.get(
         'SSM_TURNSTILE_SECRET_PATH', '/portfolio/turnstile-secret'

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -223,6 +223,12 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: contact-form
+          # Bypass secret para tests E2E (solo dev):
+          # - El SSM param `/portfolio/dev/turnstile-bypass-secret` debe existir
+          #   solo en stage=dev. La Lambda resuelve el valor en runtime via SSM.
+          # - turnstile.py corta el bypass por STAGE (defense-in-depth): aunque
+          #   alguien setee el secret en prod, la funcion lo ignora.
+          SSM_TURNSTILE_BYPASS_PATH: /portfolio/dev/turnstile-bypass-secret
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ContactsTable
@@ -234,6 +240,12 @@ Resources:
             TableName: !Ref RateLimitBucketsTable
         - SSMParameterReadPolicy:
             ParameterName: 'portfolio/turnstile-secret'
+        # SSM bypass secret: la IAM policy se concede siempre pero la Lambda
+        # solo lee el param si STAGE in {dev,local} (defense-in-depth en codigo).
+        # En stage=prod el SSM param no debe existir, lo que falla la lectura
+        # con ParameterNotFound y el bypass queda inerte.
+        - SSMParameterReadPolicy:
+            ParameterName: 'portfolio/dev/turnstile-bypass-secret'
         - SSMParameterReadPolicy:
             ParameterName: 'portfolio/owner-email'
         - SSMParameterReadPolicy:

--- a/serverless/tests/unit/common/cache/test_serializers.py
+++ b/serverless/tests/unit/common/cache/test_serializers.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from decimal import Decimal
+
 import pytest
 
 from common.cache.serializers import SerializationError, deserialize, serialize
@@ -67,6 +70,45 @@ class TestRoundtrip:
         result = deserialize(ser_value, encoding)
 
         assert result == value
+
+
+class TestDynamoDBTypes:
+    """
+    Tipos custom de DynamoDB (Decimal, set, bytes anidado) deben serializarse
+    sin TypeError. Reasons: boto3 Resource API retorna numericos como
+    `Decimal`, lo que rompia el cache de `get_ip_rule`.
+    """
+
+    def test_when_decimal_integer_then_serializes_as_int(self) -> None:
+        """Given Decimal(3), When serialize, Then JSON '3' (int)."""
+        ser, enc = serialize(Decimal('3'))
+        assert enc == 'json'
+        assert json.loads(ser) == 3
+
+    def test_when_decimal_float_then_serializes_as_float(self) -> None:
+        """Given Decimal('3.5'), When serialize, Then JSON 3.5 (float)."""
+        ser, enc = serialize(Decimal('3.5'))
+        assert enc == 'json'
+        assert json.loads(ser) == 3.5
+
+    def test_when_dict_with_decimal_nested_then_serializes(self) -> None:
+        """
+        Given dict con Decimal anidado (el caso real del rate-limit IP rule),
+        When serialize,
+        Then JSON con int en lugar de Decimal.
+        """
+        value = {'ip': '1.2.3.4', 'count': Decimal('5'), 'rate': Decimal('0.5')}
+        ser, enc = serialize(value)
+        assert enc == 'json'
+        result = deserialize(ser, enc)
+        assert result == {'ip': '1.2.3.4', 'count': 5, 'rate': 0.5}
+
+    def test_when_set_then_serializes_as_list(self) -> None:
+        """Given set, When serialize, Then JSON array (set -> list)."""
+        value = {1, 2, 3}
+        ser, enc = serialize(value)
+        assert enc == 'json'
+        assert sorted(deserialize(ser, enc)) == [1, 2, 3]
 
 
 class TestDeserialize:

--- a/serverless/tests/unit/contact_form/test_handler.py
+++ b/serverless/tests/unit/contact_form/test_handler.py
@@ -160,23 +160,31 @@ class TestLambdaHandler:
         body = json.loads(response['body'])
         assert body['code'] == 'CAPTCHA_INVALID'
 
-    def test_when_bypass_secret_matches_then_201(
+    def test_when_bypass_secret_matches_in_dev_then_201(
         self,
         contact_form_aws: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
-        Given header X-Turnstile-Bypass-Secret matchea,
+        Given STAGE=dev + cf_token vacio + header X-Turnstile-Bypass-Secret
+        matchea el SSM bypass param,
         When invoke handler,
         Then 201 (skip Turnstile, no HTTP call a CF).
         """
-        monkeypatch.setenv('TURNSTILE_BYPASS_SECRET', 'test-bypass-key')
+        monkeypatch.setenv('STAGE', 'dev')
+        monkeypatch.setenv(
+            'SSM_TURNSTILE_BYPASS_PATH', '/portfolio/dev/turnstile-bypass-secret'
+        )
+        monkeypatch.setattr(
+            'contact_form.turnstile.get_secret',
+            lambda _path: 'test-bypass-key',
+        )
 
         event = _build_event(body={
             'name': 'Pablo Test',
             'email': 'user@example.com',
             'message': 'Bypass test message',
-            'cf_token': 'x' * 30,
+            'cf_token': '',
         })
         event['headers']['X-Turnstile-Bypass-Secret'] = 'test-bypass-key'
 

--- a/serverless/tests/unit/contact_form/test_schemas.py
+++ b/serverless/tests/unit/contact_form/test_schemas.py
@@ -45,10 +45,14 @@ class TestContactFormInput:
         with pytest.raises(PydanticValidationError):
             ContactFormInput(**self._valid_payload(email='not-an-email'))
 
-    def test_when_cf_token_too_short_then_raises(self) -> None:
-        """Given cf_token < 20 chars, When parse, Then ValidationError."""
-        with pytest.raises(PydanticValidationError):
-            ContactFormInput(**self._valid_payload(cf_token='short'))  # noqa: S106
+    def test_when_cf_token_empty_then_accepts(self) -> None:
+        """
+        Given cf_token vacio (default), When parse, Then accepts.
+        El backend valida cf_token vs Turnstile en service layer; el schema
+        permite vacio porque el bypass de tests E2E lo requiere.
+        """
+        parsed = ContactFormInput(**self._valid_payload(cf_token=''))
+        assert parsed.cf_token == ''
 
     def test_when_message_has_html_then_sanitized(self) -> None:
         """Given message con HTML, When parse, Then escapado (XSS prevention)."""

--- a/serverless/tests/unit/contact_form/test_turnstile.py
+++ b/serverless/tests/unit/contact_form/test_turnstile.py
@@ -170,18 +170,25 @@ class TestVerifyTurnstileToken:
 
         assert exc_info.value.code == 'CAPTCHA_HOSTNAME_MISMATCH'
 
-    def test_when_bypass_secret_matches_then_skip_verify(
-        self, contact_form_aws: None, monkeypatch: pytest.MonkeyPatch
+    def test_when_cf_response_empty_and_bypass_matches_in_dev_then_skip(
+        self,
+        contact_form_aws: None,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
-        Given TURNSTILE_BYPASS_SECRET seteado + header matchea,
+        Given cf_response vacio + STAGE=dev + bypass_secret matchea SSM,
         When verify,
-        Then skip Cloudflare API (no HTTP call).
+        Then bypass aplica (no HTTP call a Cloudflare).
         """
-        monkeypatch.setenv('TURNSTILE_BYPASS_SECRET', 'test-bypass-123')
+        monkeypatch.setenv('STAGE', 'dev')
+        monkeypatch.setenv('SSM_TURNSTILE_BYPASS_PATH', '/portfolio/dev/turnstile-bypass-secret')
+        monkeypatch.setattr(
+            'contact_form.turnstile.get_secret',
+            lambda _path: 'test-bypass-123',
+        )
 
         result = verify_turnstile_token(
-            'any-cf-response',
+            '',
             remote_ip='1.2.3.4',
             bypass_secret='test-bypass-123',  # noqa: S106
         )
@@ -189,21 +196,66 @@ class TestVerifyTurnstileToken:
         assert result['success'] is True
         assert result.get('bypassed') is True
 
-    def test_when_bypass_secret_wrong_then_does_not_skip(
-        self, contact_form_aws: None, monkeypatch: pytest.MonkeyPatch
+    def test_when_cf_response_not_empty_bypass_is_ignored(
+        self,
+        contact_form_aws: None,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
-        Given bypass_secret no matchea,
+        Given cf_response NO vacio + bypass_secret presente,
         When verify,
-        Then NO skip (intenta llamar a Cloudflare).
+        Then ignora el bypass y llama a Cloudflare (regla #1: bypass solo
+        si cf_response vacio).
         """
-        monkeypatch.setenv('TURNSTILE_BYPASS_SECRET', 'real-secret')
+        monkeypatch.setenv('STAGE', 'dev')
+        monkeypatch.setenv('SSM_TURNSTILE_BYPASS_PATH', '/portfolio/dev/turnstile-bypass-secret')
+        monkeypatch.setattr(
+            'contact_form.turnstile.get_secret',
+            lambda _path: 'test-bypass-123',
+        )
 
-        # respx no activado -> la llamada HTTP es real y falla. Cae en
-        # TurnstileError CAPTCHA_FAILED por connection error.
+        # Sin respx activo, la llamada HTTP real falla -> CAPTCHA_FAILED.
         with pytest.raises(TurnstileError):
             verify_turnstile_token(
-                'any-cf-response',
+                'some-real-cf-token',
                 remote_ip='1.2.3.4',
-                bypass_secret='wrong-secret',  # noqa: S106
+                bypass_secret='test-bypass-123',  # noqa: S106
             )
+
+    def test_when_cf_response_empty_in_prod_then_reject(
+        self,
+        contact_form_aws: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """
+        Given cf_response vacio + STAGE=prod (incluso con bypass_secret),
+        When verify,
+        Then CAPTCHA_INVALID (regla #2: bypass solo en dev/local).
+        """
+        monkeypatch.setenv('STAGE', 'prod')
+
+        with pytest.raises(TurnstileError) as exc_info:
+            verify_turnstile_token(
+                '',
+                remote_ip='1.2.3.4',
+                bypass_secret='any-secret',  # noqa: S106
+            )
+
+        assert exc_info.value.code == 'CAPTCHA_INVALID'
+
+    def test_when_cf_response_empty_and_no_bypass_secret_then_reject(
+        self,
+        contact_form_aws: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """
+        Given cf_response vacio + STAGE=dev + sin bypass_secret,
+        When verify,
+        Then CAPTCHA_INVALID.
+        """
+        monkeypatch.setenv('STAGE', 'dev')
+
+        with pytest.raises(TurnstileError) as exc_info:
+            verify_turnstile_token('', remote_ip='1.2.3.4', bypass_secret=None)
+
+        assert exc_info.value.code == 'CAPTCHA_INVALID'

--- a/tests/feature/contact/contact-form.spec.ts
+++ b/tests/feature/contact/contact-form.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * @feature Contact form (React 18 + Zod) - flujo completo E2E
+ * @description Cubre:
+ *   1. Validacion Zod en cliente (errors per-field).
+ *   2. Happy path con bypass de Turnstile (POST real al Lambda dev).
+ *   3. Persistencia: tras enviar, recargar -> card visible.
+ *   4. Boton "Enviar otro mensaje" limpia storage y re-muestra el form.
+ *   5. Errores del backend (mock 400/429) renderizan correctamente.
+ *
+ * Bypass de Turnstile:
+ *   - Solo se activa si TURNSTILE_BYPASS_SECRET env var esta presente.
+ *   - El secret se inyecta a la pagina via `addInitScript` -> window.
+ *   - El frontend lee `window.__playwrightTurnstileBypass`, agrega header
+ *     `X-Turnstile-Bypass-Secret`, y envia cf_token vacio.
+ *   - El Lambda (en stage=dev) detecta cf_token vacio + secret matchea SSM
+ *     param `/portfolio/dev/turnstile-bypass-secret` -> skip Cloudflare API.
+ */
+import type { Page } from '@playwright/test'
+import { expect, subdomainUrl, test } from '../fixtures/index.js'
+
+const BYPASS_SECRET = process.env.TURNSTILE_BYPASS_SECRET ?? ''
+
+/**
+ * Navega a /contact y espera a que el React island se hidrate. El form usa
+ * `client:load` pero la hidratacion puede tardar ~200-500ms despues de
+ * `domcontentloaded`. Esperar al input[name=name] garantiza estado interactivo.
+ */
+async function gotoContactReady(page: Page): Promise<void> {
+  await page.goto(`${subdomainUrl()}/contact`, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByTestId('contact-form')).toBeVisible()
+  await expect(page.locator('input[name="name"]')).toBeVisible()
+}
+
+test.describe('Feature: Contact form (React 18 + Zod)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Inyectar bypass token ANTES de cargar la pagina. La inyeccion ocurre
+    // en cada navegacion (incluso reloads) por el contrato de addInitScript.
+    if (BYPASS_SECRET) {
+      await page.addInitScript((secret: string) => {
+        ;(
+          window as Window & { __playwrightTurnstileBypass?: string }
+        ).__playwrightTurnstileBypass = secret
+      }, BYPASS_SECRET)
+    }
+  })
+
+  test('Given form vacio When submit Then muestra errores Zod en name/email/message', async ({
+    page,
+  }) => {
+    await gotoContactReady(page)
+
+    await page.getByTestId('contact-submit').click()
+
+    await expect(page.getByTestId('error-name')).toHaveText(
+      /Minimo 2 caracteres/i,
+    )
+    await expect(page.getByTestId('error-email')).toHaveText(
+      /email es obligatorio/i,
+    )
+    await expect(page.getByTestId('error-message')).toHaveText(
+      /Minimo 10 caracteres/i,
+    )
+  })
+
+  test('Given email invalido When blur Then error de formato; al corregir desaparece', async ({
+    page,
+  }) => {
+    await gotoContactReady(page)
+
+    const emailInput = page.locator('input[name="email"]')
+    await emailInput.fill('no-es-email')
+    await emailInput.blur()
+    await expect(page.getByTestId('error-email')).toHaveText(
+      /Email invalido. Revisa el formato/i,
+    )
+
+    await emailInput.fill('pacg1991@gmail.com')
+    // Mientras tipea con error activo, debe re-validar y limpiar
+    await expect(page.getByTestId('error-email')).toBeHidden()
+  })
+
+  // -----------------------------------------------------------------
+  // Happy path + persistencia: requiere bypass secret real para que el
+  // Lambda dev acepte la peticion. Se skipea si no esta seteado.
+  // -----------------------------------------------------------------
+  test.describe('with Turnstile bypass (skipped if TURNSTILE_BYPASS_SECRET not set)', () => {
+    test.skip(
+      !BYPASS_SECRET,
+      'TURNSTILE_BYPASS_SECRET no esta seteada en el entorno',
+    )
+
+    test('Given API responde 400 con errores per-field When submit Then pintan errores del backend', async ({
+      page,
+    }) => {
+      // Solo intercepta el POST al API Gateway. NO uses '**/contact' a secas
+      // porque tambien matchea la navegacion a `/contact` (HTML).
+      await page.route(
+        /https:\/\/[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com\/[a-z]+\/contact$/,
+        async (route) => {
+          await route.fulfill({
+            status: 400,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              error: 'Validation failed',
+              code: 'INVALID_INPUT',
+              extra: {
+                errors: [
+                  {
+                    type: 'string_too_short',
+                    loc: ['body', 'message'],
+                    msg: 'Field too short',
+                    ctx: { min_length: 10 },
+                  },
+                ],
+              },
+            }),
+          })
+        },
+      )
+
+      await gotoContactReady(page)
+      await page.locator('input[name="name"]').fill('Pablo Test')
+      await page.locator('input[name="email"]').fill('pacg1991@gmail.com')
+      await page
+        .locator('textarea[name="message"]')
+        .fill('Mensaje suficientemente largo para pasar Zod cliente.')
+
+      await page.getByTestId('contact-submit').click()
+
+      await expect(page.getByTestId('error-message')).toHaveText(
+        /Minimo 10 caracteres/i,
+      )
+      await expect(page.getByTestId('contact-status')).toHaveAttribute(
+        'data-kind',
+        'error',
+      )
+    })
+
+    test('Given API responde 429 When submit Then mensaje de rate limit', async ({
+      page,
+    }) => {
+      await page.route(
+        /https:\/\/[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com\/[a-z]+\/contact$/,
+        async (route) => {
+          await route.fulfill({
+            status: 429,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              error: 'Too many requests',
+              code: 'RATE_LIMITED',
+            }),
+          })
+        },
+      )
+
+      await gotoContactReady(page)
+      await page.locator('input[name="name"]').fill('Pablo Test')
+      await page.locator('input[name="email"]').fill('pacg1991@gmail.com')
+      await page
+        .locator('textarea[name="message"]')
+        .fill('Mensaje suficientemente largo para pasar Zod cliente.')
+
+      await page.getByTestId('contact-submit').click()
+
+      await expect(page.getByTestId('contact-status')).toContainText(
+        /Demasiados intentos/i,
+      )
+    })
+
+    test('Given form valido When submit con bypass Then 201 + card de confirmacion', async ({
+      page,
+    }) => {
+      await gotoContactReady(page)
+      const uniqueMsg = `[E2E test] ${new Date().toISOString()} - mensaje suficientemente largo.`
+      await page.locator('input[name="name"]').fill('Playwright Test')
+      await page.locator('input[name="email"]').fill('pacg1991@gmail.com')
+      await page.locator('textarea[name="message"]').fill(uniqueMsg)
+
+      // Capturar la response al backend para verificar status 201
+      const responsePromise = page.waitForResponse(
+        (res) =>
+          res.url().includes('/contact') && res.request().method() === 'POST',
+      )
+      await page.getByTestId('contact-submit').click()
+      const response = await responsePromise
+      expect(response.status()).toBe(201)
+      const body = (await response.json()) as { contact_id: string }
+      expect(body.contact_id).toMatch(/^[0-9a-f-]{36}$/i)
+
+      // El card aparece
+      await expect(page.getByTestId('contact-sent-card')).toBeVisible()
+      await expect(page.getByTestId('contact-sent-id')).toHaveText(
+        body.contact_id,
+      )
+    })
+
+    test('Given mensaje enviado When recargo Then card sigue visible (localStorage)', async ({
+      page,
+    }) => {
+      // Simular estado previo: setear localStorage directo con un record valido
+      await gotoContactReady(page)
+      const future = Date.now() + 7 * 24 * 60 * 60 * 1000
+      await page.evaluate(
+        (record) => {
+          window.localStorage.setItem('contact_sent', JSON.stringify(record))
+        },
+        {
+          contactId: '019e28fc-b97d-7d79-91a5-44c9b19465b4',
+          sentAt: Date.now(),
+          expiresAt: future,
+        },
+      )
+
+      await page.reload({ waitUntil: 'domcontentloaded' })
+
+      await expect(page.getByTestId('contact-sent-card')).toBeVisible()
+      await expect(page.getByTestId('contact-sent-id')).toHaveText(
+        '019e28fc-b97d-7d79-91a5-44c9b19465b4',
+      )
+      await expect(page.getByTestId('contact-form')).toBeHidden()
+    })
+
+    test('Given card visible When click "Enviar otro mensaje" Then form vuelve a aparecer', async ({
+      page,
+    }) => {
+      await gotoContactReady(page)
+      const future = Date.now() + 7 * 24 * 60 * 60 * 1000
+      await page.evaluate(
+        (record) => {
+          window.localStorage.setItem('contact_sent', JSON.stringify(record))
+        },
+        {
+          contactId: 'test-resend-id',
+          sentAt: Date.now(),
+          expiresAt: future,
+        },
+      )
+      await page.reload({ waitUntil: 'domcontentloaded' })
+
+      await expect(page.getByTestId('contact-sent-card')).toBeVisible()
+      await page.getByTestId('contact-resend-btn').click()
+
+      await expect(page.getByTestId('contact-form')).toBeVisible()
+      await expect(page.getByTestId('contact-sent-card')).toBeHidden()
+
+      const stored = await page.evaluate(() =>
+        window.localStorage.getItem('contact_sent'),
+      )
+      expect(stored).toBe(null)
+    })
+  })
+})

--- a/tests/feature/contact/contact-form.spec.ts
+++ b/tests/feature/contact/contact-form.spec.ts
@@ -26,7 +26,9 @@ const BYPASS_SECRET = process.env.TURNSTILE_BYPASS_SECRET ?? ''
  * `domcontentloaded`. Esperar al input[name=name] garantiza estado interactivo.
  */
 async function gotoContactReady(page: Page): Promise<void> {
-  await page.goto(`${subdomainUrl()}/contact`, { waitUntil: 'domcontentloaded' })
+  await page.goto(`${subdomainUrl()}/contact`, {
+    waitUntil: 'domcontentloaded',
+  })
   await expect(page.getByTestId('contact-form')).toBeVisible()
   await expect(page.locator('input[name="name"]')).toBeVisible()
 }


### PR DESCRIPTION
## Problema

1. El form de contacto era Astro server-rendered con JS inline para validacion. Diferia del diseno y dificultaba agregar interacciones dinamicas (errors per-field on-blur, persistencia, retry).
2. Los tests E2E con Playwright contra el form requerian completar el widget Turnstile real de Cloudflare — imposible de automatizar en CI.
3. Bug latente en `serverless/src/common/cache/serializers.py`: `json.dumps` rechazaba `Decimal` (boto3 Resource API retorna numericos DynamoDB como `Decimal`), lo que rompia `get_ip_rule` del rate-limit con `SerializationError`.
4. `devtools/serverless` CLI no parseaba positionals (`serverless build` sin `--subcommands=build`).
5. `rate_limit_cmds.py` apuntaba a nombres de tabla viejos (`rate_limit_rules`) en vez de los del SAM template (`portfolio-rate-limit-rules-dev`).

## Solucion

1. Migra ContactForm a React 18 + Zod en las 6 apps Astro:
   - `ContactFormReact.tsx` con validacion Zod dinamica (on-blur + on-change si ya hay error), Turnstile via render explicito, integracion con `contact-storage` (localStorage + cookie compartida `.the-full-stack.com`, TTL 7d), card "ya enviaste" con boton "Enviar otro mensaje".
   - `ContactFormReact.astro` wrapper monta el componente con `client:load` + estilos del DS.
   - 6 `astro.config.ts`: agrega `integration react()` + `optimizeDeps.include` para react/react-dom/react-dom-client/jsx-runtime/jsx-dev-runtime (evita errores transient de Vite pre-bundle en HMR).
2. Backend Lambda contact_form: bypass de Turnstile via SSM secret. La regla: bypass aplica SOLO si `cf_token` viene vacio Y `STAGE in {dev, local}` Y el header `X-Turnstile-Bypass-Secret` matchea el SSM param `/portfolio/dev/turnstile-bypass-secret`. Astro frontend nunca envia `cf_token` vacio (siempre tiene Turnstile real), asi que esa rama solo se activa desde Playwright via `page.addInitScript`.
3. Fix del `SerializationError`: nuevo `_CacheJSONEncoder` que serializa `Decimal` (int si es entero, sino float), `set`/`frozenset` (a list) y `bytes` anidados (base64). 4 tests nuevos cubren cada tipo.
4. `devtools/serverless/flags.py`: nuevo helper `_extract_positionals()` siguiendo el patron de `devtools/docker/flags.py`. Ahora `serverless build`, `serverless deploy --stage=dev`, etc. funcionan sin pasar `--subcommands` explicito.
5. `devtools/serverless/rate_limit_cmds.py`: corrige `_RULES_TABLE` y `_BUCKETS_TABLE` al patron `portfolio-rate-limit-<recurso>-dev`.

## Como probar

### Unit tests (host)

```bash
# Backend serverless (Pydantic + Turnstile + cache)
cd serverless && uv run --project . pytest tests/unit/ -q
# Esperado: 230 passed

# Frontend (Zod schema + contact-storage)
pnpm --filter @portfolio/ui run test
# Esperado: 86 passed (84 originales + 2 branch coverage de getFieldErrors)

# Coverage threshold del pre-push hook
pnpm --filter @portfolio/ui run test:coverage
# Esperado: contact-form-schema.ts 100% branch coverage
```

### End-to-end con Lambda dev real

```bash
# 1. Cargar bypass secret del .env
export TURNSTILE_BYPASS_SECRET=$(grep "^TURNSTILE_BYPASS_SECRET=" docker/env/.local | cut -d= -f2)

# 2. Curl directo al endpoint dev (bypass aplica)
curl -X POST https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/contact \
  -H "Content-Type: application/json" \
  -H "Origin: https://the-full-stack.com" \
  -H "X-Turnstile-Bypass-Secret: $TURNSTILE_BYPASS_SECRET" \
  -d '{"name":"Pablo","email":"pacg1991@gmail.com","message":"Test del PR.","cf_token":""}'
# Esperado: HTTP 201 con {contact_id, created_at}

# 3. Curl sin bypass (rechazado)
curl -X POST https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/contact \
  -H "Content-Type: application/json" \
  -H "Origin: https://the-full-stack.com" \
  -d '{"name":"Pablo","email":"pacg1991@gmail.com","message":"Sin bypass.","cf_token":""}'
# Esperado: HTTP 403 CAPTCHA_INVALID
```

### Playwright E2E (browser)

```bash
# 1. Stack local arriba
python3 devtools/run.py docker up --env=local

# 2. Container Playwright
docker compose -p portfolio --profile feature -f docker/docker-compose/local.yml up -d feature

# 3. Correr specs con bypass
docker exec -e CI=true \
  -e TURNSTILE_BYPASS_SECRET="$(grep "^TURNSTILE_BYPASS_SECRET=" docker/env/.local | cut -d= -f2)" \
  portfolio-feature-local pnpm exec playwright test --project=desktop-chromium contact/contact-form.spec.ts
# Esperado: 7 passed en ~4s (validaciones Zod, mocks 400/429, happy path 201, persistencia, resend)
```

### Visual smoke en stack local

Abrir http://localhost:9970/contact (y los 5 subdominios `*.localhost:9970/contact`), completar el form, verificar que:
- Submit sin datos muestra errores Zod por campo.
- Submit con datos validos completa el captcha de Turnstile, envia, muestra card "Mensaje enviado" con el `contact_id`.
- Recargar mantiene el card (localStorage).
- Click "Enviar otro mensaje" limpia el state y vuelve a mostrar el form.

## TODO

- Pre-push step `feature_tests` queda omitido cuando el shell no detecta Docker; revisar si vale la pena bajar el threshold del check o pasarle explicitamente `DOCKER_HOST` desde el hook.
- Considerar `noUncheckedIndexedAccess: true` en `packages/ui/tsconfig.json` (ya esta en `tsconfig.base.json`) — algunos asserts del Playwright podrian quedar mas estrictos.
- Migration path para mover el API Gateway dev de `execute-api.us-east-1.amazonaws.com/dev` a `api.portfolio.dev.the-full-stack.com` (ver `subdomain-standard` skill). Fuera de scope de este PR.