### PR TITLE
fix(serverless): alinea CORS y whitelist Turnstile con hostnames component-based

### DIFF
--- a/serverless/src/contact_form/turnstile.py
+++ b/serverless/src/contact_form/turnstile.py
@@ -23,20 +23,10 @@ from common.ssm_client import get_secret
 
 TURNSTILE_SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
 
-# Lista de hostnames esperados (debe matchear el widget del Cloudflare dashboard).
-# 'localhost' apex se acepta siempre (compat con dev). Subdominios *.localhost
+# Hostnames siempre aceptados (compat con dev local). Subdominios *.localhost
 # se aceptan solo en stage=dev via _LOCAL_SUBDOMAIN_PATTERN (RFC 6761 garantiza
 # que resuelven a 127.0.0.1).
-_EXPECTED_HOSTNAMES = frozenset({
-    'the-full-stack.com',
-    'hub.the-full-stack.com',
-    'fintech.the-full-stack.com',
-    'architect.the-full-stack.com',
-    'leader.the-full-stack.com',
-    'vibe.the-full-stack.com',
-    'localhost',
-    '127.0.0.1',
-})
+_BASE_HOSTNAMES = frozenset({'localhost', '127.0.0.1'})
 
 # Pattern para subdominios *.localhost. Turnstile envia solo el hostname
 # (sin scheme ni puerto), por eso no incluimos http:// ni :port aqui.
@@ -45,9 +35,32 @@ _LOCAL_SUBDOMAIN_PATTERN: re.Pattern[str] = re.compile(
 )
 
 
+def _expected_hostnames() -> frozenset[str]:
+    """
+    Hostnames validos del widget Turnstile para el stage actual.
+
+    Se derivan de la env var CORS_ALLOWED_ORIGINS (la misma whitelist que
+    usa cors.py, definida por stage en Mappings.StageConfig del SAM
+    template): se extrae el host de cada origin `https://<host>`. Asi un
+    solo lugar (`StageConfig`) define los hostnames del ambiente y no hay
+    listas hardcodeadas que se desincronicen al cambiar de subdominio.
+    """
+    origins = os.environ.get('CORS_ALLOWED_ORIGINS', '').strip()
+    hosts = set(_BASE_HOSTNAMES)
+    for origin in origins.split(','):
+        origin = origin.strip()
+        if not origin:
+            continue
+        # `https://host` -> `host` (Turnstile reporta hostname sin scheme).
+        host = origin.split('://', 1)[-1].split('/', 1)[0].split(':', 1)[0]
+        if host:
+            hosts.add(host)
+    return frozenset(hosts)
+
+
 def _hostname_allowed(hostname: str) -> bool:
-    """True si hostname esta en whitelist apex o es *.localhost en stage dev."""
-    if hostname in _EXPECTED_HOSTNAMES:
+    """True si hostname esta en whitelist del stage o es *.localhost en dev."""
+    if hostname in _expected_hostnames():
         return True
     if (
         os.environ.get('STAGE', 'dev') == 'dev'

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -86,7 +86,9 @@ Globals:
         RATE_LIMIT_RULES_TABLE_NAME: !Ref RateLimitRulesTable
         RATE_LIMIT_BUCKETS_TABLE_NAME: !Ref RateLimitBucketsTable
         # SSM paths (las Lambdas resuelven valores con boto3 SSM client)
-        SSM_TURNSTILE_SECRET_PATH: /portfolio/turnstile-secret
+        # turnstile-secret es por stage: cada ambiente tiene su widget
+        # Cloudflare Turnstile (limite de 10 dominios por widget).
+        SSM_TURNSTILE_SECRET_PATH: !Sub /portfolio/${Stage}/turnstile-secret
         SSM_NEON_URL_PATH: /portfolio/neon-url
         SSM_OWNER_EMAIL_PATH: /portfolio/owner-email
         SSM_SES_FROM_PATH: /portfolio/ses-from-address
@@ -264,7 +266,7 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref RateLimitBucketsTable
         - SSMParameterReadPolicy:
-            ParameterName: 'portfolio/turnstile-secret'
+            ParameterName: !Sub 'portfolio/${Stage}/turnstile-secret'
         # SSM bypass secret: la IAM policy se concede siempre pero la Lambda
         # solo lee el param si STAGE in {dev,local} (defense-in-depth en codigo).
         # En stage=prod el SSM param no debe existir, lo que falla la lectura
@@ -329,7 +331,7 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref RateLimitBucketsTable
         - SSMParameterReadPolicy:
-            ParameterName: 'portfolio/turnstile-secret'
+            ParameterName: !Sub 'portfolio/${Stage}/turnstile-secret'
         - Statement:
             - Effect: Allow
               Action: kms:Decrypt

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -42,7 +42,7 @@ Parameters:
 # (CSV). cors.py la lee para validar el Origin header y hacer echo del valor
 # matcheado en Access-Control-Allow-Origin.
 #
-# - prod:  niches flat sobre el apex (excepcion del estandar de subdominios).
+# - prod:  apex the-full-stack.com (+ www) + niches {niche}.portfolio.the-full-stack.com.
 # - stage: patron component-based {niche}.portfolio.stage.the-full-stack.com.
 # - dev:   patron component-based {niche}.portfolio.dev.the-full-stack.com.
 #          cors.py ademas acepta *.localhost por pattern cuando STAGE=dev.
@@ -54,7 +54,7 @@ Mappings:
     stage:
       CorsAllowedOrigins: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com'
     prod:
-      CorsAllowedOrigins: 'https://the-full-stack.com,https://hub.the-full-stack.com,https://fintech.the-full-stack.com,https://architect.the-full-stack.com,https://leader.the-full-stack.com,https://vibe.the-full-stack.com'
+      CorsAllowedOrigins: 'https://the-full-stack.com,https://www.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com'
 
 # ============================================================================
 # Globals: configuracion compartida por TODAS las Lambdas del stack

--- a/serverless/tests/unit/contact_form/conftest.py
+++ b/serverless/tests/unit/contact_form/conftest.py
@@ -37,6 +37,17 @@ def contact_form_aws(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
     )
     monkeypatch.setenv('POWERTOOLS_SERVICE_NAME', 'contact-form-test')
     monkeypatch.setenv('POWERTOOLS_METRICS_NAMESPACE', 'PortfolioTest')
+    # Whitelist CORS/Turnstile (en runtime la inyecta Mappings.StageConfig).
+    monkeypatch.setenv(
+        'CORS_ALLOWED_ORIGINS',
+        'https://the-full-stack.com,'
+        'https://www.the-full-stack.com,'
+        'https://hub.portfolio.the-full-stack.com,'
+        'https://fintech.portfolio.the-full-stack.com,'
+        'https://architect.portfolio.the-full-stack.com,'
+        'https://leader.portfolio.the-full-stack.com,'
+        'https://vibe.portfolio.the-full-stack.com',
+    )
 
     with mock_aws():
         # DynamoDB tables


### PR DESCRIPTION
## Problema

El form de contacto de prod (`the-full-stack.com/contact`) mostraba el fallback "El formulario aun no esta configurado". Dos causas:

1. Los 6 Pages projects prod no tenian `PUBLIC_API_ENDPOINT` ni `PUBLIC_TURNSTILE_SITEKEY` (resuelto fuera del repo: env vars + redeploy).
2. El backend prod quedo desalineado tras la migracion component-based (PR #42):
   - `StageConfig.prod` del `template.yaml` tenia los hostnames flat viejos -> la Lambda rechazaba CORS de los niches `.portfolio`.
   - `turnstile.py` tenia `_EXPECTED_HOSTNAMES` hardcodeado con hostnames flat -> la validacion Turnstile rechazaba los niches.

## Solucion

- `StageConfig.prod`: apex `the-full-stack.com` + `www` + niches `{niche}.portfolio.the-full-stack.com`.
- `turnstile.py`: `_EXPECTED_HOSTNAMES` hardcodeado reemplazado por `_expected_hostnames()` que deriva la whitelist de `CORS_ALLOWED_ORIGINS` (misma fuente que `cors.py`, definida por stage en `Mappings.StageConfig`). Una sola fuente de verdad, sin listas que se desincronicen.
- `conftest` de contact_form: agrega `CORS_ALLOWED_ORIGINS` para que los tests reflejen el runtime.

## Infra ya aplicada (fuera del repo)

- 6 Pages projects prod: `PUBLIC_API_ENDPOINT=https://api.portfolio.the-full-stack.com` + `PUBLIC_TURNSTILE_SITEKEY` agregados, 6 redeploys hechos.
- Stacks SAM dev/stage/prod redeployados con el `turnstile.py` corregido.

## Verificado en vivo

- `the-full-stack.com/contact` ya renderiza el form (widget Turnstile + endpoint), sin el fallback.
- `POST /contact` con `Origin: fintech.portfolio.the-full-stack.com` -> la Lambda hace echo de ese origin en `Access-Control-Allow-Origin`.
- 36/36 tests de contact_form verdes.

## TODO

- Verificar en el dashboard de Cloudflare Turnstile que el widget tenga registrados los hostnames `.portfolio` (si no, la validacion del token fallaria por hostname aunque el backend ya los acepte).