### PR TITLE
feat(infra): migra los niches de prod al patron component-based

### DIFF
--- a/.claude/docs/cloudflare/05-dns-and-custom-domains.md
+++ b/.claude/docs/cloudflare/05-dns-and-custom-domains.md
@@ -16,7 +16,7 @@ providers (Route 53 lo emula con "Alias records").
 ```
 the-full-stack.com         CNAME → generic-3ab.pages.dev   (proxied)
 www.the-full-stack.com     CNAME → generic-3ab.pages.dev   (proxied)
-hub.the-full-stack.com     CNAME → hub-9sd.pages.dev       (proxied)
+hub.portfolio.the-full-stack.com     CNAME → hub-9sd.pages.dev       (proxied)
 ...
 ```
 
@@ -94,7 +94,7 @@ curl -s "https://api.cloudflare.com/client/v4/zones?name=the-full-stack.com" \
 ```json
 {
   "type": "CNAME",
-  "name": "hub.the-full-stack.com",
+  "name": "hub.portfolio.the-full-stack.com",
   "content": "hub-9sd.pages.dev",
   "proxied": true,
   "ttl": 1
@@ -172,8 +172,8 @@ tardar mas. Workaround: usar `--resolve` en curl o forzar query a
 nameservers de CF:
 
 ```bash
-curl --resolve hub.the-full-stack.com:443:104.21.59.192 https://hub.the-full-stack.com
-dig @1.1.1.1 hub.the-full-stack.com
+curl --resolve hub.portfolio.the-full-stack.com:443:104.21.59.192 https://hub.portfolio.the-full-stack.com
+dig @1.1.1.1 hub.portfolio.the-full-stack.com
 ```
 
 ## DNS records preexistentes (Vercel, otros)

--- a/.claude/docs/subdomain-standard/03-environments.md
+++ b/.claude/docs/subdomain-standard/03-environments.md
@@ -80,23 +80,21 @@ Si tu flujo no necesita stage (proyectos chicos), omitir el ambiente.
 Pero NO inventar variantes (`pre-prod`, `release-candidate`, `beta`).
 Las 3 etiquetas (dev/stage/prod) son la lista cerrada.
 
-## Caso portfolio: dev/stage del frontend (excepcion solo en prod)
+## Caso portfolio: los 3 envs del frontend
 
-El portfolio personal (apex + www + 5 niches) es excepcion permanente del
-estandar SOLO en prod: los niches van flat (`fintech.the-full-stack.com`).
-Esa excepcion NO se propaga a dev/stage — ahi SI se aplica el patron
-component-based con `product = portfolio`.
+El portfolio sigue el patron component-based con `product = portfolio`
+en los 3 ambientes. La unica excepcion es el apex en prod
+(`the-full-stack.com`), que ES el niche `generic`.
 
 | Env | apex (generic) | niches (hub/fintech/architect/leader/vibe) |
 |-----|----------------|---------------------------------------------|
-| prod | `the-full-stack.com` | `<niche>.the-full-stack.com` |
+| prod | `the-full-stack.com` (+ `www`) | `<niche>.portfolio.the-full-stack.com` |
 | stage | `portfolio.stage.the-full-stack.com` | `<niche>.portfolio.stage.the-full-stack.com` |
 | dev | `portfolio.dev.the-full-stack.com` | `<niche>.portfolio.dev.the-full-stack.com` |
 
-Razon: en dev/stage los hostnames son tecnicos (no marketing), conviene
-que sigan el estandar para no chocar con productos futuros que quieran
-nombrarse como un niche y para que `*.portfolio.dev.*` salte a la vista
-en logs. El backend del portfolio sigue la misma logica:
+En prod tambien existe `portfolio.the-full-stack.com`, que hace redirect
+301 al apex (consistencia de patron; el apex es la URL canonica de
+generic). El backend sigue la misma logica:
 `api.portfolio.{env}.the-full-stack.com` (ver
 [06-migration-backend-api](./06-migration-backend-api.md)).
 

--- a/.claude/docs/subdomain-standard/04-portfolio-exception.md
+++ b/.claude/docs/subdomain-standard/04-portfolio-exception.md
@@ -2,97 +2,110 @@
 
 > [<- 03-environments](./03-environments.md) | [05-wildcards-and-certs ->](./05-wildcards-and-certs.md)
 
-## Por que es excepcion
+## Que es excepcion (y que no)
 
-El portfolio personal (`the-full-stack.com`) precede al estandar y es
-parte del branding del owner. Migrarlo bajo el patron
-`portfolio.the-full-stack.com` o `cv.the-full-stack.com` rompe SEO,
-links externos y la narrativa del dominio (que ES el portfolio).
+El portfolio personal usa `the-full-stack.com` como dominio raiz. La
+**unica excepcion permanente** del estandar es el apex:
 
-Decision: dejarlo como excepcion permanente. El estandar aplica solo
-a productos y servicios NUEVOS bajo el dominio.
+| Hostname                 | Que es                                       | Excepcion                       |
+|--------------------------|----------------------------------------------|---------------------------------|
+| `the-full-stack.com`     | Apex — portfolio generic (full stack senior) | SI — apex no lleva `{product}`  |
+| `www.the-full-stack.com` | Alias del apex                               | SI — alias del apex             |
 
-## Subdominios reservados por el portfolio
+Todo lo demas del portfolio **sigue el estandar** con `product = portfolio`.
+Los 5 niches no son una excepcion: cuelgan de `portfolio` como components.
 
-Estos 7 hostnames NO siguen el patron y NO pueden reusarse para otros
-productos:
+## Niches bajo el estandar (product = portfolio)
 
-| Hostname | Que es |
-|----------|--------|
-| `the-full-stack.com` | Apex — portfolio generic (full stack senior) |
-| `www.the-full-stack.com` | Alias del apex |
-| `hub.the-full-stack.com` | Selector multi-niche con cards |
-| `fintech.the-full-stack.com` | Niche fintech LATAM |
-| `architect.the-full-stack.com` | Niche frontend architect |
-| `leader.the-full-stack.com` | Niche tech lead / engineering manager |
-| `vibe.the-full-stack.com` | Niche vibe coding / Claude Code |
+Los niches del portfolio son components del product `portfolio`, en los
+3 ambientes:
 
-Adicionalmente, los nichos como words (`hub`, `fintech`, `architect`,
-`leader`, `vibe`, `generic`) estan reservados como product names
-(ver [02-naming-rules.md](./02-naming-rules.md)) para evitar
-colisiones futuras.
+```text
+prod    hub.portfolio.the-full-stack.com
+        fintech.portfolio.the-full-stack.com
+        architect.portfolio.the-full-stack.com
+        leader.portfolio.the-full-stack.com
+        vibe.portfolio.the-full-stack.com
 
-## Como interactua con el estandar
+stage   hub.portfolio.stage.the-full-stack.com
+        fintech.portfolio.stage.the-full-stack.com
+        ...
 
-### Apex / www
+dev     hub.portfolio.dev.the-full-stack.com
+        fintech.portfolio.dev.the-full-stack.com
+        ...
+```
+
+El apex `the-full-stack.com` ES el niche `generic` en prod. En dev/stage
+el apex del ambiente es `portfolio.dev.the-full-stack.com` /
+`portfolio.stage.the-full-stack.com` (no hay apex desnudo en no-prod).
+
+`portfolio.the-full-stack.com` existe (consistencia de patron) y hace
+redirect 301 al apex `the-full-stack.com` — el apex es la URL canonica
+de generic.
+
+## Apex / www
 
 `the-full-stack.com` y `www.the-full-stack.com` apuntan al sitio
-portfolio generic. El apex NO esta disponible para `{product}` propio.
+portfolio generic. El apex NO esta disponible para `{product}` propio:
+es la cara del portfolio.
 
 Si en algun momento se quiere un sitio "raiz" del dominio que no sea el
 portfolio, opciones:
 
 1. Rediseñar el portfolio como hub/landing y mover el niche generic a
-   `generic.the-full-stack.com` (rompe el modelo actual).
+   un subdomain coherente con el estandar.
 2. Mantener el portfolio en el apex y poner el nuevo sitio en un
    subdomain coherente con el estandar.
 
-### Backend del portfolio
+## Backend del portfolio
 
 El backend serverless del portfolio (form de contacto, tracking pixel)
-debe migrarse al estandar como product `portfolio`:
+sigue el estandar como component `api` del product `portfolio`:
 
 ```text
 prod    api.portfolio.the-full-stack.com
+stage   api.portfolio.stage.the-full-stack.com
 dev     api.portfolio.dev.the-full-stack.com
 ```
 
-Ver [06-migration-backend-api.md](./06-migration-backend-api.md) para
-el plan concreto.
+Ver [06-migration-backend-api.md](./06-migration-backend-api.md).
 
-Notar que `portfolio.the-full-stack.com` (sin component) NO se crea —
-el portfolio "es" el dominio, no necesita una landing dedicada bajo
-ese slug.
+## Nombres reservados
 
-## Que pasa si quiero un product que choca con un nicho
+Los niches como words (`hub`, `fintech`, `architect`, `leader`, `vibe`,
+`generic`) y `portfolio` estan reservados como component/product names
+(ver [02-naming-rules.md](./02-naming-rules.md)) para evitar colisiones.
 
-Ejemplo: quiero lanzar un product comercial llamado `fintech`.
+### Que pasa si quiero un product que choca con un nicho
 
-NO podes usar `fintech.the-full-stack.com` (ya es el niche fintech del
-portfolio). Opciones:
+Ejemplo: quiero lanzar un product comercial llamado `fintech`. Ya no
+hay colision con `fintech.the-full-stack.com` (ese hostname es del
+portfolio), porque el niche del portfolio vive en
+`fintech.portfolio.the-full-stack.com`. Un product nuevo `fintech`
+usaria `fintech.the-full-stack.com` (prod) bajo el estandar.
 
-1. Renombrar el product comercialmente.
-2. Comprar otro dominio para ese product.
-3. Renombrar el niche del portfolio (rompe SEO + branding actual).
-
-La opcion 1 es la recomendada. El portfolio gana en branding y los
-products pueden tener nombres distintivos.
+Aun asi, conviene nombres distintivos para products comerciales para no
+confundir con los niches del portfolio.
 
 ## Resumen visual
 
 ```text
-EXCEPCION (portfolio):
-  the-full-stack.com               ← portfolio generic
+EXCEPCION (solo apex):
+  the-full-stack.com               ← portfolio generic (canonico)
   www.the-full-stack.com           ← alias apex
-  hub.the-full-stack.com           ← niche hub
-  fintech.the-full-stack.com       ← niche fintech
-  architect.the-full-stack.com     ← niche architect
-  leader.the-full-stack.com        ← niche leader
-  vibe.the-full-stack.com          ← niche vibe
 
-ESTANDAR (todo lo demas):
+ESTANDAR — portfolio (product = portfolio):
+  portfolio.the-full-stack.com         ← 301 -> apex
+  hub.portfolio.the-full-stack.com     ← niche hub
+  fintech.portfolio.the-full-stack.com ← niche fintech
+  architect.portfolio.the-full-stack.com
+  leader.portfolio.the-full-stack.com
+  vibe.portfolio.the-full-stack.com
+  api.portfolio.the-full-stack.com     ← backend prod
+
+ESTANDAR — otros products/servicios:
   faststruct.the-full-stack.com    ← product faststruct prod
-  api.portfolio.the-full-stack.com ← backend portfolio prod
   status.the-full-stack.com        ← servicio infra prod
   faststruct.dev.the-full-stack.com ← product faststruct dev
   ...

--- a/.claude/docs/subdomain-standard/05-wildcards-and-certs.md
+++ b/.claude/docs/subdomain-standard/05-wildcards-and-certs.md
@@ -53,8 +53,9 @@ Cloudflare emite automaticamente un cert wildcard `*.the-full-stack.com`
 
 - `faststruct.the-full-stack.com` ✅
 - `status.the-full-stack.com` ✅
-- `hub.the-full-stack.com` ✅
+- `portfolio.the-full-stack.com` ✅
 - `api.faststruct.the-full-stack.com` ❌ (2 niveles)
+- `hub.portfolio.the-full-stack.com` ❌ (2 niveles)
 
 **Cuando usar**: ya esta activo por default. Cubre los products sin
 component automaticamente. No requiere nada.

--- a/.claude/docs/subdomain-standard/07-anti-patterns.md
+++ b/.claude/docs/subdomain-standard/07-anti-patterns.md
@@ -27,7 +27,7 @@
 | `admin.the-full-stack.com` | `admin` es reservado como product | `admin.{product}.the-full-stack.com` |
 | `dev.the-full-stack.com` como product propio | `dev` reservado para env | usar otro nombre |
 | `prod.the-full-stack.com` como product propio | `prod` reservado para env | usar otro nombre |
-| `fintech.the-full-stack.com` como product propio | reservado para portfolio niche | usar otro nombre |
+| `portfolio.the-full-stack.com` como product propio | reservado: es el product del portfolio (301 al apex) | usar otro nombre |
 | `tunnel.the-full-stack.com` como product propio | reservado para infra | si es CF tunnel, scope a env: `vpn.{env}.the-full-stack.com` |
 | Product `Status` | colision con servicio infra `status` | renombrar comercialmente |
 

--- a/.claude/docs/subdomain-standard/README.md
+++ b/.claude/docs/subdomain-standard/README.md
@@ -2,8 +2,8 @@
 
 > Convencion canonica para nombrar subdominios bajo `the-full-stack.com`,
 > cubriendo productos, servicios de infra y multiples environments
-> (`dev`, `stage`, `prod`). Aplicable a todo lo que viva en el dominio
-> excepto el portfolio personal (excepcion permanente).
+> (`dev`, `stage`, `prod`). Aplicable a todo lo que viva en el dominio.
+> La unica excepcion permanente es el apex `the-full-stack.com` + `www`.
 
 ## Patron canonico
 
@@ -33,7 +33,7 @@ dev     [{component}.]{product}.dev.the-full-stack.com
 | Patron canonico + ejemplos | [01-pattern.md](./01-pattern.md) | Entender la forma `[{component}.]{product}.{env}.{domain}` |
 | Reglas de naming + reservados | [02-naming-rules.md](./02-naming-rules.md) | Antes de elegir nombre de producto o componente |
 | Environments (dev/stage/prod) | [03-environments.md](./03-environments.md) | Definir flujo dev/stage/prod, decision sobre previews por PR |
-| Excepcion del portfolio personal | [04-portfolio-exception.md](./04-portfolio-exception.md) | Por que `fintech.the-full-stack.com` no sigue el patron |
+| Excepcion del portfolio personal | [04-portfolio-exception.md](./04-portfolio-exception.md) | Por que solo el apex es excepcion y los niches usan `{niche}.portfolio.*` |
 | Wildcards y certificados | [05-wildcards-and-certs.md](./05-wildcards-and-certs.md) | Planear SSL: por hostname, wildcard 1-nivel, Advanced Cert |
 | Migracion backend serverless | [06-migration-backend-api.md](./06-migration-backend-api.md) | Plan concreto para migrar `execute-api.amazonaws.com` |
 | Anti-patterns | [07-anti-patterns.md](./07-anti-patterns.md) | Lista de formas prohibidas con razones |
@@ -49,18 +49,20 @@ dev     [{component}.]{product}.dev.the-full-stack.com
 - NUNCA inventar un 4to environment (`qa`, `uat`, `preview-N`). Para
   previews por PR usar el default de Cloudflare Pages
   (`<hash>.<project>.pages.dev`) — ver [03-environments.md](./03-environments.md).
-- El portfolio (`the-full-stack.com`, `www`, `hub`, `fintech`,
-  `architect`, `leader`, `vibe`) es excepcion permanente. Ver
+- La unica excepcion permanente es el apex `the-full-stack.com` + `www`.
+  Los 5 niches del portfolio siguen el estandar como components del
+  product `portfolio` (`{niche}.portfolio.the-full-stack.com`). Ver
   [04-portfolio-exception.md](./04-portfolio-exception.md).
 
 ## Decision flow rapida
 
 ```text
-1. Es portfolio personal? -> usar nicho existente (excepcion)
-2. Es servicio de infra atomico? -> {service}.{env}.{domain}
-3. Es product con un solo frontend? -> {product}.{env}.{domain}
-4. Es product con varios components? -> {component}.{product}.{env}.{domain}
-5. Es env temporal de PR? -> default pages.dev (no extender el estandar)
+1. Es el apex del portfolio? -> the-full-stack.com (unica excepcion)
+2. Es un niche del portfolio? -> {niche}.portfolio.{env}.{domain}
+3. Es servicio de infra atomico? -> {service}.{env}.{domain}
+4. Es product con un solo frontend? -> {product}.{env}.{domain}
+5. Es product con varios components? -> {component}.{product}.{env}.{domain}
+6. Es env temporal de PR? -> default pages.dev (no extender el estandar)
 ```
 
 ## Ejemplos rapidos
@@ -73,9 +75,12 @@ api.faststruct.the-full-stack.com           (prod, api)
 api.faststruct.dev.the-full-stack.com       (dev, api)
 api.faststruct.stage.the-full-stack.com     (stage, api)
 
-# Producto portfolio-backend (despues de migrar execute-api)
-api.portfolio.the-full-stack.com            (prod)
-api.portfolio.dev.the-full-stack.com        (dev)
+# Portfolio (product = portfolio): apex es excepcion, niches y api siguen el estandar
+the-full-stack.com                          (prod, apex = niche generic, excepcion)
+fintech.portfolio.the-full-stack.com        (prod, niche fintech)
+hub.portfolio.dev.the-full-stack.com        (dev, niche hub)
+api.portfolio.the-full-stack.com            (prod, backend)
+api.portfolio.stage.the-full-stack.com      (stage, backend)
 
 # Servicio infra status page
 status.the-full-stack.com                   (prod)

--- a/.claude/skills/cloudflare-turnstile/SKILL.md
+++ b/.claude/skills/cloudflare-turnstile/SKILL.md
@@ -182,9 +182,11 @@ import os
 
 TURNSTILE_SECRET = os.environ['TURNSTILE_SECRET']
 EXPECTED_HOSTNAMES = {
-    'the-full-stack.com', 'hub.the-full-stack.com',
-    'fintech.the-full-stack.com', 'architect.the-full-stack.com',
-    'leader.the-full-stack.com', 'vibe.the-full-stack.com',
+    'the-full-stack.com', 'hub.portfolio.the-full-stack.com',
+    'fintech.portfolio.the-full-stack.com',
+    'architect.portfolio.the-full-stack.com',
+    'leader.portfolio.the-full-stack.com',
+    'vibe.portfolio.the-full-stack.com',
 }
 
 def validate_turnstile(token: str, remote_ip: str) -> bool:

--- a/.claude/skills/subdomain-standard/SKILL.md
+++ b/.claude/skills/subdomain-standard/SKILL.md
@@ -8,8 +8,10 @@ description: >
   prod/test/localhost/infra/internal/private/vpn/tunnel + portfolio niches
   hub/fintech/architect/leader/vibe/generic), environment conventions
   (dev/stage/prod only — qa/uat/beta/preview prohibited, use stage or
-  pages.dev), portfolio personal exception (apex + www + 5 niches are
-  permanent exception that does NOT follow the pattern), wildcard SSL
+  pages.dev), portfolio personal exception (ONLY the apex the-full-stack.com
+  + www is a permanent exception; the 5 niches follow the standard as
+  components of product portfolio: {niche}.portfolio.the-full-stack.com),
+  wildcard SSL
   strategies (1-level limit, Universal SSL covers *.the-full-stack.com,
   Pages auto-cert per hostname, ACM cert for API Gateway, Advanced
   Certificate for 2-level wildcards), migration plan for the current
@@ -96,19 +98,21 @@ dev     [{component}.]{product}.dev.the-full-stack.com
   `staging`, `prod`, `production`, `test`, `qa`, `uat`, `local`,
   `localhost`, `infra`, `internal`, `private`, `vpn`, `tunnel`, `hub`,
   `fintech`, `architect`, `leader`, `vibe`, `generic`.
-- SIEMPRE el portfolio (apex + www + 5 niches) es excepcion permanente.
-  El estandar aplica solo a products + servicios NUEVOS.
+- SIEMPRE la unica excepcion permanente es el apex `the-full-stack.com`
+  + `www`. Los 5 niches del portfolio siguen el estandar como components
+  del product `portfolio` (`{niche}.portfolio.{env}.the-full-stack.com`).
 - SIEMPRE solo 3 envs formales: `dev`, `stage`, prod. Previews por PR
   usan default `<hash>.<project>.pages.dev`.
 
 ## Quick decision flow
 
 ```text
-1. Es portfolio personal? -> usar nicho existente (excepcion)
-2. Es servicio de infra atomico? -> {service}.{env}.{domain}
-3. Es product con 1 frontend? -> {product}.{env}.{domain}
-4. Es product con varios components? -> {component}.{product}.{env}.{domain}
-5. Es env temporal de PR? -> default pages.dev (NO extender estandar)
+1. Es el apex del portfolio? -> the-full-stack.com (unica excepcion)
+2. Es un niche del portfolio? -> {niche}.portfolio.{env}.{domain}
+3. Es servicio de infra atomico? -> {service}.{env}.{domain}
+4. Es product con 1 frontend? -> {product}.{env}.{domain}
+5. Es product con varios components? -> {component}.{product}.{env}.{domain}
+6. Es env temporal de PR? -> default pages.dev (NO extender estandar)
 ```
 
 ## Ejemplos clave
@@ -141,8 +145,9 @@ Mas: nombres reservados a rechazar adicionalmente segun
 ## Estado del estandar
 
 - **Adopcion**: 2026-05-15
-- **Excepciones existentes**: portfolio (7 hostnames: apex + www + 5
-  niches) — permanente.
-- **Migraciones pendientes**: backend serverless
-  (`execute-api.amazonaws.com` -> `api.portfolio.{env}.the-full-stack.com`).
-  Plan en [06-migration-backend-api.md](../../docs/subdomain-standard/06-migration-backend-api.md).
+- **Excepcion permanente**: solo el apex `the-full-stack.com` + `www`.
+  Los 5 niches del portfolio siguen el estandar como
+  `{niche}.portfolio.the-full-stack.com` (prod) + dev/stage.
+- **Migraciones pendientes**: ninguna. El backend ya usa custom domains
+  `api.portfolio.{env}.the-full-stack.com` y el frontend prod los
+  `{niche}.portfolio.the-full-stack.com`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,17 @@
 | App | URL producción | Subdominio local (puerto 9970) | Posicionamiento |
 | --- | --- | --- | --- |
 | `apps/generic` | `the-full-stack.com` | `localhost` (apex) | Full Stack Senior — todas las skills |
-| `apps/hub` | `hub.the-full-stack.com` | `hub.localhost` | Selector multi-niche con cards |
-| `apps/fintech` | `fintech.the-full-stack.com` | `fintech.localhost` | Senior Full Stack Fintech LATAM |
-| `apps/architect` | `architect.the-full-stack.com` | `architect.localhost` | Frontend Architect + Microservicios |
-| `apps/leader` | `leader.the-full-stack.com` | `leader.localhost` | Tech Lead / Engineering Manager |
-| `apps/vibe` | `vibe.the-full-stack.com` | `vibe.localhost` | Vibe Coding / Claude Code / Dev tools |
+| `apps/hub` | `hub.portfolio.the-full-stack.com` | `hub.localhost` | Selector multi-niche con cards |
+| `apps/fintech` | `fintech.portfolio.the-full-stack.com` | `fintech.localhost` | Senior Full Stack Fintech LATAM |
+| `apps/architect` | `architect.portfolio.the-full-stack.com` | `architect.localhost` | Frontend Architect + Microservicios |
+| `apps/leader` | `leader.portfolio.the-full-stack.com` | `leader.localhost` | Tech Lead / Engineering Manager |
+| `apps/vibe` | `vibe.portfolio.the-full-stack.com` | `vibe.localhost` | Vibe Coding / Claude Code / Dev tools |
 | — | — | `services.localhost` | Indice estático de servicios locales |
+
+> Prod: el apex `the-full-stack.com` (+ `www`) es generic; los 5 niches
+> cuelgan del product `portfolio`. dev/stage usan
+> `{niche}.portfolio.{env}.the-full-stack.com`. Ver
+> [.claude/docs/subdomain-standard/](.claude/docs/subdomain-standard/).
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 
 ## Sitios
 
-| App | URL | Posicionamiento |
-|-----|-----|-----------------|
-| [apps/hub](apps/hub) | `the-full-stack.com` | Landing selector con 5 cards |
-| [apps/generic](apps/generic) | `hub.the-full-stack.com` | Full Stack Senior — todas las skills |
-| [apps/fintech](apps/fintech) | `fintech.the-full-stack.com` | Senior Full Stack Fintech LATAM |
-| [apps/architect](apps/architect) | `architect.the-full-stack.com` | Frontend Architect + Microservicios |
-| [apps/leader](apps/leader) | `leader.the-full-stack.com` | Tech Lead / Engineering Manager |
-| [apps/vibe](apps/vibe) | `vibe.the-full-stack.com` | Vibe Coding / Claude Code / Dev tools |
+| App | URL producción | Posicionamiento |
+| --- | --- | --- |
+| [apps/generic](apps/generic) | `the-full-stack.com` | Full Stack Senior — todas las skills |
+| [apps/hub](apps/hub) | `hub.portfolio.the-full-stack.com` | Landing selector con 5 cards |
+| [apps/fintech](apps/fintech) | `fintech.portfolio.the-full-stack.com` | Senior Full Stack Fintech LATAM |
+| [apps/architect](apps/architect) | `architect.portfolio.the-full-stack.com` | Frontend Architect + Microservicios |
+| [apps/leader](apps/leader) | `leader.portfolio.the-full-stack.com` | Tech Lead / Engineering Manager |
+| [apps/vibe](apps/vibe) | `vibe.portfolio.the-full-stack.com` | Vibe Coding / Claude Code / Dev tools |
 
 ## Stack
 
@@ -28,12 +28,12 @@
 ```
 .
 ├── apps/
-│   ├── hub/         # the-full-stack.com (selector)
-│   ├── generic/     # hub.the-full-stack.com
-│   ├── fintech/     # fintech.the-full-stack.com
-│   ├── architect/   # architect.the-full-stack.com
-│   ├── leader/      # leader.the-full-stack.com
-│   └── vibe/        # vibe.the-full-stack.com
+│   ├── generic/     # the-full-stack.com (apex)
+│   ├── hub/         # hub.portfolio.the-full-stack.com (selector)
+│   ├── fintech/     # fintech.portfolio.the-full-stack.com
+│   ├── architect/   # architect.portfolio.the-full-stack.com
+│   ├── leader/      # leader.portfolio.the-full-stack.com
+│   └── vibe/        # vibe.portfolio.the-full-stack.com
 ├── packages/
 │   ├── content/     # Zod schemas + datos del CV + filters/sort por nicho
 │   ├── ui/          # Design system, componentes Astro, theme toggle

--- a/apps/architect/astro.config.ts
+++ b/apps/architect/astro.config.ts
@@ -10,7 +10,8 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 import { JSON_SCHEMA } from 'js-yaml'
 
-const SITE = process.env.SITE_URL ?? 'https://architect.the-full-stack.com'
+const SITE =
+  process.env.SITE_URL ?? 'https://architect.portfolio.the-full-stack.com'
 
 export default defineConfig({
   site: SITE,

--- a/apps/architect/package.json
+++ b/apps/architect/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "architect-focused portfolio site (https://architect.the-full-stack.com)",
+  "description": "architect-focused portfolio site (https://architect.portfolio.the-full-stack.com)",
   "scripts": {
     "dev": "astro dev --port 4324",
     "build": "astro build",

--- a/apps/architect/scripts/build-public-assets.mjs
+++ b/apps/architect/scripts/build-public-assets.mjs
@@ -7,7 +7,8 @@ import { buildLlmsTxt, buildRobotsTxt } from '@portfolio/seo'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
-const SITE_URL = process.env.SITE_URL ?? 'https://architect.the-full-stack.com'
+const SITE_URL =
+  process.env.SITE_URL ?? 'https://architect.portfolio.the-full-stack.com'
 const NICHE = 'architect'
 const ATS_KEYWORDS = [
   'Frontend Architect',

--- a/apps/fintech/astro.config.ts
+++ b/apps/fintech/astro.config.ts
@@ -10,7 +10,8 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 import { JSON_SCHEMA } from 'js-yaml'
 
-const SITE = process.env.SITE_URL ?? 'https://fintech.the-full-stack.com'
+const SITE =
+  process.env.SITE_URL ?? 'https://fintech.portfolio.the-full-stack.com'
 
 export default defineConfig({
   site: SITE,

--- a/apps/fintech/package.json
+++ b/apps/fintech/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "fintech-focused portfolio site (https://fintech.the-full-stack.com)",
+  "description": "fintech-focused portfolio site (https://fintech.portfolio.the-full-stack.com)",
   "scripts": {
     "dev": "astro dev --port 4323",
     "build": "astro build",

--- a/apps/fintech/public/llms.txt
+++ b/apps/fintech/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Senior Full Stack engineer specialized in Latin American fintech (Chile, Mexico). 12+ years building credit, debt-settlement and payment products with Vue/Nuxt + Django + AWS microservices. Compliance-aware (PCI DSS, KYC, PII handling).
 
-Canonical URL: https://fintech.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
+Canonical URL: https://fintech.portfolio.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — fintech
 
@@ -16,11 +16,11 @@ Senior Full Stack Developer · Fintech LATAM · Chile · México · Debt Settlem
 
 ## Pages
 
-- [Home](https://fintech.the-full-stack.com/): Pablo Contreras — Fintech LATAM · Vue · Django · AWS
-- [About](https://fintech.the-full-stack.com/about): Education, languages, awards, publications, references
-- [Certificates](https://fintech.the-full-stack.com/certificates): Technical certifications relevant to this profile
-- [CV (HTML)](https://fintech.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
-- [CV (EN)](https://fintech.the-full-stack.com/cv-en.html): ATS-friendly CV in English
+- [Home](https://fintech.portfolio.the-full-stack.com/): Pablo Contreras — Fintech LATAM · Vue · Django · AWS
+- [About](https://fintech.portfolio.the-full-stack.com/about): Education, languages, awards, publications, references
+- [Certificates](https://fintech.portfolio.the-full-stack.com/certificates): Technical certifications relevant to this profile
+- [CV (HTML)](https://fintech.portfolio.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
+- [CV (EN)](https://fintech.portfolio.the-full-stack.com/cv-en.html): ATS-friendly CV in English
 
 ## Identity
 

--- a/apps/fintech/public/robots.txt
+++ b/apps/fintech/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://fintech.the-full-stack.com/sitemap.xml
-Sitemap: https://fintech.the-full-stack.com/sitemap-index.xml
+Sitemap: https://fintech.portfolio.the-full-stack.com/sitemap.xml
+Sitemap: https://fintech.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/fintech/scripts/build-public-assets.mjs
+++ b/apps/fintech/scripts/build-public-assets.mjs
@@ -7,7 +7,8 @@ import { buildLlmsTxt, buildRobotsTxt } from '@portfolio/seo'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
-const SITE_URL = process.env.SITE_URL ?? 'https://fintech.the-full-stack.com'
+const SITE_URL =
+  process.env.SITE_URL ?? 'https://fintech.portfolio.the-full-stack.com'
 const NICHE = 'fintech'
 const ATS_KEYWORDS = [
   'Senior Full Stack Developer',

--- a/apps/generic/package.json
+++ b/apps/generic/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Generic portfolio site — hub.the-full-stack.com",
+  "description": "Generic portfolio site — the-full-stack.com (apex)",
   "scripts": {
     "dev": "astro dev --port 4321",
     "build": "astro build",

--- a/apps/generic/public/_redirects
+++ b/apps/generic/public/_redirects
@@ -1,0 +1,5 @@
+# Redirect 301: portfolio.the-full-stack.com -> apex the-full-stack.com
+# El hostname portfolio.the-full-stack.com existe por consistencia del
+# estandar de subdominios, pero el apex es la URL canonica de generic.
+# Preserva el path completo via :splat.
+https://portfolio.the-full-stack.com/*  https://the-full-stack.com/:splat  301

--- a/apps/generic/public/llms.txt
+++ b/apps/generic/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Senior Full Stack Engineer with 12+ years of experience in Vue/Nuxt, Django, AWS and LATAM fintech (Chile, Mexico). Cross-cutting expertise: fintech, architecture, tech leadership and vibe coding with Claude Code.
 
-Canonical URL: https://hub.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
+Canonical URL: https://the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — generic
 
@@ -16,11 +16,11 @@ Senior Full Stack Developer · Senior Software Engineer · Vue 3 · Nuxt · Type
 
 ## Pages
 
-- [Home](https://hub.the-full-stack.com/): Senior Full Stack Engineer (Vue + Django + AWS), 8+ years
-- [About](https://hub.the-full-stack.com/about): Education, languages, awards, publications, references
-- [Certificates](https://hub.the-full-stack.com/certificates): 11 certifications from Udemy and DevTalles
-- [CV (HTML)](https://hub.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
-- [CV (EN)](https://hub.the-full-stack.com/cv-en.html): ATS-friendly CV in English
+- [Home](https://the-full-stack.com/): Senior Full Stack Engineer (Vue + Django + AWS), 8+ years
+- [About](https://the-full-stack.com/about): Education, languages, awards, publications, references
+- [Certificates](https://the-full-stack.com/certificates): 11 certifications from Udemy and DevTalles
+- [CV (HTML)](https://the-full-stack.com/cv.html): ATS-friendly CV in Spanish
+- [CV (EN)](https://the-full-stack.com/cv-en.html): ATS-friendly CV in English
 
 ## Identity
 

--- a/apps/generic/public/robots.txt
+++ b/apps/generic/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://hub.the-full-stack.com/sitemap.xml
-Sitemap: https://hub.the-full-stack.com/sitemap-index.xml
+Sitemap: https://the-full-stack.com/sitemap.xml
+Sitemap: https://the-full-stack.com/sitemap-index.xml

--- a/apps/generic/scripts/build-public-assets.mjs
+++ b/apps/generic/scripts/build-public-assets.mjs
@@ -16,7 +16,7 @@ import { buildLlmsTxt, buildRobotsTxt } from '@portfolio/seo'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
-const SITE_URL = process.env.SITE_URL ?? 'https://hub.the-full-stack.com'
+const SITE_URL = process.env.SITE_URL ?? 'https://the-full-stack.com'
 const NICHE = 'generic'
 const ATS_KEYWORDS = [
   'Senior Full Stack Developer',

--- a/apps/hub/astro.config.ts
+++ b/apps/hub/astro.config.ts
@@ -10,7 +10,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 import { JSON_SCHEMA } from 'js-yaml'
 
-const SITE = process.env.SITE_URL ?? 'https://hub.the-full-stack.com'
+const SITE = process.env.SITE_URL ?? 'https://hub.portfolio.the-full-stack.com'
 
 export default defineConfig({
   site: SITE,

--- a/apps/hub/src/pages/contact.astro
+++ b/apps/hub/src/pages/contact.astro
@@ -8,12 +8,15 @@ const apiEndpoint = (import.meta.env.PUBLIC_API_ENDPOINT || '') as string
 const turnstileSitekey = (import.meta.env.PUBLIC_TURNSTILE_SITEKEY ||
   '') as string
 const contactEndpoint = apiEndpoint ? `${apiEndpoint}/contact` : ''
+// Hostname propio del env (Pages inyecta SITE_URL; fallback prod).
+const siteUrl = (import.meta.env.SITE_URL ||
+  'https://hub.portfolio.the-full-stack.com') as string
 ---
 
 <BaseLayout
   title="Contacto — Pablo Contreras"
   description="Hablemos de tu proyecto. Respondo en menos de 24h."
-  canonicalUrl="https://hub.the-full-stack.com/contact"
+  canonicalUrl={`${siteUrl}/contact`}
 >
   <main class="contact-page">
     <section class="contact-section">

--- a/apps/leader/astro.config.ts
+++ b/apps/leader/astro.config.ts
@@ -10,7 +10,8 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 import { JSON_SCHEMA } from 'js-yaml'
 
-const SITE = process.env.SITE_URL ?? 'https://leader.the-full-stack.com'
+const SITE =
+  process.env.SITE_URL ?? 'https://leader.portfolio.the-full-stack.com'
 
 export default defineConfig({
   site: SITE,

--- a/apps/leader/package.json
+++ b/apps/leader/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "leader-focused portfolio site (https://leader.the-full-stack.com)",
+  "description": "leader-focused portfolio site (https://leader.portfolio.the-full-stack.com)",
   "scripts": {
     "dev": "astro dev --port 4325",
     "build": "astro build",

--- a/apps/leader/scripts/build-public-assets.mjs
+++ b/apps/leader/scripts/build-public-assets.mjs
@@ -7,7 +7,8 @@ import { buildLlmsTxt, buildRobotsTxt } from '@portfolio/seo'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
-const SITE_URL = process.env.SITE_URL ?? 'https://leader.the-full-stack.com'
+const SITE_URL =
+  process.env.SITE_URL ?? 'https://leader.portfolio.the-full-stack.com'
 const NICHE = 'leader'
 const ATS_KEYWORDS = [
   'Tech Lead',

--- a/apps/vibe/astro.config.ts
+++ b/apps/vibe/astro.config.ts
@@ -10,7 +10,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
 import { JSON_SCHEMA } from 'js-yaml'
 
-const SITE = process.env.SITE_URL ?? 'https://vibe.the-full-stack.com'
+const SITE = process.env.SITE_URL ?? 'https://vibe.portfolio.the-full-stack.com'
 
 export default defineConfig({
   site: SITE,

--- a/apps/vibe/package.json
+++ b/apps/vibe/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "vibe-focused portfolio site (https://vibe.the-full-stack.com)",
+  "description": "vibe-focused portfolio site (https://vibe.portfolio.the-full-stack.com)",
   "scripts": {
     "dev": "astro dev --port 4326",
     "build": "astro build",

--- a/apps/vibe/scripts/build-public-assets.mjs
+++ b/apps/vibe/scripts/build-public-assets.mjs
@@ -7,7 +7,8 @@ import { buildLlmsTxt, buildRobotsTxt } from '@portfolio/seo'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PUBLIC_DIR = resolve(__dirname, '../public')
-const SITE_URL = process.env.SITE_URL ?? 'https://vibe.the-full-stack.com'
+const SITE_URL =
+  process.env.SITE_URL ?? 'https://vibe.portfolio.the-full-stack.com'
 const NICHE = 'vibe'
 const ATS_KEYWORDS = [
   'AI-Augmented Developer',

--- a/cloudflare/pages-config.md
+++ b/cloudflare/pages-config.md
@@ -1,41 +1,71 @@
 # Cloudflare Pages — Configuración de proyectos
 
-> 6 proyectos Cloudflare Pages, uno por app. Cada uno con su dominio asignado.
+> 18 proyectos Cloudflare Pages: 6 apps x 3 ambientes (prod / dev / stage).
+> Deploy git-native (Cloudflare construye desde el repo, sin GitHub Actions).
 
 ## Tabla de proyectos
 
-| App | CF Project name | Production URL | Dist path |
-|-----|-----------------|----------------|-----------|
-| `apps/hub` | `portfolio-hub` | `the-full-stack.com` | `apps/hub/dist` |
-| `apps/generic` | `portfolio-generic` | `hub.the-full-stack.com` | `apps/generic/dist` |
-| `apps/fintech` | `portfolio-fintech` | `fintech.the-full-stack.com` | `apps/fintech/dist` |
-| `apps/architect` | `portfolio-architect` | `architect.the-full-stack.com` | `apps/architect/dist` |
-| `apps/leader` | `portfolio-leader` | `leader.the-full-stack.com` | `apps/leader/dist` |
-| `apps/vibe` | `portfolio-vibe` | `vibe.the-full-stack.com` | `apps/vibe/dist` |
+### Producción (branch `main`)
 
-## Setup manual (una sola vez)
+| App | CF Project | Production URL | Dist path |
+| --- | --- | --- | --- |
+| `apps/generic` | `generic` | `the-full-stack.com` (+ `www`) | `apps/generic/dist` |
+| `apps/hub` | `hub` | `hub.portfolio.the-full-stack.com` | `apps/hub/dist` |
+| `apps/fintech` | `fintech` | `fintech.portfolio.the-full-stack.com` | `apps/fintech/dist` |
+| `apps/architect` | `architect` | `architect.portfolio.the-full-stack.com` | `apps/architect/dist` |
+| `apps/leader` | `leader` | `leader.portfolio.the-full-stack.com` | `apps/leader/dist` |
+| `apps/vibe` | `vibe` | `vibe.portfolio.the-full-stack.com` | `apps/vibe/dist` |
 
-1. **Login en Cloudflare Dashboard** → `Pages → Create a project → Direct Upload`.
-2. Crear los 6 proyectos con los nombres de la tabla. **No** conectar a Git desde Cloudflare; GitHub Actions hace el deploy.
-3. **Asignar dominios** en cada proyecto:
-   - `portfolio-hub` → custom domain `the-full-stack.com` (root)
-   - `portfolio-generic` → custom domain `hub.the-full-stack.com`
-   - `portfolio-fintech` → custom domain `fintech.the-full-stack.com`
-   - (idem para architect, leader, vibe)
-4. **Generar API token** con permiso `Cloudflare Pages — Edit`:
-   - User profile → API Tokens → Create custom token
-   - Permissions: `Account · Cloudflare Pages · Edit`, `Zone · DNS · Read`
-   - Account resources: Include - your account
-   - Zone resources: Include - the-full-stack.com
-5. **Agregar secrets en GitHub** (`Settings → Secrets and variables → Actions`):
-   - `CLOUDFLARE_API_TOKEN` — el token del paso 4
-   - `CLOUDFLARE_ACCOUNT_ID` — Account ID del dashboard
+`portfolio.the-full-stack.com` existe como CNAME que redirige 301 al apex.
+
+### Dev (branch `dev`) y Stage (branch `stage`)
+
+Mismos 6 proyectos por env con sufijo `-dev` / `-stage`:
+
+| Project | Production URL |
+| --- | --- |
+| `<app>-dev` | `[<niche>.]portfolio.dev.the-full-stack.com` |
+| `<app>-stage` | `[<niche>.]portfolio.stage.the-full-stack.com` |
+
+El apex de dev/stage es `portfolio.{env}.the-full-stack.com` (= generic).
+
+## Deploy git-native
+
+Cada proyecto está conectado al repo `bypabloc/cv` con su
+`production_branch` (`main` / `dev` / `stage`). Cloudflare buildea con:
+
+```text
+build_command:   pnpm install --frozen-lockfile && pnpm --filter @portfolio/<app>... build
+destination_dir: apps/<app>/dist
+root_dir:        (vacio)
+```
+
+Un push a la branch correspondiente dispara el build + deploy. No hay
+workflow de GitHub Actions para el deploy del frontend.
+
+## Variables de entorno por proyecto (build env vars)
+
+Cada proyecto define las env vars que `site-urls.ts` lee en build time:
+
+| Env var | prod | dev | stage |
+| --- | --- | --- | --- |
+| `BASE_DOMAIN` | `portfolio.the-full-stack.com` | `portfolio.dev.the-full-stack.com` | `portfolio.stage.the-full-stack.com` |
+| `APEX_DOMAIN` | `the-full-stack.com` | (no se setea) | (no se setea) |
+| `BASE_SCHEME` | `https` | `https` | `https` |
+| `SITE_URL` | hostname propio de la app | idem | idem |
+| `NODE_VERSION` | `24` | `24` | `24` |
+| `PNPM_VERSION` | `11.0.9` | `11.0.9` | `11.0.9` |
+
+`APEX_DOMAIN` solo se setea en prod: ahi el apex de generic
+(`the-full-stack.com`) difiere del dominio de los niches
+(`portfolio.the-full-stack.com`). En dev/stage el apex del env coincide
+con `BASE_DOMAIN`, asi que `APEX_DOMAIN` no se necesita.
 
 ## Headers de seguridad
 
 Cada app sirve un `_headers` con:
 
-```
+```text
 /*
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
@@ -45,34 +75,17 @@ Cada app sirve un `_headers` con:
   X-Frame-Options: DENY
 ```
 
-> Nota: `script-src 'unsafe-inline'` es necesario por el script inline anti-FOUC del BaseLayout. Si querés CSP estricto sin `'unsafe-inline'`, mover ese script a un archivo separado e incluir el hash en CSP.
-
-## Deploy
-
-GitHub Actions `deploy.yml` se dispara en push a `main`:
-
-- Solo se rebuilda lo que cambió (path filtering por carpeta `apps/<app>/`).
-- Si cambia un `packages/*`, se rebuilda **todo** (broadcast).
-- Manual: usar workflow_dispatch en GitHub UI con app específica.
-
-## Variables de entorno por app (CF Pages)
-
-Cada proyecto puede definir `SITE_URL` para reescribir la canonical (útil si el dominio cambia):
-
-| Project | Env var | Value |
-|---------|---------|-------|
-| `portfolio-hub` | `SITE_URL` | `https://the-full-stack.com` |
-| `portfolio-generic` | `SITE_URL` | `https://hub.the-full-stack.com` |
-| ... | ... | ... |
+> Nota: `script-src 'unsafe-inline'` es necesario por el script inline anti-FOUC del BaseLayout.
 
 ## Verificación post-deploy
 
 ```bash
-# Reemplazar <subdomain> por hub/fintech/architect/leader/vibe
-curl -sI https://<subdomain>.the-full-stack.com/ | grep -i 'content-security\|strict-transport'
-curl -s https://<subdomain>.the-full-stack.com/llms.txt | head -5
-curl -s https://<subdomain>.the-full-stack.com/robots.txt
-curl -s https://<subdomain>.the-full-stack.com/sitemap-index.xml | head -5
+# prod
+curl -sI https://fintech.portfolio.the-full-stack.com/ | grep -i 'strict-transport'
+curl -s https://fintech.portfolio.the-full-stack.com/llms.txt | head -5
+# dev / stage
+curl -sI https://fintech.portfolio.dev.the-full-stack.com/
+curl -sI https://fintech.portfolio.stage.the-full-stack.com/
 ```
 
 ## Rollback

--- a/packages/app-shared/src/lib/site-urls.ts
+++ b/packages/app-shared/src/lib/site-urls.ts
@@ -1,29 +1,37 @@
 /**
  * @module site-urls
  * @description URLs absolutas de los 6 sitios del portfolio, derivadas de
- *   las env vars `BASE_DOMAIN` + `BASE_SCHEME` + `BASE_PORT`. Cualquier app
- *   puede leer estas URLs para enlazar a los otros sitios sin hardcodear el
- *   dominio de produccion.
+ *   las env vars `BASE_DOMAIN` + `BASE_SCHEME` + `BASE_PORT` (+ `APEX_DOMAIN`
+ *   opcional). Cualquier app puede leer estas URLs para enlazar a los otros
+ *   sitios sin hardcodear el dominio.
  *
  *   Convencion:
- *   - `generic` mapea al apex (sin subdominio): `https://the-full-stack.com`
+ *   - Los 5 niches mapean a `<key>.<BASE_DOMAIN>`.
+ *   - `generic` mapea al apex del ambiente:
+ *     - Si `APEX_DOMAIN` esta definida, `generic` usa ese hostname. Esto
+ *       cubre prod, donde los niches viven en `<niche>.portfolio.the-full-stack.com`
+ *       (`BASE_DOMAIN=portfolio.the-full-stack.com`) pero el apex de generic
+ *       es `the-full-stack.com` (`APEX_DOMAIN=the-full-stack.com`).
+ *     - Si `APEX_DOMAIN` NO esta definida, `generic` usa `BASE_DOMAIN` tal
+ *       cual. Esto cubre dev/stage/local, donde el apex del env coincide con
+ *       el `BASE_DOMAIN` (`portfolio.dev.the-full-stack.com`, `localhost`).
  *   - `hub` es el selector multi-niche, NO es un niche del CV
- *     (Niche solo cubre fintech/architect/leader/vibe/generic)
- *   - El resto mapea a `<key>.<BASE_DOMAIN>`
+ *     (Niche solo cubre fintech/architect/leader/vibe/generic).
  *   - Si `BASE_PORT` es el estandar del scheme (80 para http, 443 para https)
  *     o esta vacio, se omite del resultado.
  *
- *   Fallback (todas las env vacias o no definidas): produccion (the-full-stack.com).
+ *   Fallback (todas las env vacias o no definidas): produccion — niches en
+ *   `<niche>.portfolio.the-full-stack.com`, apex generic en `the-full-stack.com`.
  *   Esto preserva el comportamiento de `pnpm run build` sin Docker.
  *
  * @example
  *   // BASE_DOMAIN=localhost BASE_SCHEME=http BASE_PORT=9970
  *   SITE_URLS.hub       // "http://hub.localhost:9970"
- *   buildSiteUrl('hub') // idem
+ *   SITE_URLS.generic   // "http://localhost:9970" (apex = BASE_DOMAIN)
  *
- *   // BASE_DOMAIN=the-full-stack.com BASE_SCHEME=https BASE_PORT=
- *   SITE_URLS.fintech   // "https://fintech.the-full-stack.com"
- *   SITE_URLS.generic   // "https://the-full-stack.com" (apex, sin subdominio)
+ *   // prod: BASE_DOMAIN=portfolio.the-full-stack.com APEX_DOMAIN=the-full-stack.com
+ *   SITE_URLS.fintech   // "https://fintech.portfolio.the-full-stack.com"
+ *   SITE_URLS.generic   // "https://the-full-stack.com" (apex via APEX_DOMAIN)
  */
 
 /** Sitios desplegables del monorepo: los 5 niches + el hub selector. */
@@ -35,7 +43,11 @@ export type SiteKey =
   | 'leader'
   | 'vibe'
 
-const DEFAULT_DOMAIN = 'the-full-stack.com'
+// Defaults de prod: los niches cuelgan de `portfolio.the-full-stack.com`,
+// el apex de generic es `the-full-stack.com`. Cubren `pnpm run build` sin
+// env vars (build local de prueba) replicando produccion.
+const DEFAULT_DOMAIN = 'portfolio.the-full-stack.com'
+const DEFAULT_APEX = 'the-full-stack.com'
 const DEFAULT_SCHEME = 'https'
 
 type EnvBag = Record<string, string | undefined>
@@ -70,15 +82,25 @@ function isStandardPort(scheme: string, port: string): boolean {
  * @function buildSiteUrl
  * @description Construye la URL absoluta del sitio para un site key dado.
  *
+ *   Los 5 niches cuelgan de `BASE_DOMAIN`. `generic` usa `APEX_DOMAIN` si
+ *   esta definida (caso prod, donde el apex difiere del dominio de los
+ *   niches); si no, usa `BASE_DOMAIN` (caso dev/stage/local).
+ *
  * @param {SiteKey} key - "generic" (apex) | "hub" | "fintech" | "architect" | "leader" | "vibe"
  * @returns {string} URL absoluta sin trailing slash
  */
 export function buildSiteUrl(key: SiteKey): string {
-  const domain = readEnv('BASE_DOMAIN') || DEFAULT_DOMAIN
+  const baseDomain = readEnv('BASE_DOMAIN')
+  const domain = baseDomain || DEFAULT_DOMAIN
   const scheme = readEnv('BASE_SCHEME') || DEFAULT_SCHEME
   const port = readEnv('BASE_PORT')
+  // Apex de `generic`: APEX_DOMAIN si esta seteada. Si no:
+  // - con BASE_DOMAIN definido (dev/stage/local) el apex = BASE_DOMAIN.
+  // - sin ninguna env var, el apex = DEFAULT_APEX (fallback prod).
+  const apexDomain =
+    readEnv('APEX_DOMAIN') || (baseDomain ? domain : DEFAULT_APEX)
 
-  const host = key === 'generic' ? domain : `${key}.${domain}`
+  const host = key === 'generic' ? apexDomain : `${key}.${domain}`
   const portSuffix = port && !isStandardPort(scheme, port) ? `:${port}` : ''
 
   return `${scheme}://${host}${portSuffix}`

--- a/packages/app-shared/tests/unit/lib/define-site-config.test.ts
+++ b/packages/app-shared/tests/unit/lib/define-site-config.test.ts
@@ -16,12 +16,12 @@ const baseOverrides = {
 describe('defineSiteConfig', () => {
   it('Given niche fintech without siteUrl When invoked Then SITE_URL derives from niche', () => {
     const r = defineSiteConfig({ niche: 'fintech', overrides: baseOverrides })
-    expect(r.SITE_URL).toBe('https://fintech.the-full-stack.com')
+    expect(r.SITE_URL).toBe('https://fintech.portfolio.the-full-stack.com')
   })
 
   it('Given niche architect Then SITE_URL uses architect subdomain', () => {
     const r = defineSiteConfig({ niche: 'architect', overrides: baseOverrides })
-    expect(r.SITE_URL).toBe('https://architect.the-full-stack.com')
+    expect(r.SITE_URL).toBe('https://architect.portfolio.the-full-stack.com')
   })
 
   it('Given niche generic Then SITE_URL is the apex domain (env-driven default)', () => {
@@ -40,7 +40,9 @@ describe('defineSiteConfig', () => {
 
   it('Given default ogImagePath When invoked Then OG_IMAGE is SITE_URL + /og-image.svg', () => {
     const r = defineSiteConfig({ niche: 'vibe', overrides: baseOverrides })
-    expect(r.OG_IMAGE).toBe('https://vibe.the-full-stack.com/og-image.svg')
+    expect(r.OG_IMAGE).toBe(
+      'https://vibe.portfolio.the-full-stack.com/og-image.svg',
+    )
   })
 
   it('Given custom ogImagePath When invoked Then OG_IMAGE uses the custom path', () => {
@@ -49,7 +51,9 @@ describe('defineSiteConfig', () => {
       ogImagePath: '/custom-og.png',
       overrides: baseOverrides,
     })
-    expect(r.OG_IMAGE).toBe('https://fintech.the-full-stack.com/custom-og.png')
+    expect(r.OG_IMAGE).toBe(
+      'https://fintech.portfolio.the-full-stack.com/custom-og.png',
+    )
   })
 
   it('Given valid input When invoked Then NICHE === niche', () => {

--- a/packages/app-shared/tests/unit/lib/site-urls.test.ts
+++ b/packages/app-shared/tests/unit/lib/site-urls.test.ts
@@ -52,26 +52,34 @@ describe('SITE_URLS', () => {
     })
   })
 
-  describe('prod env (BASE_DOMAIN=the-full-stack.com, BASE_SCHEME=https, BASE_PORT empty)', () => {
+  describe('prod env component-based (BASE_DOMAIN=portfolio.the-full-stack.com, APEX_DOMAIN=the-full-stack.com)', () => {
     beforeEach(() => {
-      vi.stubEnv('BASE_DOMAIN', 'the-full-stack.com')
+      vi.stubEnv('BASE_DOMAIN', 'portfolio.the-full-stack.com')
+      vi.stubEnv('APEX_DOMAIN', 'the-full-stack.com')
       vi.stubEnv('BASE_SCHEME', 'https')
       vi.stubEnv('BASE_PORT', '')
     })
 
-    it('Given env prod When read SITE_URLS.generic Then returns "https://the-full-stack.com" [AC-2]', async () => {
+    it('Given env prod When read SITE_URLS.generic Then returns the apex "https://the-full-stack.com" [AC-2]', async () => {
       const { SITE_URLS } = await import('../../../src/lib/site-urls')
       expect(SITE_URLS.generic).toBe('https://the-full-stack.com')
     })
 
-    it('Given env prod When read SITE_URLS.hub Then returns "https://hub.the-full-stack.com" [AC-2]', async () => {
+    it('Given env prod When read SITE_URLS.hub Then returns "https://hub.portfolio.the-full-stack.com" [AC-2]', async () => {
       const { SITE_URLS } = await import('../../../src/lib/site-urls')
-      expect(SITE_URLS.hub).toBe('https://hub.the-full-stack.com')
+      expect(SITE_URLS.hub).toBe('https://hub.portfolio.the-full-stack.com')
     })
 
-    it('Given env prod When read SITE_URLS.fintech Then returns "https://fintech.the-full-stack.com" [AC-2]', async () => {
+    it('Given env prod When read SITE_URLS.fintech Then returns "https://fintech.portfolio.the-full-stack.com" [AC-2]', async () => {
       const { SITE_URLS } = await import('../../../src/lib/site-urls')
-      expect(SITE_URLS.fintech).toBe('https://fintech.the-full-stack.com')
+      expect(SITE_URLS.fintech).toBe(
+        'https://fintech.portfolio.the-full-stack.com',
+      )
+    })
+
+    it('Given env prod When read SITE_URLS.vibe Then returns "https://vibe.portfolio.the-full-stack.com" [AC-2]', async () => {
+      const { SITE_URLS } = await import('../../../src/lib/site-urls')
+      expect(SITE_URLS.vibe).toBe('https://vibe.portfolio.the-full-stack.com')
     })
   })
 
@@ -82,14 +90,14 @@ describe('SITE_URLS', () => {
       vi.stubEnv('BASE_PORT', '')
     })
 
-    it('Given no env vars When read SITE_URLS.generic Then falls back to prod "https://the-full-stack.com" [AC-3]', async () => {
+    it('Given no env vars When read SITE_URLS.generic Then falls back to the apex "https://the-full-stack.com" [AC-3]', async () => {
       const { SITE_URLS } = await import('../../../src/lib/site-urls')
       expect(SITE_URLS.generic).toBe('https://the-full-stack.com')
     })
 
-    it('Given no env vars When read SITE_URLS.vibe Then falls back to prod "https://vibe.the-full-stack.com" [AC-3]', async () => {
+    it('Given no env vars When read SITE_URLS.vibe Then falls back to "https://vibe.portfolio.the-full-stack.com" [AC-3]', async () => {
       const { SITE_URLS } = await import('../../../src/lib/site-urls')
-      expect(SITE_URLS.vibe).toBe('https://vibe.the-full-stack.com')
+      expect(SITE_URLS.vibe).toBe('https://vibe.portfolio.the-full-stack.com')
     })
   })
 

--- a/packages/seo/src/lib/build-person-schema.ts
+++ b/packages/seo/src/lib/build-person-schema.ts
@@ -14,7 +14,7 @@
  *     profile,
  *     niche: 'fintech',
  *     locale: 'en',
- *     canonicalUrl: 'https://fintech.the-full-stack.com/',
+ *     canonicalUrl: 'https://fintech.portfolio.the-full-stack.com/',
  *     knowsAbout: ['Vue', 'Django', 'AWS', 'Fintech'],
  *   })
  *   //  '{"@context":"https://schema.org","@type":"Person",...}'

--- a/packages/seo/src/lib/build-profile-page-schema.ts
+++ b/packages/seo/src/lib/build-profile-page-schema.ts
@@ -13,7 +13,7 @@
  * @example
  *   const ld = buildProfilePageSchema({
  *     profile, niche: 'fintech', locale: 'es',
- *     canonicalUrl: 'https://fintech.the-full-stack.com/',
+ *     canonicalUrl: 'https://fintech.portfolio.the-full-stack.com/',
  *     knowsAbout: ['Vue', 'Django']
  *   })
  */

--- a/packages/seo/tests/unit/build-llms-txt.test.ts
+++ b/packages/seo/tests/unit/build-llms-txt.test.ts
@@ -9,7 +9,7 @@ import { buildLlmsTxt } from '../../src/lib/build-llms-txt'
 describe('buildLlmsTxt', () => {
   it('Given fintech niche When build Then contains H1, summary and pages', () => {
     const out = buildLlmsTxt({
-      siteUrl: 'https://fintech.the-full-stack.com/',
+      siteUrl: 'https://fintech.portfolio.the-full-stack.com/',
       profile,
       niche: 'fintech',
       pages: [
@@ -29,10 +29,10 @@ describe('buildLlmsTxt', () => {
     expect(out).toMatch(/Latin American fintech/u)
     expect(out).toMatch(/## Pages/u)
     expect(out).toContain(
-      '- [Home](https://fintech.the-full-stack.com/): Senior fintech engineer for LATAM',
+      '- [Home](https://fintech.portfolio.the-full-stack.com/): Senior fintech engineer for LATAM',
     )
     expect(out).toContain(
-      '- [Experience](https://fintech.the-full-stack.com/experience): 9 roles in 8 employers',
+      '- [Experience](https://fintech.portfolio.the-full-stack.com/experience): 9 roles in 8 employers',
     )
     expect(out).toContain('LinkedIn: https://linkedin.com/in/bypabloc')
     expect(out).toContain('GitHub: https://github.com/bypabloc')

--- a/packages/seo/tests/unit/build-person-schema.test.ts
+++ b/packages/seo/tests/unit/build-person-schema.test.ts
@@ -12,7 +12,7 @@ describe('buildPersonSchema', () => {
       profile,
       niche: 'fintech',
       locale: 'en',
-      canonicalUrl: 'https://fintech.the-full-stack.com/',
+      canonicalUrl: 'https://fintech.portfolio.the-full-stack.com/',
       knowsAbout: ['Vue', 'Django', 'AWS', 'Fintech'],
     })
     const parsed = JSON.parse(ld)
@@ -22,7 +22,7 @@ describe('buildPersonSchema', () => {
     expect(parsed.alternateName).toBe('bypabloc')
     expect(parsed.jobTitle).toMatch(/Fintech/u)
     expect(parsed.email).toBe('pacg1991@gmail.com')
-    expect(parsed.url).toBe('https://fintech.the-full-stack.com/')
+    expect(parsed.url).toBe('https://fintech.portfolio.the-full-stack.com/')
     expect(parsed.knowsAbout).toEqual(['Vue', 'Django', 'AWS', 'Fintech'])
     expect(parsed.address.addressLocality).toBe('Lima, Perú')
     expect(parsed.sameAs).toContain('https://linkedin.com/in/bypabloc')
@@ -34,7 +34,7 @@ describe('buildPersonSchema', () => {
       profile,
       niche: 'architect',
       locale: 'es',
-      canonicalUrl: 'https://architect.the-full-stack.com/',
+      canonicalUrl: 'https://architect.portfolio.the-full-stack.com/',
       knowsAbout: ['Microservicios'],
     })
     const parsed = JSON.parse(ld)

--- a/packages/seo/tests/unit/build-profile-page-schema.test.ts
+++ b/packages/seo/tests/unit/build-profile-page-schema.test.ts
@@ -13,7 +13,7 @@ describe('buildProfilePageSchema', () => {
       profile,
       niche: 'fintech',
       locale: 'en',
-      canonicalUrl: 'https://fintech.the-full-stack.com/',
+      canonicalUrl: 'https://fintech.portfolio.the-full-stack.com/',
       knowsAbout: ['Vue', 'Django'],
     })
     const parsed = JSON.parse(ld)
@@ -29,7 +29,7 @@ describe('buildProfilePageSchema', () => {
       profile,
       niche: 'fintech',
       locale: 'en',
-      canonicalUrl: 'https://fintech.the-full-stack.com/',
+      canonicalUrl: 'https://fintech.portfolio.the-full-stack.com/',
       knowsAbout: ['Vue', 'Django'],
     })
     const parsed = JSON.parse(ld)
@@ -43,7 +43,7 @@ describe('buildProfilePageSchema', () => {
       profile,
       niche: 'architect',
       locale: 'es',
-      canonicalUrl: 'https://architect.the-full-stack.com/',
+      canonicalUrl: 'https://architect.portfolio.the-full-stack.com/',
       knowsAbout: [],
     })
     const parsed = JSON.parse(ld)
@@ -57,7 +57,7 @@ describe('buildProfilePageSchema', () => {
       profile,
       niche: 'vibe',
       locale: 'en',
-      canonicalUrl: 'https://vibe.the-full-stack.com/',
+      canonicalUrl: 'https://vibe.portfolio.the-full-stack.com/',
       knowsAbout: [],
     })
     const parsed = JSON.parse(ld)

--- a/packages/ui/src/components/Nav.astro
+++ b/packages/ui/src/components/Nav.astro
@@ -28,7 +28,7 @@ interface NavItem {
   label: string
   /**
    * Si true, abre en otra pestana (target=_blank). Util para links a otros
-   * dominios del portfolio (ej. "Otras vistas" -> hub.the-full-stack.com).
+   * dominios del portfolio (ej. "Otras vistas" -> hub.portfolio.the-full-stack.com).
    */
   external?: boolean
 }

--- a/packages/ui/tests/unit/contact-storage.test.ts
+++ b/packages/ui/tests/unit/contact-storage.test.ts
@@ -81,7 +81,7 @@ describe('buildCookieString', () => {
   it('Given the-full-stack.com hostname When build Then includes Domain=.the-full-stack.com', () => {
     const result = buildCookieString('value-x', {
       maxAgeSeconds: 604800,
-      hostname: 'fintech.the-full-stack.com',
+      hostname: 'fintech.portfolio.the-full-stack.com',
       protocol: 'https:',
     })
     expect(result).toBe(
@@ -131,7 +131,7 @@ describe('buildCookieString', () => {
 describe('buildExpiredCookieString', () => {
   it('Given hostname When build expired Then uses Max-Age=0 and same Domain', () => {
     const result = buildExpiredCookieString({
-      hostname: 'fintech.the-full-stack.com',
+      hostname: 'fintech.portfolio.the-full-stack.com',
       protocol: 'https:',
     })
     expect(result).toBe(

--- a/serverless/DEPLOYMENT.md
+++ b/serverless/DEPLOYMENT.md
@@ -36,9 +36,9 @@ Antes de empezar el deploy, completar estos pasos manuales (una vez):
    - Crear widget en https://dash.cloudflare.com -> Turnstile -> Add site
    - Mode: **Managed**
    - Hostnames: los 6 subdominios del portfolio (`the-full-stack.com`,
-     `hub.the-full-stack.com`, `fintech.the-full-stack.com`,
-     `architect.the-full-stack.com`, `leader.the-full-stack.com`,
-     `vibe.the-full-stack.com`)
+     `hub.portfolio.the-full-stack.com`, `fintech.portfolio.the-full-stack.com`,
+     `architect.portfolio.the-full-stack.com`, `leader.portfolio.the-full-stack.com`,
+     `vibe.portfolio.the-full-stack.com`)
    - Anotar `TURNSTILE_SITEKEY` y `TURNSTILE_SECRET`
 3. **Neon PostgreSQL**
    - Crear proyecto serverless en https://console.neon.tech

--- a/serverless/docs/secrets.md
+++ b/serverless/docs/secrets.md
@@ -22,7 +22,7 @@
 - **Quien lo lee**: Lambda `contact_form` para validar tokens contra
   `https://challenges.cloudflare.com/turnstile/v0/siteverify`. Tambien
   Lambda `turnstile_validator` (SPEC-007).
-- **Hostnames cubiertos**: `the-full-stack.com`, `hub/fintech/architect/leader/vibe.the-full-stack.com`,
+- **Hostnames cubiertos**: `the-full-stack.com`, `hub/fintech/architect/leader/vibe.portfolio.the-full-stack.com`,
   `localhost`, `127.0.0.1`.
 - **Rotacion**: cuando el widget Turnstile se regenera en Cloudflare dashboard
   (o cuando se sospecha leak). Comando:


### PR DESCRIPTION
## Problema

En prod los 5 niches del portfolio usaban hostnames flat (`hub.the-full-stack.com`, `fintech.the-full-stack.com`, etc.) como excepcion del estandar de subdominios. Decision revisada: prod tambien sigue el patron component-based, igual que dev/stage. Solo el apex queda como excepcion.

## Solucion

Los 5 niches pasan a `{niche}.portfolio.the-full-stack.com`. La unica excepcion permanente es el apex `the-full-stack.com` + `www`.

| | Antes | Ahora |
| --- | --- | --- |
| generic | `the-full-stack.com` | `the-full-stack.com` (sin cambio, apex) |
| niches | `{niche}.the-full-stack.com` | `{niche}.portfolio.the-full-stack.com` |
| nuevo | — | `portfolio.the-full-stack.com` → 301 al apex |

1. **site-urls.ts**: nueva env var `APEX_DOMAIN`. `generic` usa `APEX_DOMAIN` si esta definida (prod, donde el apex difiere del dominio de los niches); si no, usa `BASE_DOMAIN` (dev/stage/local). Defaults cambiados para que `pnpm run build` sin env replique prod.
2. **Redirect**: `apps/generic/public/_redirects` con el 301 de `portfolio.the-full-stack.com` al apex.
3. Fallback `SITE` de los `astro.config.ts`, prebuild scripts, descripciones de `package.json`, `canonicalUrl` del contacto del hub (ahora derivado de `SITE_URL`).
4. Tests de `app-shared` y `seo` + docs (estandar de subdominios, CLAUDE.md, README.md, cloudflare/pages-config.md).

## Infra ya provisionada (fuera del repo)

- 6 CNAMEs nuevos (`{niche}.portfolio` + `portfolio.the-full-stack.com`).
- 6 custom domains nuevos en los Pages projects prod (`active`, verificados HTTP 200).
- 5 custom domains flat + 5 CNAMEs flat **eliminados**.
- `BASE_DOMAIN` + `APEX_DOMAIN` + `SITE_URL` actualizados en los 6 Pages projects prod.

## Como probar

1. Mergear a `dev` (no afecta prod). El deploy de prod se dispara al promover a `main`.
2. Build local: `BASE_DOMAIN=portfolio.the-full-stack.com APEX_DOMAIN=the-full-stack.com SITE_URL=https://fintech.portfolio.the-full-stack.com pnpm --filter @portfolio/fintech run build` — verificar sitemap/canonical.
3. Post-deploy a main: `curl -I https://fintech.portfolio.the-full-stack.com`, `curl -I https://portfolio.the-full-stack.com` (debe dar 301 al apex).

## TODO

- Promover a `main` para que el deploy git-native de Cloudflare rebuildee los 6 proyectos prod con las env vars nuevas (el `_redirects` se activa con ese deploy).
- Los hostnames flat viejos (`hub.the-full-stack.com`, etc.) ya no resuelven — sin redirect, segun lo decidido.