### PR TITLE
ci(workflows): enforce flujo de promocion dev a stage a main

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -78,20 +78,63 @@ style(components): unifica spacing del Footer con tokens del DS
 
 ## Branching strategy
 
-- `main` (o `master`) — produccion / live site desplegado
-- `dev` — desarrollo, rama base para features (opcional en proyectos solo)
+Ramas de entorno (protegidas, deploy automatico a Cloudflare Pages):
+
+- `main` — produccion / live site desplegado (`the-full-stack.com`)
+- `stage` — release candidate (`*.portfolio.stage.the-full-stack.com`)
+- `dev` — desarrollo, rama base para features (`*.portfolio.dev.the-full-stack.com`)
+
+Ramas de trabajo (efimeras, separador `/` obligatorio para VS Code):
+
 - `feature/<nombre>` — nuevas funcionalidades / paginas
 - `fix/<nombre>` — correcciones
 - `chore/<nombre>` — mantenimiento, deps, configs
 - `docs/<nombre>` — solo cambios de documentacion
-- Separador `/` obligatorio para VS Code
+- `release/<nombre>` — promocion de entorno (ver flujo abajo)
+
+## Flujo de promocion dev -> stage -> main (OBLIGATORIO)
+
+Las ramas de entorno se promueven SIEMPRE en cadena, nunca salteando:
+
+```text
+feature/* --PR--> dev --PR--> stage --PR--> main
+```
+
+Reglas duras:
+
+- Un PR a `main` SOLO puede tener como head `stage` (o una `release/*`
+  rebaseada desde `stage`). NUNCA `dev -> main` directo.
+- Un PR a `stage` SOLO puede tener como head `dev` (o una `release/*`).
+- Enforced por el workflow `branch-flow-guard.yml` + ruleset de GitHub.
+
+**Por que NUNCA `dev -> main` directo**: si un commit llega a `main` sin
+pasar por `stage`, la siguiente promocion `dev -> stage` (merge rebase)
+le reescribe el hash. Resultado: el mismo cambio con SHA distinto en
+`main` y en `stage` -> el PR `stage -> main` da conflicto fantasma.
+
+### Como promover
+
+1. `dev -> stage`: `gh pr create --base stage --head dev`.
+2. `stage -> main`: `gh pr create --base main --head stage`.
+3. Si el PR `stage -> main` da conflicto (commits que llegaron a `main`
+   sin pasar por `stage`): crear `release/promote-stage-to-main` desde
+   `origin/stage`, `git rebase origin/main` (git salta los commits ya
+   aplicados por patch-id), abrir el PR desde esa `release/*`.
+
+### Resincronizar tras un hotfix directo a main
+
+Si por emergencia un fix entra directo a `main`, propagarlo el MISMO dia
+a `stage` y `dev` para evitar la divergencia: PR `main -> stage` y
+`stage -> dev` (o cherry-pick controlado). No dejar ramas divergentes.
 
 ## Merge strategy
 
-- **Rebase-only** — no merge commits, no squash
-- Historial lineal entre `dev` y `main`
+- **Rebase-only** — no merge commits, no squash. Configurado en GitHub:
+  solo `allow_rebase_merge` habilitado.
+- Historial lineal entre `dev`, `stage` y `main`
 - NUNCA force push en ramas compartidas
 - Resolver conflictos con rebase, no merge
+- `delete_branch_on_merge` activo: las ramas de trabajo se borran al mergear
 
 ## Antes de cada commit
 
@@ -113,7 +156,9 @@ style(components): unifica spacing del Footer con tokens del DS
 
 ## Pull Requests
 
-- Target: `dev` (features), `main` (releases) — o `main` directo si no hay rama `dev`
+- Target: `dev` para features/fixes/chores. Promocion a `stage` y `main`
+  solo via el flujo en cadena (ver "Flujo de promocion" arriba) — NUNCA
+  un PR de feature directo a `stage` o `main`.
 - CI ejecuta mismos quality gates que pre-push
 - Trigger: PRs a `main`/`master`/`dev`
 - Template automatico: `.github/pull_request_template.md` (si existe)

--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -1,0 +1,64 @@
+# @config branch-flow-guard.yml
+# @description Enforce del flujo de promocion dev -> stage -> main.
+#   Falla si un PR tiene como base una rama de entorno (main/stage) pero su
+#   head NO es la rama de origen permitida. Evita el salto dev -> main
+#   directo, que causa divergencia de hashes al promover luego dev -> stage.
+# @triggers pull_request (opened, reopened, synchronize, edited) a main o stage
+#
+# Reglas:
+#   - PR a `main`  -> head debe ser `stage` o `release/*`
+#   - PR a `stage` -> head debe ser `dev`
+#
+# Marcar este job como required status check en el ruleset de main y stage
+# para que el enforce sea real (no se puede mergear sin el check verde).
+name: Branch Flow Guard
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches: [main, master, stage]
+
+jobs:
+  guard:
+    name: Validate promotion source
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check PR head matches the allowed promotion source
+        env:
+          BASE: ${{ github.base_ref }}
+          HEAD: ${{ github.head_ref }}
+        run: |
+          echo "PR: $HEAD -> $BASE"
+          case "$BASE" in
+            main|master)
+              # A produccion solo se promueve desde stage (o una release/* rebaseada desde stage).
+              case "$HEAD" in
+                stage|release/*)
+                  echo "OK: '$HEAD' es un origen valido para '$BASE'."
+                  ;;
+                *)
+                  echo "::error::PR a '$BASE' debe venir de 'stage' o 'release/*', no de '$HEAD'."
+                  echo "Flujo correcto: dev -> stage -> main. NUNCA dev -> main directo."
+                  echo "Ver .claude/rules/git-workflow.md (Branching strategy)."
+                  exit 1
+                  ;;
+              esac
+              ;;
+            stage)
+              # A stage solo se promueve desde dev (o una release/* preparada desde dev).
+              case "$HEAD" in
+                dev|release/*)
+                  echo "OK: '$HEAD' es un origen valido para 'stage'."
+                  ;;
+                *)
+                  echo "::error::PR a 'stage' debe venir de 'dev' o 'release/*', no de '$HEAD'."
+                  echo "Flujo correcto: feature -> dev -> stage -> main."
+                  echo "Ver .claude/rules/git-workflow.md (Branching strategy)."
+                  exit 1
+                  ;;
+              esac
+              ;;
+            *)
+              echo "OK: '$BASE' no es una rama de entorno; sin restriccion de origen."
+              ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, master, dev]
+    branches: [main, master, dev, stage]
   push:
-    branches: [main, dev]
+    branches: [main, dev, stage]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problema

El flujo de promocion `dev -> stage -> main` era solo una convencion en docs, no estaba enforced. Esto causa un conflicto recurrente:

1. Un commit llega a `main` sin pasar por `stage` (un PR `dev -> main` directo o un hotfix).
2. La siguiente promocion `dev -> stage` (merge rebase) le reescribe el hash.
3. El mismo cambio queda con SHA distinto en `main` y en `stage`.
4. El PR `stage -> main` da `CONFLICTING` (conflicto fantasma por divergencia de hashes).

Diagnostico de la config actual del repo:

- Ninguna rama tiene branch protection ni rulesets en GitHub (`gh api .../branches/main/protection` -> 404).
- 3 estrategias de merge habilitadas (`merge_commit`, `squash`, `rebase`) — el proyecto es rebase-only.
- `ci.yml` no disparaba en PRs hacia `stage`: el PR `stage -> main` no corria CI.

## Solucion

1. **`branch-flow-guard.yml`** (nuevo): workflow que falla si un PR a `main` no viene de `stage`/`release-*`, o un PR a `stage` no viene de `dev`/`release-*`. Marcado como required check en los rulesets de `main` y `stage` -> imposible saltar el flujo.
2. **`ci.yml`**: triggers `pull_request` y `push` extendidos para incluir `stage` (ahora el PR `stage -> main` corre CI).
3. **`git-workflow.md`**: documenta las 3 ramas de entorno, el flujo de promocion en cadena obligatorio, por que nunca `dev -> main` directo, como resolver el conflicto con una `release/*` rebaseada y como resincronizar tras un hotfix.

Acompanado de cambios de config en GitHub (fuera de este PR, via `gh api`): rulesets de `main` y `stage` (PR obligatorio + CI verde + guard required + branch up-to-date) y merge settings rebase-only + `delete_branch_on_merge`.

## Como probar

1. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/branch-flow-guard.yml'))"` — YAML valido.
2. Logica del guard verificada: `dev->main` BLOCK, `stage->main` ALLOW, `release/*->main` ALLOW, `dev->stage` ALLOW, `feature/x->stage` BLOCK.
3. Tras el merge, abrir un PR de prueba `dev -> main` debe fallar el check "Branch Flow Guard".

## TODO

Vacio.