### PR TITLE
fix(config): permite Turnstile y CF analytics en la CSP

### DIFF
--- a/apps/architect/public/_headers
+++ b/apps/architect/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/fintech/public/_headers
+++ b/apps/fintech/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/generic/public/_headers
+++ b/apps/generic/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/hub/public/_headers
+++ b/apps/hub/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/leader/public/_headers
+++ b/apps/leader/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/vibe/public/_headers
+++ b/apps/vibe/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 


### PR DESCRIPTION
## Problema

El widget Turnstile de `/contact` no renderiza en ningun entorno
(dev/stage/prod). La consola del browser muestra:

```
Loading the script 'https://challenges.cloudflare.com/turnstile/v0/api.js'
violates the following Content Security Policy directive:
"script-src 'self' 'unsafe-inline' ..."
```

La CSP de `apps/*/public/_headers` tiene `script-src` restringido a
`'self'`, asi que el browser **bloquea el script de Turnstile antes de
ejecutarlo** -> el widget nunca se monta -> el form siempre dice "Por
favor completa el captcha". Mismos sintomas con la fuente inline
(`data:font/woff2` bloqueada por `font-src 'self'`) y el beacon de
analytics de Cloudflare Pages.

## Solucion

Se amplia la CSP de las 6 apps (sus `_headers` son identicos) con los
origenes minimos necesarios:

1. `script-src` += `https://challenges.cloudflare.com` (script Turnstile)
   y `https://static.cloudflareinsights.com` (beacon CF Pages analytics)
2. `frame-src https://challenges.cloudflare.com` (Turnstile monta un
   iframe para el challenge interactivo; directiva nueva)
3. `connect-src` += `https://challenges.cloudflare.com` (fetch al
   challenge) y los 3 endpoints del API Gateway
   `api.portfolio.{dev,stage,}.the-full-stack.com` (el POST del form).
   Se incluyen los 3 porque `_headers` es estatico, no parametrizable
   por entorno; todos son subdominios propios
4. `font-src` += `data:` (una fuente se sirve inline como `data:font/woff2`)

Sin cambios en el resto de directivas (`object-src 'none'`,
`frame-ancestors 'none'`, etc. se mantienen).

## Como probar

1. Deploy del preview de dev
2. Abrir `https://portfolio.dev.the-full-stack.com/contact`
3. La consola NO debe mostrar errores de CSP sobre `challenges.cloudflare.com`
4. El widget Turnstile debe renderizar y resolver el challenge
5. Completar el form y enviar: el `POST /contact` responde 200

## TODO

Vacio.