### PR TITLE
fix(infra): redirect portfolio.the-full-stack.com via Cloudflare Redirect Rule

### DIFF
--- a/.claude/docs/subdomain-standard/04-portfolio-exception.md
+++ b/.claude/docs/subdomain-standard/04-portfolio-exception.md
@@ -42,7 +42,11 @@ el apex del ambiente es `portfolio.dev.the-full-stack.com` /
 
 `portfolio.the-full-stack.com` existe (consistencia de patron) y hace
 redirect 301 al apex `the-full-stack.com` — el apex es la URL canonica
-de generic.
+de generic. El redirect se implementa con una Cloudflare Redirect Rule
+a nivel de zona (`http.host eq "portfolio.the-full-stack.com"`), NO con
+un `_redirects` de Pages: el proyecto `generic` sirve tanto el apex como
+`portfolio.*`, asi que un `_redirects` por path redirigiria tambien el
+apex. La Redirect Rule discrimina por hostname.
 
 ## Apex / www
 

--- a/apps/generic/public/_redirects
+++ b/apps/generic/public/_redirects
@@ -1,5 +1,0 @@
-# Redirect 301: portfolio.the-full-stack.com -> apex the-full-stack.com
-# El hostname portfolio.the-full-stack.com existe por consistencia del
-# estandar de subdominios, pero el apex es la URL canonica de generic.
-# Preserva el path completo via :splat.
-https://portfolio.the-full-stack.com/*  https://the-full-stack.com/:splat  301


### PR DESCRIPTION
## Problema

El `_redirects` agregado en el PR #42 (`apps/generic/public/_redirects`) no funciona: Cloudflare Pages aplica `_redirects` por path dentro del proyecto y no discrimina por hostname. Como el proyecto `generic` sirve tanto el apex `the-full-stack.com` como `portfolio.the-full-stack.com`, una regla por path redirigiria ambos. Resultado: `portfolio.the-full-stack.com` devolvia HTTP 200 en vez de 301.

## Solucion

- Elimina `apps/generic/public/_redirects` (codigo muerto).
- El redirect 301 se implementa con una **Cloudflare Redirect Rule** a nivel de zona que discrimina por `http.host eq "portfolio.the-full-stack.com"`. Ya esta activa y verificada.
- Documenta el motivo en `04-portfolio-exception.md`.

## Verificado en vivo

```
portfolio.the-full-stack.com/        -> 301 -> the-full-stack.com/
portfolio.the-full-stack.com/about?x=1 -> 301 -> the-full-stack.com/about?x=1
the-full-stack.com/                  -> 200 (apex no afectado)
```

## TODO

Vacio.