### PR TITLE
feat(tracking): Fase 1 — SES funcional + tracking page_load (SPEC-100/101/102)

### DIFF
--- a/apps/hub/src/pages/contact.astro
+++ b/apps/hub/src/pages/contact.astro
@@ -2,6 +2,7 @@
 import { profile } from '@portfolio/content'
 import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
+import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
 import BaseLayout from '@portfolio/ui/layouts/BaseLayout.astro'
 
 const apiEndpoint = (import.meta.env.PUBLIC_API_ENDPOINT || '') as string
@@ -57,6 +58,10 @@ const siteUrl = (import.meta.env.SITE_URL ||
       </div>
     </section>
   </main>
+  <TrackingPixel
+    apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
+    niche="hub"
+  />
 </BaseLayout>
 
 <style>

--- a/apps/hub/src/pages/en/index.astro
+++ b/apps/hub/src/pages/en/index.astro
@@ -4,6 +4,7 @@ import { buildPersonSchema } from '@portfolio/seo'
 import { nicheTokensToCssVars } from '@portfolio/ui'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import MeshGradientBg from '@portfolio/ui/components/MeshGradientBg.astro'
+import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
 /**
  * @page index (en) — hub selector
  */
@@ -102,6 +103,10 @@ const hubStyle = nicheTokensToCssVars('hub')
     name="Pablo Contreras"
     contacts={profile.contacts}
     locale="en"
+  />
+  <TrackingPixel
+    apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
+    niche="hub"
   />
 </BaseLayout>
 

--- a/apps/hub/src/pages/index.astro
+++ b/apps/hub/src/pages/index.astro
@@ -4,6 +4,7 @@ import { buildPersonSchema } from '@portfolio/seo'
 import { nicheTokensToCssVars } from '@portfolio/ui'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import MeshGradientBg from '@portfolio/ui/components/MeshGradientBg.astro'
+import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
 /**
  * @page index (es) — hub selector
  * @description Landing en the-full-stack.com. 5 cards para los 5 sitios.
@@ -104,6 +105,10 @@ const hubStyle = nicheTokensToCssVars('hub')
     name="Pablo Contreras"
     contacts={profile.contacts}
     locale="es"
+  />
+  <TrackingPixel
+    apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
+    niche="hub"
   />
 </BaseLayout>
 

--- a/packages/app-shared/src/layouts/SitePageLayout.astro
+++ b/packages/app-shared/src/layouts/SitePageLayout.astro
@@ -8,6 +8,7 @@ import {
 import { nicheTokensToCssVars } from '@portfolio/ui'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import Nav from '@portfolio/ui/components/Nav.astro'
+import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
 /**
  * @layout SitePageLayout
  * @description Wrapper compartido. Cada app pasa siteUrl + niche + strings.
@@ -134,6 +135,10 @@ const nicheStyle = nicheTokensToCssVars(niche)
     name="Pablo Contreras"
     contacts={profile.contacts}
     locale={locale}
+  />
+  <TrackingPixel
+    apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
+    niche={niche}
   />
   <script>
     import {

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -13,6 +13,11 @@ export { projects } from './data/projects/index'
 export { publications } from './data/publications/index'
 export { references } from './data/references/index'
 export { skills } from './data/skills/index'
+export {
+  EVENT_TYPES,
+  type EventTypeCode,
+  type EventTypeId,
+} from './lib/event-types'
 export { filterByNiche } from './lib/filter-by-niche'
 export { formatRange, formatYearMonth } from './lib/format-date'
 export { sortByPriority } from './lib/sort-by-priority'

--- a/packages/content/src/lib/event-types.ts
+++ b/packages/content/src/lib/event-types.ts
@@ -1,0 +1,36 @@
+/**
+ * @module event-types
+ * @description Catalogo de tipos de evento de tracking. Replica los UUID de la
+ *   tabla SQL `event_types` (fuente de verdad: migration 006 + seed de
+ *   SPEC-200). El cliente usa estas constantes en build-time, sin consultar la
+ *   DB ni hacer requests extra.
+ *
+ *   Un test de paridad (event-types.test.ts) verifica que cada UUID de
+ *   `EVENT_TYPES` coincide con el del seed SQL — cualquier divergencia falla.
+ *
+ * @example
+ *   import { EVENT_TYPES } from '@portfolio/content'
+ *   const payload = { event_type_id: EVENT_TYPES.PAGE_LOAD }
+ */
+
+/**
+ * Mapa de tipos de evento -> UUID del catalogo `event_types`.
+ *
+ * Fase 1 expone solo `PAGE_LOAD`. SPEC-200 amplia con clicks, embudo de
+ * contacto y engagement (mismos UUID del seed SQL).
+ */
+export const EVENT_TYPES = {
+  PAGE_LOAD: '019e372b-e0a7-7154-8279-8829bcf6a08c',
+} as const
+
+/**
+ * @type EventTypeCode
+ * @description Union de las claves validas de `EVENT_TYPES`.
+ */
+export type EventTypeCode = keyof typeof EVENT_TYPES
+
+/**
+ * @type EventTypeId
+ * @description Union de los valores UUID validos de `EVENT_TYPES`.
+ */
+export type EventTypeId = (typeof EVENT_TYPES)[EventTypeCode]

--- a/packages/content/tests/unit/event-types.test.ts
+++ b/packages/content/tests/unit/event-types.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @description Tests del catalogo de tipos de evento.
+ *
+ *   Cubre dos cosas:
+ *   1. Formato: cada valor de `EVENT_TYPES` es un UUID string valido.
+ *   2. Paridad SQL <-> TS: el seed de `serverless/migrations/006_event_types.sql`
+ *      y `EVENT_TYPES` deben usar exactamente los mismos UUID. Si alguien edita
+ *      uno sin el otro, este test falla y atrapa el drift.
+ *
+ *   El test parsea el INSERT del .sql con un regex, extrae los pares
+ *   (code_name, uuid) y verifica contra las constantes TS.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { EVENT_TYPES, type EventTypeCode } from '../../src/lib/event-types'
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Parsea los pares (code_name, uuid) del INSERT de la migration de seed.
+ *
+ * Las filas del seed tienen la forma:
+ *   ('<uuid>', '<code_name>', '<description>')
+ * Se extrae uuid + code_name (los dos primeros literales de cada tupla).
+ */
+function parseSeedUuids(sqlPath: string): Map<string, string> {
+  const sql = readFileSync(sqlPath, 'utf-8')
+  const rowRe = /\(\s*'([0-9a-f-]{36})'\s*,\s*'([a-z_]+)'/gi
+  const pairs = new Map<string, string>()
+  for (const match of sql.matchAll(rowRe)) {
+    const uuid = match[1]
+    const codeName = match[2]
+    if (uuid && codeName) {
+      pairs.set(codeName, uuid)
+    }
+  }
+  return pairs
+}
+
+const seed006 = parseSeedUuids(
+  resolve(__dirname, '../../../../serverless/migrations/006_event_types.sql'),
+)
+
+describe('EVENT_TYPES', () => {
+  it('Given EVENT_TYPES.PAGE_LOAD When inspect Then is a valid UUID string', () => {
+    expect(EVENT_TYPES.PAGE_LOAD).toMatch(UUID_RE)
+  })
+
+  it('Given the barrel @portfolio/content When import EVENT_TYPES Then it is exported and typed', () => {
+    const code: EventTypeCode = 'PAGE_LOAD'
+    expect(EVENT_TYPES[code]).toBe('019e372b-e0a7-7154-8279-8829bcf6a08c')
+  })
+})
+
+describe('event_types catalog parity (SQL <-> TS)', () => {
+  it('Given migration 006 seed When parse Then page_load UUID matches EVENT_TYPES.PAGE_LOAD', () => {
+    expect(seed006.get('page_load')).toBe(EVENT_TYPES.PAGE_LOAD)
+  })
+
+  it('Given the SQL seed When compared Then every seeded code_name has a matching TS constant', () => {
+    // Fase 1: el seed 006 solo trae page_load. SPEC-200 amplia el seed y el
+    // mapa; este loop ya cubre el catalogo completo cuando crezca.
+    const tsByCode: Record<string, string> = {
+      page_load: EVENT_TYPES.PAGE_LOAD,
+    }
+    for (const [codeName, uuid] of seed006) {
+      expect(tsByCode[codeName]).toBe(uuid)
+    }
+  })
+})

--- a/packages/ui/src/components/TrackingPixel.astro
+++ b/packages/ui/src/components/TrackingPixel.astro
@@ -1,11 +1,15 @@
 ---
 /**
  * @component TrackingPixel
- * @description Tracking pixel client-side: envia evento al backend
- * tracking_pixel SOLO si el user dio consent en CookieBanner.
+ * @description Tracking pixel client-side: envia un evento `page_load` al
+ * backend tracking_pixel SOLO si el user dio consent en CookieBanner (o si
+ * la pagina lleva el flag de QA `?cf_track=force`).
  *
- * Implementacion: client:idle (post page load), envia 1 POST /track con
- * session_id (UUIDv4 persisted en localStorage) + page metadata + UTMs.
+ * Implementacion: client:idle (post page load). Cada carga genera un
+ * `event_id` (UUIDv4) propio para idempotencia y envia `POST /track` con
+ * `event_type_id` = EVENT_TYPES.PAGE_LOAD, `session_id` + page metadata +
+ * UTMs. Re-dispara en `astro:after-swap` para trackear navegacion SPA con
+ * View Transitions (cada navegacion = un page_load nuevo).
  *
  * @props {string} apiEndpoint - URL base del API Gateway
  * @props {string} [niche] - niche del subdominio
@@ -13,27 +17,57 @@
  * @example
  *   <TrackingPixel apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT} niche="generic" />
  */
+import { EVENT_TYPES } from '@portfolio/content'
+
 interface Props {
   apiEndpoint: string
   niche?: string
 }
 const { apiEndpoint, niche = 'generic' } = Astro.props
+const pageLoadEventTypeId = EVENT_TYPES.PAGE_LOAD
 ---
 
 <script
   is:inline
   data-api-endpoint={apiEndpoint}
   data-niche={niche}
-  define:vars={{ apiEndpoint, niche }}
+  define:vars={{ apiEndpoint, niche, pageLoadEventTypeId }}
 >
   ;(() => {
     if (!apiEndpoint) return
 
+    // Con View Transitions el script is:inline se re-ejecuta en cada
+    // navegacion. Guardar un flag en window evita registrar los listeners
+    // (after-swap, consent-changed) mas de una vez y disparar tracking
+    // duplicado. La navegacion SPA ya la cubre el listener astro:after-swap.
+    if (window.__cfTrackingPixelInit) return
+    window.__cfTrackingPixelInit = true
+
     const STORAGE_CONSENT = 'cf_consent'
     const STORAGE_SESSION = 'cf_session'
 
-    // Solo enviar si el user acepto
-    function hasConsent() {
+    // UUID v4 (con fallback para browsers sin crypto.randomUUID)
+    function uuid() {
+      if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+        return crypto.randomUUID()
+      }
+      return `${Date.now()}-${Math.random().toString(36).slice(2)}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    }
+
+    // QA bypass: ?cf_track=force permite trackear sin cf_consent (solo E2E).
+    function isForced() {
+      try {
+        return new URLSearchParams(window.location.search).get('cf_track') === 'force'
+      } catch {
+        return false
+      }
+    }
+
+    // Solo enviar si el user acepto, o si esta forzado por el flag de QA.
+    function canTrack() {
+      if (isForced()) return true
       try {
         return localStorage.getItem(STORAGE_CONSENT) === 'accepted'
       } catch {
@@ -45,13 +79,7 @@ const { apiEndpoint, niche = 'generic' } = Astro.props
       try {
         let sid = localStorage.getItem(STORAGE_SESSION)
         if (!sid || sid.length < 20) {
-          // UUID v4 fallback (sin crypto.randomUUID en browsers viejos)
-          sid =
-            typeof crypto !== 'undefined' && crypto.randomUUID
-              ? crypto.randomUUID().replace(/-/g, '')
-              : `${Date.now()}-${Math.random().toString(36).slice(2)}-${Math.random()
-                  .toString(36)
-                  .slice(2)}`
+          sid = uuid().replace(/-/g, '')
           localStorage.setItem(STORAGE_SESSION, sid)
         }
         return sid
@@ -77,10 +105,15 @@ const { apiEndpoint, niche = 'generic' } = Astro.props
     }
 
     function track() {
-      if (!hasConsent()) return
+      if (!canTrack()) return
 
       const payload = {
         session_id: getSessionId(),
+        // event_id: UUIDv4 propio de ESTE evento (idempotencia en reintentos
+        // de sendBeacon). Sin guiones para encajar en el limite del backend.
+        event_id: uuid().replace(/-/g, ''),
+        // event_type_id: tipo del catalogo event_types (page_load).
+        event_type_id: pageLoadEventTypeId,
         page_url: window.location.href.slice(0, 500),
         page_title: document.title.slice(0, 200),
         page_path: window.location.pathname.slice(0, 300),
@@ -122,7 +155,13 @@ const { apiEndpoint, niche = 'generic' } = Astro.props
       setTimeout(track, 100)
     }
 
-    // Re-track si consent cambia despues
+    // Navegacion SPA (View Transitions): cada after-swap es un page_load
+    // nuevo con su propio event_id.
+    document.addEventListener('astro:after-swap', () => {
+      track()
+    })
+
+    // Re-track si consent cambia despues (el user acepta el banner)
     document.addEventListener('portfolio:consent-changed', (e) => {
       const detail = e.detail
       if (detail && detail.value === 'accepted') {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,9 +1,11 @@
 /**
  * @module @portfolio/ui
- * @description Barrel TS del paquete. Componentes Astro se importan directo:
+ * @description Barrel TS del paquete. Los componentes Astro NO se re-exportan
+ *   desde este barrel (un .astro no es un modulo TS) — se importan directo:
  *
  *   import BaseLayout from '@portfolio/ui/layouts/BaseLayout.astro'
  *   import Hero from '@portfolio/ui/components/Hero.astro'
+ *   import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
  *
  *   import { applyTheme } from '@portfolio/ui'
  */

--- a/serverless/migrations/006_event_types.down.sql
+++ b/serverless/migrations/006_event_types.down.sql
@@ -1,0 +1,9 @@
+-- Rollback 006: elimina la tabla catalogo event_types.
+-- Debe correr DESPUES del rollback de 007 (que tiene la FK a esta tabla);
+-- el runner aplica los .down.sql en orden inverso, asi que 007 ya se revirtio.
+
+BEGIN;
+
+DROP TABLE IF EXISTS event_types;
+
+COMMIT;

--- a/serverless/migrations/006_event_types.sql
+++ b/serverless/migrations/006_event_types.sql
@@ -1,0 +1,31 @@
+-- Migration 006: catalogo event_types
+-- Tabla catalogo de tipos de evento de tracking. Fuente de verdad de los
+-- UUID; el frontend los replica como constantes TS (packages/content).
+--
+-- El seed usa UUID literales fijos (NO uuidv7() en runtime) porque el cliente
+-- necesita conocer el valor en build-time para replicarlo como constante.
+-- Fase 1 siembra solo page_load; SPEC-200 amplia el seed con el resto.
+--
+-- Idempotente: CREATE TABLE IF NOT EXISTS + INSERT ON CONFLICT DO NOTHING.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS event_types (
+    -- UUIDv7 literal fijado en el seed (no uuidv7() de PG: el cliente lo
+    -- replica como constante TS en build-time)
+    id UUID PRIMARY KEY,
+    code_name TEXT UNIQUE NOT NULL,
+    description TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed Fase 1: solo page_load. El resto del catalogo lo siembra SPEC-200.
+INSERT INTO event_types (id, code_name, description) VALUES
+    (
+        '019e372b-e0a7-7154-8279-8829bcf6a08c',
+        'page_load',
+        'Carga inicial de una pagina del portfolio'
+    )
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/serverless/migrations/007_tracking_event_columns.down.sql
+++ b/serverless/migrations/007_tracking_event_columns.down.sql
@@ -1,0 +1,15 @@
+-- Rollback 007: revierte las columnas event_id/event_type_id de tracking_events.
+-- Elimina el constraint, el indice y las dos columnas (exacto del forward).
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_tracking_event_type;
+
+ALTER TABLE tracking_events
+    DROP CONSTRAINT IF EXISTS fk_tracking_events_event_type;
+
+ALTER TABLE tracking_events
+    DROP COLUMN IF EXISTS event_id,
+    DROP COLUMN IF EXISTS event_type_id;
+
+COMMIT;

--- a/serverless/migrations/007_tracking_event_columns.sql
+++ b/serverless/migrations/007_tracking_event_columns.sql
@@ -1,0 +1,38 @@
+-- Migration 007: columnas event_id + event_type_id en tracking_events
+-- Enlaza cada evento de tracking con su tipo en el catalogo event_types.
+--
+-- event_id    : UUID del evento generado por el cliente (idempotencia en
+--               reintentos de sendBeacon). NO es FK.
+-- event_type_id: FK al catalogo event_types(id).
+--
+-- tracking_events esta particionada por RANGE(created_at): el ALTER TABLE
+-- sobre la tabla padre propaga a todas las particiones. PG soporta FK en
+-- tablas particionadas (PG12+).
+--
+-- Idempotente: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS. El
+-- ADD CONSTRAINT no soporta IF NOT EXISTS en PG, asi que va dentro de un
+-- bloque DO que verifica pg_constraint primero (el runner cmd_db_migrate
+-- re-aplica todos los .sql, debe poder correr esta migration dos veces).
+
+BEGIN;
+
+ALTER TABLE tracking_events
+    ADD COLUMN IF NOT EXISTS event_id UUID,
+    ADD COLUMN IF NOT EXISTS event_type_id UUID;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_tracking_events_event_type'
+    ) THEN
+        ALTER TABLE tracking_events
+            ADD CONSTRAINT fk_tracking_events_event_type
+            FOREIGN KEY (event_type_id) REFERENCES event_types (id);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_tracking_event_type
+    ON tracking_events (event_type_id);
+
+COMMIT;

--- a/serverless/src/contact_form/notification.py
+++ b/serverless/src/contact_form/notification.py
@@ -29,6 +29,7 @@ def _render_mustache_lite(template: str, context: dict[str, Any]) -> str:
     NO uses Jinja2 (peso adicional al Layer). Esto es suficiente para nuestro
     template plano. Si el value es None/empty, el bloque se omite.
     """
+
     # Conditional blocks: {{#var}}...{{/var}}
     def conditional_replacer(match: re.Match[str]) -> str:
         var = match.group(1)
@@ -55,6 +56,27 @@ def _render_mustache_lite(template: str, context: dict[str, Any]) -> str:
     return rendered
 
 
+def parse_recipients(raw: str) -> list[str]:
+    """
+    Parsea el parametro SSM `owner-email` como lista CSV de destinatarios.
+
+    El parametro puede contener uno o varios correos separados por coma. Se
+    aplica trim a cada entrada y se descartan las vacias (tolera comas
+    sobrantes o espacios alrededor).
+
+    Args:
+        raw: valor crudo del parametro SSM (ej. " a@x.com , b@y.com ").
+
+    Returns:
+        Lista de direcciones limpias, sin entradas vacias.
+
+    Example:
+        parse_recipients(' a@x.com , b@y.com ')  # ['a@x.com', 'b@y.com']
+        parse_recipients('a@x.com,,b@y.com,')    # ['a@x.com', 'b@y.com']
+    """
+    return [item.strip() for item in raw.split(',') if item.strip()]
+
+
 def send_owner_email(contact: dict[str, Any]) -> str:
     """
     Envia un email transaccional al owner del portfolio.
@@ -73,21 +95,25 @@ def send_owner_email(contact: dict[str, Any]) -> str:
     )
 
     from_address = get_parameter(from_address_path)
-    owner_email = get_parameter(owner_email_path)
+    recipients = parse_recipients(get_parameter(owner_email_path))
 
     # Render templates
-    html_template = (_TEMPLATES_DIR / 'owner_email.html').read_text(encoding='utf-8')
-    text_template = (_TEMPLATES_DIR / 'owner_email.txt').read_text(encoding='utf-8')
+    html_template = (_TEMPLATES_DIR / 'owner_email.html').read_text(
+        encoding='utf-8'
+    )
+    text_template = (_TEMPLATES_DIR / 'owner_email.txt').read_text(
+        encoding='utf-8'
+    )
 
     context = {**contact, 'niche': contact.get('niche', 'generic')}
     html_body = _render_mustache_lite(html_template, context)
     text_body = _render_mustache_lite(text_template, context)
 
-    subject = f"Portfolio · Nuevo contacto de {contact.get('name', '')} ({contact.get('niche', 'generic')})"
+    subject = f'Portfolio · Nuevo contacto de {contact.get("name", "")} ({contact.get("niche", "generic")})'
 
     response = _ses_client().send_email(
-        FromEmailAddress=f"The Full Stack <{from_address}>",
-        Destination={'ToAddresses': [owner_email]},
+        FromEmailAddress=f'The Full Stack <{from_address}>',
+        Destination={'ToAddresses': recipients},
         ReplyToAddresses=[contact.get('email', from_address)],
         Content={
             'Simple': {
@@ -106,7 +132,7 @@ def send_owner_email(contact: dict[str, Any]) -> str:
         extra={
             'message_id': message_id,
             'contact_id': contact.get('contact_id'),
-            'owner_email': owner_email,
+            'recipient_count': len(recipients),
         },
     )
     return message_id

--- a/serverless/src/contact_form/service.py
+++ b/serverless/src/contact_form/service.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from aws_lambda_powertools.metrics import MetricUnit
+
 from common.logger import logger
+from common.metrics import metrics
 from common.turnstile import verify_turnstile_token
 from contact_form.notification import send_owner_email
 from contact_form.persistence import save_contact
@@ -71,7 +74,13 @@ def process_contact_form(
             'failed to send owner email (contact already persisted)',
             extra={'contact_id': result['contact_id']},
         )
-        # NO re-raise: el form se guardo en DynamoDB; el stream_processor
-        # podra reintentar o el owner puede consultar el dashboard.
+        # NO re-raise: el form se guardo en DynamoDB y el lead no se pierde.
+        # El fallo se hace VISIBLE con una metrica CloudWatch para poder
+        # detectarlo sin romper la respuesta 201 del usuario.
+        metrics.add_metric(
+            name='OwnerEmailFailed',
+            unit=MetricUnit.Count,
+            value=1,
+        )
 
     return result

--- a/serverless/src/stream_processor/pg_writer.py
+++ b/serverless/src/stream_processor/pg_writer.py
@@ -41,7 +41,9 @@ def is_event_processed(event_id: str) -> bool:
         return cur.fetchone() is not None
 
 
-def mark_event_processed(event_id: str, *, event_type: str, table_name: str) -> None:
+def mark_event_processed(
+    event_id: str, *, event_type: str, table_name: str
+) -> None:
     """Inserta el event_id en processed_stream_events (idempotente)."""
     conn = _get_connection()
     with conn.cursor() as cur:
@@ -84,7 +86,8 @@ def upsert_tracking(payload: dict[str, Any]) -> None:
                 session_id, page_id, stream_event_id, created_at, expires_at,
                 page_url, page_title, page_path, referrer,
                 utm_source, utm_medium, utm_campaign, utm_content, utm_term,
-                viewport_width, viewport_height, niche, ip, country,
+                viewport_width, viewport_height, niche,
+                event_id, event_type_id, ip, country,
                 user_agent, browser, browser_version, os, device_type
             ) VALUES (
                 %(session_id)s, %(page_id)s, %(stream_event_id)s,
@@ -93,6 +96,7 @@ def upsert_tracking(payload: dict[str, Any]) -> None:
                 %(utm_source)s, %(utm_medium)s, %(utm_campaign)s,
                 %(utm_content)s, %(utm_term)s,
                 %(viewport_width)s, %(viewport_height)s, %(niche)s,
+                %(event_id)s, %(event_type_id)s,
                 %(ip)s::inet, %(country)s, %(user_agent)s,
                 %(browser)s, %(browser_version)s, %(os)s, %(device_type)s
             )

--- a/serverless/src/stream_processor/transformers.py
+++ b/serverless/src/stream_processor/transformers.py
@@ -119,6 +119,9 @@ def parse_tracking_record(record: dict[str, Any]) -> dict[str, Any] | None:
         'viewport_width': _to_int(image.get('viewport_width')),
         'viewport_height': _to_int(image.get('viewport_height')),
         'niche': image.get('niche'),
+        # Identificadores del evento (SPEC-102)
+        'event_id': image.get('event_id'),
+        'event_type_id': image.get('event_type_id'),
         'ip': image.get('ip'),
         'country': image.get('country'),
         'user_agent': image.get('user_agent'),

--- a/serverless/src/tracking_pixel/persistence.py
+++ b/serverless/src/tracking_pixel/persistence.py
@@ -43,13 +43,23 @@ def save_tracking_event(payload: dict[str, Any]) -> dict[str, Any]:
         'created_at': created_at,
         'expires_at': expires_at,
         'page_url': payload['page_url'],
+        # Identificadores del evento (SPEC-102): event_id da idempotencia,
+        # event_type_id es el tipo del catalogo event_types.
+        'event_id': payload['event_id'],
+        'event_type_id': payload['event_type_id'],
     }
 
     # Campos opcionales (solo si tienen valor)
     for optional_field in (
-        'page_title', 'page_path', 'referrer',
-        'utm_source', 'utm_medium', 'utm_campaign',
-        'utm_content', 'utm_term', 'niche',
+        'page_title',
+        'page_path',
+        'referrer',
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_content',
+        'utm_term',
+        'niche',
     ):
         value = payload.get(optional_field)
         if value:
@@ -63,8 +73,13 @@ def save_tracking_event(payload: dict[str, Any]) -> dict[str, Any]:
 
     # Metadata enrichment
     for meta_field in (
-        'ip', 'country', 'user_agent',
-        'browser', 'browser_version', 'os', 'device_type',
+        'ip',
+        'country',
+        'user_agent',
+        'browser',
+        'browser_version',
+        'os',
+        'device_type',
     ):
         if payload.get(meta_field):
             item[meta_field] = payload[meta_field]

--- a/serverless/src/tracking_pixel/schemas.py
+++ b/serverless/src/tracking_pixel/schemas.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class TrackingEventInput(BaseModel):
@@ -10,6 +12,14 @@ class TrackingEventInput(BaseModel):
 
     # Session: cliente genera UUID4 en localStorage al primer visit
     session_id: str = Field(..., min_length=20, max_length=64)
+
+    # Identificador del evento: UUIDv4 generado por el cliente, uno por
+    # evento. Sirve de idempotencia ante reintentos de sendBeacon.
+    event_id: str = Field(..., min_length=32, max_length=36)
+
+    # Tipo de evento: UUID del catalogo event_types (FK). Requerido: todo
+    # evento debe estar tipado (page_load, etc.).
+    event_type_id: str = Field(..., min_length=36, max_length=36)
 
     # Page metadata (cliente lo provee)
     page_url: str = Field(..., max_length=500)
@@ -33,3 +43,18 @@ class TrackingEventInput(BaseModel):
 
     # Opcional: cf_token de Turnstile invisible (best-effort, no enforced)
     cf_token: str | None = Field(default=None, max_length=2048)
+
+    @field_validator('event_id', 'event_type_id')
+    @classmethod
+    def validate_uuid(cls, v: str) -> str:
+        """
+        Valida que el valor sea un UUID bien formado.
+
+        El cliente puede enviar el UUID con o sin guiones (`event_id` se
+        genera con `crypto.randomUUID()` y a veces se compacta). Se acepta
+        cualquiera de las dos formas y se devuelve el string original;
+        `UUID()` lanza ValueError si el formato es invalido, que Pydantic
+        convierte en ValidationError -> 400 INVALID_INPUT.
+        """
+        UUID(v)
+        return v

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -250,6 +250,10 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: contact-form
+          # Region de SES explicita: notification.py defaultea a us-east-1 si
+          # falta, pero declararla evita depender del default de boto3 (que
+          # podria resolver otra region del entorno de ejecucion).
+          AWS_SES_REGION: us-east-1
           # Bypass secret para tests E2E (solo dev):
           # - El SSM param `/portfolio/dev/turnstile-bypass-secret` debe existir
           #   solo en stage=dev. La Lambda resuelve el valor en runtime via SSM.

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -296,6 +296,12 @@ Resources:
               Resource:
                 - !Sub arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/the-full-stack.com
                 - !Sub arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/no-reply@the-full-stack.com
+                # La domain identity the-full-stack.com tiene un default
+                # configuration set. SES v2 lo aplica a todo SendEmail desde
+                # esa identidad y exige permiso sobre el ARN del config set
+                # ademas del de la identidad — sin esto SES devuelve
+                # AccessDeniedException sobre el configuration-set.
+                - !Sub arn:aws:ses:${AWS::Region}:${AWS::AccountId}:configuration-set/my-first-configuration-set
       Events:
         PostContact:
           Type: Api

--- a/serverless/tests/unit/contact_form/test_notification.py
+++ b/serverless/tests/unit/contact_form/test_notification.py
@@ -2,11 +2,56 @@
 
 from __future__ import annotations
 
+import boto3
 import pytest
 
-from contact_form.notification import _render_mustache_lite, send_owner_email
+from contact_form.notification import (
+    _render_mustache_lite,
+    parse_recipients,
+    send_owner_email,
+)
 
 pytestmark = pytest.mark.unit
+
+
+class TestParseRecipients:
+    """parse_recipients - parsing CSV del parametro SSM owner-email."""
+
+    def test_when_two_emails_then_two_entries(self) -> None:
+        """
+        Given owner-email con dos correos separados por coma,
+        When se parsea,
+        Then retorna una lista con las dos direcciones.
+        """
+        result = parse_recipients('pacg1991@gmail.com,bypabloc@gmail.com')
+        assert result == ['pacg1991@gmail.com', 'bypabloc@gmail.com']
+
+    def test_when_single_email_then_one_entry(self) -> None:
+        """
+        Given owner-email con un solo correo (sin comas),
+        When se parsea,
+        Then retorna una lista de un elemento.
+        """
+        result = parse_recipients('owner@example.com')
+        assert result == ['owner@example.com']
+
+    def test_when_whitespace_around_then_trimmed(self) -> None:
+        """
+        Given owner-email con espacios alrededor de cada correo [AC-2],
+        When se parsea,
+        Then cada entrada queda sin espacios.
+        """
+        result = parse_recipients(' a@x.com , b@y.com ')
+        assert result == ['a@x.com', 'b@y.com']
+
+    def test_when_empty_entries_then_discarded(self) -> None:
+        """
+        Given owner-email con comas sobrantes que generan entradas vacias [AC-3],
+        When se parsea,
+        Then las entradas vacias se descartan.
+        """
+        result = parse_recipients('a@x.com,,b@y.com,')
+        assert result == ['a@x.com', 'b@y.com']
 
 
 class TestRenderMustacheLite:
@@ -67,15 +112,46 @@ class TestSendOwnerEmail:
         validamos que NO lanza excepcion.
         """
         # No raise -> success path
-        result = send_owner_email({
-            'contact_id': 'abc-123',
-            'created_at': '2026-05-14T15:00:00Z',
-            'name': 'Pablo',
-            'email': 'p@example.com',
-            'message': 'Hola mundo',
-            'niche': 'generic',
-            'ip': '1.2.3.4',
-        })
+        result = send_owner_email(
+            {
+                'contact_id': 'abc-123',
+                'created_at': '2026-05-14T15:00:00Z',
+                'name': 'Pablo',
+                'email': 'p@example.com',
+                'message': 'Hola mundo',
+                'niche': 'generic',
+                'ip': '1.2.3.4',
+            }
+        )
 
         # message_id puede ser string vacio si moto no lo retorna
+        assert isinstance(result, str)
+
+    def test_when_owner_email_is_csv_then_sends_to_all(
+        self, contact_form_aws: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given el SSM owner-email con dos correos en CSV [AC-1],
+        When send_owner_email se invoca,
+        Then SES recibe la llamada con los dos destinatarios (no excepcion).
+        """
+        ssm = boto3.client('ssm', region_name='us-east-1')
+        ssm.put_parameter(
+            Name='/portfolio-test/owner-email',
+            Value='pacg1991@gmail.com,bypabloc@gmail.com',
+            Type='String',
+            Overwrite=True,
+        )
+
+        result = send_owner_email(
+            {
+                'contact_id': 'abc-123',
+                'created_at': '2026-05-17T15:00:00Z',
+                'name': 'Pablo',
+                'email': 'p@example.com',
+                'message': 'Hola mundo',
+                'niche': 'generic',
+            }
+        )
+
         assert isinstance(result, str)

--- a/serverless/tests/unit/contact_form/test_service.py
+++ b/serverless/tests/unit/contact_form/test_service.py
@@ -1,0 +1,91 @@
+"""Tests de contact_form.service (orquestacion persist + email + metrica)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contact_form import service
+from contact_form.service import process_contact_form
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def _no_turnstile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutraliza la verificacion de Turnstile (no es lo que se testea aqui)."""
+    monkeypatch.setattr(
+        service, 'verify_turnstile_token', lambda *a, **kw: None
+    )
+
+
+class TestProcessContactFormEmailMetric:
+    """process_contact_form - metrica OwnerEmailFailed (no-bloqueante)."""
+
+    def test_when_email_fails_then_persists_and_emits_metric(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _no_turnstile: None,
+    ) -> None:
+        """
+        Given send_owner_email lanza una excepcion [AC-4],
+        When se procesa el contacto,
+        Then el contacto queda persistido, se emite OwnerEmailFailed=1
+        y no se re-raise (process_contact_form retorna el resultado normal).
+        """
+        saved = {'contact_id': 'c-123', 'created_at': '2026-05-17T00:00:00Z'}
+        monkeypatch.setattr(service, 'save_contact', lambda _payload: saved)
+
+        def _raise(_contact: dict) -> str:
+            msg = 'SES boom'
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(service, 'send_owner_email', _raise)
+        service.metrics.clear_metrics()
+
+        result = process_contact_form(
+            validated_input={
+                'name': 'Pablo',
+                'email': 'p@example.com',
+                'message': 'Hola mundo largo',
+            },
+            cf_response='token',
+            ip='1.2.3.4',
+        )
+
+        captured = dict(service.metrics.metric_set)
+
+        assert result == saved
+        assert 'OwnerEmailFailed' in captured
+        assert captured['OwnerEmailFailed']['Value'] == [1.0]
+
+    def test_when_email_succeeds_then_no_metric(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _no_turnstile: None,
+    ) -> None:
+        """
+        Given send_owner_email tiene exito [AC-5],
+        When se procesa el contacto,
+        Then NO se emite la metrica OwnerEmailFailed.
+        """
+        saved = {'contact_id': 'c-456', 'created_at': '2026-05-17T00:00:00Z'}
+        monkeypatch.setattr(service, 'save_contact', lambda _payload: saved)
+        monkeypatch.setattr(
+            service, 'send_owner_email', lambda _contact: 'msg-id'
+        )
+        service.metrics.clear_metrics()
+
+        result = process_contact_form(
+            validated_input={
+                'name': 'Pablo',
+                'email': 'p@example.com',
+                'message': 'Hola mundo largo',
+            },
+            cf_response='token',
+            ip='1.2.3.4',
+        )
+
+        captured = dict(service.metrics.metric_set)
+
+        assert result == saved
+        assert 'OwnerEmailFailed' not in captured

--- a/serverless/tests/unit/stream_processor/test_pg_writer.py
+++ b/serverless/tests/unit/stream_processor/test_pg_writer.py
@@ -1,0 +1,234 @@
+"""Tests de stream_processor.pg_writer (INSERT a Neon con event ids)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from stream_processor import pg_writer
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeCursor:
+    """Cursor fake que captura el SQL y los params del ultimo execute()."""
+
+    def __init__(self) -> None:
+        self.sql: str = ''
+        self.params: Any = None
+        self.fetch_result: Any = None
+        self.executed: list[tuple[str, Any]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.sql = sql
+        self.params = params
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        return self.fetch_result
+
+
+class _FakeConnection:
+    """Conexion fake: entrega siempre el mismo _FakeCursor."""
+
+    def __init__(self) -> None:
+        self.cursor_obj = _FakeCursor()
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class TestGetConnection:
+    """_get_connection - lazy connection cacheada entre invocaciones warm."""
+
+    def test_when_no_connection_then_connects_once_and_caches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given el singleton _conn sin inicializar,
+        When _get_connection se invoca dos veces,
+        Then psycopg.connect se llama una sola vez (la 2a reusa el cache).
+        """
+        import psycopg
+
+        monkeypatch.setattr(pg_writer, '_conn', None)
+
+        calls: list[str] = []
+
+        def _fake_connect(db_url: str, **_kw: Any) -> _FakeConnection:
+            calls.append(db_url)
+            return _FakeConnection()
+
+        monkeypatch.setattr(psycopg, 'connect', _fake_connect)
+        monkeypatch.setattr(
+            'common.ssm_client.get_secret', lambda _path: 'postgres://x'
+        )
+
+        first = pg_writer._get_connection()
+        second = pg_writer._get_connection()
+
+        assert first is second
+        assert calls == ['postgres://x']
+
+
+class TestUpsertTracking:
+    """upsert_tracking - el INSERT incluye event_id y event_type_id."""
+
+    def test_when_payload_has_event_ids_then_insert_includes_columns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un payload de tracking con event_id y event_type_id [AC-7],
+        When upsert_tracking arma el INSERT,
+        Then la sentencia nombra ambas columnas y los params se pasan.
+        """
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        payload = {
+            'session_id': 'sess-3',
+            'page_id': 'page-uuid-3',
+            'stream_event_id': 'evt-200',
+            'created_at': '2026-05-17T00:00:00Z',
+            'expires_at': 1750000000,
+            'page_url': 'https://the-full-stack.com/',
+            'page_title': None,
+            'page_path': None,
+            'referrer': None,
+            'utm_source': None,
+            'utm_medium': None,
+            'utm_campaign': None,
+            'utm_content': None,
+            'utm_term': None,
+            'viewport_width': None,
+            'viewport_height': None,
+            'niche': 'generic',
+            'event_id': 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+            'event_type_id': '019e372b-e0a7-7154-8279-8829bcf6a08c',
+            'ip': None,
+            'country': None,
+            'user_agent': None,
+            'browser': None,
+            'browser_version': None,
+            'os': None,
+            'device_type': None,
+        }
+
+        pg_writer.upsert_tracking(payload)
+
+        sql = fake_conn.cursor_obj.sql
+        assert 'event_id' in sql
+        assert 'event_type_id' in sql
+        assert '%(event_id)s' in sql
+        assert '%(event_type_id)s' in sql
+        assert fake_conn.cursor_obj.params == payload
+
+
+class TestUpsertContact:
+    """upsert_contact - INSERT idempotente en contacts."""
+
+    def test_when_called_then_insert_has_on_conflict_do_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un payload de contacto,
+        When upsert_contact arma el INSERT,
+        Then la sentencia usa ON CONFLICT (id) DO NOTHING (idempotencia).
+        """
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        pg_writer.upsert_contact({'id': 'contact-uuid'})
+
+        assert 'ON CONFLICT (id) DO NOTHING' in fake_conn.cursor_obj.sql
+
+
+class TestIdempotencyLog:
+    """is_event_processed + mark_event_processed - log de idempotencia."""
+
+    def test_when_event_in_log_then_is_processed_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un event_id ya registrado en processed_stream_events [AC-5],
+        When is_event_processed lo consulta,
+        Then retorna True (el handler lo saltea, no duplica la fila).
+        """
+        fake_conn = _FakeConnection()
+        fake_conn.cursor_obj.fetch_result = (1,)
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        assert pg_writer.is_event_processed('evt-already-done') is True
+
+    def test_when_event_not_in_log_then_is_processed_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un event_id que no esta en processed_stream_events [AC-5],
+        When is_event_processed lo consulta,
+        Then retorna False.
+        """
+        fake_conn = _FakeConnection()
+        fake_conn.cursor_obj.fetch_result = None
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        assert pg_writer.is_event_processed('evt-new') is False
+
+    def test_when_mark_processed_then_insert_on_conflict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un event_id procesado,
+        When mark_event_processed lo registra,
+        Then el INSERT usa ON CONFLICT DO NOTHING.
+        """
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        pg_writer.mark_event_processed(
+            'evt-1', event_type='INSERT', table_name='tracking'
+        )
+
+        assert 'ON CONFLICT (event_id) DO NOTHING' in fake_conn.cursor_obj.sql
+
+
+class TestTransactionControl:
+    """commit / rollback - control de transaccion."""
+
+    def test_when_commit_then_connection_commits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Given una conexion abierta, When commit(), Then conn.commit()."""
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        pg_writer.commit()
+
+        assert fake_conn.committed is True
+
+    def test_when_rollback_then_connection_rolls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Given una conexion abierta, When rollback(), Then conn.rollback()."""
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        pg_writer.rollback()
+
+        assert fake_conn.rolled_back is True

--- a/serverless/tests/unit/stream_processor/test_transformers.py
+++ b/serverless/tests/unit/stream_processor/test_transformers.py
@@ -105,6 +105,36 @@ class TestParseTrackingRecord:
         }
         assert parse_tracking_record(record) is None
 
+    def test_when_insert_with_event_ids_then_payload_includes_them(
+        self,
+    ) -> None:
+        """
+        Given INSERT tracking con event_id y event_type_id en el image [AC-7],
+        When parse_tracking_record,
+        Then el payload incluye ambos campos con su valor.
+        """
+        record = {
+            'eventID': 'evt-101',
+            'eventName': 'INSERT',
+            'dynamodb': {
+                'NewImage': {
+                    'session_id': {'S': 'sess-2'},
+                    'page_id': {'S': 'page-uuid-2'},
+                    'page_url': {'S': 'https://x.com'},
+                    'event_id': {'S': 'a1b2c3d4e5f60718293a4b5c6d7e8f90'},
+                    'event_type_id': {
+                        'S': '019e372b-e0a7-7154-8279-8829bcf6a08c'
+                    },
+                },
+            },
+        }
+        result = parse_tracking_record(record)
+        assert result is not None
+        assert result['event_id'] == 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+        assert result['event_type_id'] == (
+            '019e372b-e0a7-7154-8279-8829bcf6a08c'
+        )
+
 
 class TestDetectTable:
     def test_when_contacts_arn_then_contacts(self) -> None:
@@ -120,5 +150,7 @@ class TestDetectTable:
         assert detect_table(record) == 'tracking'
 
     def test_when_unknown_arn_then_unknown(self) -> None:
-        record = {'eventSourceARN': 'arn:aws:dynamodb:us-east-1:123:table/other/stream/x'}
+        record = {
+            'eventSourceARN': 'arn:aws:dynamodb:us-east-1:123:table/other/stream/x'
+        }
         assert detect_table(record) == 'unknown'

--- a/serverless/tests/unit/tracking_pixel/test_handler.py
+++ b/serverless/tests/unit/tracking_pixel/test_handler.py
@@ -17,7 +17,9 @@ pytestmark = pytest.mark.unit
 class MockLambdaContext:
     function_name: str = 'test-track'
     memory_limit_in_mb: int = 256
-    invoked_function_arn: str = 'arn:aws:lambda:us-east-1:000000000000:function:track'
+    invoked_function_arn: str = (
+        'arn:aws:lambda:us-east-1:000000000000:function:track'
+    )
     aws_request_id: str = 'test-req-id'
 
     def get_remaining_time_in_millis(self) -> int:
@@ -59,29 +61,33 @@ class TestTrackingHandler:
         When invoke handler,
         Then 204 sin body.
         """
-        event = _build_event(body={
-            'session_id': 'session-uuid-1234567890abcdef',
-            'page_url': 'https://the-full-stack.com/projects',
-            'page_title': 'Projects',
-            'page_path': '/projects',
-            'utm_source': 'twitter',
-            'viewport_width': 1920,
-            'viewport_height': 1080,
-            'niche': 'fintech',
-        })
+        event = _build_event(
+            body={
+                'session_id': 'session-uuid-1234567890abcdef',
+                'event_id': 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+                'event_type_id': '019e372b-e0a7-7154-8279-8829bcf6a08c',
+                'page_url': 'https://the-full-stack.com/projects',
+                'page_title': 'Projects',
+                'page_path': '/projects',
+                'utm_source': 'twitter',
+                'viewport_width': 1920,
+                'viewport_height': 1080,
+                'niche': 'fintech',
+            }
+        )
 
         response = lambda_handler(event, _ctx())
 
         assert response['statusCode'] == 204
         assert response['body'] == ''
 
-    def test_when_missing_session_id_then_400(
-        self, tracking_aws: None
-    ) -> None:
+    def test_when_missing_session_id_then_400(self, tracking_aws: None) -> None:
         """Given sin session_id, When invoke, Then 400 INVALID_INPUT."""
-        event = _build_event(body={
-            'page_url': 'https://the-full-stack.com/',
-        })
+        event = _build_event(
+            body={
+                'page_url': 'https://the-full-stack.com/',
+            }
+        )
 
         response = lambda_handler(event, _ctx())
 

--- a/serverless/tests/unit/tracking_pixel/test_persistence.py
+++ b/serverless/tests/unit/tracking_pixel/test_persistence.py
@@ -1,0 +1,48 @@
+"""Tests de tracking_pixel.persistence (item DynamoDB con event ids)."""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+
+from tracking_pixel.persistence import save_tracking_event
+
+pytestmark = pytest.mark.unit
+
+_SESSION_ID = 'session-uuid-1234567890abcdef'
+_EVENT_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+_PAGE_LOAD = '019e372b-e0a7-7154-8279-8829bcf6a08c'
+
+
+class TestSaveTrackingEvent:
+    """save_tracking_event - escritura del item en DynamoDB."""
+
+    def test_when_event_ids_present_then_persisted_as_attributes(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un payload con event_id y event_type_id [AC-4],
+        When save_tracking_event escribe el item,
+        Then el item de DynamoDB contiene ambos atributos con su valor.
+        """
+        result = save_tracking_event(
+            {
+                'session_id': _SESSION_ID,
+                'event_id': _EVENT_ID,
+                'event_type_id': _PAGE_LOAD,
+                'page_url': 'https://the-full-stack.com/',
+            }
+        )
+
+        table = boto3.resource('dynamodb', region_name='us-east-1').Table(
+            'portfolio-tracking-test'
+        )
+        item = table.get_item(
+            Key={
+                'session_id': result['session_id'],
+                'page_id': result['page_id'],
+            }
+        )['Item']
+
+        assert item['event_id'] == _EVENT_ID
+        assert item['event_type_id'] == _PAGE_LOAD

--- a/serverless/tests/unit/tracking_pixel/test_schemas.py
+++ b/serverless/tests/unit/tracking_pixel/test_schemas.py
@@ -1,0 +1,93 @@
+"""Tests del schema TrackingEventInput (event_id + event_type_id)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tracking_pixel.schemas import TrackingEventInput
+
+pytestmark = pytest.mark.unit
+
+_SESSION_ID = 'session-uuid-1234567890abcdef'
+_EVENT_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+_PAGE_LOAD = '019e372b-e0a7-7154-8279-8829bcf6a08c'
+
+
+def _base_body(**overrides: object) -> dict[str, object]:
+    """Body minimo valido de /track, con overrides opcionales."""
+    body: dict[str, object] = {
+        'session_id': _SESSION_ID,
+        'event_id': _EVENT_ID,
+        'event_type_id': _PAGE_LOAD,
+        'page_url': 'https://the-full-stack.com/',
+    }
+    body.update(overrides)
+    return body
+
+
+class TestTrackingEventInputEventIds:
+    """TrackingEventInput - validacion de event_id / event_type_id."""
+
+    def test_when_valid_event_ids_then_accepted(self) -> None:
+        """
+        Given un body con event_id y event_type_id UUID validos [AC-4],
+        When se valida con Pydantic,
+        Then ambos campos quedan en el modelo con su valor.
+        """
+        model = TrackingEventInput(**_base_body())
+
+        assert model.event_id == _EVENT_ID
+        assert model.event_type_id == _PAGE_LOAD
+
+    def test_when_event_type_id_hyphenated_uuid_then_accepted(self) -> None:
+        """
+        Given event_id en forma con guiones (UUID4 de 36 chars) [AC-4],
+        When se valida,
+        Then se acepta (el validador tolera con/sin guiones).
+        """
+        model = TrackingEventInput(
+            **_base_body(event_id='a1b2c3d4-e5f6-4718-a93a-4b5c6d7e8f90')
+        )
+
+        assert model.event_id == 'a1b2c3d4-e5f6-4718-a93a-4b5c6d7e8f90'
+
+    def test_when_missing_event_type_id_then_validation_error(self) -> None:
+        """
+        Given un body sin event_type_id [AC-5],
+        When se valida,
+        Then Pydantic lanza ValidationError (el handler -> 400 INVALID_INPUT).
+        """
+        body = _base_body()
+        del body['event_type_id']
+
+        with pytest.raises(ValidationError) as exc_info:
+            TrackingEventInput(**body)
+
+        assert 'event_type_id' in str(exc_info.value)
+
+    def test_when_event_type_id_malformed_then_validation_error(self) -> None:
+        """
+        Given event_type_id con la longitud correcta pero no-UUID [AC-6],
+        When se valida,
+        Then Pydantic lanza ValidationError (el validador UUID() rechaza).
+        """
+        # 36 chars, formato de guiones correcto, pero 'zzzz' no es hex.
+        with pytest.raises(ValidationError):
+            TrackingEventInput(
+                **_base_body(
+                    event_type_id='zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz'
+                )
+            )
+
+    def test_when_event_id_malformed_then_validation_error(self) -> None:
+        """
+        Given event_id con la longitud correcta pero no-UUID [AC-6],
+        When se valida,
+        Then Pydantic lanza ValidationError.
+        """
+        # 32 chars pero 'g' no es un digito hexadecimal valido.
+        with pytest.raises(ValidationError):
+            TrackingEventInput(
+                **_base_body(event_id='gggggggggggggggggggggggggggggggg')
+            )

--- a/tests/feature/tracking/track-pageload.spec.ts
+++ b/tests/feature/tracking/track-pageload.spec.ts
@@ -74,7 +74,6 @@ async function captureTrackRequests(page: Page): Promise<TrackPayload[]> {
  * Espera (poll) hasta que `captured` tenga al menos `min` elementos.
  */
 async function waitForCount(
-  page: Page,
   captured: TrackPayload[],
   min: number,
 ): Promise<void> {
@@ -96,7 +95,7 @@ test.describe('Feature: TrackingPixel page_load (SPEC-102)', () => {
       await page.goto(`${subdomainUrl(host)}/?cf_track=force`, {
         waitUntil: 'domcontentloaded',
       })
-      await waitForCount(page, captured, 1)
+      await waitForCount(captured, 1)
 
       // Assert
       const payload = captured[0]
@@ -119,11 +118,11 @@ test.describe('Feature: TrackingPixel page_load (SPEC-102)', () => {
     await page.goto(`${base}/?cf_track=force`, {
       waitUntil: 'domcontentloaded',
     })
-    await waitForCount(page, captured, 1)
+    await waitForCount(captured, 1)
     await page.goto(`${base}/about?cf_track=force`, {
       waitUntil: 'domcontentloaded',
     })
-    await waitForCount(page, captured, 2)
+    await waitForCount(captured, 2)
 
     // Assert
     expect(captured[0].session_id).toBe(captured[1].session_id)
@@ -141,7 +140,7 @@ test.describe('Feature: TrackingPixel page_load (SPEC-102)', () => {
     await page.goto(`${subdomainUrl()}/?cf_track=force`, {
       waitUntil: 'domcontentloaded',
     })
-    await waitForCount(page, captured, 1)
+    await waitForCount(captured, 1)
 
     await page.evaluate(() => {
       const nav = (window as unknown as { navigate?: (href: string) => void })
@@ -153,7 +152,7 @@ test.describe('Feature: TrackingPixel page_load (SPEC-102)', () => {
         window.location.href = '/about?cf_track=force'
       }
     })
-    await waitForCount(page, captured, 2)
+    await waitForCount(captured, 2)
 
     // Assert: el ultimo evento es de /about, con event_id propio
     const last = captured[captured.length - 1]

--- a/tests/feature/tracking/track-pageload.spec.ts
+++ b/tests/feature/tracking/track-pageload.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * @feature TrackingPixel - evento page_load en las 6 apps
+ * @description Verifica el cableado end-to-end del TrackingPixel (SPEC-102):
+ *   - cada subdominio emite POST /track con event_id + event_type_id al cargar
+ *   - la navegacion SPA (View Transitions) re-dispara un page_load nuevo
+ *   - sin consentimiento y sin ?cf_track=force NO se emite ningun /track
+ *
+ *   El pixel envia el evento por navigator.sendBeacon (con fallback a fetch).
+ *   El body de sendBeacon viaja como Blob y Playwright no expone su postData
+ *   de forma fiable, asi que el test neutraliza sendBeacon con addInitScript:
+ *   el pixel cae al path `fetch`, cuyo postData SI es legible.
+ */
+import { expect, type Page, subdomainUrl, test } from '../fixtures/index.js'
+
+/**
+ * Deshabilita navigator.sendBeacon para forzar el fallback a fetch() del
+ * pixel. fetch expone el postData de forma fiable en Playwright; sendBeacon
+ * (que envia un Blob) no.
+ */
+async function disableSendBeacon(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    })
+  })
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i
+const PAGE_LOAD_TYPE = '019e372b-e0a7-7154-8279-8829bcf6a08c'
+
+const SUBDOMAINS = [
+  { name: 'generic (apex)', host: undefined },
+  { name: 'hub', host: 'hub' },
+  { name: 'fintech', host: 'fintech' },
+  { name: 'architect', host: 'architect' },
+  { name: 'leader', host: 'leader' },
+  { name: 'vibe', host: 'vibe' },
+] as const
+
+interface TrackPayload {
+  session_id: string
+  event_id: string
+  event_type_id: string
+  page_url: string
+  [key: string]: unknown
+}
+
+/**
+ * Intercepta los POST a `/track` con page.route, los responde 204 (sin
+ * depender del backend AWS) y acumula los payloads en el array devuelto.
+ *
+ * Requiere disableSendBeacon: con sendBeacon deshabilitado el pixel usa
+ * fetch(), que page.route SI intercepta.
+ */
+async function captureTrackRequests(page: Page): Promise<TrackPayload[]> {
+  const captured: TrackPayload[] = []
+  await page.route('**/track', async (route) => {
+    const request = route.request()
+    if (request.method() === 'POST') {
+      try {
+        captured.push(JSON.parse(request.postData() ?? '{}') as TrackPayload)
+      } catch {
+        // payload no JSON: lo ignoramos
+      }
+    }
+    await route.fulfill({ status: 204, body: '' })
+  })
+  return captured
+}
+
+/**
+ * Espera (poll) hasta que `captured` tenga al menos `min` elementos.
+ */
+async function waitForCount(
+  page: Page,
+  captured: TrackPayload[],
+  min: number,
+): Promise<void> {
+  await expect
+    .poll(() => captured.length, { timeout: 10000 })
+    .toBeGreaterThanOrEqual(min)
+}
+
+test.describe('Feature: TrackingPixel page_load (SPEC-102)', () => {
+  for (const { name, host } of SUBDOMAINS) {
+    test(`Given ${name} con ?cf_track=force When carga Then emite POST /track con event_type_id [AC-1]`, async ({
+      page,
+    }) => {
+      // Arrange
+      await disableSendBeacon(page)
+      const captured = await captureTrackRequests(page)
+
+      // Act
+      await page.goto(`${subdomainUrl(host)}/?cf_track=force`, {
+        waitUntil: 'domcontentloaded',
+      })
+      await waitForCount(page, captured, 1)
+
+      // Assert
+      const payload = captured[0]
+      expect(payload.event_type_id).toBe(PAGE_LOAD_TYPE)
+      expect(payload.event_id).toMatch(UUID_RE)
+      expect(payload.session_id.length).toBeGreaterThanOrEqual(20)
+      expect(payload.page_url).toContain(host ?? 'localhost')
+    })
+  }
+
+  test('Given dos cargas en la misma sesion When inspecciono Then mismo session_id y event_id distinto [AC-2]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+    const base = subdomainUrl()
+
+    // Act: dos cargas completas (full reload) en la misma sesion del browser
+    await page.goto(`${base}/?cf_track=force`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await waitForCount(page, captured, 1)
+    await page.goto(`${base}/about?cf_track=force`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await waitForCount(page, captured, 2)
+
+    // Assert
+    expect(captured[0].session_id).toBe(captured[1].session_id)
+    expect(captured[0].event_id).not.toBe(captured[1].event_id)
+  })
+
+  test('Given navegacion SPA de / a /about When after-swap Then segundo /track con page_url nueva [AC-3]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+
+    // Act: cargar el home y navegar via View Transition manteniendo el flag
+    await page.goto(`${subdomainUrl()}/?cf_track=force`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await waitForCount(page, captured, 1)
+
+    await page.evaluate(() => {
+      const nav = (window as unknown as { navigate?: (href: string) => void })
+        .navigate
+      // Astro expone navigate() con ClientRouter activo; fallback a location.
+      if (nav) {
+        nav('/about?cf_track=force')
+      } else {
+        window.location.href = '/about?cf_track=force'
+      }
+    })
+    await waitForCount(page, captured, 2)
+
+    // Assert: el ultimo evento es de /about, con event_id propio
+    const last = captured[captured.length - 1]
+    expect(last.page_url).toContain('/about')
+    expect(last.event_id).not.toBe(captured[0].event_id)
+  })
+
+  test('Given pagina sin consentimiento y sin flag When carga Then NO se emite /track [AC-8]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+
+    // Act: cargar sin ?cf_track=force y sin cf_consent en localStorage
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+    // Dar tiempo al requestIdleCallback del pixel (timeout 2000ms)
+    await page.waitForTimeout(4000)
+
+    // Assert
+    expect(captured.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problema

Fase 1 del plan `docs/specs/tracking-and-ses/`. El backend serverless tenia dos piezas a medio terminar:

1. **SPEC-100 — el email de `/contact` no llegaba.** El contacto se guardaba en DynamoDB (parecia exito, HTTP 201) pero el email al owner fallaba sin dejar rastro: `service.py` envolvia `send_owner_email()` en un `except Exception` que solo logueaba, sin metrica. Ademas el envio era a un solo destinatario.
2. **SPEC-101 — no existia catalogo de tipos de evento.** El sistema de tracking necesita distinguir `page_load`, clicks, etc. con una fuente de verdad unica.
3. **SPEC-102 — `POST /track` nunca se invocaba.** El componente `TrackingPixel.astro` existia en `packages/ui` pero estaba huerfano: no se montaba en ningun layout.

## Solucion

1. **SPEC-100 — SES funcional multi-destinatario**:
   - `notification.py`: `parse_recipients()` parsea el SSM `owner-email` como CSV (trim + descarta vacios) y envia a N destinatarios.
   - `service.py`: emite la metrica CloudWatch `OwnerEmailFailed` cuando el email falla — el fallo se vuelve visible sin bloquear la respuesta 201.
   - `template.yaml`: `AWS_SES_REGION=us-east-1` explicito.
   - SSM `/portfolio/owner-email` actualizado a CSV con los 2 correos del owner.
   - **fix IAM**: el smoke en dev destapo la causa raiz real (no era SSM faltante): `AccessDeniedException` de SES sobre el `configuration-set`. La domain identity tiene un default config set y el IAM role no tenia permiso sobre su ARN. Se agrego al `Resource` del statement `ses:SendEmail`.
2. **SPEC-101 — catalogo `event_types`**:
   - Migration `006`: tabla `event_types` (PK uuid, `code_name` UNIQUE) + seed `page_load`.
   - Migration `007`: columnas `event_id` + `event_type_id` (FK) en `tracking_events`, `ADD CONSTRAINT` idempotente.
   - `packages/content/src/lib/event-types.ts`: objeto `EVENT_TYPES` + tipos, re-exportado del barrel. Test de paridad SQL <-> TS.
3. **SPEC-102 — TrackingPixel `page_load` en las 6 apps**:
   - `TrackingPixel.astro`: agrega `event_id` (UUIDv4 por evento) + `event_type_id`, re-dispara en `astro:after-swap` (navegacion SPA), flag QA `?cf_track=force`, guard `window.__cfTrackingPixelInit` contra listeners duplicados.
   - Montado via `SitePageLayout` (5 apps) + las 3 paginas de `hub`.
   - Backend `tracking_pixel` (schemas/persistence) y `stream_processor` (transformers/pg_writer) aceptan, persisten y replican los identificadores.

## Como probar

**Verificacion local (sin AWS):**
```bash
# Backend serverless
cd serverless && .venv/bin/python -m pytest -m unit tests/unit/   # 250 passed
# Frontend
pnpm --filter @portfolio/content exec vitest run tests/unit/event-types.test.ts
pnpm run build                                                     # 6 apps
# E2E (requiere stack local: python devtools/run.py docker up --env=local)
python devtools/run.py test_runner --module=feature --type=feature --env=local   # 156 passed
```

**Verificacion en dev (ya ejecutada):**
- `POST /track` con `{event_id, event_type_id, session_id, page_url}` -> 204; sin `event_type_id` -> 400 `INVALID_INPUT`.
- El evento aparece en DynamoDB `portfolio-tracking-dev` con `event_id`/`event_type_id` y se replica a Neon `tracking_events`.
- `POST /contact` (con bypass Turnstile) -> 201 -> log `owner email sent recipient_count=2`, sin `OwnerEmailFailed`.

**Migrations Neon:** `006`/`007` probadas `up`+`down`+`up` en Postgres 18 local y aplicadas a la rama `main` de Neon.

## TODO

Fuera de scope de Fase 1 (no bloquean esta PR):

- **Bug en `devtools/serverless/database.py`**: `cmd_db_migrate` usa `glob('*.sql')` que captura tambien los `.down.sql` — correria los `DROP TABLE` de `001_init_schema.down.sql`. No se uso (las migrations se aplicaron con `psql` directo). Deberia corregirse para que invoque `serverless/scripts/migrate.py`.
- 4 errores `mypy` pre-existentes en `serverless/src/common/` (`validators.py`, `ssm_client.py`) — los aborda SPEC-204 (Fase 2).
- `ses-from-address` esta como `noreply@the-full-stack.com` (sin guion); el spec mencionaba `no-reply@`. Ambos funcionan (domain identity los cubre).
- Fase 2 (SPEC-200..204) no empieza hasta que esta Fase 1 este en `main` y se confirme la recepcion del email.