### PR TITLE
promote: dev -> stage (fixes Turnstile + docs merge-commit)

### DIFF
--- a/.claude/commands/push-pr-merge.md
+++ b/.claude/commands/push-pr-merge.md
@@ -1,8 +1,8 @@
 ---
 description: >
   Push de la rama actual, crea PR con gh, espera GitHub Actions, mergea
-  rebase a la base (default dev) y deja al usuario en dev con el pull
-  aplicado. Flujo end-to-end de cierre de feature.
+  con merge commit a la base (default dev) y deja al usuario en dev con el
+  pull aplicado. Flujo end-to-end de cierre de feature.
 argument-hint: "[base=dev] [--draft]"
 ---
 
@@ -159,11 +159,20 @@ Si el PR es draft, NO mergees — reporta que esta listo para revision y termina
 Si NO es draft:
 
 ```bash
-gh pr merge "$PR_NUMBER" --rebase --delete-branch 2>&1 | tail -10
+# Feature -> dev: merge commit + borrar la feature branch (es efimera).
+# Promocion dev -> stage / stage -> main: merge commit SIN --delete-branch
+# (las ramas de entorno son permanentes).
+if [ "$BASE" = "stage" ] || [ "$BASE" = "main" ] || [ "$BASE" = "master" ]; then
+  gh pr merge "$PR_NUMBER" --merge 2>&1 | tail -10
+else
+  gh pr merge "$PR_NUMBER" --merge --delete-branch 2>&1 | tail -10
+fi
 ```
 
-`--rebase` mantiene historia lineal (regla del proyecto en
-`.claude/rules/git-workflow.md`). `--delete-branch` limpia origin.
+`--merge` (merge commit) preserva los SHAs y evita la divergencia entre
+`dev`/`stage`/`main` — regla del proyecto en `.claude/rules/git-workflow.md`.
+El proyecto es **merge-commit-only**: `--rebase` y `--squash` estan
+deshabilitados en GitHub.
 
 ### 7. Switch a base + pull
 
@@ -215,8 +224,10 @@ git branch -d "$BRANCH" 2>&1 || true
 - NUNCA `git push --no-verify` (rompe quality gates del proyecto).
 - NUNCA mergear sin CI verde. Si fuerza el merge, reportar que el usuario
   debe usar `gh pr merge --admin` manualmente.
-- NUNCA usar `--squash` ni `--merge` (commits de merge). El proyecto es
-  rebase-only (`.claude/rules/git-workflow.md`).
+- SIEMPRE mergear con `--merge` (merge commit). NUNCA `--rebase` ni
+  `--squash`: el proyecto es merge-commit-only — el merge commit preserva
+  los SHAs y evita la divergencia entre `dev`/`stage`/`main`
+  (`.claude/rules/git-workflow.md`).
 - NUNCA atribucion de IA en titulo, body, ni comentarios del PR (politica
   global, hook `prepare-commit-msg` la elimina si se cuela).
 - NUNCA mergear si el PR es draft — solo reportar.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,5 +1,5 @@
 ---
-description: "Workflow de Git: conventional commits, branching strategy, PR process, merge strategy rebase-only, y quality gates obligatorios"
+description: "Workflow de Git: conventional commits, branching strategy, PR process, merge strategy merge-commit-only, y quality gates obligatorios"
 ---
 
 # Git Workflow Standards - Portfolio
@@ -90,7 +90,11 @@ Ramas de trabajo (efimeras, separador `/` obligatorio para VS Code):
 - `fix/<nombre>` — correcciones
 - `chore/<nombre>` — mantenimiento, deps, configs
 - `docs/<nombre>` — solo cambios de documentacion
-- `release/<nombre>` — promocion de entorno (ver flujo abajo)
+
+> Las promociones de entorno se hacen con un PR directo `dev -> stage` y
+> `stage -> main` (merge commit). NO se usan ramas `release/*`: con merge
+> commit las ramas no divergen, asi que no hace falta una rama puente
+> rebaseada (ver "Flujo de promocion" abajo).
 
 ## Flujo de promocion dev -> stage -> main (OBLIGATORIO)
 
@@ -100,41 +104,68 @@ Las ramas de entorno se promueven SIEMPRE en cadena, nunca salteando:
 feature/* --PR--> dev --PR--> stage --PR--> main
 ```
 
+TODOS los PRs se mergean con **merge commit** (una sola estrategia, ver
+"Merge strategy" abajo).
+
 Reglas duras:
 
-- Un PR a `main` SOLO puede tener como head `stage` (o una `release/*`
-  rebaseada desde `stage`). NUNCA `dev -> main` directo.
-- Un PR a `stage` SOLO puede tener como head `dev` (o una `release/*`).
+- Un PR a `main` SOLO puede tener como head `stage`. NUNCA `dev -> main`
+  directo.
+- Un PR a `stage` SOLO puede tener como head `dev`.
 - Enforced por el workflow `branch-flow-guard.yml` + ruleset de GitHub.
-
-**Por que NUNCA `dev -> main` directo**: si un commit llega a `main` sin
-pasar por `stage`, la siguiente promocion `dev -> stage` (merge rebase)
-le reescribe el hash. Resultado: el mismo cambio con SHA distinto en
-`main` y en `stage` -> el PR `stage -> main` da conflicto fantasma.
 
 ### Como promover
 
-1. `dev -> stage`: `gh pr create --base stage --head dev`.
-2. `stage -> main`: `gh pr create --base main --head stage`.
-3. Si el PR `stage -> main` da conflicto (commits que llegaron a `main`
-   sin pasar por `stage`): crear `release/promote-stage-to-main` desde
-   `origin/stage`, `git rebase origin/main` (git salta los commits ya
-   aplicados por patch-id), abrir el PR desde esa `release/*`.
+1. `dev -> stage`: `gh pr create --base stage --head dev`, mergear con
+   `gh pr merge --merge` (NUNCA `--delete-branch`: `dev` es permanente).
+2. `stage -> main`: `gh pr create --base main --head stage`, mergear con
+   `gh pr merge --merge`.
+
+El PR de promocion es directo `dev -> stage` y `stage -> main`: sin
+conflictos, sin `release/*` branches, sin rebase manual. El merge commit
+preserva los SHAs de los commits promovidos, asi que las tres ramas
+comparten exactamente los mismos commits (mas un merge commit por
+promocion). No hay divergencia.
 
 ### Resincronizar tras un hotfix directo a main
 
 Si por emergencia un fix entra directo a `main`, propagarlo el MISMO dia
-a `stage` y `dev` para evitar la divergencia: PR `main -> stage` y
-`stage -> dev` (o cherry-pick controlado). No dejar ramas divergentes.
+a `stage` y `dev` con merge commit (PR `main -> stage`, luego
+`stage -> dev`). No dejar ramas divergentes.
 
 ## Merge strategy
 
-- **Rebase-only** — no merge commits, no squash. Configurado en GitHub:
-  solo `allow_rebase_merge` habilitado.
-- Historial lineal entre `dev`, `stage` y `main`
-- NUNCA force push en ramas compartidas
-- Resolver conflictos con rebase, no merge
-- `delete_branch_on_merge` activo: las ramas de trabajo se borran al mergear
+**Merge commit para TODOS los PRs** — una sola estrategia, sin excepciones:
+
+- Feature -> `dev`: `gh pr merge --merge --delete-branch` (la feature
+  branch es efimera, se borra al mergear).
+- Promocion `dev -> stage` y `stage -> main`: `gh pr merge --merge`
+  (SIN `--delete-branch` — las ramas de entorno son permanentes).
+
+En GitHub solo esta habilitado `allow_merge_commit`; `allow_rebase_merge`
+y `allow_squash_merge` estan deshabilitados.
+
+### Por que merge commit y NO rebase
+
+El rebase RE-APLICA cada commit con un SHA nuevo. Si se rebasea al
+promover `dev -> stage`, el commit `feat: X` que estaba en `dev` como
+`abc123` aparece en `stage` como `def456`: mismo contenido, hash distinto.
+git identifica commits por SHA, no por contenido — entonces el siguiente
+PR `dev -> stage` ve `abc123` y `def456` como commits diferentes que
+tocan las mismas lineas y da **conflicto fantasma**.
+
+El merge commit PRESERVA los SHAs: el commit `abc123` de `dev` se mergea
+a `stage` siendo `abc123`. `stage` y `dev` comparten el SHA -> cero
+divergencia, cero conflicto. Por eso TODO se mergea con merge commit.
+
+Trade-off aceptado: la historia tiene un merge commit por cada PR (no es
+100% lineal), a cambio de cero divergencia entre `dev`/`stage`/`main` y
+un unico metodo de merge para todos los PRs.
+
+- NUNCA force push en ramas compartidas (`dev`, `stage`, `main`)
+- Conflictos en una feature branch se resuelven con `git merge origin/dev`
+  (o `git rebase origin/dev` dentro de la propia feature branch antes de
+  abrir el PR — el rebase local de una feature no afecta la divergencia)
 
 ## Antes de cada commit
 
@@ -183,14 +214,14 @@ Si por urgencia se mergea con comentarios pendientes, registrar issue separado y
 ## Workflow diario
 
 ```bash
-git checkout main && git pull --rebase
+git checkout dev && git pull         # dev es la rama base de features
 git checkout -b feature/nueva-funcionalidad
 # ... desarrollo + tests ...
-pnpm exec biome check .             # antes de stage
+pnpm exec biome check .
 pnpm exec tsc --noEmit
 pnpm exec vitest run
-git add -p                          # staging selectivo
+git add -p                           # staging selectivo
 git commit -m "feat(scope): subject en espanol"
 git push origin feature/nueva-funcionalidad
-# crear PR → main (o dev si existe)
+# crear PR -> dev, mergear con merge commit (gh pr merge --merge --delete-branch)
 ```

--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -2,12 +2,18 @@
 # @description Enforce del flujo de promocion dev -> stage -> main.
 #   Falla si un PR tiene como base una rama de entorno (main/stage) pero su
 #   head NO es la rama de origen permitida. Evita el salto dev -> main
-#   directo, que causa divergencia de hashes al promover luego dev -> stage.
+#   directo.
 # @triggers pull_request (opened, reopened, synchronize, edited) a main o stage
 #
 # Reglas:
-#   - PR a `main`  -> head debe ser `stage` o `release/*`
-#   - PR a `stage` -> head debe ser `dev`
+#   - PR a `main`  -> head debe ser `stage` (o `release/*` solo en emergencias)
+#   - PR a `stage` -> head debe ser `dev`   (o `release/*` solo en emergencias)
+#
+# Flujo normal: PR directo dev -> stage y stage -> main, mergeados con
+# merge commit (NO rebase). El merge commit preserva los SHAs, asi que las
+# ramas no divergen y no hace falta una rama puente. Las `release/*` quedan
+# permitidas solo como escape hatch para hotfixes / cherry-picks puntuales.
+# Ver .claude/rules/git-workflow.md.
 #
 # Marcar este job como required status check en el ruleset de main y stage
 # para que el enforce sea real (no se puede mergear sin el check verde).
@@ -31,7 +37,7 @@ jobs:
           echo "PR: $HEAD -> $BASE"
           case "$BASE" in
             main|master)
-              # A produccion solo se promueve desde stage (o una release/* rebaseada desde stage).
+              # A produccion se promueve desde stage (release/* solo en emergencias).
               case "$HEAD" in
                 stage|release/*)
                   echo "OK: '$HEAD' es un origen valido para '$BASE'."
@@ -45,7 +51,7 @@ jobs:
               esac
               ;;
             stage)
-              # A stage solo se promueve desde dev (o una release/* preparada desde dev).
+              # A stage se promueve desde dev (release/* solo en emergencias).
               case "$HEAD" in
                 dev|release/*)
                   echo "OK: '$HEAD' es un origen valido para 'stage'."

--- a/apps/architect/public/_headers
+++ b/apps/architect/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/fintech/public/_headers
+++ b/apps/fintech/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/generic/public/_headers
+++ b/apps/generic/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/hub/public/_headers
+++ b/apps/hub/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/leader/public/_headers
+++ b/apps/leader/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/apps/vibe/public/_headers
+++ b/apps/vibe/public/_headers
@@ -3,6 +3,6 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://challenges.cloudflare.com https://api.portfolio.the-full-stack.com https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
   X-Frame-Options: DENY
 

--- a/docker/env/client/.example
+++ b/docker/env/client/.example
@@ -27,6 +27,20 @@ PUBLIC_API_ENDPOINT=
 
 # Cloudflare Turnstile sitekey publica del widget Portfolio Backend.
 # Es publica (no es secreto): se inyecta en el HTML del frontend.
+#
+# IMPORTANTE: hay UN widget Turnstile POR ENTORNO (dev / stage / prod), cada
+# uno con su propio par sitekey + secret. El sitekey que va aqui DEBE emparejar
+# con el secret en SSM `/portfolio/{stage}/turnstile-secret` del mismo entorno;
+# si no emparejan, `siteverify` devuelve `invalid-input-secret` y el backend
+# responde 403 al form de contacto. Mapeo de los widgets "Portfolio Backend":
+#   .local  -> reusa el widget de dev   (su allowlist incluye localhost)
+#   .dev    -> widget "Portfolio Backend (dev)"
+#   .stage  -> widget "Portfolio Backend (stage)"
+#   .prod   -> widget "Portfolio Backend (prod)"
+# El sitekey de cada widget se ve en el dashboard de Cloudflare Turnstile;
+# el secret se rota con `serverless setup-ssm` (ver serverless-secrets.md).
+# En los deploys de Cloudflare Pages el sitekey vive como env var del proyecto
+# Pages (uno por app x entorno), no en estos archivos.
 PUBLIC_TURNSTILE_SITEKEY=
 
 # Sitekey publica del widget Turnstile (mismo valor que PUBLIC_TURNSTILE_SITEKEY;

--- a/packages/ui/src/components/ContactFormReact.tsx
+++ b/packages/ui/src/components/ContactFormReact.tsx
@@ -39,8 +39,12 @@ import {
   saveContactRecord,
 } from '../lib/contact-storage'
 
+// `?render=explicit`: desactiva el render implicito de Turnstile (el que
+// escanea el DOM buscando `.cf-turnstile`). El widget se monta solo via
+// turnstile.render() explicito — evita el doble render y el warning
+// "a widget already exists in this container".
 const TURNSTILE_SCRIPT_URL =
-  'https://challenges.cloudflare.com/turnstile/v0/api.js'
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
 
 interface TurnstileGlobal {
   render?: (
@@ -576,10 +580,14 @@ export default function ContactFormReact({
           )}
         </div>
 
-        {/* Turnstile widget: solo se renderiza si NO hay bypass de tests */}
+        {/* Turnstile widget: solo se renderiza si NO hay bypass de tests.
+            La clase NO es `cf-turnstile`: esa clase dispara el render
+            implicito de Turnstile (que necesita data-sitekey en el div y
+            choca con el render explicito de mas abajo). El widget se monta
+            con turnstile.render() explicito sobre este ref. */}
         {!bypassTokenRef.current && (
           <div
-            className="cf-turnstile"
+            className="turnstile-widget"
             ref={turnstileContainerRef}
             data-testid="turnstile-container"
           />


### PR DESCRIPTION
## Problema

Promocion de `dev` a `stage`. Acumula 3 cambios listos para release:

1. **Doble render del widget Turnstile** (#65) — el form de `/contact`
   montaba el widget dos veces (render implicito + explicito).
2. **CSP bloqueaba Turnstile** (#66) — `script-src` no permitia
   `challenges.cloudflare.com`, el widget nunca cargaba en stage/prod.
3. **Docs del workflow merge-commit** (#64) — ya promovido en su momento;
   viaja como parte del historial compartido.

## Solucion

1. `?render=explicit` + `className="turnstile-widget"` en
   `ContactFormReact.tsx`.
2. CSP de las 6 apps ampliada con `challenges.cloudflare.com`
   (script-src/frame-src/connect-src), `static.cloudflareinsights.com`,
   los endpoints del API Gateway y `data:` en font-src.
3. Migracion documental rebase-only -> merge-commit-only.

## Como probar

1. Tras el deploy de stage, abrir
   `https://portfolio.stage.the-full-stack.com/contact`
2. La consola NO debe mostrar errores de CSP sobre Turnstile
3. El widget Turnstile renderiza una sola vez y resuelve el challenge
4. Enviar el form: `POST /contact` responde 200

Verificado funcionando en dev (`portfolio.dev.the-full-stack.com/contact`).

## TODO

Vacio.