### PR TITLE
chore(seo): actualiza llms.txt y robots.txt de los niches al patron component-based

### DIFF
--- a/apps/architect/public/llms.txt
+++ b/apps/architect/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Frontend Architect with deep microservices and distributed systems experience. 12+ years designing scalable architectures: microfrontend (Vue/Nuxt) + 8+ Django microservices + AWS API Gateway + PostgreSQL/Redis/SQS + observability with CloudWatch/Sentry.
 
-Canonical URL: https://architect.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
+Canonical URL: https://architect.portfolio.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — architect
 
@@ -16,11 +16,11 @@ Frontend Architect · Software Architect · Microservices · Microfrontend · Di
 
 ## Pages
 
-- [Home](https://architect.the-full-stack.com/): Pablo Contreras — Architect · Microservicios · Microfrontends
-- [About](https://architect.the-full-stack.com/about): Education, languages, awards, publications, references
-- [Certificates](https://architect.the-full-stack.com/certificates): Technical certifications relevant to this profile
-- [CV (HTML)](https://architect.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
-- [CV (EN)](https://architect.the-full-stack.com/cv-en.html): ATS-friendly CV in English
+- [Home](https://architect.portfolio.the-full-stack.com/): Pablo Contreras — Architect · Microservicios · Microfrontends
+- [About](https://architect.portfolio.the-full-stack.com/about): Education, languages, awards, publications, references
+- [Certificates](https://architect.portfolio.the-full-stack.com/certificates): Technical certifications relevant to this profile
+- [CV (HTML)](https://architect.portfolio.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
+- [CV (EN)](https://architect.portfolio.the-full-stack.com/cv-en.html): ATS-friendly CV in English
 
 ## Identity
 

--- a/apps/architect/public/robots.txt
+++ b/apps/architect/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://architect.the-full-stack.com/sitemap.xml
-Sitemap: https://architect.the-full-stack.com/sitemap-index.xml
+Sitemap: https://architect.portfolio.the-full-stack.com/sitemap.xml
+Sitemap: https://architect.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/hub/public/llms.txt
+++ b/apps/hub/public/llms.txt
@@ -2,15 +2,15 @@
 
 > Pablo Contreras is a senior Full Stack engineer (Vue + Django + AWS) with 8+ years of experience, specialized in LATAM fintech (Chile, Mexico). This is the entry point to 5 specialized portfolio sites — pick the angle that matches your need.
 
-Canonical: https://the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Peru. Contact: pacg1991@gmail.com.
+Canonical: https://hub.portfolio.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Peru. Contact: pacg1991@gmail.com.
 
 ## Sites
 
-- [Generic Full Stack](https://hub.the-full-stack.com): all 8+ years of experience, all skills.
-- [Fintech LATAM](https://fintech.the-full-stack.com): Chile, Mexico, debt settlement, credit scoring.
-- [Architect](https://architect.the-full-stack.com): microservices, microfrontend, scalable systems.
-- [Tech Lead](https://leader.the-full-stack.com): team leadership, mentoring, shipping product.
-- [Vibe Coding](https://vibe.the-full-stack.com): Claude Code, Cursor, dev tools, AI workflows.
+- [Generic Full Stack](https://the-full-stack.com): all 8+ years of experience, all skills.
+- [Fintech LATAM](https://fintech.portfolio.the-full-stack.com): Chile, Mexico, debt settlement, credit scoring.
+- [Architect](https://architect.portfolio.the-full-stack.com): microservices, microfrontend, scalable systems.
+- [Tech Lead](https://leader.portfolio.the-full-stack.com): team leadership, mentoring, shipping product.
+- [Vibe Coding](https://vibe.portfolio.the-full-stack.com): Claude Code, Cursor, dev tools, AI workflows.
 
 ## Identity
 

--- a/apps/hub/public/robots.txt
+++ b/apps/hub/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://the-full-stack.com/sitemap.xml
-Sitemap: https://the-full-stack.com/sitemap-index.xml
+Sitemap: https://hub.portfolio.the-full-stack.com/sitemap.xml
+Sitemap: https://hub.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/leader/public/llms.txt
+++ b/apps/leader/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Tech Lead and Engineering Manager. 4 leadership roles, 8 teams led, 11+ years shipping product. Innovator of the Year 2023 at Destacame for automating internal operations. Mentoring + delivery + organizational resilience during reorganizations.
 
-Canonical URL: https://leader.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
+Canonical URL: https://leader.portfolio.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — leader
 
@@ -16,11 +16,11 @@ Tech Lead · Engineering Manager · Staff Engineer · Team Lead · Mentoring · 
 
 ## Pages
 
-- [Home](https://leader.the-full-stack.com/): Pablo Contreras — Tech Lead · Mentoring · Shipping fintech
-- [About](https://leader.the-full-stack.com/about): Education, languages, awards, publications, references
-- [Certificates](https://leader.the-full-stack.com/certificates): Technical certifications relevant to this profile
-- [CV (HTML)](https://leader.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
-- [CV (EN)](https://leader.the-full-stack.com/cv-en.html): ATS-friendly CV in English
+- [Home](https://leader.portfolio.the-full-stack.com/): Pablo Contreras — Tech Lead · Mentoring · Shipping fintech
+- [About](https://leader.portfolio.the-full-stack.com/about): Education, languages, awards, publications, references
+- [Certificates](https://leader.portfolio.the-full-stack.com/certificates): Technical certifications relevant to this profile
+- [CV (HTML)](https://leader.portfolio.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
+- [CV (EN)](https://leader.portfolio.the-full-stack.com/cv-en.html): ATS-friendly CV in English
 
 ## Identity
 

--- a/apps/leader/public/robots.txt
+++ b/apps/leader/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://leader.the-full-stack.com/sitemap.xml
-Sitemap: https://leader.the-full-stack.com/sitemap-index.xml
+Sitemap: https://leader.portfolio.the-full-stack.com/sitemap.xml
+Sitemap: https://leader.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/vibe/public/llms.txt
+++ b/apps/vibe/public/llms.txt
@@ -2,7 +2,7 @@
 
 > AI-Augmented Software Engineer. Using Claude Code since launch (May 2025), previously Claude web + my own FastStruct VS Code extension. Rolled out Claude Code at Destacame with standardized skills/rules/docs structure. Builds CLIs to centralize team processes. AI is a tool, not an author — all code is human-reviewed and tested.
 
-Canonical URL: https://vibe.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
+Canonical URL: https://vibe.portfolio.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Perú. Availability: Remote-friendly · LATAM/US timezone. Contact: pacg1991@gmail.com.
 
 ## Highlights — vibe
 
@@ -18,11 +18,11 @@ AI-Augmented Developer · Vibe Coding · Claude Code · Cursor · Prompt Enginee
 
 ## Pages
 
-- [Home](https://vibe.the-full-stack.com/): Pablo Contreras — Vibe Coding · Claude Code · Cursor · Dev tools
-- [About](https://vibe.the-full-stack.com/about): Education, languages, awards, publications, references
-- [Certificates](https://vibe.the-full-stack.com/certificates): Technical certifications relevant to this profile
-- [CV (HTML)](https://vibe.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
-- [CV (EN)](https://vibe.the-full-stack.com/cv-en.html): ATS-friendly CV in English
+- [Home](https://vibe.portfolio.the-full-stack.com/): Pablo Contreras — Vibe Coding · Claude Code · Cursor · Dev tools
+- [About](https://vibe.portfolio.the-full-stack.com/about): Education, languages, awards, publications, references
+- [Certificates](https://vibe.portfolio.the-full-stack.com/certificates): Technical certifications relevant to this profile
+- [CV (HTML)](https://vibe.portfolio.the-full-stack.com/cv.html): ATS-friendly CV in Spanish
+- [CV (EN)](https://vibe.portfolio.the-full-stack.com/cv-en.html): ATS-friendly CV in English
 
 ## Identity
 

--- a/apps/vibe/public/robots.txt
+++ b/apps/vibe/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://vibe.the-full-stack.com/sitemap.xml
-Sitemap: https://vibe.the-full-stack.com/sitemap-index.xml
+Sitemap: https://vibe.portfolio.the-full-stack.com/sitemap.xml
+Sitemap: https://vibe.portfolio.the-full-stack.com/sitemap-index.xml


### PR DESCRIPTION
## Problema

El PR #42 migro los niches de prod a `{niche}.portfolio.the-full-stack.com` pero algunos archivos generados (`llms.txt`, `robots.txt`) quedaron con los hostnames flat viejos:

- `architect/leader/vibe`: los `public/*.txt` se regeneran via prebuild, pero no se habian regenerado al cerrar el #42.
- `hub`: no tiene prebuild — su `llms.txt`/`robots.txt` son estaticos y apuntaban a hostnames viejos (incluido un link a `hub.the-full-stack.com` que era el generic).

## Solucion

- `architect/leader/vibe`: `public/llms.txt` + `public/robots.txt` regenerados por el prebuild con los hostnames nuevos.
- `hub`: `public/llms.txt` + `public/robots.txt` corregidos a mano — canonical `hub.portfolio.the-full-stack.com`, los 5 links a sitios con el patron correcto (generic al apex, niches con `.portfolio`).

## Como probar

`grep -rn "{hub,fintech,architect,leader,vibe}.the-full-stack.com" apps/*/public/*.txt` no debe devolver nada.

## TODO

Vacio.