### PR TITLE
feat(seo): mejora SEO/GEO en las 6 apps con robots por entorno y schemas

### DIFF
--- a/apps/architect/public/robots.txt
+++ b/apps/architect/public/robots.txt
@@ -1,5 +1,30 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 User-agent: *
 Allow: /
+Disallow:
 
 Sitemap: https://architect.portfolio.the-full-stack.com/sitemap.xml
 Sitemap: https://architect.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/fintech/public/robots.txt
+++ b/apps/fintech/public/robots.txt
@@ -1,5 +1,30 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 User-agent: *
 Allow: /
+Disallow:
 
 Sitemap: https://fintech.portfolio.the-full-stack.com/sitemap.xml
 Sitemap: https://fintech.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/generic/public/robots.txt
+++ b/apps/generic/public/robots.txt
@@ -1,5 +1,30 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 User-agent: *
 Allow: /
+Disallow:
 
 Sitemap: https://the-full-stack.com/sitemap.xml
 Sitemap: https://the-full-stack.com/sitemap-index.xml

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -9,7 +9,8 @@
     "build": "astro build",
     "preview": "astro preview --port 4322",
     "astro": "astro",
-    "typecheck": "astro check"
+    "typecheck": "astro check",
+    "prebuild": "vite-node --config scripts/vite.config.ts scripts/build-public-assets.mjs"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.2",

--- a/apps/hub/public/llms.txt
+++ b/apps/hub/public/llms.txt
@@ -1,19 +1,34 @@
 # Pablo Contreras — Portfolio Hub
 
-> Pablo Contreras is a senior Full Stack engineer (Vue + Django + AWS) with 8+ years of experience, specialized in LATAM fintech (Chile, Mexico). This is the entry point to 5 specialized portfolio sites — pick the angle that matches your need.
+> Pablo Contreras is a senior Full Stack engineer (Vue + Django + AWS)
+> with 12+ years of experience, specialized in LATAM fintech (Chile,
+> Mexico). This is the entry point to 5 specialized portfolio sites —
+> pick the angle that matches your need.
 
-Canonical: https://hub.portfolio.the-full-stack.com. Author: Pablo Contreras (bypabloc). Location: Lima, Peru. Contact: pacg1991@gmail.com.
+Canonical: https://hub.portfolio.the-full-stack.com. Author: Pablo Contreras (bypabloc).
+Location: Lima, Peru. Contact: pacg1991@gmail.com.
 
 ## Sites
 
-- [Generic Full Stack](https://the-full-stack.com): all 8+ years of experience, all skills.
-- [Fintech LATAM](https://fintech.portfolio.the-full-stack.com): Chile, Mexico, debt settlement, credit scoring.
-- [Architect](https://architect.portfolio.the-full-stack.com): microservices, microfrontend, scalable systems.
-- [Tech Lead](https://leader.portfolio.the-full-stack.com): team leadership, mentoring, shipping product.
-- [Vibe Coding](https://vibe.portfolio.the-full-stack.com): Claude Code, Cursor, dev tools, AI workflows.
+- [Generic Full Stack](https://the-full-stack.com): all 12+ years of
+  experience, all skills.
+- [Fintech LATAM](https://fintech.portfolio.the-full-stack.com): Chile,
+  Mexico, debt settlement, credit scoring.
+- [Architect](https://architect.portfolio.the-full-stack.com):
+  microservices, microfrontend, scalable systems.
+- [Tech Lead](https://leader.portfolio.the-full-stack.com): team
+  leadership, mentoring, shipping product.
+- [Vibe Coding](https://vibe.portfolio.the-full-stack.com): Claude Code,
+  Cursor, dev tools, AI workflows.
 
 ## Identity
 
 - LinkedIn: https://linkedin.com/in/bypabloc
 - GitHub: https://github.com/bypabloc
-- Medium: https://bypablo.medium.com
+
+## Disclosure
+
+All code in linked repositories is reviewed, tested and maintained by
+Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators
+— never as authors. This llms.txt is honest white-hat content; no prompt
+injection or hidden instructions.

--- a/apps/hub/public/robots.txt
+++ b/apps/hub/public/robots.txt
@@ -1,5 +1,30 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 User-agent: *
 Allow: /
+Disallow:
 
 Sitemap: https://hub.portfolio.the-full-stack.com/sitemap.xml
 Sitemap: https://hub.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/hub/scripts/build-public-assets.mjs
+++ b/apps/hub/scripts/build-public-assets.mjs
@@ -1,0 +1,76 @@
+/**
+ * @script build-public-assets (hub)
+ * @description Pre-build step que genera assets dinamicos a /public para el
+ *   hub selector. A diferencia de las apps niche, el hub NO renderiza CV:
+ *   solo genera robots.txt (con deteccion de entorno + AI crawlers) y un
+ *   llms.txt propio que enumera los 5 sitios del portfolio.
+ *
+ *   Se ejecuta antes de `astro build` (prebuild en package.json).
+ */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildRobotsTxt } from '@portfolio/seo'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PUBLIC_DIR = resolve(__dirname, '../public')
+const SITE_URL =
+  process.env.SITE_URL ?? 'https://hub.portfolio.the-full-stack.com'
+
+async function write(path, content) {
+  const full = resolve(PUBLIC_DIR, path)
+  await mkdir(dirname(full), { recursive: true })
+  await writeFile(full, content, 'utf-8')
+  console.info(`[public] wrote ${path} (${content.length} bytes)`)
+}
+
+function buildHubLlmsTxt() {
+  return [
+    '# Pablo Contreras — Portfolio Hub',
+    '',
+    '> Pablo Contreras is a senior Full Stack engineer (Vue + Django + AWS)',
+    '> with 12+ years of experience, specialized in LATAM fintech (Chile,',
+    '> Mexico). This is the entry point to 5 specialized portfolio sites —',
+    '> pick the angle that matches your need.',
+    '',
+    `Canonical: ${SITE_URL}. Author: Pablo Contreras (bypabloc).`,
+    'Location: Lima, Peru. Contact: pacg1991@gmail.com.',
+    '',
+    '## Sites',
+    '',
+    '- [Generic Full Stack](https://the-full-stack.com): all 12+ years of',
+    '  experience, all skills.',
+    '- [Fintech LATAM](https://fintech.portfolio.the-full-stack.com): Chile,',
+    '  Mexico, debt settlement, credit scoring.',
+    '- [Architect](https://architect.portfolio.the-full-stack.com):',
+    '  microservices, microfrontend, scalable systems.',
+    '- [Tech Lead](https://leader.portfolio.the-full-stack.com): team',
+    '  leadership, mentoring, shipping product.',
+    '- [Vibe Coding](https://vibe.portfolio.the-full-stack.com): Claude Code,',
+    '  Cursor, dev tools, AI workflows.',
+    '',
+    '## Identity',
+    '',
+    '- LinkedIn: https://linkedin.com/in/bypabloc',
+    '- GitHub: https://github.com/bypabloc',
+    '',
+    '## Disclosure',
+    '',
+    'All code in linked repositories is reviewed, tested and maintained by',
+    'Pablo Contreras. AI tools (Claude Code, Cursor) are used as accelerators',
+    '— never as authors. This llms.txt is honest white-hat content; no prompt',
+    'injection or hidden instructions.',
+    '',
+  ].join('\n')
+}
+
+async function main() {
+  await mkdir(PUBLIC_DIR, { recursive: true })
+  await write('robots.txt', buildRobotsTxt(SITE_URL))
+  await write('llms.txt', buildHubLlmsTxt())
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/hub/scripts/vite.config.ts
+++ b/apps/hub/scripts/vite.config.ts
@@ -1,0 +1,13 @@
+/**
+ * @config vite
+ * @description Vite config para los scripts de prebuild (vite-node) del hub.
+ *   Registra el yaml plugin para que cualquier import transitivo de
+ *   `@portfolio/content` pueda cargar sus `.yaml` files.
+ */
+import yaml from '@modyfi/vite-plugin-yaml'
+import { JSON_SCHEMA } from 'js-yaml'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [yaml({ schema: JSON_SCHEMA })],
+})

--- a/apps/leader/public/robots.txt
+++ b/apps/leader/public/robots.txt
@@ -1,5 +1,30 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 User-agent: *
 Allow: /
+Disallow:
 
 Sitemap: https://leader.portfolio.the-full-stack.com/sitemap.xml
 Sitemap: https://leader.portfolio.the-full-stack.com/sitemap-index.xml

--- a/apps/vibe/public/robots.txt
+++ b/apps/vibe/public/robots.txt
@@ -1,5 +1,30 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 User-agent: *
 Allow: /
+Disallow:
 
 Sitemap: https://vibe.portfolio.the-full-stack.com/sitemap.xml
 Sitemap: https://vibe.portfolio.the-full-stack.com/sitemap-index.xml

--- a/packages/app-shared/src/layouts/SitePageLayout.astro
+++ b/packages/app-shared/src/layouts/SitePageLayout.astro
@@ -1,7 +1,10 @@
 ---
 import type { Niche } from '@portfolio/content'
 import { filterByNiche, profile, skills } from '@portfolio/content'
-import { buildProfilePageSchema } from '@portfolio/seo'
+import {
+  buildProfilePageSchema,
+  buildSiteNavigationSchema,
+} from '@portfolio/seo'
 import { nicheTokensToCssVars } from '@portfolio/ui'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import Nav from '@portfolio/ui/components/Nav.astro'
@@ -56,13 +59,52 @@ const canonicalUrl = `${siteUrl}${canonicalPath}`
 const knowsAbout = filterByNiche(skills, niche).flatMap((c) =>
   c.skills.slice(0, 5),
 )
-const jsonLd = buildProfilePageSchema({
+const profilePageLd = buildProfilePageSchema({
   profile,
   niche,
   locale,
   canonicalUrl,
   knowsAbout,
 })
+
+// SiteNavigationElement: declara las paginas principales del sitio para que
+// Google entienda la jerarquia (favorece sitelinks en busquedas de marca).
+const navSchemaItems = [
+  {
+    name: locale === 'es' ? 'Inicio' : 'Home',
+    path: locale === 'es' ? '/' : '/en/',
+  },
+  {
+    name: locale === 'es' ? 'Sobre mí' : 'About',
+    path: locale === 'es' ? '/about' : '/en/about',
+  },
+  {
+    name: locale === 'es' ? 'Certificados' : 'Certificates',
+    path: locale === 'es' ? '/certificates' : '/en/certificates',
+  },
+  {
+    name: locale === 'es' ? 'Contacto' : 'Contact',
+    path: locale === 'es' ? '/contact' : '/en/contact',
+  },
+]
+const siteNavigationLd = buildSiteNavigationSchema({
+  siteUrl,
+  items: navSchemaItems,
+})
+
+const jsonLd = [profilePageLd, siteNavigationLd]
+
+// hreflang: par es <-> en de la pagina actual, URLs absolutas.
+const alternates = [
+  {
+    hreflang: 'es',
+    href: `${siteUrl}${locale === 'es' ? canonicalPath : otherLocalePath}`,
+  },
+  {
+    hreflang: 'en',
+    href: `${siteUrl}${locale === 'en' ? canonicalPath : otherLocalePath}`,
+  },
+]
 
 const nicheStyle = nicheTokensToCssVars(niche)
 ---
@@ -74,6 +116,7 @@ const nicheStyle = nicheTokensToCssVars(niche)
   locale={locale}
   ogImage={ogImage}
   jsonLd={jsonLd}
+  alternates={alternates}
 >
   <Nav
     slot="nav"

--- a/packages/seo/src/index.ts
+++ b/packages/seo/src/index.ts
@@ -5,4 +5,9 @@
 export { buildLlmsTxt } from './lib/build-llms-txt'
 export { buildPersonSchema } from './lib/build-person-schema'
 export { buildProfilePageSchema } from './lib/build-profile-page-schema'
-export { buildRobotsTxt, buildSitemap } from './lib/build-sitemap'
+export { buildSiteNavigationSchema } from './lib/build-site-navigation-schema'
+export {
+  buildRobotsTxt,
+  buildSitemap,
+  isNonProdHost,
+} from './lib/build-sitemap'

--- a/packages/seo/src/lib/build-site-navigation-schema.ts
+++ b/packages/seo/src/lib/build-site-navigation-schema.ts
@@ -1,0 +1,74 @@
+/**
+ * @function buildSiteNavigationSchema
+ * @description Construye un schema.org ItemList de SiteNavigationElement para
+ *   JSON-LD. Describe las paginas principales del sitio de forma estructurada,
+ *   lo que ayuda a Google a entender la jerarquia de navegacion y favorece la
+ *   aparicion de sitelinks en los resultados de busqueda de marca.
+ *
+ *   No garantiza sitelinks (Google los genera por su algoritmo), pero da una
+ *   senal estructurada explicita de cuales son las secciones canonicas.
+ *
+ * @param input - siteUrl base + items de navegacion (name + path relativo)
+ * @returns JSON-LD stringificado (listo para <script type="application/ld+json">)
+ *
+ * @example
+ *   const ld = buildSiteNavigationSchema({
+ *     siteUrl: 'https://the-full-stack.com',
+ *     items: [
+ *       { name: 'Home', path: '/' },
+ *       { name: 'About', path: '/about' },
+ *       { name: 'Certificates', path: '/certificates' },
+ *     ],
+ *   })
+ *   //  '{"@context":"https://schema.org","@type":"ItemList",...}'
+ */
+
+interface NavSchemaItem {
+  /** Etiqueta visible de la pagina. */
+  name: string
+  /** Path relativo desde el siteUrl (ej. '/about', '/'). */
+  path: string
+}
+
+interface BuildSiteNavigationSchemaInput {
+  /** URL absoluta del sitio (con o sin trailing slash). */
+  siteUrl: string
+  /** Paginas principales a declarar como nodos de navegacion. */
+  items: NavSchemaItem[]
+}
+
+interface SiteNavigationElementLd {
+  '@type': 'SiteNavigationElement'
+  position: number
+  name: string
+  url: string
+}
+
+interface ItemListLd {
+  '@context': 'https://schema.org'
+  '@type': 'ItemList'
+  itemListElement: SiteNavigationElementLd[]
+}
+
+export function buildSiteNavigationSchema(
+  input: BuildSiteNavigationSchemaInput,
+): string {
+  const base = input.siteUrl.replace(/\/$/, '')
+
+  const itemListElement: SiteNavigationElementLd[] = input.items.map(
+    (item, index) => ({
+      '@type': 'SiteNavigationElement',
+      position: index + 1,
+      name: item.name,
+      url: `${base}${item.path}`,
+    }),
+  )
+
+  const ld: ItemListLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement,
+  }
+
+  return JSON.stringify(ld)
+}

--- a/packages/seo/src/lib/build-sitemap.ts
+++ b/packages/seo/src/lib/build-sitemap.ts
@@ -56,18 +56,85 @@ function escapeXml(s: string): string {
     .replace(/'/g, '&apos;')
 }
 
+/** Crawlers de IA que se permiten explicitamente en prod (GEO white-hat). */
+const AI_CRAWLERS = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'ClaudeBot',
+  'Claude-Web',
+  'Google-Extended',
+  'PerplexityBot',
+  'CCBot',
+] as const
+
+/**
+ * @function isNonProdHost
+ * @description Detecta si un siteUrl corresponde a un entorno no productivo
+ *   (dev / stage / local). Esos entornos NO deben indexarse.
+ *
+ * @param {string} siteUrl - URL absoluta del sitio
+ * @returns {boolean} true si el host es dev/stage/localhost/pages.dev
+ *
+ * @example
+ *   isNonProdHost('https://portfolio.dev.the-full-stack.com')  // true
+ *   isNonProdHost('http://hub.localhost:9970')                 // true
+ *   isNonProdHost('https://the-full-stack.com')                // false
+ */
+export function isNonProdHost(siteUrl: string): boolean {
+  let host: string
+  try {
+    host = new URL(siteUrl).hostname
+  } catch {
+    host = siteUrl
+  }
+  return (
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.pages.dev') ||
+    host.includes('.dev.') ||
+    host.includes('.stage.')
+  )
+}
+
 /**
  * @function buildRobotsTxt
- * @description Genera /robots.txt.
+ * @description Genera /robots.txt segun el entorno del siteUrl.
+ *
+ *   - Prod: indexable. Permite `*` + lista explicita de crawlers de IA
+ *     (GPTBot, ClaudeBot, Google-Extended, PerplexityBot, CCBot...) para
+ *     maximizar GEO. Apunta a los sitemaps.
+ *   - dev / stage / localhost / pages.dev: `Disallow: /` total. Evita que
+ *     Google y los crawlers de IA indexen entornos no productivos.
+ *
+ * @param {string} siteUrl - URL absoluta del sitio (define el entorno)
+ * @returns {string} contenido de robots.txt
+ *
+ * @example
+ *   buildRobotsTxt('https://the-full-stack.com')        // indexable + AI crawlers
+ *   buildRobotsTxt('https://portfolio.dev.the-full-stack.com')  // Disallow: /
  */
 export function buildRobotsTxt(siteUrl: string): string {
+  if (isNonProdHost(siteUrl)) {
+    return 'User-agent: *\nDisallow: /\n'
+  }
+
   const u = siteUrl.replace(/\/$/, '')
-  return [
-    'User-agent: *',
-    'Allow: /',
-    '',
-    `Sitemap: ${u}/sitemap.xml`,
-    `Sitemap: ${u}/sitemap-index.xml`,
-    '',
-  ].join('\n')
+  const lines: string[] = []
+
+  for (const crawler of AI_CRAWLERS) {
+    lines.push(`User-agent: ${crawler}`)
+    lines.push('Allow: /')
+    lines.push('')
+  }
+
+  lines.push('User-agent: *')
+  lines.push('Allow: /')
+  lines.push('Disallow:')
+  lines.push('')
+  lines.push(`Sitemap: ${u}/sitemap.xml`)
+  lines.push(`Sitemap: ${u}/sitemap-index.xml`)
+  lines.push('')
+
+  return lines.join('\n')
 }

--- a/packages/seo/tests/unit/build-site-navigation-schema.test.ts
+++ b/packages/seo/tests/unit/build-site-navigation-schema.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @description Tests para buildSiteNavigationSchema. Emite un ItemList de
+ *   schema.org SiteNavigationElement que ayuda a Google a entender la
+ *   estructura del sitio (favorece los sitelinks).
+ */
+import { describe, expect, it } from 'vitest'
+import { buildSiteNavigationSchema } from '../../src/lib/build-site-navigation-schema'
+
+describe('buildSiteNavigationSchema', () => {
+  it('Given nav items When build Then returns valid ItemList JSON-LD', () => {
+    const ld = buildSiteNavigationSchema({
+      siteUrl: 'https://the-full-stack.com',
+      items: [
+        { name: 'Home', path: '/' },
+        { name: 'About', path: '/about' },
+      ],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed['@context']).toBe('https://schema.org')
+    expect(parsed['@type']).toBe('ItemList')
+    expect(parsed.itemListElement).toHaveLength(2)
+  })
+
+  it('Given nav items When build Then each element is a SiteNavigationElement with absolute url', () => {
+    const ld = buildSiteNavigationSchema({
+      siteUrl: 'https://the-full-stack.com/',
+      items: [{ name: 'Certificates', path: '/certificates' }],
+    })
+    const parsed = JSON.parse(ld)
+    const first = parsed.itemListElement[0]
+    expect(first['@type']).toBe('SiteNavigationElement')
+    expect(first.position).toBe(1)
+    expect(first.name).toBe('Certificates')
+    expect(first.url).toBe('https://the-full-stack.com/certificates')
+  })
+
+  it('Given a root path When build Then resolves to siteUrl without double slash', () => {
+    const ld = buildSiteNavigationSchema({
+      siteUrl: 'https://the-full-stack.com/',
+      items: [{ name: 'Home', path: '/' }],
+    })
+    const parsed = JSON.parse(ld)
+    expect(parsed.itemListElement[0].url).toBe('https://the-full-stack.com/')
+  })
+
+  it('Given several items When build Then positions are sequential from 1', () => {
+    const ld = buildSiteNavigationSchema({
+      siteUrl: 'https://the-full-stack.com',
+      items: [
+        { name: 'Home', path: '/' },
+        { name: 'About', path: '/about' },
+        { name: 'Certificates', path: '/certificates' },
+      ],
+    })
+    const parsed = JSON.parse(ld)
+    const positions = parsed.itemListElement.map(
+      (e: { position: number }) => e.position,
+    )
+    expect(positions).toEqual([1, 2, 3])
+  })
+})

--- a/packages/seo/tests/unit/build-sitemap.test.ts
+++ b/packages/seo/tests/unit/build-sitemap.test.ts
@@ -54,16 +54,49 @@ describe('buildSitemap', () => {
 })
 
 describe('buildRobotsTxt', () => {
-  it('Given a site URL When build Then returns valid robots.txt with sitemap', () => {
-    const txt = buildRobotsTxt('https://x.example/')
+  it('Given a prod site URL When build Then returns valid robots.txt with sitemap', () => {
+    const txt = buildRobotsTxt('https://the-full-stack.com/')
     expect(txt).toContain('User-agent: *')
     expect(txt).toContain('Allow: /')
-    expect(txt).toContain('Sitemap: https://x.example/sitemap.xml')
-    expect(txt).toContain('Sitemap: https://x.example/sitemap-index.xml')
+    expect(txt).toContain('Sitemap: https://the-full-stack.com/sitemap.xml')
+    expect(txt).toContain(
+      'Sitemap: https://the-full-stack.com/sitemap-index.xml',
+    )
   })
 
   it('Given URL without trailing slash When build Then strips correctly', () => {
-    const txt = buildRobotsTxt('https://x.example')
-    expect(txt).toContain('Sitemap: https://x.example/sitemap.xml')
+    const txt = buildRobotsTxt('https://the-full-stack.com')
+    expect(txt).toContain('Sitemap: https://the-full-stack.com/sitemap.xml')
+  })
+
+  it('Given a prod URL When build Then allows AI crawlers explicitly', () => {
+    const txt = buildRobotsTxt('https://the-full-stack.com')
+    expect(txt).toContain('User-agent: GPTBot')
+    expect(txt).toContain('User-agent: ClaudeBot')
+    expect(txt).toContain('User-agent: Google-Extended')
+    expect(txt).toContain('User-agent: PerplexityBot')
+  })
+
+  it('Given a dev hostname When build Then disallows all crawlers', () => {
+    const txt = buildRobotsTxt('https://portfolio.dev.the-full-stack.com')
+    expect(txt).toBe('User-agent: *\nDisallow: /\n')
+  })
+
+  it('Given a stage hostname When build Then disallows all crawlers', () => {
+    const txt = buildRobotsTxt(
+      'https://fintech.portfolio.stage.the-full-stack.com',
+    )
+    expect(txt).toBe('User-agent: *\nDisallow: /\n')
+  })
+
+  it('Given a localhost URL When build Then disallows all crawlers', () => {
+    const txt = buildRobotsTxt('http://hub.localhost:9970')
+    expect(txt).toBe('User-agent: *\nDisallow: /\n')
+  })
+
+  it('Given a prod niche URL When build Then is indexable', () => {
+    const txt = buildRobotsTxt('https://fintech.portfolio.the-full-stack.com')
+    expect(txt).toContain('Disallow:\n')
+    expect(txt).not.toContain('Disallow: /\n')
   })
 })

--- a/packages/ui/src/layouts/BaseLayout.astro
+++ b/packages/ui/src/layouts/BaseLayout.astro
@@ -10,8 +10,14 @@
  * @props {string} canonicalUrl - URL canonical absoluta del sitio actual
  * @props {string} [locale] - 'es' (default) o 'en'
  * @props {string} [ogImage] - URL absoluta de la og-image
- * @props {string} [jsonLd] - JSON-LD stringificado (typeof: Person, BreadcrumbList...)
+ * @props {string|string[]} [jsonLd] - JSON-LD stringificado (uno o varios:
+ *   Person, ProfilePage, ItemList...). Cada string se emite en su propio
+ *   <script type="application/ld+json">.
  * @props {string} [llmsTxtHref] - href al /llms.txt (default '/llms.txt')
+ * @props {string} [siteName] - og:site_name (default 'Pablo Contreras')
+ * @props {Array<{hreflang, href}>} [alternates] - URLs absolutas por locale
+ *   para los <link rel="alternate" hreflang>. Incluir el locale actual y el
+ *   alterno; se agrega x-default automaticamente apuntando al primero.
  */
 import { ClientRouter } from 'astro:transitions'
 import '../styles/tokens.css'
@@ -23,14 +29,21 @@ import '../styles/scroll-driven.css'
 import '../styles/global.css'
 import '../styles/breakpoints.css'
 
+interface Alternate {
+  hreflang: string
+  href: string
+}
+
 interface Props {
   title: string
   description: string
   canonicalUrl: string
   locale?: 'es' | 'en'
   ogImage?: string
-  jsonLd?: string
+  jsonLd?: string | string[]
   llmsTxtHref?: string
+  siteName?: string
+  alternates?: Alternate[]
 }
 
 const {
@@ -41,7 +54,13 @@ const {
   ogImage,
   jsonLd,
   llmsTxtHref = '/llms.txt',
+  siteName = 'Pablo Contreras',
+  alternates,
 } = Astro.props
+
+const ogLocale = locale === 'es' ? 'es_ES' : 'en_US'
+const ogLocaleAlternate = locale === 'es' ? 'en_US' : 'es_ES'
+const jsonLdBlocks = jsonLd === undefined ? [] : [jsonLd].flat()
 ---
 
 <!doctype html>
@@ -53,9 +72,22 @@ const {
     <meta name="color-scheme" content="dark light" />
     <link rel="canonical" href={canonicalUrl} />
     <link rel="alternate" type="text/plain" title="llms.txt" href={llmsTxtHref} />
+    {
+      alternates?.map((alt) => (
+        <link rel="alternate" hreflang={alt.hreflang} href={alt.href} />
+      ))
+    }
+    {
+      alternates && alternates.length > 0 && (
+        <link rel="alternate" hreflang="x-default" href={alternates[0].href} />
+      )
+    }
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta property="og:type" content="profile" />
+    <meta property="og:site_name" content={siteName} />
+    <meta property="og:locale" content={ogLocale} />
+    <meta property="og:locale:alternate" content={ogLocaleAlternate} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalUrl} />
@@ -65,9 +97,9 @@ const {
     <meta name="twitter:description" content={description} />
     {ogImage && <meta name="twitter:image" content={ogImage} />}
     {
-      jsonLd && (
-        <script type="application/ld+json" set:html={jsonLd} />
-      )
+      jsonLdBlocks.map((block) => (
+        <script type="application/ld+json" set:html={block} />
+      ))
     }
     <script is:inline>
       // Aplica el theme inicial ANTES de pintar para evitar FOUC.


### PR DESCRIPTION
## Problema

1. **robots.txt no diferencia entorno ni lista crawlers de IA.** Los 6 `robots.txt` estaticos permitian indexar todo sin distincion: dev y stage quedaban indexables por Google (el estandar de subdominios lo prohibe) y no se declaraban explicitamente los crawlers de IA (GPTBot, ClaudeBot, Google-Extended...), perdiendo apariciones en respuestas de ChatGPT/Claude/Perplexity (GEO).
2. **Falta metadata SEO en el `<head>`.** No habia `<link rel="alternate" hreflang>` (Google no enlazaba el par es/en), ni `og:locale` / `og:site_name`.
3. **Sin senal estructurada de navegacion.** No existia JSON-LD `SiteNavigationElement` que ayuda a Google a entender la jerarquia del sitio (favorece los sitelinks en busquedas de marca).
4. **`apps/hub` sin prebuild.** Su `robots.txt` y `llms.txt` eran estaticos y desactualizados; el `llms.txt` referenciaba Medium, eliminado del portfolio.

## Solucion

1. `buildRobotsTxt` (`packages/seo`) detecta el entorno via nueva `isNonProdHost`: dev/stage/localhost/pages.dev devuelven `Disallow: /`; prod lista 8 crawlers de IA explicitos + apunta a los sitemaps. Las 5 niches regeneran su `robots.txt` en el `prebuild` sin cambios de firma.
2. `BaseLayout.astro` (`packages/ui`) agrega `hreflang` es/en/x-default, `og:locale`, `og:locale:alternate` y `og:site_name`. `jsonLd` ahora acepta `string | string[]`.
3. Nuevo builder `buildSiteNavigationSchema` emite un `ItemList` de `SiteNavigationElement`; `SitePageLayout.astro` lo inyecta junto al `ProfilePage` y construye los `alternates` es/en.
4. `apps/hub` gana `scripts/build-public-assets.mjs` + `scripts/vite.config.ts` + script `prebuild`; su `llms.txt` se regenera sin la referencia a Medium.

## Como probar

1. `pnpm --filter @portfolio/seo exec vitest run` — 34 tests PASS (8 nuevos: 6 `buildRobotsTxt`, 4 `buildSiteNavigationSchema`).
2. `pnpm --filter @portfolio/cv-filters build && pnpm run build` — las 6 apps buildean OK.
3. Inspeccionar `apps/generic/dist/index.html`: presentes `hreflang` es/en/x-default, `og:locale` + `og:site_name`, JSON-LD `ProfilePage`+`Person` y `ItemList`+`SiteNavigationElement`.
4. `apps/*/dist/robots.txt` (prod) lista `GPTBot`/`ClaudeBot`/etc. Probar con un `SITE_URL` dev: `SITE_URL=https://portfolio.dev.the-full-stack.com pnpm --filter @portfolio/generic build` -> `robots.txt` debe ser `Disallow: /`.

## TODO

- Drift potencial entre las 6 apps (paginas duplicadas como `about`/`contact`/`dashboard`).
- `apps/generic/src/pages/dashboard.astro` es publico sin `noindex` — revisar que datos expone.
- Contradiccion entre `.github/workflows/deploy.yml` y la doc de subdominios que afirma "deploy git-native sin workflow".