### PR TITLE
chore(hooks): protege la rama stage

### DIFF
--- a/.claude/hooks/protect-branch.sh
+++ b/.claude/hooks/protect-branch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # PreToolUse hook (matcher: Bash).
 # Bloquea git commit y git push directos cuando HEAD esta en una rama
-# protegida (master/main/dev/release).
+# protegida (master/main/dev/stage/release).
 #
 # Politica: trabajo siempre en feature/fix/chore branches, merge via PR.
 
@@ -27,7 +27,7 @@ BRANCH="$(current_branch)"
 
 # Lista de ramas protegidas.
 case "$BRANCH" in
-  master|main|dev|release) ;;
+  master|main|dev|stage|release) ;;
   *) exit 0 ;;
 esac
 
@@ -39,13 +39,13 @@ case "$CMD" in
   *"git merge"*) OP="merge" ;;
 esac
 
-# Excepcion: git push origin master/main/dev/release ya esta en deny list de Bash.
+# Excepcion: git push origin master/main/dev/stage/release ya esta en deny list de Bash.
 # Pero git push (sin args) en rama protegida tambien debe bloquearse.
 
 echo "Bloqueado por protect-branch: estas en rama protegida '$BRANCH'." >&2
 echo "Operacion rechazada: $OP" >&2
 echo "Politica del proyecto (.claude/rules/git-workflow.md):" >&2
-echo "  - NUNCA $OP directo en master/main/dev/release." >&2
+echo "  - NUNCA $OP directo en master/main/dev/stage/release." >&2
 echo "  - Crea feature/fix/chore branch primero:" >&2
 echo "      git checkout -b feature/<nombre>" >&2
 echo "  - Despues abre PR con /pr-create o gh pr create." >&2


### PR DESCRIPTION
## Problema

La rama `stage` es ahora una rama de deploy: Cloudflare Pages la escucha para los proyectos `<app>-stage`. Pero el hook `protect-branch.sh` solo protegia `master/main/dev/release`, dejando `stage` sin proteccion contra commit/push directo.

## Solucion

Agrega `stage` a la lista de ramas protegidas del hook `.claude/hooks/protect-branch.sh` (case de la rama actual + mensajes).

## Como probar

Estando en la rama `stage`, intentar `git push` o `git commit`: el hook debe bloquear con exit 2.

```
echo '{"tool_input":{"command":"git push"}}' | bash .claude/hooks/protect-branch.sh
# -> Bloqueado por protect-branch: estas en rama protegida 'stage'
```

## TODO

Vacio.