### PR TITLE
chore(hooks): renombra la rama protegida release a stage

### DIFF
--- a/.claude/hooks/protect-branch.sh
+++ b/.claude/hooks/protect-branch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # PreToolUse hook (matcher: Bash).
 # Bloquea git commit y git push directos cuando HEAD esta en una rama
-# protegida (master/main/dev/stage/release).
+# protegida (master/main/dev/stage).
 #
 # Politica: trabajo siempre en feature/fix/chore branches, merge via PR.
 
@@ -27,7 +27,7 @@ BRANCH="$(current_branch)"
 
 # Lista de ramas protegidas.
 case "$BRANCH" in
-  master|main|dev|stage|release) ;;
+  master|main|dev|stage) ;;
   *) exit 0 ;;
 esac
 
@@ -39,13 +39,13 @@ case "$CMD" in
   *"git merge"*) OP="merge" ;;
 esac
 
-# Excepcion: git push origin master/main/dev/stage/release ya esta en deny list de Bash.
+# Excepcion: git push origin master/main/dev/stage ya esta en deny list de Bash.
 # Pero git push (sin args) en rama protegida tambien debe bloquearse.
 
 echo "Bloqueado por protect-branch: estas en rama protegida '$BRANCH'." >&2
 echo "Operacion rechazada: $OP" >&2
 echo "Politica del proyecto (.claude/rules/git-workflow.md):" >&2
-echo "  - NUNCA $OP directo en master/main/dev/stage/release." >&2
+echo "  - NUNCA $OP directo en master/main/dev/stage." >&2
 echo "  - Crea feature/fix/chore branch primero:" >&2
 echo "      git checkout -b feature/<nombre>" >&2
 echo "  - Despues abre PR con /pr-create o gh pr create." >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ y [.claude/rules/harness-protocol.md](.claude/rules/harness-protocol.md).
 - `attribution.commit` y `attribution.pr` están vacíos en
   [.claude/settings.json](.claude/settings.json) — defensa en profundidad
   contra atribución de IA.
-- Branches `main`, `master`, `dev`, `release` están protegidas: el hook
+- Branches `main`, `master`, `dev`, `stage` están protegidas: el hook
   `protect-branch.sh` bloquea `git push` directo.
 - Subdominios `*.localhost` resuelven a 127.0.0.1 por RFC 6761 (no requiere
   editar `/etc/hosts` en el host). Dentro de containers Docker con

--- a/devtools/harness_init/README.md
+++ b/devtools/harness_init/README.md
@@ -25,7 +25,7 @@ python devtools/run.py harness_init --quiet
    marketplace, cross). JSON válido y respeta `one_feature_at_a_time` por
    módulo. Si un módulo no tiene archivo, no es error (solo aviso).
 3. **Docker** — daemon corriendo y containers principales up
-4. **Branch** — la actual no debe ser protegida (master/dev/release)
+4. **Branch** — la actual no debe ser protegida (master/main/dev/stage)
 5. **`docs/progress/`** — limpio, sin temporales viejos de subagentes
 
 ## Cuando usarlo

--- a/devtools/harness_init/flags.py
+++ b/devtools/harness_init/flags.py
@@ -11,7 +11,7 @@ arnes (Harness Engineering) este listo para empezar a trabajar:
   2. Cualquier docs/<módulo>/feature_list.json existente es JSON válido y
      respeta `one_feature_at_a_time` (por módulo)
   3. Docker daemon corriendo + containers principales up
-  4. Branch actual no es protegida (master/dev/release)
+  4. Branch actual no es protegida (master/main/dev/stage)
   5. docs/progress/ esta limpio (sin temporales viejos)
 
 Exit code 0 si OK, 1 si hay errores críticos.


### PR DESCRIPTION
## Problema

La documentacion y el harness mencionaban una rama protegida `release` que no se usa: la rama de staging del proyecto es `stage`. Ademas las listas de ramas protegidas estaban desalineadas entre si:

1. `protect-branch.sh` listaba `master|main|dev|stage|release` — `release` redundante (no existe esa rama).
2. `CLAUDE.md` listaba `main, master, dev, release` — omitia `stage` (que el hook SI protege) e incluia `release`.
3. `harness_init` (README.md + flags.py) listaban `master/dev/release` — omitian `main` e incluian `release`.

## Solucion

1. `protect-branch.sh`: elimina `release` de las 4 ocurrencias (`stage` ya estaba presente, no se duplica).
2. `CLAUDE.md`: lista de ramas protegidas alineada al hook -> `main, master, dev, stage`.
3. `harness_init` README.md + flags.py: lista corregida a `master/main/dev/stage`.

Alcance acotado: SOLO las 4 menciones de la rama git `release`. NO se tocaron las ~50 ocurrencias de `pre-release` / `release_lock` / `releases` (key de la API de PyPI) / `bloquea release`, que son terminologia legitima de versionado y del modulo de cache.

## Como probar

1. `bash -n .claude/hooks/protect-branch.sh` — sintaxis valida.
2. `devtools/.venv/bin/python -m py_compile devtools/harness_init/flags.py` — compila.
3. Estando en una rama feature/fix/chore, `git commit` y `git push` siguen permitidos; en `master/main/dev/stage` siguen bloqueados.

## TODO

Vacio.