### PR TITLE
fix(components): elimina el doble render del widget Turnstile

### DIFF
--- a/docker/env/client/.example
+++ b/docker/env/client/.example
@@ -27,6 +27,20 @@ PUBLIC_API_ENDPOINT=
 
 # Cloudflare Turnstile sitekey publica del widget Portfolio Backend.
 # Es publica (no es secreto): se inyecta en el HTML del frontend.
+#
+# IMPORTANTE: hay UN widget Turnstile POR ENTORNO (dev / stage / prod), cada
+# uno con su propio par sitekey + secret. El sitekey que va aqui DEBE emparejar
+# con el secret en SSM `/portfolio/{stage}/turnstile-secret` del mismo entorno;
+# si no emparejan, `siteverify` devuelve `invalid-input-secret` y el backend
+# responde 403 al form de contacto. Mapeo de los widgets "Portfolio Backend":
+#   .local  -> reusa el widget de dev   (su allowlist incluye localhost)
+#   .dev    -> widget "Portfolio Backend (dev)"
+#   .stage  -> widget "Portfolio Backend (stage)"
+#   .prod   -> widget "Portfolio Backend (prod)"
+# El sitekey de cada widget se ve en el dashboard de Cloudflare Turnstile;
+# el secret se rota con `serverless setup-ssm` (ver serverless-secrets.md).
+# En los deploys de Cloudflare Pages el sitekey vive como env var del proyecto
+# Pages (uno por app x entorno), no en estos archivos.
 PUBLIC_TURNSTILE_SITEKEY=
 
 # Sitekey publica del widget Turnstile (mismo valor que PUBLIC_TURNSTILE_SITEKEY;

--- a/packages/ui/src/components/ContactFormReact.tsx
+++ b/packages/ui/src/components/ContactFormReact.tsx
@@ -39,8 +39,12 @@ import {
   saveContactRecord,
 } from '../lib/contact-storage'
 
+// `?render=explicit`: desactiva el render implicito de Turnstile (el que
+// escanea el DOM buscando `.cf-turnstile`). El widget se monta solo via
+// turnstile.render() explicito — evita el doble render y el warning
+// "a widget already exists in this container".
 const TURNSTILE_SCRIPT_URL =
-  'https://challenges.cloudflare.com/turnstile/v0/api.js'
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
 
 interface TurnstileGlobal {
   render?: (
@@ -576,10 +580,14 @@ export default function ContactFormReact({
           )}
         </div>
 
-        {/* Turnstile widget: solo se renderiza si NO hay bypass de tests */}
+        {/* Turnstile widget: solo se renderiza si NO hay bypass de tests.
+            La clase NO es `cf-turnstile`: esa clase dispara el render
+            implicito de Turnstile (que necesita data-sitekey en el div y
+            choca con el render explicito de mas abajo). El widget se monta
+            con turnstile.render() explicito sobre este ref. */}
         {!bypassTokenRef.current && (
           <div
-            className="cf-turnstile"
+            className="turnstile-widget"
             ref={turnstileContainerRef}
             data-testid="turnstile-container"
           />


### PR DESCRIPTION
## Problema

El formulario de `/contact` no funciona por dos causas en cadena:

1. El componente `ContactFormReact.tsx` carga el script de Turnstile sin
   `?render=explicit`, asi que Cloudflare hace **render implicito**
   (escanea el DOM buscando la clase `.cf-turnstile`) ademas del
   `turnstile.render()` explicito que ya hace el componente. Doble render
   sobre el mismo contenedor -> warning "a widget already exists in this
   container" y el widget queda en estado inconsistente.
2. El div del widget usa `className="cf-turnstile"`, justamente la clase
   que dispara ese render implicito.

## Solucion

1. Se agrega `?render=explicit` a `TURNSTILE_SCRIPT_URL`: desactiva el
   render implicito; el widget se monta solo via `turnstile.render()`.
2. Se renombra la clase del div del widget de `cf-turnstile` a
   `turnstile-widget`, eliminando el trigger del render implicito.

Ademas se documenta en `docker/env/client/.example` que hay un widget
Turnstile por entorno (dev/stage/prod) y que el `PUBLIC_TURNSTILE_SITEKEY`
debe emparejar con el secret SSM `/portfolio/{stage}/turnstile-secret` del
mismo entorno (un mismatch produce `invalid-input-secret` y 403).

## Como probar

1. `pnpm run dev` o stack local: `python devtools/run.py docker up --env=local`
2. Abrir `http://localhost:9970/contact` (o el preview deploy de dev)
3. El widget Turnstile debe renderizar **una sola vez**, sin warning
   "a widget already exists" en la consola del browser
4. Completar el form y enviar: el `POST /contact` debe responder 200
   (antes: el doble render dejaba el token en estado inconsistente)
5. Verificar en la consola que no hay `[Cloudflare Turnstile]` warnings

## TODO

Vacio.