### PR TITLE
feat(infra): entornos dev y stage para frontend + backend API custom domains

### DIFF
--- a/.claude/docs/subdomain-standard/03-environments.md
+++ b/.claude/docs/subdomain-standard/03-environments.md
@@ -100,8 +100,10 @@ en logs. El backend del portfolio sigue la misma logica:
 `api.portfolio.{env}.the-full-stack.com` (ver
 [06-migration-backend-api](./06-migration-backend-api.md)).
 
-El branch dispara el env: `dev` -> dev, `stage` -> stage, `main` -> prod
-(ver `.github/workflows/deploy.yml`).
+El branch dispara el env via la integracion git nativa de Cloudflare
+Pages: `dev` -> proyectos `<app>-dev`, `stage` -> `<app>-stage`,
+`main` -> `<app>`. Cada proyecto Pages tiene su `BASE_DOMAIN` y
+`SITE_URL` como build env vars (no hay workflow de deploy).
 
 ## Acceso restringido en no-prod
 

--- a/.claude/docs/subdomain-standard/03-environments.md
+++ b/.claude/docs/subdomain-standard/03-environments.md
@@ -80,6 +80,29 @@ Si tu flujo no necesita stage (proyectos chicos), omitir el ambiente.
 Pero NO inventar variantes (`pre-prod`, `release-candidate`, `beta`).
 Las 3 etiquetas (dev/stage/prod) son la lista cerrada.
 
+## Caso portfolio: dev/stage del frontend (excepcion solo en prod)
+
+El portfolio personal (apex + www + 5 niches) es excepcion permanente del
+estandar SOLO en prod: los niches van flat (`fintech.the-full-stack.com`).
+Esa excepcion NO se propaga a dev/stage — ahi SI se aplica el patron
+component-based con `product = portfolio`.
+
+| Env | apex (generic) | niches (hub/fintech/architect/leader/vibe) |
+|-----|----------------|---------------------------------------------|
+| prod | `the-full-stack.com` | `<niche>.the-full-stack.com` |
+| stage | `portfolio.stage.the-full-stack.com` | `<niche>.portfolio.stage.the-full-stack.com` |
+| dev | `portfolio.dev.the-full-stack.com` | `<niche>.portfolio.dev.the-full-stack.com` |
+
+Razon: en dev/stage los hostnames son tecnicos (no marketing), conviene
+que sigan el estandar para no chocar con productos futuros que quieran
+nombrarse como un niche y para que `*.portfolio.dev.*` salte a la vista
+en logs. El backend del portfolio sigue la misma logica:
+`api.portfolio.{env}.the-full-stack.com` (ver
+[06-migration-backend-api](./06-migration-backend-api.md)).
+
+El branch dispara el env: `dev` -> dev, `stage` -> stage, `main` -> prod
+(ver `.github/workflows/deploy.yml`).
+
 ## Acceso restringido en no-prod
 
 Recomendado para dev y stage:

--- a/.claude/docs/subdomain-standard/06-migration-backend-api.md
+++ b/.claude/docs/subdomain-standard/06-migration-backend-api.md
@@ -18,20 +18,29 @@ Frontend lo consume via `PUBLIC_API_ENDPOINT` en `docker/env/.{dev,prod}`.
 Aplicando el estandar (product = `portfolio`, component = `api`):
 
 ```text
-prod   https://api.portfolio.the-full-stack.com
-dev    https://api.portfolio.dev.the-full-stack.com
+prod    https://api.portfolio.the-full-stack.com
+stage   https://api.portfolio.stage.the-full-stack.com
+dev     https://api.portfolio.dev.the-full-stack.com
 ```
+
+> Nota: el stack SAM `stage` (`portfolio-backend-stage`) se despliega como
+> parte de esta migracion — el `template.yaml` agrega `stage` a los
+> `AllowedValues` del parametro `Stage` y `samconfig.toml` un bloque
+> `[stage.*]`. Cada env tiene su REST API independiente.
 
 ## Plan de migracion
 
 ### Paso 1 — Cert ACM en us-east-1
 
 API Gateway REST API requiere cert ACM en la misma region (us-east-1).
+Un solo cert con 3 SANs cubre los 3 envs:
 
 ```bash
 aws acm request-certificate \
   --domain-name api.portfolio.the-full-stack.com \
-  --subject-alternative-names api.portfolio.dev.the-full-stack.com \
+  --subject-alternative-names \
+      api.portfolio.dev.the-full-stack.com \
+      api.portfolio.stage.the-full-stack.com \
   --validation-method DNS \
   --region us-east-1 \
   --output json
@@ -58,7 +67,8 @@ Esperar el `Status: ISSUED` del cert (~5-30min).
 
 ### Paso 3 — Custom Domain Names en API Gateway
 
-Crear 2 entries (prod + dev):
+Crear 3 entries (prod + stage + dev). El bloque de abajo muestra prod+dev;
+para stage repetir con `api.portfolio.stage.the-full-stack.com`:
 
 ```bash
 # prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Cloudflare Pages
 
 on:
   push:
-    branches: [main]
+    branches: [main, stage, dev]
   workflow_dispatch:
     inputs:
       app:
@@ -21,6 +21,43 @@ env:
   PNPM_VERSION: '10.23.0'
 
 jobs:
+  resolve-env:
+    name: Resolve deploy environment
+    runs-on: ubuntu-24.04
+    outputs:
+      env: ${{ steps.env.outputs.env }}
+      base_domain: ${{ steps.env.outputs.base_domain }}
+      project_suffix: ${{ steps.env.outputs.project_suffix }}
+    steps:
+      - id: env
+        name: Map branch to environment
+        run: |
+          set -euo pipefail
+          case "${{ github.ref_name }}" in
+            main)
+              # prod: niches flat sobre el apex (excepcion del estandar)
+              echo "env=prod" >> "$GITHUB_OUTPUT"
+              echo "base_domain=the-full-stack.com" >> "$GITHUB_OUTPUT"
+              echo "project_suffix=" >> "$GITHUB_OUTPUT"
+              ;;
+            stage)
+              # stage: patron component-based {niche}.portfolio.stage.the-full-stack.com
+              echo "env=stage" >> "$GITHUB_OUTPUT"
+              echo "base_domain=portfolio.stage.the-full-stack.com" >> "$GITHUB_OUTPUT"
+              echo "project_suffix=-stage" >> "$GITHUB_OUTPUT"
+              ;;
+            dev)
+              # dev: patron component-based {niche}.portfolio.dev.the-full-stack.com
+              echo "env=dev" >> "$GITHUB_OUTPUT"
+              echo "base_domain=portfolio.dev.the-full-stack.com" >> "$GITHUB_OUTPUT"
+              echo "project_suffix=-dev" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Branch ${{ github.ref_name }} no mapea a ningun env de deploy" >&2
+              exit 1
+              ;;
+          esac
+
   detect-changes:
     name: Detect which apps changed
     runs-on: ubuntu-24.04
@@ -64,8 +101,8 @@ jobs:
           echo "apps=$JSON" >> "$GITHUB_OUTPUT"
 
   deploy:
-    name: Deploy ${{ matrix.app }}
-    needs: detect-changes
+    name: Deploy ${{ matrix.app }} (${{ needs.resolve-env.outputs.env }})
+    needs: [resolve-env, detect-changes]
     if: needs.detect-changes.outputs.apps != '[]'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -91,7 +128,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Resolve SITE_URL for ${{ matrix.app }}
+        id: site
+        run: |
+          set -euo pipefail
+          APP="${{ matrix.app }}"
+          BASE="${{ needs.resolve-env.outputs.base_domain }}"
+          # generic mapea al apex del env; el resto a <app>.<base_domain>
+          if [ "$APP" = "generic" ]; then
+            echo "site_url=https://${BASE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "site_url=https://${APP}.${BASE}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build apps/${{ matrix.app }}
+        env:
+          # SITE_URL: hostname propio de esta app en este env (sitemap/JSON-LD/OG).
+          SITE_URL: ${{ steps.site.outputs.site_url }}
+          # BASE_DOMAIN/SCHEME: usados por SITE_URLS para enlazar a las otras apps.
+          BASE_DOMAIN: ${{ needs.resolve-env.outputs.base_domain }}
+          BASE_SCHEME: https
+          BASE_PORT: ''
         run: pnpm --filter "@portfolio/${{ matrix.app }}" run build
 
       - name: Deploy to Cloudflare Pages
@@ -99,4 +156,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/${{ matrix.app }}/dist --project-name=portfolio-${{ matrix.app }} --branch=main
+          command: >-
+            pages deploy apps/${{ matrix.app }}/dist
+            --project-name=portfolio-${{ matrix.app }}${{ needs.resolve-env.outputs.project_suffix }}
+            --branch=${{ github.ref_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Cloudflare Pages
 
 on:
   push:
-    branches: [main, stage, dev]
+    branches: [main]
   workflow_dispatch:
     inputs:
       app:
@@ -21,43 +21,6 @@ env:
   PNPM_VERSION: '10.23.0'
 
 jobs:
-  resolve-env:
-    name: Resolve deploy environment
-    runs-on: ubuntu-24.04
-    outputs:
-      env: ${{ steps.env.outputs.env }}
-      base_domain: ${{ steps.env.outputs.base_domain }}
-      project_suffix: ${{ steps.env.outputs.project_suffix }}
-    steps:
-      - id: env
-        name: Map branch to environment
-        run: |
-          set -euo pipefail
-          case "${{ github.ref_name }}" in
-            main)
-              # prod: niches flat sobre el apex (excepcion del estandar)
-              echo "env=prod" >> "$GITHUB_OUTPUT"
-              echo "base_domain=the-full-stack.com" >> "$GITHUB_OUTPUT"
-              echo "project_suffix=" >> "$GITHUB_OUTPUT"
-              ;;
-            stage)
-              # stage: patron component-based {niche}.portfolio.stage.the-full-stack.com
-              echo "env=stage" >> "$GITHUB_OUTPUT"
-              echo "base_domain=portfolio.stage.the-full-stack.com" >> "$GITHUB_OUTPUT"
-              echo "project_suffix=-stage" >> "$GITHUB_OUTPUT"
-              ;;
-            dev)
-              # dev: patron component-based {niche}.portfolio.dev.the-full-stack.com
-              echo "env=dev" >> "$GITHUB_OUTPUT"
-              echo "base_domain=portfolio.dev.the-full-stack.com" >> "$GITHUB_OUTPUT"
-              echo "project_suffix=-dev" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "Branch ${{ github.ref_name }} no mapea a ningun env de deploy" >&2
-              exit 1
-              ;;
-          esac
-
   detect-changes:
     name: Detect which apps changed
     runs-on: ubuntu-24.04
@@ -101,8 +64,8 @@ jobs:
           echo "apps=$JSON" >> "$GITHUB_OUTPUT"
 
   deploy:
-    name: Deploy ${{ matrix.app }} (${{ needs.resolve-env.outputs.env }})
-    needs: [resolve-env, detect-changes]
+    name: Deploy ${{ matrix.app }}
+    needs: detect-changes
     if: needs.detect-changes.outputs.apps != '[]'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -128,27 +91,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Resolve SITE_URL for ${{ matrix.app }}
-        id: site
-        run: |
-          set -euo pipefail
-          APP="${{ matrix.app }}"
-          BASE="${{ needs.resolve-env.outputs.base_domain }}"
-          # generic mapea al apex del env; el resto a <app>.<base_domain>
-          if [ "$APP" = "generic" ]; then
-            echo "site_url=https://${BASE}" >> "$GITHUB_OUTPUT"
-          else
-            echo "site_url=https://${APP}.${BASE}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Build apps/${{ matrix.app }}
-        env:
-          # SITE_URL: hostname propio de esta app en este env (sitemap/JSON-LD/OG).
-          SITE_URL: ${{ steps.site.outputs.site_url }}
-          # BASE_DOMAIN/SCHEME: usados por SITE_URLS para enlazar a las otras apps.
-          BASE_DOMAIN: ${{ needs.resolve-env.outputs.base_domain }}
-          BASE_SCHEME: https
-          BASE_PORT: ''
         run: pnpm --filter "@portfolio/${{ matrix.app }}" run build
 
       - name: Deploy to Cloudflare Pages
@@ -156,7 +99,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: >-
-            pages deploy apps/${{ matrix.app }}/dist
-            --project-name=portfolio-${{ matrix.app }}${{ needs.resolve-env.outputs.project_suffix }}
-            --branch=${{ github.ref_name }}
+          command: pages deploy apps/${{ matrix.app }}/dist --project-name=portfolio-${{ matrix.app }} --branch=main

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/progress/.snapshot_*.md
 # Docker env files (gitignored, copy .example)
 docker/env/.local
 docker/env/.dev
+docker/env/.stage
 docker/env/.test
 docker/env/.prod
 

--- a/devtools/docker/flags.py
+++ b/devtools/docker/flags.py
@@ -11,12 +11,13 @@ from utils.flags_to_dict import set_default_values
 from utils.flags_to_dict import validate_allowed_flags
 
 
-VALID_ENVS = ['local', 'dev', 'test', 'prod']
+VALID_ENVS = ['local', 'dev', 'test', 'stage', 'prod']
 
 ENV_DESCRIPTIONS = {
     'local': 'Desarrollo local con hot reload',
     'dev': 'Desarrollo remoto (codigo en imagen)',
     'test': 'Ambiente de testing aislado',
+    'stage': 'Pre-produccion (build + preview, replica prod)',
     'prod': 'Producción con Gunicorn',
 }
 
@@ -24,6 +25,7 @@ COMPOSE_FILES = {
     'local': 'docker-compose/local.yml',
     'dev': 'docker-compose/dev.yml',
     'test': 'docker-compose/test.yml',
+    'stage': 'docker-compose/stage.yml',
     'prod': 'docker-compose/prod.yml',
 }
 

--- a/devtools/docker/help.py
+++ b/devtools/docker/help.py
@@ -140,7 +140,7 @@ def cmd_help(flags: dict[str, Any]) -> int:
     print(f'  {_c(YELLOW, "Flags globales:")}')
     print(
         f'    {_c(GREEN, "--env=<env>"):<30s} '
-        'Ambiente (local|dev|test|prod, default: local)'
+        'Ambiente (local|dev|test|stage|prod, default: local)'
     )
     print(
         f'    {_c(GREEN, "--output=json"):<30s} '

--- a/devtools/serverless/flags.py
+++ b/devtools/serverless/flags.py
@@ -17,11 +17,12 @@ from utils.flags_to_dict import validate_allowed_flags
 # Stages soportados por el backend SAM. Se mapean a samconfig.toml
 # environments. ``local`` no es un stage AWS real — apunta a sam local
 # invoke + sam local start-api + moto mocks.
-VALID_STAGES = ['local', 'dev', 'prod']
+VALID_STAGES = ['local', 'dev', 'stage', 'prod']
 
 STAGE_DESCRIPTIONS = {
     'local': 'sam local invoke / start-api con moto mocks (sin AWS)',
     'dev': 'Stack desplegado en us-east-1 (cuenta dev / sandbox)',
+    'stage': 'Stack de pre-produccion en us-east-1 (replica prod)',
     'prod': 'Stack desplegado en us-east-1 (cuenta productiva)',
 }
 

--- a/docker/docker-compose/stage.yml
+++ b/docker/docker-compose/stage.yml
@@ -1,0 +1,126 @@
+# Portfolio - stage compose (build + preview, puerto 9974).
+#
+# Stage es un ambiente de pre-produccion: replica el comportamiento de prod
+# (astro build + preview, sin HMR) para detectar errores antes del cutover
+# a produccion.
+
+x-app-environment: &app-environment
+  BASE_DOMAIN: ${BASE_DOMAIN:-localhost}
+  BASE_SCHEME: ${BASE_SCHEME:-http}
+  BASE_PORT: ${BASE_PORT:-9974}
+  # Backend serverless (vienen de docker/env/.stage). Astro los lee
+  # como import.meta.env.PUBLIC_* y los inlinea en el bundle del browser.
+  PUBLIC_API_ENDPOINT: ${PUBLIC_API_ENDPOINT:-}
+  PUBLIC_TURNSTILE_SITEKEY: ${PUBLIC_TURNSTILE_SITEKEY:-}
+
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: portfolio-nginx-stage
+    ports:
+      - "${PROXY_PORT:-9974}:80"
+    volumes:
+      - ../nginx/stage.conf:/etc/nginx/conf.d/default.conf:ro
+      - ../nginx/error-pages:/usr/share/nginx/error-pages:ro
+      - ../nginx/services-page:/usr/share/nginx/services-page:ro
+    depends_on:
+      generic:
+        condition: service_started
+      hub:
+        condition: service_started
+      fintech:
+        condition: service_started
+      architect:
+        condition: service_started
+      leader:
+        condition: service_started
+      vibe:
+        condition: service_started
+    restart: unless-stopped
+
+  generic:
+    build:
+      context: ../..
+      dockerfile: docker/dockerfiles/stage/generic/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    container_name: portfolio-generic-stage
+    environment: *app-environment
+    volumes:
+      - ../..:/app
+      - portfolio_node_modules:/app/node_modules
+    restart: unless-stopped
+
+  hub:
+    build:
+      context: ../..
+      dockerfile: docker/dockerfiles/stage/hub/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    container_name: portfolio-hub-stage
+    environment: *app-environment
+    volumes:
+      - ../..:/app
+      - portfolio_node_modules:/app/node_modules
+    restart: unless-stopped
+
+  fintech:
+    build:
+      context: ../..
+      dockerfile: docker/dockerfiles/stage/fintech/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    container_name: portfolio-fintech-stage
+    environment: *app-environment
+    volumes:
+      - ../..:/app
+      - portfolio_node_modules:/app/node_modules
+    restart: unless-stopped
+
+  architect:
+    build:
+      context: ../..
+      dockerfile: docker/dockerfiles/stage/architect/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    container_name: portfolio-architect-stage
+    environment: *app-environment
+    volumes:
+      - ../..:/app
+      - portfolio_node_modules:/app/node_modules
+    restart: unless-stopped
+
+  leader:
+    build:
+      context: ../..
+      dockerfile: docker/dockerfiles/stage/leader/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    container_name: portfolio-leader-stage
+    environment: *app-environment
+    volumes:
+      - ../..:/app
+      - portfolio_node_modules:/app/node_modules
+    restart: unless-stopped
+
+  vibe:
+    build:
+      context: ../..
+      dockerfile: docker/dockerfiles/stage/vibe/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    container_name: portfolio-vibe-stage
+    environment: *app-environment
+    volumes:
+      - ../..:/app
+      - portfolio_node_modules:/app/node_modules
+    restart: unless-stopped
+
+volumes:
+  portfolio_node_modules:

--- a/docker/dockerfiles/stage/architect/Dockerfile
+++ b/docker/dockerfiles/stage/architect/Dockerfile
@@ -1,0 +1,33 @@
+# Portfolio: stage container for apps/architect
+# Node 24 (Alpine) + pnpm 11.0.9. Build + preview (no HMR).
+
+FROM node:24-alpine
+
+RUN apk add --no-cache su-exec
+RUN corepack enable
+
+ARG UID=1000
+ARG GID=1000
+
+RUN deluser --remove-home node 2>/dev/null || true \
+    && addgroup -g ${GID} app \
+    && adduser -u ${UID} -G app -s /bin/sh -D app
+
+WORKDIR /app
+
+RUN mkdir -p /home/app/.cache /home/app/.local/share/pnpm \
+    && chown -R app:app /home/app
+
+USER app
+RUN corepack prepare pnpm@11.0.9 --activate
+USER root
+
+COPY docker/scripts/app-preview-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV CI=true
+ENV APP_NAME=architect
+
+EXPOSE 4321
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/dockerfiles/stage/fintech/Dockerfile
+++ b/docker/dockerfiles/stage/fintech/Dockerfile
@@ -1,0 +1,33 @@
+# Portfolio: stage container for apps/fintech
+# Node 24 (Alpine) + pnpm 11.0.9. Build + preview (no HMR).
+
+FROM node:24-alpine
+
+RUN apk add --no-cache su-exec
+RUN corepack enable
+
+ARG UID=1000
+ARG GID=1000
+
+RUN deluser --remove-home node 2>/dev/null || true \
+    && addgroup -g ${GID} app \
+    && adduser -u ${UID} -G app -s /bin/sh -D app
+
+WORKDIR /app
+
+RUN mkdir -p /home/app/.cache /home/app/.local/share/pnpm \
+    && chown -R app:app /home/app
+
+USER app
+RUN corepack prepare pnpm@11.0.9 --activate
+USER root
+
+COPY docker/scripts/app-preview-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV CI=true
+ENV APP_NAME=fintech
+
+EXPOSE 4321
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/dockerfiles/stage/generic/Dockerfile
+++ b/docker/dockerfiles/stage/generic/Dockerfile
@@ -1,0 +1,33 @@
+# Portfolio: stage container for apps/generic
+# Node 24 (Alpine) + pnpm 11.0.9. Build + preview (no HMR).
+
+FROM node:24-alpine
+
+RUN apk add --no-cache su-exec
+RUN corepack enable
+
+ARG UID=1000
+ARG GID=1000
+
+RUN deluser --remove-home node 2>/dev/null || true \
+    && addgroup -g ${GID} app \
+    && adduser -u ${UID} -G app -s /bin/sh -D app
+
+WORKDIR /app
+
+RUN mkdir -p /home/app/.cache /home/app/.local/share/pnpm \
+    && chown -R app:app /home/app
+
+USER app
+RUN corepack prepare pnpm@11.0.9 --activate
+USER root
+
+COPY docker/scripts/app-preview-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV CI=true
+ENV APP_NAME=generic
+
+EXPOSE 4321
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/dockerfiles/stage/hub/Dockerfile
+++ b/docker/dockerfiles/stage/hub/Dockerfile
@@ -1,0 +1,33 @@
+# Portfolio: stage container for apps/hub
+# Node 24 (Alpine) + pnpm 11.0.9. Build + preview (no HMR).
+
+FROM node:24-alpine
+
+RUN apk add --no-cache su-exec
+RUN corepack enable
+
+ARG UID=1000
+ARG GID=1000
+
+RUN deluser --remove-home node 2>/dev/null || true \
+    && addgroup -g ${GID} app \
+    && adduser -u ${UID} -G app -s /bin/sh -D app
+
+WORKDIR /app
+
+RUN mkdir -p /home/app/.cache /home/app/.local/share/pnpm \
+    && chown -R app:app /home/app
+
+USER app
+RUN corepack prepare pnpm@11.0.9 --activate
+USER root
+
+COPY docker/scripts/app-preview-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV CI=true
+ENV APP_NAME=hub
+
+EXPOSE 4321
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/dockerfiles/stage/leader/Dockerfile
+++ b/docker/dockerfiles/stage/leader/Dockerfile
@@ -1,0 +1,33 @@
+# Portfolio: stage container for apps/leader
+# Node 24 (Alpine) + pnpm 11.0.9. Build + preview (no HMR).
+
+FROM node:24-alpine
+
+RUN apk add --no-cache su-exec
+RUN corepack enable
+
+ARG UID=1000
+ARG GID=1000
+
+RUN deluser --remove-home node 2>/dev/null || true \
+    && addgroup -g ${GID} app \
+    && adduser -u ${UID} -G app -s /bin/sh -D app
+
+WORKDIR /app
+
+RUN mkdir -p /home/app/.cache /home/app/.local/share/pnpm \
+    && chown -R app:app /home/app
+
+USER app
+RUN corepack prepare pnpm@11.0.9 --activate
+USER root
+
+COPY docker/scripts/app-preview-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV CI=true
+ENV APP_NAME=leader
+
+EXPOSE 4321
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/dockerfiles/stage/vibe/Dockerfile
+++ b/docker/dockerfiles/stage/vibe/Dockerfile
@@ -1,0 +1,33 @@
+# Portfolio: stage container for apps/vibe
+# Node 24 (Alpine) + pnpm 11.0.9. Build + preview (no HMR).
+
+FROM node:24-alpine
+
+RUN apk add --no-cache su-exec
+RUN corepack enable
+
+ARG UID=1000
+ARG GID=1000
+
+RUN deluser --remove-home node 2>/dev/null || true \
+    && addgroup -g ${GID} app \
+    && adduser -u ${UID} -G app -s /bin/sh -D app
+
+WORKDIR /app
+
+RUN mkdir -p /home/app/.cache /home/app/.local/share/pnpm \
+    && chown -R app:app /home/app
+
+USER app
+RUN corepack prepare pnpm@11.0.9 --activate
+USER root
+
+COPY docker/scripts/app-preview-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENV CI=true
+ENV APP_NAME=vibe
+
+EXPOSE 4321
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/env/.example
+++ b/docker/env/.example
@@ -233,8 +233,15 @@ CI=
 
 # Base URL del API Gateway (sin trailing slash).
 # La pagina /contact arma el endpoint final como `${PUBLIC_API_ENDPOINT}/contact`.
-# dev: https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev
-# prod: https://332ivhahf2.execute-api.us-east-1.amazonaws.com/prod
+#
+# Custom domains (estandar de subdominios, post-migracion):
+#   dev:   https://api.portfolio.dev.the-full-stack.com
+#   stage: https://api.portfolio.stage.the-full-stack.com
+#   prod:  https://api.portfolio.the-full-stack.com
+#
+# URLs raw de API Gateway (deprecadas, soft-rollback 30 dias):
+#   dev:  https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev
+#   prod: https://332ivhahf2.execute-api.us-east-1.amazonaws.com/prod
 PUBLIC_API_ENDPOINT=
 
 # Cloudflare Turnstile sitekey publica del widget Portfolio Backend.

--- a/docker/nginx/stage.conf
+++ b/docker/nginx/stage.conf
@@ -1,0 +1,234 @@
+# Portfolio - nginx config (stage).
+#
+# Mapping:
+#   localhost            -> apps/generic    (Astro dev server)
+#   hub.localhost        -> apps/hub
+#   fintech.localhost    -> apps/fintech
+#   architect.localhost  -> apps/architect
+#   leader.localhost     -> apps/leader
+#   vibe.localhost       -> apps/vibe
+#   services.localhost   -> servicio estático de indice
+#
+# Todas las apps Astro exponen :4321 internamente. nginx pública solo en
+# el puerto :9974 (ver docker/env/.stage PROXY_PORT).
+
+upstream generic_app    { server generic:4321; }
+upstream hub_app        { server hub:4321; }
+upstream fintech_app    { server fintech:4321; }
+upstream architect_app  { server architect:4321; }
+upstream leader_app     { server leader:4321; }
+upstream vibe_app       { server vibe:4321; }
+
+# Defaults aplicados a todos los server blocks via include.
+# error_pages reutiliza los HTML estáticos del volume.
+
+# === localhost -> apps/generic (the-full-stack.com en prod) ===
+server {
+    listen 80;
+    server_name localhost;
+    client_max_body_size 20M;
+
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    add_header Pragma "no-cache" always;
+    expires off;
+
+    error_page 502 503 504 /loading.html;
+    error_page 400 401 403 404 405 /4xx.html;
+    error_page 500 501 /5xx.html;
+
+    location = /loading.html { root /usr/share/nginx/error-pages; internal; }
+    location = /4xx.html { root /usr/share/nginx/error-pages; internal; }
+    location = /5xx.html { root /usr/share/nginx/error-pages; internal; }
+
+    location / {
+        proxy_pass http://generic_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+}
+
+# === hub.localhost -> apps/hub (hub.the-full-stack.com en prod) ===
+server {
+    listen 80;
+    server_name hub.localhost;
+    client_max_body_size 20M;
+
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    add_header Pragma "no-cache" always;
+    expires off;
+
+    error_page 502 503 504 /loading.html;
+    error_page 400 401 403 404 405 /4xx.html;
+    error_page 500 501 /5xx.html;
+
+    location = /loading.html { root /usr/share/nginx/error-pages; internal; }
+    location = /4xx.html { root /usr/share/nginx/error-pages; internal; }
+    location = /5xx.html { root /usr/share/nginx/error-pages; internal; }
+
+    location / {
+        proxy_pass http://hub_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+}
+
+# === fintech.localhost -> apps/fintech ===
+server {
+    listen 80;
+    server_name fintech.localhost;
+    client_max_body_size 20M;
+
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    add_header Pragma "no-cache" always;
+    expires off;
+
+    error_page 502 503 504 /loading.html;
+    error_page 400 401 403 404 405 /4xx.html;
+    error_page 500 501 /5xx.html;
+
+    location = /loading.html { root /usr/share/nginx/error-pages; internal; }
+    location = /4xx.html { root /usr/share/nginx/error-pages; internal; }
+    location = /5xx.html { root /usr/share/nginx/error-pages; internal; }
+
+    location / {
+        proxy_pass http://fintech_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+}
+
+# === architect.localhost -> apps/architect ===
+server {
+    listen 80;
+    server_name architect.localhost;
+    client_max_body_size 20M;
+
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    add_header Pragma "no-cache" always;
+    expires off;
+
+    error_page 502 503 504 /loading.html;
+    error_page 400 401 403 404 405 /4xx.html;
+    error_page 500 501 /5xx.html;
+
+    location = /loading.html { root /usr/share/nginx/error-pages; internal; }
+    location = /4xx.html { root /usr/share/nginx/error-pages; internal; }
+    location = /5xx.html { root /usr/share/nginx/error-pages; internal; }
+
+    location / {
+        proxy_pass http://architect_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+}
+
+# === leader.localhost -> apps/leader ===
+server {
+    listen 80;
+    server_name leader.localhost;
+    client_max_body_size 20M;
+
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    add_header Pragma "no-cache" always;
+    expires off;
+
+    error_page 502 503 504 /loading.html;
+    error_page 400 401 403 404 405 /4xx.html;
+    error_page 500 501 /5xx.html;
+
+    location = /loading.html { root /usr/share/nginx/error-pages; internal; }
+    location = /4xx.html { root /usr/share/nginx/error-pages; internal; }
+    location = /5xx.html { root /usr/share/nginx/error-pages; internal; }
+
+    location / {
+        proxy_pass http://leader_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+}
+
+# === vibe.localhost -> apps/vibe ===
+server {
+    listen 80;
+    server_name vibe.localhost;
+    client_max_body_size 20M;
+
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    add_header Pragma "no-cache" always;
+    expires off;
+
+    error_page 502 503 504 /loading.html;
+    error_page 400 401 403 404 405 /4xx.html;
+    error_page 500 501 /5xx.html;
+
+    location = /loading.html { root /usr/share/nginx/error-pages; internal; }
+    location = /4xx.html { root /usr/share/nginx/error-pages; internal; }
+    location = /5xx.html { root /usr/share/nginx/error-pages; internal; }
+
+    location / {
+        proxy_pass http://vibe_app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+    }
+}
+
+# === services.localhost -> indice estático ===
+# Hub HTML montado en /usr/share/nginx/services-page con la lista de
+# subdominios del stack local. JS hace health check con fetch.
+server {
+    listen 80;
+    server_name services.localhost;
+
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate" always;
+    add_header Pragma "no-cache" always;
+    expires off;
+
+    error_page 502 503 504 /loading.html;
+    error_page 400 401 403 404 405 /4xx.html;
+    error_page 500 501 /5xx.html;
+
+    location = /loading.html { root /usr/share/nginx/error-pages; internal; }
+    location = /4xx.html { root /usr/share/nginx/error-pages; internal; }
+    location = /5xx.html { root /usr/share/nginx/error-pages; internal; }
+
+    location / {
+        root /usr/share/nginx/services-page;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "docker:ps": "docker compose --project-name portfolio -f docker/docker-compose/local.yml ps",
     "docker:test:up": "docker compose --project-name portfolio -f docker/docker-compose/test.yml --env-file docker/env/.test up -d --build",
     "docker:test:down": "docker compose --project-name portfolio -f docker/docker-compose/test.yml down",
+    "docker:stage:up": "docker compose --project-name portfolio -f docker/docker-compose/stage.yml --env-file docker/env/.stage up -d --build",
+    "docker:stage:down": "docker compose --project-name portfolio -f docker/docker-compose/stage.yml down",
     "feature:up": "docker compose --project-name portfolio -f docker/docker-compose/local.yml --env-file docker/env/.local --profile feature up -d feature",
     "feature:run": "docker exec portfolio-feature-local pnpm test",
     "feature:report": "docker exec portfolio-feature-local pnpm exec playwright show-report --host 0.0.0.0"

--- a/packages/app-shared/src/lib/define-site-config.ts
+++ b/packages/app-shared/src/lib/define-site-config.ts
@@ -31,7 +31,7 @@ import {
   type I18nStrings,
   type SiteOverrides,
 } from './site-config'
-import { SITE_URLS } from './site-urls'
+import { buildSiteUrl, SITE_URLS } from './site-urls'
 
 export interface DefineSiteConfigInput {
   /** Nicho del sitio. Ver `NICHES` en `@portfolio/content`. */
@@ -58,12 +58,16 @@ export interface DefineSiteConfigOutput {
 
 const DEFAULT_OG_PATH = '/og-image.svg'
 
+/**
+ * Deriva el SITE_URL default del niche cuando el caller no pasa `siteUrl`.
+ *
+ * Usa `buildSiteUrl` (env-driven via BASE_DOMAIN/SCHEME/PORT), de modo que
+ * el default respeta el ambiente activo (prod / stage / dev / local) sin
+ * hardcodear `the-full-stack.com`. En prod el niche `generic` mapea al apex
+ * del dominio; en dev/stage al apex del env (`portfolio.{env}.the-full-stack.com`).
+ */
 function defaultSiteUrlFor(niche: Niche): string {
-  if (niche === 'generic') {
-    // generic vive en hub.the-full-stack.com por convencion del proyecto
-    return 'https://hub.the-full-stack.com'
-  }
-  return `https://${niche}.the-full-stack.com`
+  return buildSiteUrl(niche)
 }
 
 export function defineSiteConfig(

--- a/packages/app-shared/tests/unit/lib/define-site-config.test.ts
+++ b/packages/app-shared/tests/unit/lib/define-site-config.test.ts
@@ -24,9 +24,9 @@ describe('defineSiteConfig', () => {
     expect(r.SITE_URL).toBe('https://architect.the-full-stack.com')
   })
 
-  it('Given niche generic Then SITE_URL is hub subdomain (project convention)', () => {
+  it('Given niche generic Then SITE_URL is the apex domain (env-driven default)', () => {
     const r = defineSiteConfig({ niche: 'generic', overrides: baseOverrides })
-    expect(r.SITE_URL).toBe('https://hub.the-full-stack.com')
+    expect(r.SITE_URL).toBe('https://the-full-stack.com')
   })
 
   it('Given explicit siteUrl When invoked Then SITE_URL is the provided value', () => {

--- a/serverless/DEPLOYMENT.md
+++ b/serverless/DEPLOYMENT.md
@@ -222,7 +222,22 @@ psql "<NEON_URL_DEV>" -c "\dt portfolio.*"
 # Espera "All smoke tests PASSED" + exit code 0
 ```
 
-### 6. Deploy a prod
+### 6. Deploy a stage
+
+Stage es un ambiente de pre-produccion (replica prod). Comparte la config
+SSM con dev/prod (`/portfolio/neon-url`, `/portfolio/turnstile-secret`).
+
+```bash
+sam deploy --config-env stage --profile tfs-dev
+./serverless/scripts/smoke_test.sh stage
+```
+
+Crea el stack `portfolio-backend-stage` (REST API `portfolio-api-stage`,
+6 Lambdas, 5 tablas DynamoDB con sufijo `-stage`). El parametro `Stage`
+de `template.yaml` acepta `dev | stage | prod` y `Mappings.StageConfig`
+define la whitelist CORS por ambiente.
+
+### 7. Deploy a prod
 
 Repetir paso 3 con `--config-env prod`. Antes:
 

--- a/serverless/INTEGRATION.md
+++ b/serverless/INTEGRATION.md
@@ -295,7 +295,7 @@ A escala 10x (~300k req/mo):
 5. **DynamoDB On-Demand**: free tier perpetuo lo cubre; Provisioned daria $12/mes minimo
 6. **Reserved concurrency baja**: contiene gastos en caso de ataque sostenido (5 contact_form / 20 tracking)
 7. **Sin VPC, sin NAT Gateway**: NAT Gateway cuesta $32/mes + GB transferido. Evitado.
-8. **Sin ACM cert para API custom domain en MVP**: usar API Gateway default URL (postpone custom domain a fase 7)
+8. **Custom domain del API via ACM + Cloudflare**: `api.portfolio.{env}.the-full-stack.com` (dev/stage) y `api.portfolio.the-full-stack.com` (prod). Un cert ACM regional con 3 SANs (us-east-1, $0) + custom domain names en API Gateway + CNAMEs DNS-only en Cloudflare. Las URLs raw `*.execute-api.amazonaws.com` quedan operativas como soft-rollback
 
 ### Trade-offs vs WAF
 

--- a/serverless/samconfig.toml
+++ b/serverless/samconfig.toml
@@ -42,6 +42,31 @@ region = "us-east-1"
 parameter_overrides = "Stage=dev LogLevel=DEBUG"
 watch = true
 
+# ---- Stage: stage ---------------------------------------------------------
+[stage.global.parameters]
+stack_name = "portfolio-backend-stage"
+
+[stage.build.parameters]
+cached = true
+parallel = true
+
+[stage.deploy.parameters]
+stack_name = "portfolio-backend-stage"
+capabilities = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
+confirm_changeset = false
+resolve_s3 = true
+region = "us-east-1"
+fail_on_empty_changeset = false
+parameter_overrides = "Stage=stage LogLevel=INFO"
+tags = "Project=portfolio Stage=stage ManagedBy=SAM"
+
+[stage.sync.parameters]
+stack_name = "portfolio-backend-stage"
+resolve_s3 = true
+region = "us-east-1"
+parameter_overrides = "Stage=stage LogLevel=DEBUG"
+watch = true
+
 # ---- Stage: prod ----------------------------------------------------------
 [prod.global.parameters]
 stack_name = "portfolio-backend-prod"

--- a/serverless/src/common/config.py
+++ b/serverless/src/common/config.py
@@ -30,7 +30,9 @@ class Settings(BaseSettings):
     )
 
     # ---- Stage / runtime markers ------------------------------------------
-    stage: str = Field(default='dev', description='Ambiente: dev | prod')
+    stage: str = Field(
+        default='dev', description='Ambiente: dev | stage | prod'
+    )
     aws_region: str = Field(default='us-east-1', alias='AWS_REGION')
     log_level: str = Field(default='INFO')
 
@@ -62,6 +64,10 @@ class Settings(BaseSettings):
     @property
     def is_prod(self) -> bool:
         return self.stage == 'prod'
+
+    @property
+    def is_stage(self) -> bool:
+        return self.stage == 'stage'
 
     @property
     def is_dev(self) -> bool:

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -21,8 +21,11 @@ Parameters:
     Default: dev
     AllowedValues:
       - dev
+      - stage
       - prod
-    Description: Ambiente del stack (dev | prod). Define naming + log level.
+    Description: >
+      Ambiente del stack (dev | stage | prod). Define naming, log level
+      y la whitelist CORS (ver Mappings StageConfig).
   LogLevel:
     Type: String
     Default: INFO
@@ -32,13 +35,26 @@ Parameters:
       - WARNING
       - ERROR
     Description: Powertools log level (default INFO; prod recomendado WARNING).
-  CorsAllowedOrigins:
-    Type: CommaDelimitedList
-    Default: 'https://the-full-stack.com,https://hub.the-full-stack.com,https://fintech.the-full-stack.com,https://architect.the-full-stack.com,https://leader.the-full-stack.com,https://vibe.the-full-stack.com'
-    Description: >
-      Whitelist de origins para CORS. La Lambda valida el Origin header y
-      hace echo del valor matcheado en Access-Control-Allow-Origin (no usar
-      '*' por compatibilidad con credentials: include en futuro).
+# ============================================================================
+# Mappings: configuracion por stage
+# ============================================================================
+# CorsAllowedOrigins se inyecta a las Lambdas como env var CORS_ALLOWED_ORIGINS
+# (CSV). cors.py la lee para validar el Origin header y hacer echo del valor
+# matcheado en Access-Control-Allow-Origin.
+#
+# - prod:  niches flat sobre el apex (excepcion del estandar de subdominios).
+# - stage: patron component-based {niche}.portfolio.stage.the-full-stack.com.
+# - dev:   patron component-based {niche}.portfolio.dev.the-full-stack.com.
+#          cors.py ademas acepta *.localhost por pattern cuando STAGE=dev.
+# ============================================================================
+Mappings:
+  StageConfig:
+    dev:
+      CorsAllowedOrigins: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com'
+    stage:
+      CorsAllowedOrigins: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com'
+    prod:
+      CorsAllowedOrigins: 'https://the-full-stack.com,https://hub.the-full-stack.com,https://fintech.the-full-stack.com,https://architect.the-full-stack.com,https://leader.the-full-stack.com,https://vibe.the-full-stack.com'
 
 # ============================================================================
 # Globals: configuracion compartida por TODAS las Lambdas del stack
@@ -78,6 +94,8 @@ Globals:
         KMS_KEY_ALIAS: alias/portfolio-lambdas
         # Stage marker para conditional behavior (ej: skip Turnstile en test)
         STAGE: !Ref Stage
+        # Whitelist CORS por stage (cors.py la lee como CSV)
+        CORS_ALLOWED_ORIGINS: !FindInMap [StageConfig, !Ref Stage, CorsAllowedOrigins]
     Tags:
       Project: portfolio
       ManagedBy: SAM
@@ -97,7 +115,12 @@ Globals:
 # no permite enviar form sin captcha resuelto.
 # ============================================================================
 Conditions:
-  IsDev: !Equals [!Ref Stage, 'dev']
+  # IsNotProd: dev y stage. Usado para el AllowOrigin del preflight CORS:
+  # ambos permiten '*' en OPTIONS porque la Lambda valida el Origin real
+  # (CORS_ALLOWED_ORIGINS) + el token Turnstile. Prod mantiene whitelist.
+  # El bypass de Turnstile NO usa una Condition CloudFormation: se gatea
+  # en codigo (turnstile.py _BYPASS_ALLOWED_STAGES = {dev, local}).
+  IsNotProd: !Not [!Equals [!Ref Stage, 'prod']]
 
 Resources:
   # ==========================================================================
@@ -178,11 +201,13 @@ Resources:
           "integrationLatency":"$context.integrationLatency",
           "latency":"$context.responseLatency"}
       Cors:
-        # En dev permitimos '*' para testear desde localhost:9970-9973 (Docker
-        # stack). En prod mantenemos whitelist estricta (apex). La Lambda igual
-        # valida Turnstile token: '*' en preflight no permite spammear sin captcha.
+        # En dev/stage permitimos '*' para el preflight OPTIONS (testear desde
+        # localhost y desde *.portfolio.{env}.the-full-stack.com). En prod
+        # mantenemos whitelist estricta (apex). La Lambda igual valida el Origin
+        # real (CORS_ALLOWED_ORIGINS) + el token Turnstile, asi que '*' en
+        # preflight no permite spammear el form sin captcha resuelto.
         AllowOrigin: !If
-          - IsDev
+          - IsNotProd
           - "'*'"
           - "'https://the-full-stack.com'"
         AllowHeaders: "'Content-Type,X-Turnstile-Token,X-Turnstile-Bypass-Secret'"

--- a/serverless/tests/unit/common/test_config.py
+++ b/serverless/tests/unit/common/test_config.py
@@ -86,6 +86,22 @@ class TestSettings:
         assert s.is_dev is True
         assert s.is_prod is False
 
+    def test_is_stage_helper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given STAGE=stage,
+        When settings.is_stage,
+        Then True y is_dev/is_prod son False.
+        """
+        monkeypatch.setenv('STAGE', 'stage')
+        get_settings.cache_clear()
+        s = Settings()
+
+        assert s.is_stage is True
+        assert s.is_dev is False
+        assert s.is_prod is False
+
 
 class TestGetSettingsCache:
     """get_settings - singleton LRU cache."""


### PR DESCRIPTION
## Problema

El dominio `the-full-stack.com` solo tenia el entorno de produccion. No habia entornos `dev` ni `stage` formales con hostname propio, y el backend serverless usaba las URLs raw de API Gateway (`*.execute-api.us-east-1.amazonaws.com`).

1. Frontend sin entornos dev/stage desplegados.
2. Backend sin custom domain (URLs raw poco mantenibles).
3. El backend SAM solo tenia stacks `dev` y `prod` — sin `stage`.

## Solucion

Aplica el estandar de subdominios con patron component-based para dev/stage (la excepcion flat de prod NO se propaga):

| Env | apex (generic) | niches | API |
| --- | --- | --- | --- |
| prod | `the-full-stack.com` | `<niche>.the-full-stack.com` | `api.portfolio.the-full-stack.com` |
| stage | `portfolio.stage.the-full-stack.com` | `<niche>.portfolio.stage.the-full-stack.com` | `api.portfolio.stage.the-full-stack.com` |
| dev | `portfolio.dev.the-full-stack.com` | `<niche>.portfolio.dev.the-full-stack.com` | `api.portfolio.dev.the-full-stack.com` |

1. **Frontend dev/stage**: 12 Cloudflare Pages projects nuevos (`<app>-dev`, `<app>-stage`) con git trigger por branch. `define-site-config.ts` deriva el `SITE_URL` via `buildSiteUrl` (env-driven). Stack Docker `stage` completo (compose + 6 dockerfiles + nginx, puerto 9974) + registro en devtools.
2. **Backend API custom domains**: cert ACM regional con 3 SANs + 3 custom domain names en API Gateway + base path mappings + CNAMEs DNS-only en Cloudflare.
3. **Stack SAM stage**: `template.yaml` acepta `Stage = dev | stage | prod`, `Mappings.StageConfig` define la whitelist CORS por env, se inyecta `CORS_ALLOWED_ORIGINS` a las Lambdas. Stack `portfolio-backend-stage` desplegado (REST API `portfolio-api-stage`, 6 Lambdas, 5 tablas DynamoDB).

## Infra ya provisionada (fuera del repo)

- Stack SAM `portfolio-backend-stage` desplegado y verificado (POST /track -> HTTP 204).
- Cert ACM `50c750aa-...` ISSUED (3 SANs).
- 3 API Gateway custom domains + base path mappings — los 3 responden HTTP 200.
- 12 Pages projects + 12 custom domains (`active`) + 15 DNS records en Cloudflare.

## Como probar

1. Mergear este PR a `dev` -> Cloudflare Pages buildea los 6 `<app>-dev` via git-native.
2. Crear branch `stage` desde `dev` -> buildea los 6 `<app>-stage`.
3. Verificar HTTPS: `curl -I https://portfolio.dev.the-full-stack.com`, `https://fintech.portfolio.stage.the-full-stack.com`, etc.
4. Verificar API: `curl https://api.portfolio.dev.the-full-stack.com/track` (custom domain).
5. Stack Docker stage local: `pnpm run docker:stage:up` (puerto 9974).

## TODO

- Correr la suite Playwright E2E (no se pudo localmente: Docker no activo en el entorno de desarrollo; el job `e2e-tests` del CI lo cubre).
- Cutover del frontend al API custom domain: activar `PUBLIC_API_ENDPOINT=https://api.portfolio.{dev,stage}.the-full-stack.com` en los env files (hoy comentado, usa la URL raw).
- Migrar el API de prod al custom domain (URLs raw siguen operativas como soft-rollback 30 dias).