### PR TITLE
release: promueve Fase 2 tracking + SES de dev a stage

### DIFF
--- a/.claude/docs/postgresql-18-analytics/README.md
+++ b/.claude/docs/postgresql-18-analytics/README.md
@@ -71,6 +71,51 @@ SELECT * FROM contacts_by_month_niche LIMIT 10;
 - **Retention**: Drop partitions > 60d automaticamente
 - **Volumen esperado**: ~200 contacts/mes, ~15k tracking events/mes (< 2MB diarios)
 
+## Correlacion contacts <-> tracking_events por session_id
+
+Desde SPEC-202 la tabla `contacts` NO duplica los datos de origen
+(`ip`/`country`/`user_agent`): guarda una columna `session_id` que enlaza
+al visitante con sus `tracking_events`. El origen del contacto (de donde
+viene, que paginas vio, que navegador uso) se consulta con un `JOIN` por
+`session_id`, una sola fuente de verdad.
+
+- `contacts.session_id` es la misma key `cf_session` que emite el
+  `TrackingPixel`. Es OPCIONAL: un visitante que rechazo el tracking no
+  tiene `cf_session` y su `session_id` queda `NULL` — el contacto se guarda
+  igual, sin correlacion.
+- NO hay FK `contacts.session_id -> tracking_events.session_id`:
+  `tracking_events` tiene TTL de 60 dias (drop de particiones) y un
+  contacto puede sobrevivir a sus eventos. La correlacion es logica, via
+  `JOIN`, no por constraint.
+- Las columnas legacy `ip`/`country`/`user_agent` de `contacts` se
+  conservan (datos historicos) pero los contactos nuevos las dejan en
+  `NULL`.
+
+### Query: journey de navegacion de un contacto
+
+Obtiene la secuencia de paginas que vio el visitante antes de contactar,
+ordenada cronologicamente:
+
+```sql
+-- Journey completo del contacto :contact_id (paginas en orden de visita).
+SELECT
+  t.created_at,
+  t.page_path,
+  t.page_title,
+  t.referrer,
+  ROW_NUMBER() OVER (ORDER BY t.created_at) AS page_sequence
+FROM contacts c
+JOIN tracking_events t ON t.session_id = c.session_id
+WHERE c.id = :contact_id
+  AND c.session_id IS NOT NULL
+ORDER BY t.created_at;
+```
+
+`c.session_id IS NOT NULL` evita el caso de un contacto sin sesion (el
+`JOIN` no haria match igual, pero el filtro explicita la intencion). Para
+el journey con `LAG`/`LEAD` (pagina previa/siguiente) ver
+[04-window-functions-analytics.md](./04-window-functions-analytics.md).
+
 ## Referencias relacionadas
 
 - `.claude/docs/postgresql-18/` — Referencia tecnica de PG18 (features del motor, config)

--- a/.claude/rules/serverless-secrets.md
+++ b/.claude/rules/serverless-secrets.md
@@ -64,19 +64,27 @@ Aplica SIEMPRE que se trabaje con:
   # y redeploy del frontend para el nuevo sitekey publico
   ```
 
-### `/portfolio/neon-url` (SecureString + KMS)
+### `/portfolio/{stage}/neon-url` (SecureString + KMS)
 
 - **Que es**: connection string PostgreSQL del proyecto Neon (pooled,
-  `sslmode=require`).
+  `sslmode=require`), una por stage para aislamiento dev/prod a nivel DB.
+- **Parametros**: `/portfolio/dev/neon-url` y `/portfolio/prod/neon-url`. El
+  `template.yaml` resuelve `SSM_NEON_URL_PATH: !Sub /portfolio/${Stage}/neon-url`
+  (SPEC-202, Fase 2). El `/portfolio/neon-url` plano queda como legacy/fallback.
 - **Quien lo lee**: Lambda `stream_processor`.
 - **Rotacion**: cuando se rota el password de `neondb_owner` en Neon Console:
 
   ```bash
   python devtools/run.py serverless setup-ssm \
-    --name=/portfolio/neon-url \
+    --name=/portfolio/dev/neon-url \
     --key-id=alias/portfolio-lambdas --env=dev
   # luego actualizar DB_URL en docker/env/server/.{dev,local,prod}
   ```
+
+> Pendiente operativo: `/portfolio/dev/neon-url` y `/portfolio/prod/neon-url`
+> se crearon en Fase 2 copiando el valor del `/portfolio/neon-url` legacy (que
+> apunta al branch Neon `production`). Para aislamiento real, rotar
+> `/portfolio/dev/neon-url` a la connection string del branch Neon `dev`.
 
   Detalle operativo de Neon: ver [neon-management.md](neon-management.md).
 

--- a/apps/hub/src/pages/contact.astro
+++ b/apps/hub/src/pages/contact.astro
@@ -2,6 +2,7 @@
 import { profile } from '@portfolio/content'
 import ContactForm from '@portfolio/ui/components/ContactFormReact.astro'
 import ContactLinks from '@portfolio/ui/components/ContactLinks.astro'
+import CookieBanner from '@portfolio/ui/components/CookieBanner.astro'
 import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
 import BaseLayout from '@portfolio/ui/layouts/BaseLayout.astro'
 
@@ -62,6 +63,7 @@ const siteUrl = (import.meta.env.SITE_URL ||
     apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
     niche="hub"
   />
+  <CookieBanner locale="es" />
 </BaseLayout>
 
 <style>

--- a/apps/hub/src/pages/en/index.astro
+++ b/apps/hub/src/pages/en/index.astro
@@ -2,6 +2,7 @@
 import { profile } from '@portfolio/content'
 import { buildPersonSchema } from '@portfolio/seo'
 import { nicheTokensToCssVars } from '@portfolio/ui'
+import CookieBanner from '@portfolio/ui/components/CookieBanner.astro'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import MeshGradientBg from '@portfolio/ui/components/MeshGradientBg.astro'
 import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
@@ -108,6 +109,7 @@ const hubStyle = nicheTokensToCssVars('hub')
     apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
     niche="hub"
   />
+  <CookieBanner locale="en" />
 </BaseLayout>
 
 <style>

--- a/apps/hub/src/pages/index.astro
+++ b/apps/hub/src/pages/index.astro
@@ -2,6 +2,7 @@
 import { profile } from '@portfolio/content'
 import { buildPersonSchema } from '@portfolio/seo'
 import { nicheTokensToCssVars } from '@portfolio/ui'
+import CookieBanner from '@portfolio/ui/components/CookieBanner.astro'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import MeshGradientBg from '@portfolio/ui/components/MeshGradientBg.astro'
 import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
@@ -110,6 +111,7 @@ const hubStyle = nicheTokensToCssVars('hub')
     apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
     niche="hub"
   />
+  <CookieBanner locale="es" />
 </BaseLayout>
 
 <style>

--- a/devtools/serverless/secrets.py
+++ b/devtools/serverless/secrets.py
@@ -32,7 +32,15 @@ _SSM_PARAMETERS: dict[str, dict[str, str]] = {
         'kind': 'SecureString',
     },
     '/portfolio/neon-url': {
-        'description': 'Neon PostgreSQL connection string (psycopg3)',
+        'description': 'Neon PostgreSQL connection string (legacy, fallback)',
+        'kind': 'SecureString',
+    },
+    '/portfolio/dev/neon-url': {
+        'description': 'Neon connection string del stage dev (psycopg3)',
+        'kind': 'SecureString',
+    },
+    '/portfolio/prod/neon-url': {
+        'description': 'Neon connection string del stage prod (psycopg3)',
         'kind': 'SecureString',
     },
     '/portfolio/owner-email': {

--- a/packages/app-shared/src/components/CvSections.astro
+++ b/packages/app-shared/src/components/CvSections.astro
@@ -144,7 +144,12 @@ const bentoSpans: Array<'sm' | 'md' | 'lg' | 'xl'> = ['lg', 'md', 'md', 'lg']
   nicheLabel={t.hero.nicheLabel}
   ctas={[
     { href: '#experience', label: t.hero.ctaPrimary, variant: 'primary' },
-    { href: cvHref, label: t.hero.ctaSecondary, variant: 'ghost' },
+    {
+      href: cvHref,
+      label: t.hero.ctaSecondary,
+      variant: 'ghost',
+      dataTrack: 'cv_download',
+    },
   ]}
 />
 

--- a/packages/app-shared/src/layouts/SitePageLayout.astro
+++ b/packages/app-shared/src/layouts/SitePageLayout.astro
@@ -6,6 +6,7 @@ import {
   buildSiteNavigationSchema,
 } from '@portfolio/seo'
 import { nicheTokensToCssVars } from '@portfolio/ui'
+import CookieBanner from '@portfolio/ui/components/CookieBanner.astro'
 import Footer from '@portfolio/ui/components/Footer.astro'
 import Nav from '@portfolio/ui/components/Nav.astro'
 import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
@@ -140,6 +141,7 @@ const nicheStyle = nicheTokensToCssVars(niche)
     apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT}
     niche={niche}
   />
+  <CookieBanner locale={locale} />
   <script>
     import {
       initMagneticCursor,

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -14,9 +14,11 @@ export { publications } from './data/publications/index'
 export { references } from './data/references/index'
 export { skills } from './data/skills/index'
 export {
+  EVENT_TYPE_BY_CODE,
   EVENT_TYPES,
   type EventTypeCode,
   type EventTypeId,
+  eventTypeIdFromCode,
 } from './lib/event-types'
 export { filterByNiche } from './lib/filter-by-niche'
 export { formatRange, formatYearMonth } from './lib/format-date'

--- a/packages/content/src/lib/event-types.ts
+++ b/packages/content/src/lib/event-types.ts
@@ -16,11 +16,32 @@
 /**
  * Mapa de tipos de evento -> UUID del catalogo `event_types`.
  *
- * Fase 1 expone solo `PAGE_LOAD`. SPEC-200 amplia con clicks, embudo de
- * contacto y engagement (mismos UUID del seed SQL).
+ * `PAGE_LOAD` se sembro en migration 006 (Fase 1). El resto lo siembra
+ * migration 008 (SPEC-200): navegacion, clicks, embudo de contacto y
+ * engagement. Cada UUID es identico al del seed SQL — el test de paridad
+ * `event-types.test.ts` falla ante cualquier divergencia.
  */
 export const EVENT_TYPES = {
+  // Navegacion
   PAGE_LOAD: '019e372b-e0a7-7154-8279-8829bcf6a08c',
+  SPA_NAVIGATION: '019e372b-e0a7-70c6-8e56-2b643ddf1702',
+  // Clicks
+  CTA_CLICK: '019e372b-e0a7-793b-84ed-690388a13b15',
+  NAV_CLICK: '019e372b-e0a7-776d-8598-81772857f6a8',
+  PROJECT_LINK_CLICK: '019e372b-e0a7-7c1b-b8e7-3d822a5ce42d',
+  EXPERIENCE_LINK_CLICK: '019e372b-e0a7-7267-8f09-f81f75d90f64',
+  CV_DOWNLOAD: '019e372b-e0a7-78a3-ad27-15dfd3d266a2',
+  THEME_TOGGLE: '019e372b-e0a7-767c-bbc4-d359c3522e86',
+  EXTERNAL_LINK_CLICK: '019e372b-e0a7-7987-8699-8e6381865036',
+  // Embudo de contacto
+  CONTACT_VIEW: '019e372b-e0a7-7f8f-b568-3fbdb8a91756',
+  CONTACT_FORM_START: '019e372b-e0a7-7467-a074-603b7e294cf8',
+  CONTACT_FORM_SUBMIT: '019e372b-e0a7-7a02-b754-606a5fe38afc',
+  CONTACT_FORM_SUCCESS: '019e372b-e0a7-7d1b-9bd3-3cb2ee92b4d7',
+  CONTACT_FORM_ERROR: '019e372b-e0a7-77f6-897f-17f41a06b2c0',
+  // Engagement
+  SCROLL_DEPTH: '019e372b-e0a7-7067-a5c5-d0baf8352385',
+  PAGE_EXIT: '019e372b-e0a7-78dd-a3b5-7cf649c4638f',
 } as const
 
 /**
@@ -34,3 +55,28 @@ export type EventTypeCode = keyof typeof EVENT_TYPES
  * @description Union de los valores UUID validos de `EVENT_TYPES`.
  */
 export type EventTypeId = (typeof EVENT_TYPES)[EventTypeCode]
+
+/**
+ * Mapa `code_name` (snake_case del catalogo SQL) -> UUID. Es el inverso del
+ * naming SCREAMING_SNAKE_CASE de `EVENT_TYPES`: lo usa `click-tracking.ts`
+ * para resolver el atributo `data-track="cta_click"` al UUID del evento.
+ */
+export const EVENT_TYPE_BY_CODE: Readonly<Record<string, string>> =
+  Object.freeze(
+    Object.fromEntries(
+      Object.entries(EVENT_TYPES).map(([code, id]) => [code.toLowerCase(), id]),
+    ),
+  )
+
+/**
+ * @function eventTypeIdFromCode
+ * @description Resuelve un `code_name` snake_case (ej. `nav_click`) al UUID
+ *   del catalogo. Retorna `undefined` si el code no existe.
+ *
+ * @example
+ *   eventTypeIdFromCode('nav_click')  // '019e372b-...'
+ *   eventTypeIdFromCode('unknown')    // undefined
+ */
+export function eventTypeIdFromCode(code: string): string | undefined {
+  return EVENT_TYPE_BY_CODE[code]
+}

--- a/packages/content/tests/unit/event-types.test.ts
+++ b/packages/content/tests/unit/event-types.test.ts
@@ -1,34 +1,68 @@
 /**
  * @description Tests del catalogo de tipos de evento.
  *
- *   Cubre dos cosas:
+ *   Cubre tres cosas:
  *   1. Formato: cada valor de `EVENT_TYPES` es un UUID string valido.
- *   2. Paridad SQL <-> TS: el seed de `serverless/migrations/006_event_types.sql`
- *      y `EVENT_TYPES` deben usar exactamente los mismos UUID. Si alguien edita
- *      uno sin el otro, este test falla y atrapa el drift.
+ *   2. Paridad SQL <-> TS: los seeds de `serverless/migrations/` (006 +
+ *      008) y `EVENT_TYPES` deben usar exactamente los mismos UUID. Si
+ *      alguien edita uno sin el otro, este test falla y atrapa el drift.
+ *   3. Mapa por code_name: `EVENT_TYPE_BY_CODE` mapea el snake_case del
+ *      catalogo SQL al UUID; `eventTypeIdFromCode` resuelve un code.
  *
- *   El test parsea el INSERT del .sql con un regex, extrae los pares
+ *   El test parsea el INSERT de cada .sql con un regex, extrae los pares
  *   (code_name, uuid) y verifica contra las constantes TS.
  */
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { EVENT_TYPES, type EventTypeCode } from '../../src/lib/event-types'
+import {
+  EVENT_TYPE_BY_CODE,
+  EVENT_TYPES,
+  type EventTypeCode,
+  eventTypeIdFromCode,
+} from '../../src/lib/event-types'
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+const MIGRATIONS_DIR = resolve(__dirname, '../../../../serverless/migrations')
+
 /**
- * Parsea los pares (code_name, uuid) del INSERT de la migration de seed.
+ * Catalogo esperado: code_name del seed SQL -> clave de `EVENT_TYPES`.
+ * Es la lista canonica de SPEC-200 (migration 008) + page_load (006).
+ * Si crece el catalogo, esta tabla y `EVENT_TYPES` deben crecer juntas.
+ */
+const EXPECTED_CATALOG: Record<string, EventTypeCode> = {
+  page_load: 'PAGE_LOAD',
+  spa_navigation: 'SPA_NAVIGATION',
+  cta_click: 'CTA_CLICK',
+  nav_click: 'NAV_CLICK',
+  project_link_click: 'PROJECT_LINK_CLICK',
+  experience_link_click: 'EXPERIENCE_LINK_CLICK',
+  cv_download: 'CV_DOWNLOAD',
+  theme_toggle: 'THEME_TOGGLE',
+  external_link_click: 'EXTERNAL_LINK_CLICK',
+  contact_view: 'CONTACT_VIEW',
+  contact_form_start: 'CONTACT_FORM_START',
+  contact_form_submit: 'CONTACT_FORM_SUBMIT',
+  contact_form_success: 'CONTACT_FORM_SUCCESS',
+  contact_form_error: 'CONTACT_FORM_ERROR',
+  scroll_depth: 'SCROLL_DEPTH',
+  page_exit: 'PAGE_EXIT',
+}
+
+/**
+ * Parsea los pares (code_name, uuid) del INSERT de una migration de seed.
  *
  * Las filas del seed tienen la forma:
  *   ('<uuid>', '<code_name>', '<description>')
  * Se extrae uuid + code_name (los dos primeros literales de cada tupla).
  */
 function parseSeedUuids(sqlPath: string): Map<string, string> {
+  const pairs = new Map<string, string>()
+  if (!existsSync(sqlPath)) return pairs
   const sql = readFileSync(sqlPath, 'utf-8')
   const rowRe = /\(\s*'([0-9a-f-]{36})'\s*,\s*'([a-z_]+)'/gi
-  const pairs = new Map<string, string>()
   for (const match of sql.matchAll(rowRe)) {
     const uuid = match[1]
     const codeName = match[2]
@@ -39,13 +73,36 @@ function parseSeedUuids(sqlPath: string): Map<string, string> {
   return pairs
 }
 
-const seed006 = parseSeedUuids(
-  resolve(__dirname, '../../../../serverless/migrations/006_event_types.sql'),
+const seed006 = parseSeedUuids(resolve(MIGRATIONS_DIR, '006_event_types.sql'))
+const seed008 = parseSeedUuids(
+  resolve(MIGRATIONS_DIR, '008_event_types_seed.sql'),
 )
+
+/**
+ * Catalogo SQL combinado: 006 (page_load) + 008 (el resto). Si 008 todavia
+ * no existe en este worktree, el test de paridad de 008 se salta con guarda.
+ */
+const seededCatalog = new Map<string, string>([...seed006, ...seed008])
 
 describe('EVENT_TYPES', () => {
   it('Given EVENT_TYPES.PAGE_LOAD When inspect Then is a valid UUID string', () => {
     expect(EVENT_TYPES.PAGE_LOAD).toMatch(UUID_RE)
+  })
+
+  it('Given every EVENT_TYPES value When inspect Then all are valid UUID strings', () => {
+    const invalid = Object.entries(EVENT_TYPES).filter(
+      ([, uuid]) => !UUID_RE.test(uuid),
+    )
+    expect(invalid).toEqual([])
+  })
+
+  it('Given EVENT_TYPES When count keys Then exposes the full 16-event catalog', () => {
+    expect(Object.keys(EVENT_TYPES).length).toBe(16)
+  })
+
+  it('Given every EVENT_TYPES value When collected Then all UUIDs are unique', () => {
+    const values = Object.values(EVENT_TYPES)
+    expect(new Set(values).size).toBe(values.length)
   })
 
   it('Given the barrel @portfolio/content When import EVENT_TYPES Then it is exported and typed', () => {
@@ -54,19 +111,59 @@ describe('EVENT_TYPES', () => {
   })
 })
 
-describe('event_types catalog parity (SQL <-> TS)', () => {
+describe('EVENT_TYPE_BY_CODE / eventTypeIdFromCode', () => {
+  it('Given code_name cta_click When eventTypeIdFromCode Then returns CTA_CLICK UUID', () => {
+    expect(eventTypeIdFromCode('cta_click')).toBe(EVENT_TYPES.CTA_CLICK)
+  })
+
+  it('Given an unknown code When eventTypeIdFromCode Then returns undefined', () => {
+    expect(eventTypeIdFromCode('not_a_real_event')).toBe(undefined)
+  })
+
+  it('Given EVENT_TYPE_BY_CODE When inspect page_load Then maps to PAGE_LOAD UUID', () => {
+    expect(EVENT_TYPE_BY_CODE.page_load).toBe(EVENT_TYPES.PAGE_LOAD)
+  })
+
+  it('Given EVENT_TYPE_BY_CODE When count entries Then has one per EVENT_TYPES key', () => {
+    expect(Object.keys(EVENT_TYPE_BY_CODE).length).toBe(
+      Object.keys(EVENT_TYPES).length,
+    )
+  })
+})
+
+describe('event_types catalog parity (SQL <-> TS) [AC-2]', () => {
+  it('Given the expected catalog When checked Then every code maps to an EVENT_TYPES key', () => {
+    for (const [, tsCode] of Object.entries(EXPECTED_CATALOG)) {
+      expect(EVENT_TYPES[tsCode]).toMatch(UUID_RE)
+    }
+  })
+
+  it('Given EVENT_TYPES When compared Then every key appears in the expected catalog', () => {
+    const expectedCodes = new Set(Object.values(EXPECTED_CATALOG))
+    const tsCodes = Object.keys(EVENT_TYPES) as EventTypeCode[]
+    const missing = tsCodes.filter((code) => !expectedCodes.has(code))
+    expect(missing).toEqual([])
+  })
+
   it('Given migration 006 seed When parse Then page_load UUID matches EVENT_TYPES.PAGE_LOAD', () => {
     expect(seed006.get('page_load')).toBe(EVENT_TYPES.PAGE_LOAD)
   })
 
-  it('Given the SQL seed When compared Then every seeded code_name has a matching TS constant', () => {
-    // Fase 1: el seed 006 solo trae page_load. SPEC-200 amplia el seed y el
-    // mapa; este loop ya cubre el catalogo completo cuando crezca.
-    const tsByCode: Record<string, string> = {
-      page_load: EVENT_TYPES.PAGE_LOAD,
+  it('Given the seeded SQL catalog When compared Then every seeded code_name matches its TS constant', () => {
+    for (const [codeName, uuid] of seededCatalog) {
+      const tsCode = EXPECTED_CATALOG[codeName]
+      expect(tsCode).not.toBe(undefined)
+      expect(EVENT_TYPES[tsCode as EventTypeCode]).toBe(uuid)
     }
-    for (const [codeName, uuid] of seed006) {
-      expect(tsByCode[codeName]).toBe(uuid)
+  })
+
+  it('Given migration 008 seed When it exists Then it seeds every non-page_load event', () => {
+    // Guarda: 008 lo crea el backend en Fase 2; si todavia no esta en este
+    // worktree el test no falla, solo se salta la comprobacion de 008.
+    if (seed008.size === 0) return
+    for (const [codeName, tsCode] of Object.entries(EXPECTED_CATALOG)) {
+      if (codeName === 'page_load') continue
+      expect(seed008.get(codeName)).toBe(EVENT_TYPES[tsCode])
     }
   })
 })

--- a/packages/ui/src/components/ContactFormReact.astro
+++ b/packages/ui/src/components/ContactFormReact.astro
@@ -4,10 +4,16 @@
  * @description Monta ContactFormReact.tsx con `client:load`. Hidrata en el
  *   cliente y comparte estilos globales del form (tokens del DS).
  *
+ *   Los UUID del embudo de contacto (`EVENT_TYPES`) se resuelven aqui, en el
+ *   frontmatter Astro (server-side), y se pasan como props. Asi el bundle del
+ *   island React NO importa `@portfolio/content` — evita que Vite re-optimice
+ *   dependencias del island en dev (mismo patron que TrackingPixel.astro).
+ *
  * @props {string} apiEndpoint - Full URL del POST /contact
  * @props {string} turnstileSitekey - Sitekey publica del widget Turnstile
  * @props {string} [niche] - Nicho del subdominio
  */
+import { EVENT_TYPES } from '@portfolio/content'
 import ContactFormReact from './ContactFormReact.tsx'
 
 interface Props {
@@ -16,12 +22,21 @@ interface Props {
   niche?: string
 }
 const { apiEndpoint, turnstileSitekey, niche = 'generic' } = Astro.props
+
+const funnelEventTypes = {
+  contactView: EVENT_TYPES.CONTACT_VIEW,
+  contactFormStart: EVENT_TYPES.CONTACT_FORM_START,
+  contactFormSubmit: EVENT_TYPES.CONTACT_FORM_SUBMIT,
+  contactFormSuccess: EVENT_TYPES.CONTACT_FORM_SUCCESS,
+  contactFormError: EVENT_TYPES.CONTACT_FORM_ERROR,
+}
 ---
 
 <ContactFormReact
   apiEndpoint={apiEndpoint}
   turnstileSitekey={turnstileSitekey}
   niche={niche}
+  funnelEventTypes={funnelEventTypes}
   client:load
 />
 

--- a/packages/ui/src/components/ContactFormReact.tsx
+++ b/packages/ui/src/components/ContactFormReact.tsx
@@ -24,6 +24,7 @@ import {
   useState,
 } from 'react'
 import {
+  buildContactPayload,
   type ContactFieldErrors,
   type ContactFormFieldName,
   ContactFormSchema,
@@ -38,6 +39,7 @@ import {
   readContactRecord,
   saveContactRecord,
 } from '../lib/contact-storage'
+import { configureTracking, trackEvent } from '../lib/track-event'
 
 // `?render=explicit`: desactiva el render implicito de Turnstile (el que
 // escanea el DOM buscando `.cf-turnstile`). El widget se monta solo via
@@ -71,10 +73,25 @@ declare global {
   }
 }
 
+/**
+ * UUID del catalogo `event_types` para los 5 eventos del embudo de contacto.
+ * Se resuelven en `ContactFormReact.astro` (server-side, desde
+ * `@portfolio/content`) y se pasan como prop: asi el bundle del island no
+ * importa `@portfolio/content` y Vite no re-optimiza el island en dev.
+ */
+interface FunnelEventTypes {
+  contactView: string
+  contactFormStart: string
+  contactFormSubmit: string
+  contactFormSuccess: string
+  contactFormError: string
+}
+
 interface ContactFormReactProps {
   apiEndpoint: string
   turnstileSitekey: string
   niche?: string
+  funnelEventTypes: FunnelEventTypes
 }
 
 interface ApiErrorBody {
@@ -103,19 +120,19 @@ const ERROR_MESSAGES: Record<number | 'default', string> = {
   default: 'Error del servidor. Intenta nuevamente en unos minutos.',
 }
 
-function buildPayload(
-  data: ContactFormValues,
-  ctx: { niche: string; cfToken: string },
-): Record<string, string> {
-  const payload: Record<string, string> = {
-    niche: ctx.niche,
-    cf_token: ctx.cfToken,
+/**
+ * Lee `localStorage.cf_session` (la misma key que usa el TrackingPixel) para
+ * enlazar el contacto con su journey de tracking (SPEC-202). Devuelve
+ * `undefined` si no hay sesion (visitante que rechazo el tracking) o si el
+ * acceso a localStorage falla — el form NUNCA debe romperse por esto.
+ */
+function readSessionId(): string | undefined {
+  try {
+    const sid = localStorage.getItem('cf_session')
+    return sid && sid.length >= 20 ? sid : undefined
+  } catch {
+    return undefined
   }
-  for (const [key, raw] of Object.entries(data)) {
-    const value = typeof raw === 'string' ? raw.trim() : ''
-    if (value) payload[key] = value
-  }
-  return payload
 }
 
 function buildHeaders(bypassSecret: string): Record<string, string> {
@@ -181,6 +198,7 @@ export default function ContactFormReact({
   apiEndpoint,
   turnstileSitekey,
   niche = 'generic',
+  funnelEventTypes,
 }: ContactFormReactProps) {
   const reactId = useId()
   const [values, setValues] = useState<ContactFormValues>(emptyValues)
@@ -200,6 +218,21 @@ export default function ContactFormReact({
       bypassTokenRef.current = window.__playwrightTurnstileBypass
     }
   }, [])
+
+  // Embudo de contacto (SPEC-200): el primer foco en cualquier campo emite
+  // `contact_form_start` una sola vez. Este flag evita repeticiones en focos
+  // posteriores [AC-5].
+  const formStartedRef = useRef<boolean>(false)
+
+  // Configura la emision de eventos con el endpoint base + niche, y emite
+  // `contact_view` al montar la pagina /contact [AC-4]. El gating de
+  // consentimiento lo resuelve `trackEvent` internamente: si el visitante no
+  // acepto el tracking, las llamadas son no-op.
+  useEffect(() => {
+    const base = apiEndpoint.replace(/\/contact$/, '')
+    configureTracking({ apiEndpoint: base, niche })
+    trackEvent(funnelEventTypes.contactView)
+  }, [apiEndpoint, niche, funnelEventTypes.contactView])
 
   // Rehidratar estado "ya envio" desde localStorage/cookie
   useEffect(() => {
@@ -319,7 +352,19 @@ export default function ContactFormReact({
     [validateField, values],
   )
 
+  /**
+   * Foco delegado en el `<form>`: el primer foco en cualquier campo emite
+   * `contact_form_start` una sola vez (el flag bloquea repeticiones) [AC-5].
+   */
+  const handleFormFocus = useCallback((): void => {
+    if (formStartedRef.current) return
+    formStartedRef.current = true
+    trackEvent(funnelEventTypes.contactFormStart)
+  }, [funnelEventTypes.contactFormStart])
+
   function handleSuccess(contactId: string): void {
+    // Embudo: la respuesta fue 201. Emite `contact_form_success` [AC-6].
+    trackEvent(funnelEventTypes.contactFormSuccess)
     const record = saveContactRecord(contactId)
     setSentRecord(record)
     setValues(emptyValues())
@@ -339,6 +384,9 @@ export default function ContactFormReact({
     httpStatus: number,
     body: (ApiErrorBody & ApiSuccessBody) | null,
   ): void {
+    // Embudo: el envio fallo (4XX/5XX). Emite `contact_form_error` con el
+    // codigo HTTP en `event_props` [AC-7].
+    trackEvent(funnelEventTypes.contactFormError, { code: String(httpStatus) })
     if (httpStatus === 400) {
       const fieldErrors = mapPydanticErrors(body?.extra?.errors ?? [])
       if (Object.keys(fieldErrors).length > 0) setErrors(fieldErrors)
@@ -385,7 +433,16 @@ export default function ContactFormReact({
     setStatus('submitting')
     setStatusMessage('Enviando...')
 
-    const payload = buildPayload(pre.data, { niche, cfToken: pre.cfToken })
+    // Embudo: el form se envia. Emite `contact_form_submit` [AC-6].
+    trackEvent(funnelEventTypes.contactFormSubmit)
+
+    // SPEC-202: enlaza el contacto con su journey via `session_id`. Ausente
+    // si el visitante no tiene `cf_session` (rechazo el tracking) [AC-2].
+    const payload = buildContactPayload(pre.data, {
+      niche,
+      cfToken: pre.cfToken,
+      sessionId: readSessionId(),
+    })
     const headers = buildHeaders(pre.bypassSecret)
 
     try {
@@ -401,6 +458,9 @@ export default function ContactFormReact({
       }
       handleApiError(response.status, body)
     } catch (_error) {
+      // Error de red: no hay codigo HTTP. Emite `contact_form_error` con
+      // `code: 'network'` para distinguirlo de los fallos 4XX/5XX [AC-7].
+      trackEvent(funnelEventTypes.contactFormError, { code: 'network' })
       setStatus('error')
       setStatusMessage('Error de red. Verifica tu conexion y reintenta.')
     }
@@ -450,6 +510,7 @@ export default function ContactFormReact({
         className="contact-form"
         noValidate
         onSubmit={handleSubmit}
+        onFocus={handleFormFocus}
         data-testid="contact-form"
         data-niche={niche}
       >

--- a/packages/ui/src/components/CookieBanner.astro
+++ b/packages/ui/src/components/CookieBanner.astro
@@ -33,8 +33,8 @@ const copy = getBannerCopy(locale)
   class="cookie-banner"
   role="dialog"
   aria-modal="true"
-  aria-labelledby="cookie-banner-text"
   aria-label={copy.ariaLabel}
+  aria-describedby="cookie-banner-text"
   hidden
 >
   <div class="cookie-banner__content">
@@ -123,7 +123,9 @@ const copy = getBannerCopy(locale)
       btn.addEventListener('click', () => {
         const action = btn.dataset.action
         if (action !== 'accept' && action !== 'reject') return
-        writeConsent(action)
+        // data-action es 'accept'/'reject'; el consentimiento persistido es
+        // 'accepted'/'rejected' (ConsentValue). TrackingPixel lee esa key.
+        writeConsent(action === 'accept' ? 'accepted' : 'rejected')
         closeBanner()
       })
     }

--- a/packages/ui/src/components/CookieBanner.astro
+++ b/packages/ui/src/components/CookieBanner.astro
@@ -1,88 +1,144 @@
 ---
 /**
  * @component CookieBanner
- * @description Banner GDPR opt-in para tracking. Persiste consent en
- * localStorage ('cf_consent' = 'accepted' | 'rejected'). NO usa cookies
- * (no cookie banner = simpler GDPR + no cookies = no banner needed
- * tecnicamente, pero por buena practica pedimos opt-in explicito para
- * el tracking pixel).
+ * @description Banner GDPR opt-in para el tracking. Persiste el consentimiento
+ * en localStorage (`cf_consent` = 'accepted' | 'rejected') — NO usa cookies.
+ * Solo se muestra mientras el usuario no respondio; el enlace "Gestionar
+ * consentimiento" del Footer lo reabre (evento `portfolio:consent-reopen`)
+ * para que revocar sea tan facil como otorgar (requisito GDPR).
+ *
+ * Accesibilidad: el banner es un `role="dialog"` con `aria-modal` y
+ * `aria-label`; al abrir, el foco entra al boton Aceptar; Tab cicla entre
+ * ambos botones (focus trap); Escape no cierra (decision deliberada: el
+ * usuario debe responder explicitamente). El foco vuelve al disparador al
+ * cerrar si el banner fue reabierto desde el Footer.
+ *
+ * @props {'es' | 'en'} [locale] - idioma de los textos (default: 'es')
  *
  * @example
- *   <CookieBanner />
+ *   <CookieBanner locale={locale} />
  */
+import { getBannerCopy } from '../lib/cookie-consent'
+
+interface Props {
+  locale?: 'es' | 'en'
+}
+
+const { locale = 'es' } = Astro.props
+const copy = getBannerCopy(locale)
 ---
 
-<div id="cookie-banner" class="cookie-banner" hidden>
+<div
+  id="cookie-banner"
+  class="cookie-banner"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="cookie-banner-text"
+  aria-label={copy.ariaLabel}
+  hidden
+>
   <div class="cookie-banner__content">
-    <p class="cookie-banner__text">
-      Este sitio usa <strong>analytics propios privacy-friendly</strong> (sin
-      cookies de terceros, datos auto-borran en 60 dias). ¿Permitis recolectar
-      tu visita para mejorar el contenido?
+    <p id="cookie-banner-text" class="cookie-banner__text">
+      {copy.bodyLead}<strong>{copy.bodyStrong}</strong>{copy.bodyTail}
     </p>
     <div class="cookie-banner__actions">
       <button
         type="button"
         class="cookie-banner__btn cookie-banner__btn--accept"
         data-action="accept"
+        data-testid="cookie-accept"
       >
-        Aceptar
+        {copy.accept}
       </button>
       <button
         type="button"
         class="cookie-banner__btn cookie-banner__btn--reject"
         data-action="reject"
+        data-testid="cookie-reject"
       >
-        Rechazar
+        {copy.reject}
       </button>
     </div>
   </div>
 </div>
 
 <script>
-  const STORAGE_KEY = 'cf_consent'
-
-  type ConsentValue = 'accepted' | 'rejected'
-
-  function readConsent(): ConsentValue | null {
-    try {
-      const value = localStorage.getItem(STORAGE_KEY)
-      if (value === 'accepted' || value === 'rejected') return value
-    } catch {
-      // localStorage no disponible (Safari private mode)
-    }
-    return null
-  }
-
-  function writeConsent(value: ConsentValue): void {
-    try {
-      localStorage.setItem(STORAGE_KEY, value)
-    } catch {
-      // localStorage no disponible
-    }
-    document.dispatchEvent(
-      new CustomEvent('portfolio:consent-changed', { detail: { value } }),
-    )
-  }
+  import {
+    readConsent,
+    writeConsent,
+    REOPEN_BANNER_EVENT,
+  } from '../lib/cookie-consent'
 
   function initCookieBanner(): void {
-    const banner = document.getElementById('cookie-banner') as HTMLDivElement | null
-    if (!banner) return
+    const banner = document.getElementById('cookie-banner')
+    if (!(banner instanceof HTMLElement)) return
 
-    const consent = readConsent()
-    if (consent !== null) {
-      // Ya respondio - no mostrar
-      return
+    // Con View Transitions el modulo se re-ejecuta en cada navegacion.
+    // Un flag en el dataset evita registrar los listeners dos veces.
+    if (banner.dataset.cfBannerInit === '1') return
+    banner.dataset.cfBannerInit = '1'
+
+    const buttons = Array.from(
+      banner.querySelectorAll<HTMLButtonElement>('[data-action]'),
+    )
+    const acceptBtn = buttons.find((b) => b.dataset.action === 'accept')
+
+    // Elemento al que devolver el foco al cerrar (cuando se reabrio desde
+    // el Footer); null en la primera visita.
+    let returnFocusTo: HTMLElement | null = null
+
+    function openBanner(opener: HTMLElement | null): void {
+      returnFocusTo = opener
+      banner.hidden = false
+      // Mover el foco al primer boton para que el teclado lo alcance.
+      acceptBtn?.focus()
     }
 
-    banner.hidden = false
+    function closeBanner(): void {
+      banner.hidden = true
+      if (returnFocusTo) {
+        returnFocusTo.focus()
+        returnFocusTo = null
+      }
+    }
 
-    banner.querySelectorAll<HTMLButtonElement>('[data-action]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const action = btn.dataset.action as ConsentValue
-        writeConsent(action)
-        banner.hidden = true
-      })
+    // Focus trap: Tab/Shift+Tab cicla solo entre los botones del banner.
+    banner.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || buttons.length === 0) return
+      const active = document.activeElement
+      const idx = buttons.indexOf(active as HTMLButtonElement)
+      event.preventDefault()
+      const last = buttons.length - 1
+      const next = event.shiftKey
+        ? idx <= 0
+          ? last
+          : idx - 1
+        : idx >= last
+          ? 0
+          : idx + 1
+      buttons[next]?.focus()
     })
+
+    for (const btn of buttons) {
+      btn.addEventListener('click', () => {
+        const action = btn.dataset.action
+        if (action !== 'accept' && action !== 'reject') return
+        writeConsent(action)
+        closeBanner()
+      })
+    }
+
+    // El Footer (u otro disparador) pide reabrir el banner para revocar.
+    document.addEventListener(REOPEN_BANNER_EVENT, (event: Event) => {
+      const opener = (event as CustomEvent<{ opener?: HTMLElement }>).detail
+        ?.opener
+      openBanner(opener instanceof HTMLElement ? opener : null)
+    })
+
+    // Primera visita: mostrar solo si el usuario no respondio aun.
+    if (readConsent() === null) {
+      openBanner(null)
+    }
   }
 
   if (document.readyState === 'loading') {
@@ -125,12 +181,15 @@
   .cookie-banner__text {
     margin: 0;
     font-size: var(--font-size-13);
-    color: var(--color-text-muted);
+    /* text-muted/40 fallan WCAG AA sobre surface; text es el principal */
+    color: var(--color-text);
+    line-height: var(--line-height-snug);
     flex: 1;
   }
 
   .cookie-banner__text strong {
     color: var(--color-text);
+    font-weight: 600;
   }
 
   .cookie-banner__actions {
@@ -146,7 +205,15 @@
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: all 150ms ease;
+    transition:
+      background var(--motion-base, 150ms) ease,
+      border-color var(--motion-base, 150ms) ease;
+  }
+
+  /* Foco siempre visible (navegacion con teclado, WCAG 2.4.7) */
+  .cookie-banner__btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   .cookie-banner__btn--accept {

--- a/packages/ui/src/components/ExperienceCard.astro
+++ b/packages/ui/src/components/ExperienceCard.astro
@@ -29,7 +29,12 @@ const remaining = Math.max(0, skills.length - visibleSkills.length)
       <p class="exp-card__company text-body">
         {
           companyUrl ? (
-            <a href={companyUrl} target="_blank" rel="noopener">
+            <a
+              href={companyUrl}
+              target="_blank"
+              rel="noopener"
+              data-track="experience_link_click"
+            >
               {company}
             </a>
           ) : (

--- a/packages/ui/src/components/Footer.astro
+++ b/packages/ui/src/components/Footer.astro
@@ -1,12 +1,15 @@
 ---
 /**
  * @component Footer
- * @description Footer minimalista con copyright + links sociales.
+ * @description Footer minimalista con copyright + links sociales + boton de
+ *   gestion de consentimiento (GDPR: revocar debe ser tan facil como otorgar).
  *
  * @props {string} name - Nombre del titular del copyright
  * @props {object} contacts - Links sociales (linkedin, github)
  * @props {string} [locale] - 'es' o 'en' (afecta copy)
  */
+import { getManageConsentLabel } from '../lib/cookie-consent'
+
 interface Props {
   name: string
   contacts: {
@@ -23,6 +26,7 @@ const copy =
   locale === 'es'
     ? `© ${year} ${name}. Todos los derechos reservados.`
     : `© ${year} ${name}. All rights reserved.`
+const manageConsentLabel = getManageConsentLabel(locale)
 ---
 
 <footer class="site-footer">
@@ -35,9 +39,42 @@ const copy =
       <li>
         <a href={contacts.github} rel="me" target="_blank">GitHub</a>
       </li>
+      <li>
+        <button
+          type="button"
+          class="site-footer__consent"
+          data-action="reopen-consent"
+          data-testid="manage-consent"
+        >
+          {manageConsentLabel}
+        </button>
+      </li>
     </ul>
   </div>
 </footer>
+
+<script>
+  import { REOPEN_BANNER_EVENT } from '../lib/cookie-consent'
+
+  function initManageConsent(): void {
+    const buttons = document.querySelectorAll<HTMLButtonElement>(
+      '[data-action="reopen-consent"]',
+    )
+    for (const btn of buttons) {
+      if (btn.dataset.cfConsentInit === '1') continue
+      btn.dataset.cfConsentInit = '1'
+      btn.addEventListener('click', () => {
+        // El banner devuelve el foco a este boton al cerrarse.
+        document.dispatchEvent(
+          new CustomEvent(REOPEN_BANNER_EVENT, { detail: { opener: btn } }),
+        )
+      })
+    }
+  }
+
+  initManageConsent()
+  document.addEventListener('astro:after-swap', initManageConsent)
+</script>
 
 <style>
   /* Mobile-first */
@@ -65,16 +102,31 @@ const copy =
   }
   .site-footer__links {
     display: flex;
+    align-items: center;
     gap: var(--space-16);
   }
-  .site-footer__links a {
+  .site-footer__links a,
+  .site-footer__consent {
     font-family: var(--font-mono);
     font-size: var(--font-size-12);
     color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: var(--letter-spacing-wider);
   }
-  .site-footer__links a:hover {
+  .site-footer__links a:hover,
+  .site-footer__consent:hover {
     color: var(--color-text);
+  }
+  /* El boton de consentimiento se ve como un link del footer */
+  .site-footer__consent {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+  }
+  .site-footer__consent:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: var(--radius-xs);
   }
 </style>

--- a/packages/ui/src/components/HeroImpact.astro
+++ b/packages/ui/src/components/HeroImpact.astro
@@ -27,6 +27,8 @@ interface Cta {
   href: string
   label: string
   variant?: 'primary' | 'ghost'
+  /** Code de tracking (`data-track`) — ej. `cv_download` para la descarga del CV. */
+  dataTrack?: string
 }
 
 interface Props {
@@ -82,6 +84,7 @@ const {
                 'magnetic',
                 `hero-impact__cta--${cta.variant ?? 'primary'}`,
               ]}
+              data-track={cta.dataTrack}
             >
               {cta.label}
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">

--- a/packages/ui/src/components/Nav.astro
+++ b/packages/ui/src/components/Nav.astro
@@ -70,6 +70,7 @@ const menuLabel = currentLocale === 'es' ? 'Abrir menú' : 'Open menu'
                 ]}
                 target={item.external ? '_blank' : undefined}
                 rel={item.external ? 'noopener noreferrer' : undefined}
+                data-track="nav_click"
               >
                 {item.label}
                 {item.external && (

--- a/packages/ui/src/components/ProjectCard.astro
+++ b/packages/ui/src/components/ProjectCard.astro
@@ -52,14 +52,26 @@ const {
   <footer class="proj-card__footer">
     {
       url && (
-        <a href={url} target="_blank" rel="noopener" class="proj-card__link">
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener"
+          class="proj-card__link"
+          data-track="project_link_click"
+        >
           Live ↗
         </a>
       )
     }
     {
       repo && (
-        <a href={repo} target="_blank" rel="noopener" class="proj-card__link">
+        <a
+          href={repo}
+          target="_blank"
+          rel="noopener"
+          class="proj-card__link"
+          data-track="project_link_click"
+        >
           Repo ↗
         </a>
       )

--- a/packages/ui/src/components/ThemeToggle.astro
+++ b/packages/ui/src/components/ThemeToggle.astro
@@ -25,6 +25,7 @@ const {
   id="theme-toggle"
   class="theme-toggle"
   aria-label={label.system}
+  data-track="theme_toggle"
   data-label-system={label.system}
   data-label-dark={label.dark}
   data-label-light={label.light}

--- a/packages/ui/src/components/TrackingPixel.astro
+++ b/packages/ui/src/components/TrackingPixel.astro
@@ -1,15 +1,18 @@
 ---
 /**
  * @component TrackingPixel
- * @description Tracking pixel client-side: envia un evento `page_load` al
- * backend tracking_pixel SOLO si el user dio consent en CookieBanner (o si
- * la pagina lleva el flag de QA `?cf_track=force`).
+ * @description Cableado de tracking client-side del portfolio. Monta UN punto
+ * de entrada que: emite `page_load` (carga inicial + cada navegacion SPA via
+ * `astro:after-swap` como `spa_navigation`), inicializa el tracking delegado
+ * de clicks (`initClickTracking`) y el de scroll depth (`initScrollDepth`), y
+ * emite `page_exit` cuando la pestana pasa a `hidden`.
  *
- * Implementacion: client:idle (post page load). Cada carga genera un
- * `event_id` (UUIDv4) propio para idempotencia y envia `POST /track` con
- * `event_type_id` = EVENT_TYPES.PAGE_LOAD, `session_id` + page metadata +
- * UTMs. Re-dispara en `astro:after-swap` para trackear navegacion SPA con
- * View Transitions (cada navegacion = un page_load nuevo).
+ * Toda emision pasa por `track-event.ts`: gating de consentimiento
+ * (`localStorage.cf_consent === 'accepted'`) con bypass de QA `?cf_track=force`.
+ * Sin consentimiento ni flag: cero eventos (GDPR por defecto).
+ *
+ * El flag `window.__cfTrackingPixelInit` evita registrar listeners dos veces
+ * cuando View Transitions re-ejecuta el script en cada navegacion.
  *
  * @props {string} apiEndpoint - URL base del API Gateway
  * @props {string} [niche] - niche del subdominio
@@ -17,156 +20,86 @@
  * @example
  *   <TrackingPixel apiEndpoint={import.meta.env.PUBLIC_API_ENDPOINT} niche="generic" />
  */
-import { EVENT_TYPES } from '@portfolio/content'
+import { EVENT_TYPES } from '@portfolio/content/lib/event-types'
 
 interface Props {
   apiEndpoint: string
   niche?: string
 }
 const { apiEndpoint, niche = 'generic' } = Astro.props
-const pageLoadEventTypeId = EVENT_TYPES.PAGE_LOAD
 ---
 
-<script
-  is:inline
+<div
+  id="cf-tracking-pixel"
+  hidden
   data-api-endpoint={apiEndpoint}
   data-niche={niche}
-  define:vars={{ apiEndpoint, niche, pageLoadEventTypeId }}
+  data-page-load={EVENT_TYPES.PAGE_LOAD}
+  data-spa-navigation={EVENT_TYPES.SPA_NAVIGATION}
+  data-page-exit={EVENT_TYPES.PAGE_EXIT}
 >
-  ;(() => {
-    if (!apiEndpoint) return
+</div>
 
-    // Con View Transitions el script is:inline se re-ejecuta en cada
-    // navegacion. Guardar un flag en window evita registrar los listeners
-    // (after-swap, consent-changed) mas de una vez y disparar tracking
-    // duplicado. La navegacion SPA ya la cubre el listener astro:after-swap.
-    if (window.__cfTrackingPixelInit) return
-    window.__cfTrackingPixelInit = true
+<script>
+  import { initClickTracking } from '../lib/click-tracking'
+  import { initScrollDepth } from '../lib/scroll-depth'
+  import { configureTracking, trackEvent } from '../lib/track-event'
 
-    const STORAGE_CONSENT = 'cf_consent'
-    const STORAGE_SESSION = 'cf_session'
+  interface CfTrackingWindow extends Window {
+    __cfTrackingPixelInit?: boolean
+  }
 
-    // UUID v4 (con fallback para browsers sin crypto.randomUUID)
-    function uuid() {
-      if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-        return crypto.randomUUID()
-      }
-      return `${Date.now()}-${Math.random().toString(36).slice(2)}-${Math.random()
-        .toString(36)
-        .slice(2)}`
+  const host = document.getElementById('cf-tracking-pixel')
+  const apiEndpoint = host?.dataset.apiEndpoint ?? ''
+
+  if (host && apiEndpoint) {
+    const win = window as CfTrackingWindow
+    const pageLoadId = host.dataset.pageLoad ?? ''
+    const spaNavigationId = host.dataset.spaNavigation ?? ''
+    const pageExitId = host.dataset.pageExit ?? ''
+
+    configureTracking({
+      apiEndpoint,
+      niche: host.dataset.niche ?? 'generic',
+    })
+
+    // page_load de la carga actual. requestIdleCallback evita competir con
+    // el render inicial; fallback setTimeout para browsers sin la API.
+    const emitPageLoad = (): void => {
+      trackEvent(pageLoadId, { page_path: window.location.pathname })
     }
-
-    // QA bypass: ?cf_track=force permite trackear sin cf_consent (solo E2E).
-    function isForced() {
-      try {
-        return new URLSearchParams(window.location.search).get('cf_track') === 'force'
-      } catch {
-        return false
-      }
-    }
-
-    // Solo enviar si el user acepto, o si esta forzado por el flag de QA.
-    function canTrack() {
-      if (isForced()) return true
-      try {
-        return localStorage.getItem(STORAGE_CONSENT) === 'accepted'
-      } catch {
-        return false
-      }
-    }
-
-    function getSessionId() {
-      try {
-        let sid = localStorage.getItem(STORAGE_SESSION)
-        if (!sid || sid.length < 20) {
-          sid = uuid().replace(/-/g, '')
-          localStorage.setItem(STORAGE_SESSION, sid)
-        }
-        return sid
-      } catch {
-        return `nostorage-${Date.now()}-${Math.random().toString(36).slice(2)}`
-      }
-    }
-
-    function getUTMs() {
-      const params = new URLSearchParams(window.location.search)
-      const utms = {}
-      ;[
-        'utm_source',
-        'utm_medium',
-        'utm_campaign',
-        'utm_content',
-        'utm_term',
-      ].forEach((k) => {
-        const v = params.get(k)
-        if (v) utms[k] = v.slice(0, 100)
-      })
-      return utms
-    }
-
-    function track() {
-      if (!canTrack()) return
-
-      const payload = {
-        session_id: getSessionId(),
-        // event_id: UUIDv4 propio de ESTE evento (idempotencia en reintentos
-        // de sendBeacon). Sin guiones para encajar en el limite del backend.
-        event_id: uuid().replace(/-/g, ''),
-        // event_type_id: tipo del catalogo event_types (page_load).
-        event_type_id: pageLoadEventTypeId,
-        page_url: window.location.href.slice(0, 500),
-        page_title: document.title.slice(0, 200),
-        page_path: window.location.pathname.slice(0, 300),
-        referrer: document.referrer ? document.referrer.slice(0, 500) : undefined,
-        viewport_width: window.innerWidth,
-        viewport_height: window.innerHeight,
-        niche,
-        ...getUTMs(),
-      }
-
-      // sendBeacon es preferible (sigue funcionando si user cierra la tab)
-      const url = `${apiEndpoint}/track`
-      const body = JSON.stringify(payload)
-      try {
-        if (navigator.sendBeacon) {
-          const blob = new Blob([body], { type: 'application/json' })
-          navigator.sendBeacon(url, blob)
-          return
-        }
-      } catch {
-        // continua con fetch fallback
-      }
-
-      // Fallback fetch
-      fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body,
-        keepalive: true,
-      }).catch(() => {
-        // silently ignore - tracking es fire-and-forget
-      })
-    }
-
-    // Lanzar despues que la pagina termine de cargar + idle
     if ('requestIdleCallback' in window) {
-      window.requestIdleCallback(track, { timeout: 2000 })
+      window.requestIdleCallback(emitPageLoad, { timeout: 2000 })
     } else {
-      setTimeout(track, 100)
+      setTimeout(emitPageLoad, 100)
     }
 
-    // Navegacion SPA (View Transitions): cada after-swap es un page_load
-    // nuevo con su propio event_id.
-    document.addEventListener('astro:after-swap', () => {
-      track()
-    })
+    // Con View Transitions el script se re-ejecuta en cada navegacion. El
+    // flag en window evita registrar los listeners (after-swap, click,
+    // scroll, visibilitychange, consent) mas de una vez.
+    if (!win.__cfTrackingPixelInit) {
+      win.__cfTrackingPixelInit = true
 
-    // Re-track si consent cambia despues (el user acepta el banner)
-    document.addEventListener('portfolio:consent-changed', (e) => {
-      const detail = e.detail
-      if (detail && detail.value === 'accepted') {
-        track()
-      }
-    })
-  })()
+      initClickTracking()
+      initScrollDepth()
+
+      // Navegacion SPA: cada after-swap es una navegacion nueva.
+      document.addEventListener('astro:after-swap', () => {
+        trackEvent(spaNavigationId, { page_path: window.location.pathname })
+      })
+
+      // page_exit: el usuario deja la pestana (cambio de app, cierre).
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          trackEvent(pageExitId, { page_path: window.location.pathname })
+        }
+      })
+
+      // Re-emite page_load si el consentimiento cambia despues (banner).
+      document.addEventListener('portfolio:consent-changed', (e) => {
+        const detail = (e as CustomEvent<{ value?: string }>).detail
+        if (detail?.value === 'accepted') emitPageLoad()
+      })
+    }
+  }
 </script>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,10 +6,27 @@
  *   import BaseLayout from '@portfolio/ui/layouts/BaseLayout.astro'
  *   import Hero from '@portfolio/ui/components/Hero.astro'
  *   import TrackingPixel from '@portfolio/ui/components/TrackingPixel.astro'
+ *   import CookieBanner from '@portfolio/ui/components/CookieBanner.astro'
  *
- *   import { applyTheme } from '@portfolio/ui'
+ *   import { applyTheme, getManageConsentLabel } from '@portfolio/ui'
  */
 
+export { buildClickProps, initClickTracking } from './lib/click-tracking'
+export type {
+  BannerCopy,
+  BannerLocale,
+  ConsentValue,
+} from './lib/cookie-consent'
+export {
+  CONSENT_CHANGED_EVENT,
+  getBannerCopy,
+  getManageConsentLabel,
+  isConsentValue,
+  REOPEN_BANNER_EVENT,
+  readConsent,
+  STORAGE_KEY,
+  writeConsent,
+} from './lib/cookie-consent'
 export { initMagneticCursor } from './lib/magnetic-cursor'
 export { initMobileNav } from './lib/mobile-nav'
 export {
@@ -21,6 +38,11 @@ export {
 export { initNumberCounters } from './lib/number-counter'
 export { deobfuscateEmail, obfuscateEmail } from './lib/obfuscate-email'
 export { initRevealOnScroll } from './lib/reveal-on-scroll'
+export {
+  computeScrollPercent,
+  initScrollDepth,
+  SCROLL_THRESHOLDS,
+} from './lib/scroll-depth'
 export type { Theme } from './lib/theme-toggle'
 export {
   applyTheme,
@@ -29,3 +51,16 @@ export {
   readStoredTheme,
   storeTheme,
 } from './lib/theme-toggle'
+export {
+  buildTrackPayload,
+  configureTracking,
+  generateEventId,
+  getSessionId,
+  hasTrackingConsent,
+  isTrackingForced,
+  resetTrackingConfig,
+  sendBeaconPayload,
+  type TrackEventPayload,
+  type TrackingConfig,
+  trackEvent,
+} from './lib/track-event'

--- a/packages/ui/src/lib/click-tracking.ts
+++ b/packages/ui/src/lib/click-tracking.ts
@@ -1,0 +1,72 @@
+/**
+ * @module click-tracking
+ * @description Event delegation para tracking de clicks. `initClickTracking()`
+ *   registra UN solo listener en `document`: cuando el usuario hace click,
+ *   busca el `data-track="<code>"` mas cercano (el elemento o un ancestro via
+ *   `closest()`), resuelve el `code` al UUID del catalogo `EVENT_TYPES` y
+ *   emite el evento con `trackEvent`.
+ *
+ *   Event delegation (vs N listeners): funciona con contenido que aparece
+ *   tras navegacion SPA — no hay que re-registrar nada en `astro:after-swap`.
+ *
+ * @example
+ *   import { initClickTracking } from '@portfolio/ui/lib/click-tracking'
+ *   const cleanup = initClickTracking()
+ *   // en el HTML: <a data-track="cta_click" href="/contact">Contactar</a>
+ */
+import { eventTypeIdFromCode } from '@portfolio/content/lib/event-types'
+import { trackEvent } from './track-event'
+
+const TRACK_ATTR = 'data-track'
+const TRACK_SELECTOR = '[data-track]'
+
+/**
+ * @function buildClickProps
+ * @description Arma `event_props` con el contexto del elemento clickeado:
+ *   `code`, y si es (o contiene) un ancla, el `href` y `text` del link.
+ *
+ * @param {Element} el - el elemento que lleva `data-track`
+ * @param {string} code - el valor de `data-track`
+ * @returns {Record<string, unknown>} props para `trackEvent`
+ */
+export function buildClickProps(
+  el: Element,
+  code: string,
+): Record<string, unknown> {
+  const props: Record<string, unknown> = { code }
+  const anchor = el instanceof HTMLAnchorElement ? el : el.querySelector('a')
+  if (anchor instanceof HTMLAnchorElement) {
+    if (anchor.href) props.href = anchor.href.slice(0, 500)
+    const text = anchor.textContent?.trim()
+    if (text) props.text = text.slice(0, 120)
+  }
+  return props
+}
+
+/**
+ * @function initClickTracking
+ * @description Registra el listener delegado de clicks en `document`.
+ *   Idempotente entre navegaciones SPA: el listener vive en `document`,
+ *   que persiste a traves de los `astro:after-swap`.
+ *
+ * @returns {() => void} cleanup que remueve el listener
+ */
+export function initClickTracking(): () => void {
+  const doc = globalThis.document
+  if (!doc) return () => undefined
+
+  const handler = (event: Event): void => {
+    const target = event.target
+    if (!(target instanceof Element)) return
+    const tracked = target.closest(TRACK_SELECTOR)
+    if (!tracked) return
+    const code = tracked.getAttribute(TRACK_ATTR)
+    if (!code) return
+    const eventTypeId = eventTypeIdFromCode(code)
+    if (!eventTypeId) return
+    trackEvent(eventTypeId, buildClickProps(tracked, code))
+  }
+
+  doc.addEventListener('click', handler, { capture: true })
+  return () => doc.removeEventListener('click', handler, { capture: true })
+}

--- a/packages/ui/src/lib/contact-form-schema.ts
+++ b/packages/ui/src/lib/contact-form-schema.ts
@@ -9,6 +9,7 @@
  *   - message: 10..5000 chars
  *   - company/role/budget/timeline: opcionales con max length
  *   - service_type: literal o vacio
+ *   - session_id: opcional, 20..64 chars cuando esta presente (SPEC-202)
  */
 import { z } from 'zod'
 
@@ -70,6 +71,23 @@ export type ContactFormFieldName = keyof ContactFormValues
 export type ContactFieldErrors = Partial<Record<ContactFormFieldName, string>>
 
 /**
+ * @schema SessionIdSchema
+ * @description Validacion del `session_id` opcional del `POST /contact`
+ *   (SPEC-202). Espejo del Pydantic backend: cuando esta presente debe medir
+ *   20..64 chars; ausente es valido (visitante sin `cf_session`).
+ *
+ * @example
+ *   SessionIdSchema.safeParse(undefined)            // success (ausente)
+ *   SessionIdSchema.safeParse('a'.repeat(32))       // success
+ *   SessionIdSchema.safeParse('short')              // error: min 20
+ */
+export const SessionIdSchema = z
+  .string()
+  .min(20, 'session_id invalido (minimo 20 caracteres).')
+  .max(64, 'session_id invalido (maximo 64 caracteres).')
+  .optional()
+
+/**
  * @function getFieldErrors
  * @description Convierte un ZodError a un dict `{field: firstMessage}`.
  */
@@ -99,4 +117,56 @@ export function emptyValues(): ContactFormValues {
     budget: '',
     timeline: '',
   }
+}
+
+/**
+ * @type ContactPayloadContext
+ * @description Contexto que `buildContactPayload` adjunta al body del POST,
+ *   ademas de los campos del form: `niche`, token Turnstile y el
+ *   `session_id` opcional de tracking (SPEC-202).
+ */
+export interface ContactPayloadContext {
+  niche: string
+  cfToken: string
+  /** `session_id` de `localStorage.cf_session`. Ausente si no hay sesion. */
+  sessionId?: string
+}
+
+/**
+ * @function buildContactPayload
+ * @description Funcion pura: arma el body del `POST /contact` desde los
+ *   valores del form + el contexto. Recorta strings y descarta campos vacios.
+ *   El `session_id` (SPEC-202) se agrega SOLO si viene un valor no vacio: un
+ *   visitante sin `cf_session` produce un body sin la clave `session_id`.
+ *
+ * @param {ContactFormValues} data - Valores validados del formulario
+ * @param {ContactPayloadContext} ctx - niche + token Turnstile + session_id
+ *
+ * @returns {Record<string, string>} Body listo para `JSON.stringify`
+ *
+ * @example
+ *   buildContactPayload(values, { niche: 'generic', cfToken: 't' })
+ *   // -> { niche: 'generic', cf_token: 't', name: '...', ... }  (sin session_id)
+ *   buildContactPayload(values, {
+ *     niche: 'generic', cfToken: 't', sessionId: 'a'.repeat(32),
+ *   })
+ *   // -> { ..., session_id: 'aaaa...' }
+ */
+export function buildContactPayload(
+  data: ContactFormValues,
+  ctx: ContactPayloadContext,
+): Record<string, string> {
+  const payload: Record<string, string> = {
+    niche: ctx.niche,
+    cf_token: ctx.cfToken,
+  }
+  for (const [key, raw] of Object.entries(data)) {
+    const value = typeof raw === 'string' ? raw.trim() : ''
+    if (value) payload[key] = value
+  }
+  // session_id opcional: nunca enviar la clave si no hay sesion (AC-2).
+  if (ctx.sessionId) {
+    payload.session_id = ctx.sessionId
+  }
+  return payload
 }

--- a/packages/ui/src/lib/cookie-consent.ts
+++ b/packages/ui/src/lib/cookie-consent.ts
@@ -1,0 +1,162 @@
+/**
+ * @module cookie-consent
+ * @description Logica pura del consentimiento GDPR del portfolio. El banner
+ *   `CookieBanner.astro` y el enlace de gestion del `Footer` consumen estas
+ *   funciones; mantenerlas en un modulo TS aparte las vuelve testeables sin
+ *   renderear el componente Astro.
+ *
+ *   El consentimiento vive en localStorage (key `cf_consent`, valores
+ *   `accepted` | `rejected`). NO se usan cookies. La key NO debe cambiar:
+ *   `TrackingPixel.astro` la lee para decidir si emite eventos.
+ *
+ *   API:
+ *     readConsent(storage?)        - lee el consentimiento persistido
+ *     writeConsent(value, ...)     - persiste y despacha consent-changed
+ *     getBannerCopy(locale)        - textos i18n del banner por locale
+ *     getManageConsentLabel(...)   - etiqueta del enlace del Footer por locale
+ */
+
+/**
+ * @type ConsentValue
+ * @description Valor del consentimiento persistido en localStorage.
+ */
+export type ConsentValue = 'accepted' | 'rejected'
+
+/**
+ * @type BannerLocale
+ * @description Locale soportado por los textos del banner.
+ */
+export type BannerLocale = 'es' | 'en'
+
+/**
+ * @type BannerCopy
+ * @description Conjunto de strings i18n que renderiza el banner.
+ */
+export interface BannerCopy {
+  /** Etiqueta accesible del dialog (aria-label). */
+  ariaLabel: string
+  /** Texto del cuerpo del banner (parte previa al fragmento destacado). */
+  bodyLead: string
+  /** Fragmento destacado dentro del cuerpo (va en <strong>). */
+  bodyStrong: string
+  /** Texto del cuerpo posterior al fragmento destacado. */
+  bodyTail: string
+  /** Etiqueta del boton de aceptacion. */
+  accept: string
+  /** Etiqueta del boton de rechazo. */
+  reject: string
+}
+
+/** Key de localStorage. NO cambiar: TrackingPixel.astro la lee. */
+export const STORAGE_KEY = 'cf_consent'
+
+/** Nombre del evento que se despacha al cambiar el consentimiento. */
+export const CONSENT_CHANGED_EVENT = 'portfolio:consent-changed'
+
+/** Nombre del evento que pide reabrir el banner (lo emite el Footer). */
+export const REOPEN_BANNER_EVENT = 'portfolio:consent-reopen'
+
+const BANNER_COPY: Record<BannerLocale, BannerCopy> = {
+  es: {
+    ariaLabel: 'Consentimiento de analytics',
+    bodyLead: 'Este sitio usa ',
+    bodyStrong: 'analytics propios privacy-friendly',
+    bodyTail:
+      ' (sin cookies de terceros, los datos se auto-borran en 60 dias). ' +
+      '¿Permitis recolectar tu visita para mejorar el contenido?',
+    accept: 'Aceptar',
+    reject: 'Rechazar',
+  },
+  en: {
+    ariaLabel: 'Analytics consent',
+    bodyLead: 'This site uses ',
+    bodyStrong: 'privacy-friendly first-party analytics',
+    bodyTail:
+      ' (no third-party cookies, data auto-deletes after 60 days). ' +
+      'May we collect your visit to improve the content?',
+    accept: 'Accept',
+    reject: 'Reject',
+  },
+}
+
+const MANAGE_CONSENT_LABEL: Record<BannerLocale, string> = {
+  es: 'Gestionar consentimiento',
+  en: 'Manage consent',
+}
+
+/**
+ * @function isConsentValue
+ * @description Type guard para `ConsentValue`.
+ */
+export function isConsentValue(value: unknown): value is ConsentValue {
+  return value === 'accepted' || value === 'rejected'
+}
+
+/**
+ * @function readConsent
+ * @description Lee el consentimiento persistido. `null` si el usuario aun no
+ *   respondio o si localStorage no esta disponible (Safari private mode).
+ */
+export function readConsent(storage?: Storage): ConsentValue | null {
+  try {
+    const s = storage ?? globalThis.localStorage
+    const raw = s?.getItem(STORAGE_KEY)
+    return isConsentValue(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @function writeConsent
+ * @description Persiste el consentimiento en localStorage y despacha el
+ *   evento `portfolio:consent-changed` para que `TrackingPixel.astro`
+ *   reaccione. Si localStorage falla, igual se despacha el evento.
+ *
+ * @example
+ *   writeConsent('accepted')   // persiste + dispara consent-changed
+ *   writeConsent('rejected')   // persiste + dispara consent-changed
+ */
+export function writeConsent(
+  value: ConsentValue,
+  storage?: Storage,
+  target?: EventTarget,
+): void {
+  try {
+    const s = storage ?? globalThis.localStorage
+    s?.setItem(STORAGE_KEY, value)
+  } catch {
+    /* storage unavailable (private mode); el evento igual se despacha */
+  }
+  const dispatcher = target ?? globalThis.document
+  dispatcher?.dispatchEvent(
+    new CustomEvent<{ value: ConsentValue }>(CONSENT_CHANGED_EVENT, {
+      detail: { value },
+    }),
+  )
+}
+
+/**
+ * @function getBannerCopy
+ * @description Devuelve los textos i18n del banner para el locale dado.
+ *   Cualquier locale no soportado cae a 'es'.
+ *
+ * @example
+ *   getBannerCopy('en').accept   // "Accept"
+ *   getBannerCopy('es').accept   // "Aceptar"
+ */
+export function getBannerCopy(locale: BannerLocale): BannerCopy {
+  return BANNER_COPY[locale] ?? BANNER_COPY.es
+}
+
+/**
+ * @function getManageConsentLabel
+ * @description Etiqueta del enlace del Footer que reabre el banner.
+ *
+ * @example
+ *   getManageConsentLabel('es')  // "Gestionar consentimiento"
+ *   getManageConsentLabel('en')  // "Manage consent"
+ */
+export function getManageConsentLabel(locale: BannerLocale): string {
+  return MANAGE_CONSENT_LABEL[locale] ?? MANAGE_CONSENT_LABEL.es
+}

--- a/packages/ui/src/lib/scroll-depth.ts
+++ b/packages/ui/src/lib/scroll-depth.ts
@@ -1,0 +1,82 @@
+/**
+ * @module scroll-depth
+ * @description Tracking de engagement por profundidad de scroll.
+ *   `initScrollDepth()` emite un evento `scroll_depth` al cruzar cada umbral
+ *   discreto (25/50/75/100 %), UNA sola vez por umbral. No es streaming
+ *   continuo: acota el volumen de eventos.
+ *
+ *   Usa un scroll listener con throttle via `requestAnimationFrame` (el
+ *   patron de `IntersectionObserver` de `reveal-on-scroll.ts` no aplica:
+ *   no hay un elemento marcador por umbral, se mide el % del documento).
+ *
+ * @example
+ *   import { initScrollDepth } from '@portfolio/ui/lib/scroll-depth'
+ *   const cleanup = initScrollDepth()
+ */
+import { EVENT_TYPES } from '@portfolio/content/lib/event-types'
+import { trackEvent } from './track-event'
+
+/** Umbrales de profundidad (porcentaje del documento). */
+export const SCROLL_THRESHOLDS: readonly number[] = [25, 50, 75, 100]
+
+/**
+ * @function computeScrollPercent
+ * @description Calcula el porcentaje de scroll del documento (0-100). Si el
+ *   documento no tiene scroll (cabe entero en el viewport) retorna 100.
+ *
+ * @param {Window} win - referencia a window
+ * @param {HTMLElement} root - `document.documentElement`
+ * @returns {number} porcentaje 0-100 (entero clampeado)
+ */
+export function computeScrollPercent(win: Window, root: HTMLElement): number {
+  const scrollable = root.scrollHeight - win.innerHeight
+  if (scrollable <= 0) return 100
+  const ratio = win.scrollY / scrollable
+  const pct = Math.round(ratio * 100)
+  return Math.min(100, Math.max(0, pct))
+}
+
+/**
+ * @function initScrollDepth
+ * @description Registra el tracking de scroll depth. Cada umbral
+ *   (25/50/75/100 %) emite `scroll_depth` una sola vez; cruzarlo de nuevo
+ *   no re-emite. Si la pagina ya nace por encima de un umbral, lo emite al
+ *   inicializar.
+ *
+ * @returns {() => void} cleanup que remueve el scroll listener
+ */
+export function initScrollDepth(): () => void {
+  const win = globalThis.window
+  const doc = globalThis.document
+  if (!win || !doc?.documentElement) return () => undefined
+
+  const root = doc.documentElement
+  const fired = new Set<number>()
+  let ticking = false
+
+  const evaluate = (): void => {
+    ticking = false
+    const pct = computeScrollPercent(win, root)
+    for (const threshold of SCROLL_THRESHOLDS) {
+      if (pct >= threshold && !fired.has(threshold)) {
+        fired.add(threshold)
+        trackEvent(EVENT_TYPES.SCROLL_DEPTH, { depth: threshold })
+      }
+    }
+  }
+
+  const onScroll = (): void => {
+    if (ticking) return
+    ticking = true
+    if (typeof win.requestAnimationFrame === 'function') {
+      win.requestAnimationFrame(evaluate)
+    } else {
+      evaluate()
+    }
+  }
+
+  // Evalua el estado inicial (paginas cortas cruzan umbrales al cargar).
+  evaluate()
+  win.addEventListener('scroll', onScroll, { passive: true })
+  return () => win.removeEventListener('scroll', onScroll)
+}

--- a/packages/ui/src/lib/track-event.ts
+++ b/packages/ui/src/lib/track-event.ts
@@ -1,0 +1,215 @@
+/**
+ * @module track-event
+ * @description API unica de emision de eventos de tracking del frontend.
+ *
+ *   `trackEvent(eventTypeId, props?)` arma el payload `POST /track`: genera un
+ *   `event_id` (UUIDv4 por evento, para idempotencia en reintentos de
+ *   sendBeacon), adjunta `session_id` (localStorage `cf_session`, la misma
+ *   key del pixel page_load), `page_url`, y `event_props` opcional.
+ *
+ *   GATING: solo emite si hay consentimiento — `localStorage.cf_consent`
+ *   debe ser `'accepted'`. El flag de QA `?cf_track=force` lo bypassa (para
+ *   E2E). Sin consentimiento ni flag: cero eventos (GDPR por defecto).
+ *
+ *   `TrackingPixel.astro` y los inicializadores `initClickTracking` /
+ *   `initScrollDepth` usan este modulo: nadie duplica la logica de envio.
+ *
+ * @example
+ *   import { configureTracking, trackEvent } from '@portfolio/ui/lib/track-event'
+ *   configureTracking({ apiEndpoint: 'https://api.example.com', niche: 'generic' })
+ *   trackEvent(EVENT_TYPES.CTA_CLICK, { href: '/contact' })
+ */
+
+const STORAGE_CONSENT = 'cf_consent'
+const STORAGE_SESSION = 'cf_session'
+const CONSENT_ACCEPTED = 'accepted'
+const QA_FLAG = 'cf_track'
+const QA_FLAG_VALUE = 'force'
+
+/**
+ * @type TrackingConfig
+ * @description Configuracion del modulo: endpoint del API Gateway + niche.
+ */
+export interface TrackingConfig {
+  /** URL base del API Gateway (sin `/track`). */
+  apiEndpoint: string
+  /** Niche del subdominio (se adjunta al payload). */
+  niche?: string
+}
+
+/**
+ * @type TrackEventPayload
+ * @description Forma del body que se envia a `POST /track`.
+ */
+export interface TrackEventPayload {
+  session_id: string
+  event_id: string
+  event_type_id: string
+  page_url: string
+  niche: string
+  event_props?: Record<string, unknown>
+}
+
+let config: TrackingConfig | null = null
+
+/**
+ * @function configureTracking
+ * @description Setea el endpoint + niche del modulo. Debe invocarse una vez
+ *   antes del primer `trackEvent` (lo hace `TrackingPixel.astro`).
+ */
+export function configureTracking(next: TrackingConfig): void {
+  config = next
+}
+
+/**
+ * @function resetTrackingConfig
+ * @description Limpia la configuracion. Solo para aislamiento entre tests.
+ */
+export function resetTrackingConfig(): void {
+  config = null
+}
+
+/**
+ * @function generateEventId
+ * @description UUIDv4 por evento. Usa `crypto.randomUUID` con fallback para
+ *   browsers viejos. Se devuelve sin guiones para encajar en el limite que
+ *   valida el backend.
+ *
+ * @returns {string} identificador unico del evento (hex, sin guiones)
+ */
+export function generateEventId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID().replace(/-/g, '')
+  }
+  const rand = (): string => Math.random().toString(36).slice(2)
+  return `${Date.now().toString(36)}${rand()}${rand()}`
+}
+
+/**
+ * @function isTrackingForced
+ * @description True si la URL lleva `?cf_track=force` (bypass de QA del
+ *   gating de consentimiento, usado por los tests E2E).
+ */
+export function isTrackingForced(): boolean {
+  try {
+    const search = globalThis.location?.search ?? ''
+    return new URLSearchParams(search).get(QA_FLAG) === QA_FLAG_VALUE
+  } catch {
+    return false
+  }
+}
+
+/**
+ * @function hasTrackingConsent
+ * @description True si el usuario acepto el tracking (`cf_consent` =
+ *   `'accepted'`) o si la URL lleva el flag de QA `?cf_track=force`.
+ */
+export function hasTrackingConsent(): boolean {
+  if (isTrackingForced()) return true
+  try {
+    return localStorage.getItem(STORAGE_CONSENT) === CONSENT_ACCEPTED
+  } catch {
+    return false
+  }
+}
+
+/**
+ * @function getSessionId
+ * @description Lee (o crea) el `session_id` persistido en localStorage
+ *   `cf_session` — la misma key del pixel page_load, para que clicks,
+ *   scroll y page_load compartan sesion.
+ */
+export function getSessionId(): string {
+  try {
+    let sid = localStorage.getItem(STORAGE_SESSION)
+    if (!sid || sid.length < 20) {
+      sid = generateEventId()
+      localStorage.setItem(STORAGE_SESSION, sid)
+    }
+    return sid
+  } catch {
+    return `nostorage-${generateEventId()}`
+  }
+}
+
+/**
+ * @function buildTrackPayload
+ * @description Arma el payload `POST /track` para un evento. Funcion pura:
+ *   no envia nada (separada de `trackEvent` para poder testear el shape).
+ *
+ * @param {string} eventTypeId - UUID del tipo de evento (de `EVENT_TYPES`)
+ * @param {Record<string, unknown>} [props] - datos del evento (`event_props`)
+ * @returns {TrackEventPayload} body listo para serializar
+ */
+export function buildTrackPayload(
+  eventTypeId: string,
+  props?: Record<string, unknown>,
+): TrackEventPayload {
+  const payload: TrackEventPayload = {
+    session_id: getSessionId(),
+    event_id: generateEventId(),
+    event_type_id: eventTypeId,
+    page_url: (globalThis.location?.href ?? '').slice(0, 500),
+    niche: config?.niche ?? 'generic',
+  }
+  if (props && Object.keys(props).length > 0) {
+    payload.event_props = props
+  }
+  return payload
+}
+
+/**
+ * @function sendBeaconPayload
+ * @description Envia el body a `POST /track` via `navigator.sendBeacon`
+ *   (sigue funcionando si el usuario cierra la pestana), con fallback a
+ *   `fetch` keepalive. Fire-and-forget: cualquier error se ignora.
+ *
+ * @returns {boolean} true si se entrego (a beacon o fetch), false si no
+ */
+export function sendBeaconPayload(payload: TrackEventPayload): boolean {
+  if (!config?.apiEndpoint) return false
+  const url = `${config.apiEndpoint}/track`
+  const body = JSON.stringify(payload)
+  try {
+    if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+      const blob = new Blob([body], { type: 'application/json' })
+      return navigator.sendBeacon(url, blob)
+    }
+  } catch {
+    // continua con el fallback fetch
+  }
+  try {
+    void fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {
+      // tracking es fire-and-forget
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * @function trackEvent
+ * @description Emite un evento de tracking. GATING: si no hay consentimiento
+ *   ni el flag `?cf_track=force`, NO emite nada y retorna false.
+ *
+ * @param {string} eventTypeId - UUID del tipo de evento (de `EVENT_TYPES`)
+ * @param {Record<string, unknown>} [props] - contexto del evento
+ * @returns {boolean} true si se emitio, false si el gating lo bloqueo
+ *
+ * @example
+ *   trackEvent(EVENT_TYPES.THEME_TOGGLE, { theme: 'dark' })
+ */
+export function trackEvent(
+  eventTypeId: string,
+  props?: Record<string, unknown>,
+): boolean {
+  if (!hasTrackingConsent()) return false
+  const payload = buildTrackPayload(eventTypeId, props)
+  return sendBeaconPayload(payload)
+}

--- a/packages/ui/tests/unit/click-tracking.test.ts
+++ b/packages/ui/tests/unit/click-tracking.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @description Tests de click-tracking: el listener delegado en `document`
+ *   resuelve el `data-track` del elemento clickeado o de un ancestro via
+ *   `closest()`, lo mapea al UUID del catalogo y emite el evento [AC-3].
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildClickProps,
+  initClickTracking,
+} from '../../src/lib/click-tracking'
+import {
+  configureTracking,
+  resetTrackingConfig,
+} from '../../src/lib/track-event'
+
+const CTA_CLICK = '019e372b-e0a7-793b-84ed-690388a13b15'
+
+describe('click-tracking', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    localStorage.clear()
+    localStorage.setItem('cf_consent', 'accepted')
+    resetTrackingConfig()
+    configureTracking({ apiEndpoint: 'https://api.test', niche: 'generic' })
+    navigator.sendBeacon = vi.fn().mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    localStorage.clear()
+    resetTrackingConfig()
+    vi.restoreAllMocks()
+  })
+
+  describe('buildClickProps', () => {
+    it('Given a plain element with data-track When buildClickProps Then props carry the code only', () => {
+      const div = document.createElement('div')
+      div.setAttribute('data-track', 'theme_toggle')
+      expect(buildClickProps(div, 'theme_toggle')).toEqual({
+        code: 'theme_toggle',
+      })
+    })
+
+    it('Given an anchor with data-track When buildClickProps Then props carry code, href and text', () => {
+      const a = document.createElement('a')
+      a.href = 'https://x.test/contact'
+      a.textContent = 'Contactar'
+      a.setAttribute('data-track', 'cta_click')
+      expect(buildClickProps(a, 'cta_click')).toEqual({
+        code: 'cta_click',
+        href: 'https://x.test/contact',
+        text: 'Contactar',
+      })
+    })
+  })
+
+  describe('initClickTracking', () => {
+    it('Given a document present When initClickTracking Then returns a function cleanup', () => {
+      const cleanup = initClickTracking()
+      expect(typeof cleanup).toBe('function')
+      cleanup()
+    })
+
+    it('Given globalThis.document is undefined When initClickTracking Then returns a noop cleanup without throwing', () => {
+      vi.stubGlobal('document', undefined)
+      const cleanup = initClickTracking()
+      expect(typeof cleanup).toBe('function')
+      cleanup()
+      vi.unstubAllGlobals()
+    })
+
+    it('Given a data-track element with an empty value When clicked Then sends nothing', () => {
+      const el = document.createElement('button')
+      el.setAttribute('data-track', '')
+      document.body.appendChild(el)
+
+      const cleanup = initClickTracking()
+      el.click()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+      cleanup()
+    })
+
+    it('Given an element with data-track When clicked Then sends a beacon with the resolved event_type_id', async () => {
+      const a = document.createElement('a')
+      a.href = 'https://x.test/contact'
+      a.setAttribute('data-track', 'cta_click')
+      document.body.appendChild(a)
+
+      const cleanup = initClickTracking()
+      a.click()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(1)
+      const [, blob] = vi.mocked(navigator.sendBeacon).mock.calls[0] ?? []
+      const body = JSON.parse(await (blob as Blob).text()) as {
+        event_type_id: string
+      }
+      expect(body.event_type_id).toBe(CTA_CLICK)
+      cleanup()
+    })
+
+    it('Given a child of a data-track ancestor When the child is clicked Then resolves the ancestor via closest()', () => {
+      const a = document.createElement('a')
+      a.href = 'https://x.test/contact'
+      a.setAttribute('data-track', 'cta_click')
+      const icon = document.createElement('span')
+      a.appendChild(icon)
+      document.body.appendChild(a)
+
+      const cleanup = initClickTracking()
+      icon.click()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(1)
+      cleanup()
+    })
+
+    it('Given a click outside any data-track element When clicked Then sends nothing', () => {
+      const plain = document.createElement('button')
+      document.body.appendChild(plain)
+
+      const cleanup = initClickTracking()
+      plain.click()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+      cleanup()
+    })
+
+    it('Given an unknown data-track code When clicked Then sends nothing (no UUID resolved)', () => {
+      const el = document.createElement('button')
+      el.setAttribute('data-track', 'not_a_real_event')
+      document.body.appendChild(el)
+
+      const cleanup = initClickTracking()
+      el.click()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+      cleanup()
+    })
+
+    it('Given cleanup was invoked When an element is clicked Then sends nothing (listener removed)', () => {
+      const a = document.createElement('a')
+      a.href = 'https://x.test/contact'
+      a.setAttribute('data-track', 'cta_click')
+      document.body.appendChild(a)
+
+      const cleanup = initClickTracking()
+      cleanup()
+      a.click()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+    })
+
+    it('Given no consent When a data-track element is clicked Then sends nothing (gating) [AC-12]', () => {
+      localStorage.removeItem('cf_consent')
+      const a = document.createElement('a')
+      a.href = 'https://x.test/contact'
+      a.setAttribute('data-track', 'cta_click')
+      document.body.appendChild(a)
+
+      const cleanup = initClickTracking()
+      a.click()
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+      cleanup()
+    })
+  })
+})

--- a/packages/ui/tests/unit/contact-form-schema.test.ts
+++ b/packages/ui/tests/unit/contact-form-schema.test.ts
@@ -5,9 +5,11 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import {
+  buildContactPayload,
   ContactFormSchema,
   emptyValues,
   getFieldErrors,
+  SessionIdSchema,
 } from '../../src/lib/contact-form-schema'
 
 describe('ContactFormSchema', () => {
@@ -174,5 +176,121 @@ describe('emptyValues', () => {
       budget: '',
       timeline: '',
     })
+  })
+})
+
+describe('SessionIdSchema (SPEC-202)', () => {
+  it('Given session_id ausente When parse Then success (es opcional)', () => {
+    const result = SessionIdSchema.safeParse(undefined)
+    expect(result.success).toBe(true)
+  })
+
+  it('Given session_id de 32 chars When parse Then success', () => {
+    const result = SessionIdSchema.safeParse('a'.repeat(32))
+    expect(result.success).toBe(true)
+  })
+
+  it('Given session_id en el limite de 20 chars When parse Then success', () => {
+    const result = SessionIdSchema.safeParse('a'.repeat(20))
+    expect(result.success).toBe(true)
+  })
+
+  it('Given session_id en el limite de 64 chars When parse Then success', () => {
+    const result = SessionIdSchema.safeParse('a'.repeat(64))
+    expect(result.success).toBe(true)
+  })
+
+  it('Given session_id de 19 chars When parse Then error de minimo', () => {
+    const result = SessionIdSchema.safeParse('a'.repeat(19))
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'session_id invalido (minimo 20 caracteres).',
+      )
+    }
+  })
+
+  it('Given session_id de 65 chars When parse Then error de maximo', () => {
+    const result = SessionIdSchema.safeParse('a'.repeat(65))
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'session_id invalido (maximo 64 caracteres).',
+      )
+    }
+  })
+})
+
+describe('buildContactPayload (SPEC-202)', () => {
+  const baseValues = {
+    ...emptyValues(),
+    name: 'Pablo',
+    email: 'pacg1991@gmail.com',
+    message: 'Mensaje suficientemente largo para pasar.',
+  }
+
+  it('Given sessionId presente When build Then el payload incluye session_id [AC-1]', () => {
+    // Arrange
+    const sessionId = 'a'.repeat(32)
+
+    // Act
+    const payload = buildContactPayload(baseValues, {
+      niche: 'generic',
+      cfToken: 'tok',
+      sessionId,
+    })
+
+    // Assert
+    expect(payload.session_id).toBe(sessionId)
+    expect(payload.niche).toBe('generic')
+    expect(payload.cf_token).toBe('tok')
+    expect(payload.name).toBe('Pablo')
+  })
+
+  it('Given sessionId ausente When build Then el payload NO tiene la clave session_id [AC-2]', () => {
+    // Act
+    const payload = buildContactPayload(baseValues, {
+      niche: 'generic',
+      cfToken: 'tok',
+    })
+
+    // Assert
+    expect('session_id' in payload).toBe(false)
+  })
+
+  it('Given sessionId string vacio When build Then el payload NO tiene la clave session_id [AC-2]', () => {
+    // Act
+    const payload = buildContactPayload(baseValues, {
+      niche: 'generic',
+      cfToken: 'tok',
+      sessionId: '',
+    })
+
+    // Assert
+    expect('session_id' in payload).toBe(false)
+  })
+
+  it('Given campos opcionales vacios When build Then se descartan del payload', () => {
+    // Act
+    const payload = buildContactPayload(baseValues, {
+      niche: 'fintech',
+      cfToken: 'tok',
+    })
+
+    // Assert
+    expect('company' in payload).toBe(false)
+    expect('role' in payload).toBe(false)
+    expect('service_type' in payload).toBe(false)
+  })
+
+  it('Given campos con espacios When build Then se recortan los valores', () => {
+    // Act
+    const payload = buildContactPayload(
+      { ...baseValues, company: '  Acme  ' },
+      { niche: 'generic', cfToken: 'tok', sessionId: 'a'.repeat(20) },
+    )
+
+    // Assert
+    expect(payload.company).toBe('Acme')
   })
 })

--- a/packages/ui/tests/unit/cookie-consent.test.ts
+++ b/packages/ui/tests/unit/cookie-consent.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @description Tests para cookie-consent (logica del CookieBanner GDPR).
+ *   Cubre AC-2, AC-3, AC-6 (gating) y AC-8 (i18n). Usa happy-dom.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  CONSENT_CHANGED_EVENT,
+  getBannerCopy,
+  getManageConsentLabel,
+  isConsentValue,
+  REOPEN_BANNER_EVENT,
+  readConsent,
+  STORAGE_KEY,
+  writeConsent,
+} from '../../src/lib/cookie-consent'
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() {
+    return this.store.size
+  }
+  clear() {
+    this.store.clear()
+  }
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+}
+
+const throwingStorage: Storage = {
+  length: 0,
+  clear: () => undefined,
+  getItem: () => {
+    throw new Error('storage disabled')
+  },
+  key: () => null,
+  removeItem: () => undefined,
+  setItem: () => {
+    throw new Error('storage disabled')
+  },
+}
+
+describe('constants', () => {
+  it('Given the module When read STORAGE_KEY Then it is "cf_consent"', () => {
+    expect(STORAGE_KEY).toBe('cf_consent')
+  })
+
+  it('Given the module When read event names Then they are namespaced', () => {
+    expect(CONSENT_CHANGED_EVENT).toBe('portfolio:consent-changed')
+    expect(REOPEN_BANNER_EVENT).toBe('portfolio:consent-reopen')
+  })
+})
+
+describe('isConsentValue', () => {
+  it('Given "accepted" or "rejected" When check Then returns true', () => {
+    expect(isConsentValue('accepted')).toBe(true)
+    expect(isConsentValue('rejected')).toBe(true)
+  })
+
+  it('Given an invalid value When check Then returns false', () => {
+    expect(isConsentValue('maybe')).toBe(false)
+    expect(isConsentValue(null)).toBe(false)
+    expect(isConsentValue(undefined)).toBe(false)
+    expect(isConsentValue(1)).toBe(false)
+  })
+})
+
+describe('readConsent', () => {
+  it('Given empty storage When read Then returns null', () => {
+    const s = new MemoryStorage()
+    expect(readConsent(s)).toBe(null)
+  })
+
+  it('Given stored "accepted" When read Then returns "accepted"', () => {
+    const s = new MemoryStorage()
+    s.setItem(STORAGE_KEY, 'accepted')
+    expect(readConsent(s)).toBe('accepted')
+  })
+
+  it('Given stored "rejected" When read Then returns "rejected"', () => {
+    const s = new MemoryStorage()
+    s.setItem(STORAGE_KEY, 'rejected')
+    expect(readConsent(s)).toBe('rejected')
+  })
+
+  it('Given stored garbage When read Then returns null', () => {
+    const s = new MemoryStorage()
+    s.setItem(STORAGE_KEY, 'banana')
+    expect(readConsent(s)).toBe(null)
+  })
+
+  it('Given storage that throws When read Then returns null', () => {
+    expect(readConsent(throwingStorage)).toBe(null)
+  })
+})
+
+describe('writeConsent', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('Given "accepted" When write Then persists "accepted" to storage', () => {
+    const s = new MemoryStorage()
+    const target = new EventTarget()
+    writeConsent('accepted', s, target)
+    expect(s.getItem(STORAGE_KEY)).toBe('accepted')
+  })
+
+  it('Given "rejected" When write Then persists "rejected" to storage', () => {
+    const s = new MemoryStorage()
+    const target = new EventTarget()
+    writeConsent('rejected', s, target)
+    expect(s.getItem(STORAGE_KEY)).toBe('rejected')
+  })
+
+  it('Given "accepted" When write Then dispatches consent-changed with value', () => {
+    const s = new MemoryStorage()
+    const target = new EventTarget()
+    const received: string[] = []
+    target.addEventListener(CONSENT_CHANGED_EVENT, (event) => {
+      received.push((event as CustomEvent<{ value: string }>).detail.value)
+    })
+    writeConsent('accepted', s, target)
+    expect(received).toEqual(['accepted'])
+  })
+
+  it('Given "rejected" When write Then dispatches consent-changed with value', () => {
+    const s = new MemoryStorage()
+    const target = new EventTarget()
+    const received: string[] = []
+    target.addEventListener(CONSENT_CHANGED_EVENT, (event) => {
+      received.push((event as CustomEvent<{ value: string }>).detail.value)
+    })
+    writeConsent('rejected', s, target)
+    expect(received).toEqual(['rejected'])
+  })
+
+  it('Given storage that throws When write Then still dispatches the event', () => {
+    const target = new EventTarget()
+    const received: string[] = []
+    target.addEventListener(CONSENT_CHANGED_EVENT, (event) => {
+      received.push((event as CustomEvent<{ value: string }>).detail.value)
+    })
+    writeConsent('accepted', throwingStorage, target)
+    expect(received).toEqual(['accepted'])
+  })
+
+  it('Given no explicit target When write Then dispatches on document', () => {
+    const s = new MemoryStorage()
+    const received: string[] = []
+    const handler = (event: Event) => {
+      received.push((event as CustomEvent<{ value: string }>).detail.value)
+    }
+    document.addEventListener(CONSENT_CHANGED_EVENT, handler)
+    writeConsent('rejected', s)
+    document.removeEventListener(CONSENT_CHANGED_EVENT, handler)
+    expect(received).toEqual(['rejected'])
+  })
+})
+
+describe('getBannerCopy', () => {
+  it('Given locale "es" When get copy Then accept button is "Aceptar"', () => {
+    expect(getBannerCopy('es').accept).toBe('Aceptar')
+  })
+
+  it('Given locale "es" When get copy Then reject button is "Rechazar"', () => {
+    expect(getBannerCopy('es').reject).toBe('Rechazar')
+  })
+
+  it('Given locale "en" When get copy Then accept button is "Accept"', () => {
+    expect(getBannerCopy('en').accept).toBe('Accept')
+  })
+
+  it('Given locale "en" When get copy Then reject button is "Reject"', () => {
+    expect(getBannerCopy('en').reject).toBe('Reject')
+  })
+
+  it('Given locale "es" When get copy Then ariaLabel is in Spanish', () => {
+    expect(getBannerCopy('es').ariaLabel).toBe('Consentimiento de analytics')
+  })
+
+  it('Given locale "en" When get copy Then ariaLabel is in English', () => {
+    expect(getBannerCopy('en').ariaLabel).toBe('Analytics consent')
+  })
+
+  it('Given an unknown locale When get copy Then falls back to Spanish', () => {
+    const copy = getBannerCopy('fr' as unknown as 'es')
+    expect(copy.accept).toBe('Aceptar')
+  })
+})
+
+describe('getManageConsentLabel', () => {
+  it('Given locale "es" When get label Then is "Gestionar consentimiento"', () => {
+    expect(getManageConsentLabel('es')).toBe('Gestionar consentimiento')
+  })
+
+  it('Given locale "en" When get label Then is "Manage consent"', () => {
+    expect(getManageConsentLabel('en')).toBe('Manage consent')
+  })
+
+  it('Given an unknown locale When get label Then falls back to Spanish', () => {
+    expect(getManageConsentLabel('de' as unknown as 'es')).toBe(
+      'Gestionar consentimiento',
+    )
+  })
+})

--- a/packages/ui/tests/unit/scroll-depth.test.ts
+++ b/packages/ui/tests/unit/scroll-depth.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @description Tests de scroll-depth: emite un evento `scroll_depth` por cada
+ *   umbral cruzado (25/50/75/100 %), UNA sola vez cada uno [AC-8].
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  computeScrollPercent,
+  initScrollDepth,
+  SCROLL_THRESHOLDS,
+} from '../../src/lib/scroll-depth'
+import {
+  configureTracking,
+  resetTrackingConfig,
+} from '../../src/lib/track-event'
+
+/** Setea las metricas de scroll del documento y dispara un scroll event. */
+function setScroll(opts: {
+  scrollY: number
+  scrollHeight: number
+  innerHeight: number
+}): void {
+  Object.defineProperty(window, 'scrollY', {
+    value: opts.scrollY,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    value: opts.innerHeight,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    value: opts.scrollHeight,
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('scroll-depth', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('cf_consent', 'accepted')
+    resetTrackingConfig()
+    configureTracking({ apiEndpoint: 'https://api.test', niche: 'generic' })
+    navigator.sendBeacon = vi.fn().mockReturnValue(true)
+    // rAF sincrono para que evaluate() corra dentro del test.
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    resetTrackingConfig()
+    vi.restoreAllMocks()
+  })
+
+  describe('computeScrollPercent', () => {
+    it('Given a document without scroll When computeScrollPercent Then returns 100', () => {
+      const pct = computeScrollPercent(
+        { scrollY: 0, innerHeight: 800 } as Window,
+        { scrollHeight: 800 } as HTMLElement,
+      )
+      expect(pct).toBe(100)
+    })
+
+    it('Given the page scrolled halfway When computeScrollPercent Then returns 50', () => {
+      const pct = computeScrollPercent(
+        { scrollY: 600, innerHeight: 800 } as Window,
+        { scrollHeight: 2000 } as HTMLElement,
+      )
+      expect(pct).toBe(50)
+    })
+
+    it('Given scroll beyond the bottom When computeScrollPercent Then clamps to 100', () => {
+      const pct = computeScrollPercent(
+        { scrollY: 9999, innerHeight: 800 } as Window,
+        { scrollHeight: 2000 } as HTMLElement,
+      )
+      expect(pct).toBe(100)
+    })
+  })
+
+  describe('SCROLL_THRESHOLDS', () => {
+    it('Given the threshold list When inspected Then it is exactly 25/50/75/100', () => {
+      expect(SCROLL_THRESHOLDS).toEqual([25, 50, 75, 100])
+    })
+  })
+
+  describe('initScrollDepth', () => {
+    it('Given a long page at the top When init Then emits no scroll_depth event yet', () => {
+      setScroll({ scrollY: 0, scrollHeight: 4000, innerHeight: 800 })
+      const cleanup = initScrollDepth()
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+      cleanup()
+    })
+
+    it('Given a long page When scrolled to 50% Then emits scroll_depth once for 25 and once for 50', () => {
+      setScroll({ scrollY: 0, scrollHeight: 4000, innerHeight: 800 })
+      const cleanup = initScrollDepth()
+
+      setScroll({ scrollY: 1600, scrollHeight: 4000, innerHeight: 800 })
+      window.dispatchEvent(new Event('scroll'))
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(2)
+      cleanup()
+    })
+
+    it('Given the 50% threshold already crossed When scrolling within it again Then does NOT re-emit [AC-8]', () => {
+      setScroll({ scrollY: 0, scrollHeight: 4000, innerHeight: 800 })
+      const cleanup = initScrollDepth()
+
+      setScroll({ scrollY: 1600, scrollHeight: 4000, innerHeight: 800 })
+      window.dispatchEvent(new Event('scroll'))
+      // mismo punto: 25 y 50 ya disparados, no re-emite
+      window.dispatchEvent(new Event('scroll'))
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(2)
+      cleanup()
+    })
+
+    it('Given a full scroll to the bottom When dispatched Then emits exactly 4 scroll_depth events (one per threshold) [AC-8]', () => {
+      setScroll({ scrollY: 0, scrollHeight: 4000, innerHeight: 800 })
+      const cleanup = initScrollDepth()
+
+      setScroll({ scrollY: 3200, scrollHeight: 4000, innerHeight: 800 })
+      window.dispatchEvent(new Event('scroll'))
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(4)
+      cleanup()
+    })
+
+    it('Given the bottom reached and another scroll event When dispatched Then no further events (all thresholds spent)', () => {
+      setScroll({ scrollY: 0, scrollHeight: 4000, innerHeight: 800 })
+      const cleanup = initScrollDepth()
+
+      setScroll({ scrollY: 3200, scrollHeight: 4000, innerHeight: 800 })
+      window.dispatchEvent(new Event('scroll'))
+      window.dispatchEvent(new Event('scroll'))
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(4)
+      cleanup()
+    })
+
+    it('Given a short page (no scrollbar) When init Then emits all 4 thresholds immediately (100%)', () => {
+      setScroll({ scrollY: 0, scrollHeight: 700, innerHeight: 800 })
+      const cleanup = initScrollDepth()
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(4)
+      cleanup()
+    })
+
+    it('Given cleanup invoked When a scroll event fires Then no event is emitted (listener removed)', () => {
+      setScroll({ scrollY: 0, scrollHeight: 4000, innerHeight: 800 })
+      const cleanup = initScrollDepth()
+      cleanup()
+
+      setScroll({ scrollY: 3200, scrollHeight: 4000, innerHeight: 800 })
+      window.dispatchEvent(new Event('scroll'))
+
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/packages/ui/tests/unit/track-event.test.ts
+++ b/packages/ui/tests/unit/track-event.test.ts
@@ -1,0 +1,212 @@
+/**
+ * @description Tests de track-event: la API unica de emision de eventos.
+ *   Verifica que `trackEvent` arma el payload con `event_id`/`session_id`/
+ *   `event_type_id`/`event_props` [AC-3], y que respeta el gating de
+ *   consentimiento (`cf_consent`) y el bypass de QA `?cf_track=force`
+ *   [AC-12].
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildTrackPayload,
+  configureTracking,
+  generateEventId,
+  getSessionId,
+  hasTrackingConsent,
+  isTrackingForced,
+  resetTrackingConfig,
+  sendBeaconPayload,
+  type TrackEventPayload,
+  trackEvent,
+} from '../../src/lib/track-event'
+
+const PAGE_LOAD = '019e372b-e0a7-7154-8279-8829bcf6a08c'
+const CTA_CLICK = '019e372b-e0a7-793b-84ed-690388a13b15'
+
+/** Setea la query string que ve el modulo (location.search). */
+function setSearch(search: string): void {
+  Object.defineProperty(window, 'location', {
+    value: { href: `https://x.test/${search}`, search, pathname: '/' },
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('track-event', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    resetTrackingConfig()
+    configureTracking({ apiEndpoint: 'https://api.test', niche: 'generic' })
+    setSearch('')
+    navigator.sendBeacon = vi.fn().mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    resetTrackingConfig()
+  })
+
+  describe('generateEventId', () => {
+    it('Given crypto.randomUUID When generateEventId Then returns a 32-char hex string without dashes', () => {
+      const id = generateEventId()
+      expect(id).toMatch(/^[0-9a-f]{32}$/i)
+    })
+
+    it('Given two calls When generateEventId Then returns distinct ids', () => {
+      expect(generateEventId()).not.toBe(generateEventId())
+    })
+  })
+
+  describe('isTrackingForced', () => {
+    it('Given URL with ?cf_track=force When isTrackingForced Then returns true', () => {
+      setSearch('?cf_track=force')
+      expect(isTrackingForced()).toBe(true)
+    })
+
+    it('Given URL without the QA flag When isTrackingForced Then returns false', () => {
+      setSearch('?utm_source=x')
+      expect(isTrackingForced()).toBe(false)
+    })
+  })
+
+  describe('hasTrackingConsent', () => {
+    it('Given cf_consent=accepted When hasTrackingConsent Then returns true', () => {
+      localStorage.setItem('cf_consent', 'accepted')
+      expect(hasTrackingConsent()).toBe(true)
+    })
+
+    it('Given no cf_consent and no flag When hasTrackingConsent Then returns false', () => {
+      expect(hasTrackingConsent()).toBe(false)
+    })
+
+    it('Given cf_consent=rejected When hasTrackingConsent Then returns false', () => {
+      localStorage.setItem('cf_consent', 'rejected')
+      expect(hasTrackingConsent()).toBe(false)
+    })
+
+    it('Given no consent but ?cf_track=force When hasTrackingConsent Then returns true', () => {
+      setSearch('?cf_track=force')
+      expect(hasTrackingConsent()).toBe(true)
+    })
+  })
+
+  describe('getSessionId', () => {
+    it('Given empty localStorage When getSessionId Then creates and persists cf_session', () => {
+      const sid = getSessionId()
+      expect(localStorage.getItem('cf_session')).toBe(sid)
+    })
+
+    it('Given an existing cf_session When getSessionId Then returns the stored value', () => {
+      const stored = 'abcdef0123456789abcdef0123456789'
+      localStorage.setItem('cf_session', stored)
+      expect(getSessionId()).toBe(stored)
+    })
+
+    it('Given localStorage.getItem throws When getSessionId Then returns a nostorage- fallback id', () => {
+      vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+        throw new Error('blocked')
+      })
+      expect(getSessionId()).toMatch(/^nostorage-[0-9a-f]+$/i)
+    })
+  })
+
+  describe('sendBeaconPayload', () => {
+    const payload: TrackEventPayload = {
+      session_id: 's',
+      event_id: 'e',
+      event_type_id: PAGE_LOAD,
+      page_url: 'https://x.test/',
+      niche: 'generic',
+    }
+
+    it('Given no configured endpoint When sendBeaconPayload Then returns false without sending', () => {
+      resetTrackingConfig()
+      expect(sendBeaconPayload(payload)).toBe(false)
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+    })
+
+    it('Given navigator.sendBeacon is unavailable When sendBeaconPayload Then falls back to fetch', () => {
+      // @ts-expect-error: simulate a browser without sendBeacon
+      navigator.sendBeacon = undefined
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response(null, { status: 204 }))
+      vi.stubGlobal('fetch', fetchMock)
+      const result = sendBeaconPayload(payload)
+      expect(result).toBe(true)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('buildTrackPayload', () => {
+    it('Given an event type and props When buildTrackPayload Then includes event_id, session_id, event_type_id and event_props', () => {
+      localStorage.setItem('cf_session', 'session000000000000000000000000')
+      const payload = buildTrackPayload(CTA_CLICK, { href: '/contact' })
+      expect(payload).toEqual({
+        session_id: 'session000000000000000000000000',
+        event_id: payload.event_id,
+        event_type_id: CTA_CLICK,
+        page_url: 'https://x.test/',
+        niche: 'generic',
+        event_props: { href: '/contact' },
+      })
+    })
+
+    it('Given the event_id field When buildTrackPayload Then it is a 32-char hex string', () => {
+      const payload = buildTrackPayload(PAGE_LOAD)
+      expect(payload.event_id).toMatch(/^[0-9a-f]{32}$/i)
+    })
+
+    it('Given no props When buildTrackPayload Then omits event_props', () => {
+      const payload = buildTrackPayload(PAGE_LOAD)
+      expect(payload.event_props).toBe(undefined)
+    })
+
+    it('Given an empty props object When buildTrackPayload Then omits event_props', () => {
+      const payload = buildTrackPayload(PAGE_LOAD, {})
+      expect(payload.event_props).toBe(undefined)
+    })
+  })
+
+  describe('trackEvent gating', () => {
+    it('Given no consent and no QA flag When trackEvent Then does NOT send and returns false [AC-12]', () => {
+      const result = trackEvent(CTA_CLICK, { href: '/x' })
+      expect(result).toBe(false)
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(0)
+    })
+
+    it('Given cf_consent=accepted When trackEvent Then sends a beacon to /track and returns true', () => {
+      localStorage.setItem('cf_consent', 'accepted')
+      const result = trackEvent(CTA_CLICK, { href: '/contact' })
+      expect(result).toBe(true)
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(1)
+    })
+
+    it('Given consent When trackEvent Then beacon URL is the configured endpoint + /track', () => {
+      localStorage.setItem('cf_consent', 'accepted')
+      trackEvent(PAGE_LOAD)
+      const [url] = vi.mocked(navigator.sendBeacon).mock.calls[0] ?? []
+      expect(url).toBe('https://api.test/track')
+    })
+
+    it('Given consent When trackEvent Then the beacon body carries event_type_id and event_props', async () => {
+      localStorage.setItem('cf_consent', 'accepted')
+      trackEvent(CTA_CLICK, { href: '/contact' })
+      const [, blob] = vi.mocked(navigator.sendBeacon).mock.calls[0] ?? []
+      const text = await (blob as Blob).text()
+      const body = JSON.parse(text) as {
+        event_type_id: string
+        event_props: { href: string }
+      }
+      expect(body.event_type_id).toBe(CTA_CLICK)
+      expect(body.event_props).toEqual({ href: '/contact' })
+    })
+
+    it('Given no consent but ?cf_track=force When trackEvent Then sends the beacon (QA bypass)', () => {
+      setSearch('?cf_track=force')
+      const result = trackEvent(PAGE_LOAD)
+      expect(result).toBe(true)
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/serverless/DEPLOYMENT.md
+++ b/serverless/DEPLOYMENT.md
@@ -85,16 +85,6 @@ aws kms create-alias --profile tfs-dev --region us-east-1 \
 
 ### 3. Cargar secrets a SSM Parameter Store
 
-Generar password del dashboard:
-
-```bash
-DASHBOARD_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(16))")
-DASHBOARD_HASH=$(python3 -c "import bcrypt; print(bcrypt.hashpw('$DASHBOARD_PASSWORD'.encode(), bcrypt.gensalt(rounds=12)).decode())")
-echo "Password (GUARDAR ESTE VALOR): $DASHBOARD_PASSWORD"
-```
-
-Guardar parametros:
-
 ```bash
 PROFILE=tfs-dev
 REGION=us-east-1
@@ -118,11 +108,6 @@ aws ssm put-parameter --profile $PROFILE --region $REGION \
   --name /portfolio/ses-from-address \
   --type String \
   --value "no-reply@<dominio-verificado>"
-
-aws ssm put-parameter --profile $PROFILE --region $REGION \
-  --name /portfolio/dashboard-password-hash \
-  --type SecureString --key-id alias/portfolio-lambdas \
-  --value "$DASHBOARD_HASH"
 ```
 
 Verificar:
@@ -211,8 +196,9 @@ DATABASE_URL="<NEON_URL_DEV>" python scripts/migrate.py up
 Verificar tablas:
 
 ```bash
-psql "<NEON_URL_DEV>" -c "\dt portfolio.*"
-# Espera: contacts, tracking_events, daily_metrics, top_pages_daily, migrations_log
+psql "<NEON_URL_DEV>" -c "\dt"
+# Espera: contacts, tracking_events, event_types,
+#         processed_stream_events, migrations_log
 ```
 
 ### 5. Smoke test
@@ -279,24 +265,15 @@ Cada app es un proyecto Pages separado. Configurado por Wrangler / API
 token (ver `.claude/docs/cloudflare/`). En CI/CD el push a `main`
 dispara el deploy.
 
-### 4. Activar dashboard
-
-URL: `https://the-full-stack.com/dashboard`
-Credenciales:
-
-- Usuario: `owner`
-- Password: el valor `DASHBOARD_PASSWORD` generado en Setup 3
-
 ## Post-deploy checklist
 
 - [ ] Stack `portfolio-backend-dev` en `CREATE_COMPLETE`
-- [ ] 5 Lambdas en estado `Active`
+- [ ] 3 Lambdas en estado `Active`
 - [ ] 5 tablas DynamoDB con `Status: ACTIVE`
 - [ ] API GW retorna 200 al `OPTIONS /contact`
 - [ ] Smoke test pasa (`scripts/smoke_test.sh dev`)
-- [ ] Migrations aplicadas en Neon (5 migrations en `migrations_log`)
+- [ ] Migrations aplicadas en Neon (registradas en `migrations_log`)
 - [ ] Email de prueba llega al `owner-email`
-- [ ] Dashboard accesible con basic auth
 - [ ] AWS Billing Alarm creada
 - [ ] Outputs actualizados en `docs/deployment-outputs-{dev,prod}.md`
 
@@ -309,7 +286,8 @@ Credenciales:
 | `No module named 'common'` en Lambda | `CodeUri`/`Handler` mal | Ver `template.yaml`: `CodeUri: src/`, `Handler: contact_form.handler.lambda_handler` |
 | `email-validator` import error | Layer no incluye `pydantic[email]` | Re-build layer con `pip install pydantic[email]` en `requirements.txt` |
 | Smoke test 502 en `/contact` | Lambda timeout o env var missing | Tail logs: `sam logs -n ContactFormFunction --stack-name portfolio-backend-dev --tail` |
-| Dashboard 500 en `/dashboard/summary` | Neon connection failed | Verificar `/portfolio/neon-url` apunta al branch correcto |
+| `POST /track` => 400 `INVALID_INPUT` | Body sin `event_type_id` o UUID malformado | Enviar `event_id` + `event_type_id` UUID validos (ver SPEC-102) |
+| `tracking_events` row sin replicar a Neon | StreamProcessor falla / Neon connection | Verificar `/portfolio/neon-url`; tail logs de `StreamProcessorFunction` |
 
 Mas casos en [RUNBOOK.md](RUNBOOK.md#troubleshooting).
 

--- a/serverless/RUNBOOK.md
+++ b/serverless/RUNBOOK.md
@@ -44,7 +44,7 @@ sam logs -n StreamProcessorFunction --stack-name portfolio-backend-dev \
   --profile tfs-dev --filter "ERROR"
 
 # Rango de tiempo
-sam logs -n AggregatorFunction --stack-name portfolio-backend-dev \
+sam logs -n TrackingPixelFunction --stack-name portfolio-backend-dev \
   --profile tfs-dev --start-time '10min ago'
 ```
 
@@ -57,7 +57,7 @@ sam local invoke ContactFormFunction \
 
 # Remoto (stage real)
 aws lambda invoke --profile tfs-dev --region us-east-1 \
-  --function-name portfolio-backend-dev-AggregatorFunction \
+  --function-name portfolio-backend-dev-StreamProcessorFunction \
   --payload '{}' /tmp/response.json
 cat /tmp/response.json
 ```
@@ -229,6 +229,17 @@ aws cloudwatch describe-alarms --profile tfs-dev --region us-east-1 \
   warm-up con CloudWatch Events cada 5min si critico)
 - Logs: buscar `psycopg.OperationalError: timeout`
 
+### `POST /track` responde `400 INVALID_INPUT`
+
+- El body de `/track` exige `event_type_id` (UUID del catalogo
+  `event_types`, FK) y `event_id` (UUID del evento). Un body sin
+  `event_type_id` o con un UUID malformado falla la validacion Pydantic
+  de `TrackingEventInput` y la Lambda responde `400 INVALID_INPUT`.
+- Verificar que el frontend (`TrackingPixel.astro`, ver SPEC-102) envia
+  ambos campos: `event_id` como UUIDv4 por evento y `event_type_id` con
+  el UUID de `page_load` del modulo de constantes de `@portfolio/content`.
+- Confirmar el contrato del body con `src/tracking_pixel/schemas.py`.
+
 ### DLQ recibe mensajes constantes
 
 - Probable schema mismatch despues de migration
@@ -264,8 +275,8 @@ aws sesv2 list-suppressed-destinations --profile tfs-dev --region us-east-1
 
 ### Ataque DDoS sostenido
 
-1. Confirmar via API GW dashboard (`Count` metric explota)
-2. Identificar IPs origen via `tracking_events.ip_address` en Neon
+1. Confirmar via la consola de API Gateway (`Count` metric explota)
+2. Identificar IPs origen via `tracking_events.ip` en Neon
 3. Bloquear IPs en `portfolio-rate-limit-rules-{stage}` (ver
    "Agregar regla de rate-limit")
 4. Si bot pool grande, activar AWS WAF temporal:
@@ -274,7 +285,7 @@ aws sesv2 list-suppressed-destinations --profile tfs-dev --region us-east-1
    # (no esta IaC porque es opcional/temporal)
    ```
 5. Si Cloudflare cubre el frontend, activar "Under Attack Mode" en
-   Cloudflare dashboard (5 segundos challenge)
+   la consola de Cloudflare (5 segundos challenge)
 6. Logear el incidente con cantidad de IPs + ventana de tiempo
 
 ## Cuando escalar
@@ -286,7 +297,7 @@ aws sesv2 list-suppressed-destinations --profile tfs-dev --region us-east-1
 ## Decisiones operacionales
 
 - **0 AWS::CloudWatch::Alarm operacionales** — logs son la fuente
-  de verdad. Filtros de log + dashboards manuales con CW Logs Insights
+  de verdad. Filtros de log + consultas manuales con CW Logs Insights
 - **Billing alarm como unica alarma** — la mas barata y la unica que
   importa para un portfolio personal sin SLA
 - **Sin PagerDuty/Opsgenie** — proyecto personal, no hay on-call

--- a/serverless/migrations/005_migrations_log.sql
+++ b/serverless/migrations/005_migrations_log.sql
@@ -11,11 +11,12 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 );
 
 -- Auto-registrar las migrations corridas (idempotente: ON CONFLICT DO NOTHING)
+-- Las migrations 003/004 nunca existieron (servian al dashboard descartado);
+-- se quitan de este INSERT. Para los stages donde el 005 ya corrio con esas
+-- filas, la migration 008 las borra (ver SPEC-204).
 INSERT INTO schema_migrations (version) VALUES
     ('001_init_schema'),
     ('002_indexes'),
-    ('003_materialized_views'),
-    ('004_aggregates_tables'),
     ('005_migrations_log')
 ON CONFLICT (version) DO NOTHING;
 

--- a/serverless/migrations/008_event_types_seed.down.sql
+++ b/serverless/migrations/008_event_types_seed.down.sql
@@ -1,0 +1,24 @@
+-- Rollback 008: elimina las filas del seed de SPEC-200 de event_types.
+-- Borra exactamente los 15 code_name sembrados por el forward; page_load
+-- (sembrado en 006) NO se toca. Es el reverso exacto del 008 forward.
+--
+-- Sin BEGIN/COMMIT: el runner migrate.py ya envuelve el rollback en una
+-- transaccion.
+
+DELETE FROM event_types WHERE code_name IN (
+    'spa_navigation',
+    'cta_click',
+    'nav_click',
+    'project_link_click',
+    'experience_link_click',
+    'cv_download',
+    'theme_toggle',
+    'external_link_click',
+    'contact_view',
+    'contact_form_start',
+    'contact_form_submit',
+    'contact_form_success',
+    'contact_form_error',
+    'scroll_depth',
+    'page_exit'
+);

--- a/serverless/migrations/008_event_types_seed.sql
+++ b/serverless/migrations/008_event_types_seed.sql
@@ -1,0 +1,97 @@
+-- Migration 008: seed del catalogo event_types completo (SPEC-200)
+-- Amplia el seed de la migration 006 (que solo sembro page_load) con el
+-- resto del catalogo: navegacion, clicks, embudo de contacto y engagement.
+--
+-- Los UUID son literales fijos (UUIDv7), NO uuidv7() en runtime: el frontend
+-- los replica como constantes TS en build-time (packages/content). La fuente
+-- de verdad de estos literales es SPEC-101 seccion 0.
+--
+-- page_load (sembrado en 006) NO se re-inserta aqui.
+--
+-- Idempotente: INSERT ON CONFLICT (id) DO NOTHING. El runner cmd_db_migrate
+-- re-aplica todos los .sql, debe poder correr esta migration dos veces.
+--
+-- Sin BEGIN/COMMIT: el runner migrate.py ya envuelve cada migration en una
+-- transaccion (autocommit=False + commit por archivo).
+
+INSERT INTO event_types (id, code_name, description) VALUES
+    -- Navegacion
+    (
+        '019e372b-e0a7-70c6-8e56-2b643ddf1702',
+        'spa_navigation',
+        'Navegacion client-side entre vistas sin recarga de pagina'
+    ),
+    -- Clicks
+    (
+        '019e372b-e0a7-793b-84ed-690388a13b15',
+        'cta_click',
+        'Click en un call-to-action principal de la pagina'
+    ),
+    (
+        '019e372b-e0a7-776d-8598-81772857f6a8',
+        'nav_click',
+        'Click en un item de la barra de navegacion'
+    ),
+    (
+        '019e372b-e0a7-7c1b-b8e7-3d822a5ce42d',
+        'project_link_click',
+        'Click en un enlace de proyecto (demo en vivo o repositorio)'
+    ),
+    (
+        '019e372b-e0a7-7267-8f09-f81f75d90f64',
+        'experience_link_click',
+        'Click en el enlace externo de una experiencia laboral'
+    ),
+    (
+        '019e372b-e0a7-78a3-ad27-15dfd3d266a2',
+        'cv_download',
+        'Descarga o apertura del CV del portfolio'
+    ),
+    (
+        '019e372b-e0a7-767c-bbc4-d359c3522e86',
+        'theme_toggle',
+        'Cambio de tema dark/light/system mediante el toggle'
+    ),
+    (
+        '019e372b-e0a7-7987-8699-8e6381865036',
+        'external_link_click',
+        'Click en un enlace externo generico fuera del portfolio'
+    ),
+    -- Embudo de contacto
+    (
+        '019e372b-e0a7-7f8f-b568-3fbdb8a91756',
+        'contact_view',
+        'Carga de la pagina de contacto del portfolio'
+    ),
+    (
+        '019e372b-e0a7-7467-a074-603b7e294cf8',
+        'contact_form_start',
+        'Primer foco en un campo del formulario de contacto'
+    ),
+    (
+        '019e372b-e0a7-7a02-b754-606a5fe38afc',
+        'contact_form_submit',
+        'Envio del formulario de contacto por el usuario'
+    ),
+    (
+        '019e372b-e0a7-7d1b-9bd3-3cb2ee92b4d7',
+        'contact_form_success',
+        'Respuesta exitosa del backend al envio del formulario de contacto'
+    ),
+    (
+        '019e372b-e0a7-77f6-897f-17f41a06b2c0',
+        'contact_form_error',
+        'Respuesta de error del backend al envio del formulario de contacto'
+    ),
+    -- Engagement
+    (
+        '019e372b-e0a7-7067-a5c5-d0baf8352385',
+        'scroll_depth',
+        'Cruce de un umbral de profundidad de scroll (25/50/75/100 %)'
+    ),
+    (
+        '019e372b-e0a7-78dd-a3b5-7cf649c4638f',
+        'page_exit',
+        'Abandono de la pestana del portfolio (visibilitychange a hidden)'
+    )
+ON CONFLICT (id) DO NOTHING;

--- a/serverless/migrations/009_tracking_event_props.down.sql
+++ b/serverless/migrations/009_tracking_event_props.down.sql
@@ -1,0 +1,8 @@
+-- Rollback 009: revierte la columna event_props de tracking_events.
+-- Elimina la columna jsonb agregada por el forward (reverso exacto).
+--
+-- Sin BEGIN/COMMIT: el runner migrate.py ya envuelve el rollback en una
+-- transaccion.
+
+ALTER TABLE tracking_events
+    DROP COLUMN IF EXISTS event_props;

--- a/serverless/migrations/009_tracking_event_props.sql
+++ b/serverless/migrations/009_tracking_event_props.sql
@@ -1,0 +1,18 @@
+-- Migration 009: columna event_props jsonb en tracking_events (SPEC-200)
+-- Almacena datos especificos por tipo de evento (href del link clickeado,
+-- profundidad de scroll, campo del formulario, codigo de error, etc.).
+--
+-- event_props: JSONB nullable. Un solo campo flexible evita una columna por
+-- atributo y mantiene el schema estable al agregar tipos de evento nuevos.
+--
+-- tracking_events esta particionada por RANGE(created_at): el ALTER TABLE
+-- sobre la tabla padre propaga a todas las particiones.
+--
+-- Idempotente: ADD COLUMN IF NOT EXISTS. El runner cmd_db_migrate re-aplica
+-- todos los .sql, debe poder correr esta migration dos veces.
+--
+-- Sin BEGIN/COMMIT: el runner migrate.py ya envuelve cada migration en una
+-- transaccion (autocommit=False + commit por archivo).
+
+ALTER TABLE tracking_events
+    ADD COLUMN IF NOT EXISTS event_props JSONB;

--- a/serverless/migrations/010_contacts_session_id.down.sql
+++ b/serverless/migrations/010_contacts_session_id.down.sql
@@ -1,0 +1,10 @@
+-- Rollback 010: revierte SOLO la columna session_id de contacts.
+-- Elimina el indice y la columna session_id (exacto del forward).
+--
+-- NO toca ip/country/user_agent: son columnas legacy con datos
+-- historicos, no fueron creadas por esta migration.
+
+DROP INDEX IF EXISTS idx_contacts_session_id;
+
+ALTER TABLE contacts
+    DROP COLUMN IF EXISTS session_id;

--- a/serverless/migrations/010_contacts_session_id.sql
+++ b/serverless/migrations/010_contacts_session_id.sql
@@ -1,0 +1,24 @@
+-- Migration 010: columna session_id en contacts
+-- Enlaza cada contacto con su sesion de tracking (cf_session) para
+-- correlacionar con tracking_events sin duplicar ip/country/user_agent.
+--
+-- session_id : identificador de sesion del visitante (20-64 chars),
+--              misma key cf_session que emite el TrackingPixel. NO es FK:
+--              tracking_events tiene TTL de 60 dias y un contacto puede
+--              sobrevivir a sus eventos -> correlacion logica via JOIN.
+--
+-- Las columnas legacy ip/country/user_agent NO se tocan: conservan los
+-- datos historicos ya capturados. Los contactos nuevos las dejan en NULL
+-- (el stream_processor deja de poblarlas).
+--
+-- El runner cmd_db_migrate re-aplica todos los .sql, debe poder correr
+-- esta migration dos veces -> ADD COLUMN IF NOT EXISTS + CREATE INDEX
+-- IF NOT EXISTS. El runner ya envuelve cada migration en una transaccion.
+
+ALTER TABLE contacts
+    ADD COLUMN IF NOT EXISTS session_id TEXT;
+
+-- Correlacion: WHERE session_id = X (JOIN con tracking_events).
+CREATE INDEX IF NOT EXISTS idx_contacts_session_id
+    ON contacts (session_id)
+    WHERE session_id IS NOT NULL;

--- a/serverless/migrations/011_cleanup_phantom_migrations.down.sql
+++ b/serverless/migrations/011_cleanup_phantom_migrations.down.sql
@@ -1,0 +1,8 @@
+-- Rollback 011: restaura las filas fantasma en schema_migrations.
+--
+-- Revierte exactamente el DELETE del forward dejando schema_migrations en
+-- el estado previo al 011. ON CONFLICT DO NOTHING por idempotencia.
+INSERT INTO schema_migrations (version) VALUES
+    ('003_materialized_views'),
+    ('004_aggregates_tables')
+ON CONFLICT (version) DO NOTHING;

--- a/serverless/migrations/011_cleanup_phantom_migrations.sql
+++ b/serverless/migrations/011_cleanup_phantom_migrations.sql
@@ -1,0 +1,14 @@
+-- Migration 011: limpieza de filas fantasma en schema_migrations (SPEC-204)
+--
+-- El INSERT de la migration 005 registraba '003_materialized_views' y
+-- '004_aggregates_tables' como migrations aplicadas, pero esos archivos
+-- nunca existieron (servian al dashboard, descartado). En los stages donde
+-- el 005 ya corrio, esas dos filas quedaron en schema_migrations e inducen
+-- a pensar que esas migrations existen.
+--
+-- El runner (scripts/migrate.py) NO valida checksum al re-aplicar, asi que
+-- editar el .sql del 005 solo evita el problema en un fresh apply; esta
+-- migration es la que efectivamente borra las filas fantasma de un DB ya
+-- migrado. Idempotente: si las filas no estan, el DELETE no hace nada.
+DELETE FROM schema_migrations
+WHERE version IN ('003_materialized_views', '004_aggregates_tables');

--- a/serverless/scripts/smoke_test.sh
+++ b/serverless/scripts/smoke_test.sh
@@ -9,7 +9,6 @@
 #   - AWS CLI configurada con profile tfs-dev
 #   - jq instalado
 #   - curl 8+
-#   - DASHBOARD_PASSWORD exportado (si se valida dashboard)
 #
 # Exit codes:
 #   0 - todos los smoke tests pasaron
@@ -95,62 +94,49 @@ else
   log_fail "POST /contact sin token => ${HTTP_CODE} (esperado 400). Body: ${BODY}"
 fi
 
-# 4. Test POST /track con session valido (espera 204)
+# 4. Test POST /track con body valido post-Fase 1 (espera 204)
+#    El contrato de /track exige event_id + event_type_id (UUID) ademas
+#    de session_id y page_url (ver SPEC-102 / src/tracking_pixel/schemas.py).
 log_info "Test POST /track..."
-SESSION_ID="smoke-$(date +%s)-${RANDOM}"
+SESSION_ID="smoke-session-$(date +%s)-${RANDOM}"
+EVENT_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
+# event_type_id: UUID del tipo page_load del catalogo event_types.
+EVENT_TYPE_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
   -X POST "${API_ENDPOINT}/track" \
   -H "Content-Type: application/json" \
   -d "{
-    \"event_name\": \"page_view\",
-    \"page_path\": \"/smoke-test\",
-    \"session_id\": \"${SESSION_ID}\"
+    \"session_id\": \"${SESSION_ID}\",
+    \"event_id\": \"${EVENT_ID}\",
+    \"event_type_id\": \"${EVENT_TYPE_ID}\",
+    \"page_url\": \"https://the-full-stack.com/smoke-test\",
+    \"page_path\": \"/smoke-test\"
   }")
 
-if [[ "$HTTP_CODE" == "204" || "$HTTP_CODE" == "200" ]]; then
+if [[ "$HTTP_CODE" == "204" ]]; then
   log_pass "POST /track => ${HTTP_CODE}"
 else
   log_fail "POST /track => ${HTTP_CODE} (esperado 204)"
 fi
 
-# 5. Test GET /dashboard/summary sin auth (espera 401)
-log_info "Test GET /dashboard/summary sin auth (espera 401)..."
+# 5. Test POST /track sin event_type_id (espera 400 INVALID_INPUT)
+log_info "Test POST /track sin event_type_id (espera 400)..."
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-  -X GET "${API_ENDPOINT}/dashboard/summary?days=30")
+  -X POST "${API_ENDPOINT}/track" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"session_id\": \"${SESSION_ID}\",
+    \"event_id\": \"${EVENT_ID}\",
+    \"page_url\": \"https://the-full-stack.com/smoke-test\"
+  }")
 
-if [[ "$HTTP_CODE" == "401" ]]; then
-  log_pass "GET /dashboard sin auth => 401"
+if [[ "$HTTP_CODE" == "400" ]]; then
+  log_pass "POST /track sin event_type_id => 400 (validacion correcta)"
 else
-  log_fail "GET /dashboard sin auth => ${HTTP_CODE} (esperado 401)"
+  log_fail "POST /track sin event_type_id => ${HTTP_CODE} (esperado 400)"
 fi
 
-# 6. Test GET /dashboard/summary con auth si DASHBOARD_PASSWORD definido
-if [[ -n "${DASHBOARD_PASSWORD:-}" ]]; then
-  log_info "Test GET /dashboard/summary con auth..."
-  AUTH=$(echo -n "owner:${DASHBOARD_PASSWORD}" | base64)
-  RESPONSE=$(curl -s -w "\n%{http_code}" \
-    -X GET "${API_ENDPOINT}/dashboard/summary?days=30" \
-    -H "Authorization: Basic ${AUTH}")
-
-  HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-  BODY=$(echo "$RESPONSE" | head -n -1)
-
-  if [[ "$HTTP_CODE" == "200" ]]; then
-    # Validar shape del JSON
-    if echo "$BODY" | jq -e '.contacts and .tracking' >/dev/null 2>&1; then
-      log_pass "GET /dashboard con auth => 200 + JSON shape OK"
-      log_info "Summary: $(echo "$BODY" | jq -c '.')"
-    else
-      log_fail "GET /dashboard => 200 pero shape invalido: ${BODY}"
-    fi
-  else
-    log_fail "GET /dashboard con auth => ${HTTP_CODE} (esperado 200)"
-  fi
-else
-  log_info "Skip dashboard auth test (DASHBOARD_PASSWORD no definido)"
-fi
-
-# 7. Verificar DynamoDB tracking table tiene el event recien insertado
+# 6. Verificar DynamoDB tracking table tiene el event recien insertado
 log_info "Esperando 2s para propagacion DynamoDB Stream..."
 sleep 2
 log_info "Verificando event en DynamoDB tracking-${STAGE}..."
@@ -170,7 +156,7 @@ else
   log_fail "DynamoDB tracking-${STAGE} NO tiene el event session_id=${SESSION_ID}"
 fi
 
-# 8. Verificar SES domain identity
+# 7. Verificar SES domain identity
 log_info "Verificando SES domain identity..."
 SES_FROM=$(aws ssm get-parameter \
   --profile "$PROFILE" --region "$REGION" \

--- a/serverless/scripts/smoke_test.sh
+++ b/serverless/scripts/smoke_test.sh
@@ -74,8 +74,11 @@ else
   log_fail "OPTIONS /contact => ${HTTP_CODE} (esperado 200/204)"
 fi
 
-# 3. Test POST /contact sin Turnstile token (espera 400 INVALID_INPUT)
-log_info "Test POST /contact sin cf_token (espera 400)..."
+# 3. Test POST /contact sin Turnstile token (espera 403 CAPTCHA_INVALID)
+#    cf_token es opcional en el schema Pydantic (default ''); un token vacio
+#    sin bypass valido NO es un error de input (400) sino un rechazo de
+#    captcha -> TurnstileError, status_code 403 (ver common/exceptions.py).
+log_info "Test POST /contact sin cf_token (espera 403)..."
 RESPONSE=$(curl -s -w "\n%{http_code}" \
   -X POST "${API_ENDPOINT}/contact" \
   -H "Content-Type: application/json" \
@@ -88,10 +91,10 @@ RESPONSE=$(curl -s -w "\n%{http_code}" \
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | head -n -1)
 
-if [[ "$HTTP_CODE" == "400" ]]; then
-  log_pass "POST /contact sin token => 400 (validacion correcta)"
+if [[ "$HTTP_CODE" == "403" ]]; then
+  log_pass "POST /contact sin token => 403 (captcha rechazado correctamente)"
 else
-  log_fail "POST /contact sin token => ${HTTP_CODE} (esperado 400). Body: ${BODY}"
+  log_fail "POST /contact sin token => ${HTTP_CODE} (esperado 403). Body: ${BODY}"
 fi
 
 # 4. Test POST /track con body valido post-Fase 1 (espera 204)

--- a/serverless/src/contact_form/persistence.py
+++ b/serverless/src/contact_form/persistence.py
@@ -35,18 +35,17 @@ def save_contact(payload: dict[str, Any]) -> dict[str, str]:
         'email': payload['email'],
         'message': payload['message'],
     }
-    # Campos opcionales: solo agregar si tienen valor (DynamoDB no permite empty strings)
+    # Campos opcionales: solo agregar si tienen valor (DynamoDB no permite
+    # empty strings). session_id enlaza el contacto con tracking_events; el
+    # origen (ip/country/user_agent) ya no se duplica aqui - se consulta en
+    # tracking via JOIN por session_id.
     for optional_field in (
         'company', 'role', 'service_type', 'budget', 'timeline', 'niche',
+        'session_id',
     ):
         value = payload.get(optional_field)
         if value:
             item[optional_field] = value
-
-    # Metadata de la request (IP, country, user-agent) para auditoria
-    for meta_field in ('ip', 'country', 'user_agent'):
-        if payload.get(meta_field):
-            item[meta_field] = payload[meta_field]
 
     table.put_item(Item=item)
 

--- a/serverless/src/contact_form/schemas.py
+++ b/serverless/src/contact_form/schemas.py
@@ -33,6 +33,11 @@ class ContactFormInput(BaseModel):
     # Niche del subdominio (apex/generic | hub | fintech | architect | leader | vibe)
     niche: str | None = Field(default=None, max_length=50)
 
+    # Session de tracking (cf_session del TrackingPixel). Opcional: un
+    # visitante que rechazo el tracking no tiene cf_session -> el contacto
+    # se guarda igual sin correlacion. Validado 20-64 chars cuando viene.
+    session_id: str | None = Field(default=None, min_length=20, max_length=64)
+
     @field_validator('name', 'message', 'company', 'role', 'budget', 'timeline')
     @classmethod
     def sanitize_strings(cls, v: str | None) -> str | None:

--- a/serverless/src/contact_form/service.py
+++ b/serverless/src/contact_form/service.py
@@ -32,11 +32,13 @@ def process_contact_form(
 
     Args:
         validated_input: dict del Pydantic ContactFormInput (sin cf_token).
+            Incluye `session_id` opcional, clave de correlacion con tracking.
         cf_response: token Turnstile separado de los campos del form.
-        ip: IP del cliente (CF-Connecting-IP).
+        ip: IP del cliente (CF-Connecting-IP). Se usa para Turnstile y
+            rate-limit; NO se persiste en contacts.
         bypass_secret: header X-Turnstile-Bypass-Secret (opcional, tests).
-        country: country code (CF-IPCountry).
-        user_agent: user-agent de la request.
+        country: country code (CF-IPCountry). Ya no se persiste en contacts.
+        user_agent: user-agent de la request. Ya no se persiste en contacts.
 
     Returns:
         Dict con `contact_id` y `created_at` ISO 8601.
@@ -44,21 +46,23 @@ def process_contact_form(
     Raises:
         TurnstileError: si el captcha falla.
         ClientError: si DynamoDB o SES fallan.
+
+    Note:
+        country y user_agent llegan por compatibilidad de interfaz con el
+        handler, pero contacts ya no duplica datos de origen (SPEC-202): se
+        consultan en tracking_events via JOIN por session_id.
     """
-    # 1. Verify Turnstile token
+    # 1. Verify Turnstile token (la IP se usa para anti-abuso, no se persiste)
     verify_turnstile_token(
         cf_response,
         remote_ip=ip,
         bypass_secret=bypass_secret,
     )
 
-    # 2. Persist en DynamoDB (incluir metadata de la request)
-    payload = {**validated_input, 'ip': ip}
-    if country:
-        payload['country'] = country
-    if user_agent:
-        payload['user_agent'] = user_agent
-
+    # 2. Persist en DynamoDB. NO se inyecta ip/country/user_agent al payload:
+    # contacts deja de duplicar datos de origen, se enlazan con
+    # tracking_events via session_id (incluido en validated_input).
+    payload = dict(validated_input)
     result = save_contact(payload)
     logger.info(
         'contact persisted',

--- a/serverless/src/stream_processor/pg_writer.py
+++ b/serverless/src/stream_processor/pg_writer.py
@@ -54,8 +54,32 @@ def mark_event_processed(
         )
 
 
+def _adapt_event_props(payload: dict[str, Any]) -> dict[str, Any]:
+    """
+    Adapta event_props del payload al tipo jsonb de psycopg.
+
+    psycopg v3 no adapta un dict plano a jsonb por si solo: hay que envolverlo
+    con psycopg.types.json.Jsonb. Retorna una copia del payload con
+    event_props envuelto (o None si el evento no trae event_props).
+    """
+    from psycopg.types.json import Jsonb
+
+    adapted = dict(payload)
+    raw = adapted.get('event_props')
+    adapted['event_props'] = Jsonb(raw) if raw is not None else None
+    return adapted
+
+
 def upsert_contact(payload: dict[str, Any]) -> None:
-    """UPSERT en Neon.contacts."""
+    """
+    UPSERT en Neon.contacts.
+
+    session_id enlaza el contacto con tracking_events (correlacion via JOIN).
+    ip/country/user_agent siguen en el INSERT por compatibilidad de schema,
+    pero los contactos nuevos los reciben en NULL: contacts deja de duplicar
+    datos de origen (SPEC-202). Las columnas legacy conservan filas
+    historicas; solo se dejan de poblar.
+    """
     conn = _get_connection()
     with conn.cursor() as cur:
         cur.execute(
@@ -63,12 +87,12 @@ def upsert_contact(payload: dict[str, Any]) -> None:
             INSERT INTO contacts (
                 id, stream_event_id, created_at, name, email, message,
                 company, role, service_type, budget, timeline, niche,
-                ip, country, user_agent
+                session_id, ip, country, user_agent
             ) VALUES (
                 %(id)s, %(stream_event_id)s, %(created_at)s, %(name)s,
                 %(email)s, %(message)s, %(company)s, %(role)s,
                 %(service_type)s, %(budget)s, %(timeline)s, %(niche)s,
-                %(ip)s::inet, %(country)s, %(user_agent)s
+                %(session_id)s, %(ip)s::inet, %(country)s, %(user_agent)s
             )
             ON CONFLICT (id) DO NOTHING
             """,
@@ -87,7 +111,7 @@ def upsert_tracking(payload: dict[str, Any]) -> None:
                 page_url, page_title, page_path, referrer,
                 utm_source, utm_medium, utm_campaign, utm_content, utm_term,
                 viewport_width, viewport_height, niche,
-                event_id, event_type_id, ip, country,
+                event_id, event_type_id, event_props, ip, country,
                 user_agent, browser, browser_version, os, device_type
             ) VALUES (
                 %(session_id)s, %(page_id)s, %(stream_event_id)s,
@@ -96,12 +120,12 @@ def upsert_tracking(payload: dict[str, Any]) -> None:
                 %(utm_source)s, %(utm_medium)s, %(utm_campaign)s,
                 %(utm_content)s, %(utm_term)s,
                 %(viewport_width)s, %(viewport_height)s, %(niche)s,
-                %(event_id)s, %(event_type_id)s,
+                %(event_id)s, %(event_type_id)s, %(event_props)s,
                 %(ip)s::inet, %(country)s, %(user_agent)s,
                 %(browser)s, %(browser_version)s, %(os)s, %(device_type)s
             )
             """,
-            payload,
+            _adapt_event_props(payload),
         )
 
 

--- a/serverless/src/stream_processor/transformers.py
+++ b/serverless/src/stream_processor/transformers.py
@@ -72,9 +72,14 @@ def parse_contact_record(record: dict[str, Any]) -> dict[str, Any] | None:
         'budget': image.get('budget'),
         'timeline': image.get('timeline'),
         'niche': image.get('niche'),
-        'ip': image.get('ip'),
-        'country': image.get('country'),
-        'user_agent': image.get('user_agent'),
+        # session_id: clave de correlacion con tracking_events (SPEC-202).
+        'session_id': image.get('session_id'),
+        # ip/country/user_agent: columnas legacy. contacts ya no las
+        # duplica - el contact_form dejo de escribirlas en DynamoDB, asi
+        # que el image no las trae y el INSERT en Neon las recibe NULL.
+        'ip': None,
+        'country': None,
+        'user_agent': None,
     }
 
 
@@ -122,6 +127,10 @@ def parse_tracking_record(record: dict[str, Any]) -> dict[str, Any] | None:
         # Identificadores del evento (SPEC-102)
         'event_id': image.get('event_id'),
         'event_type_id': image.get('event_type_id'),
+        # Datos especificos por tipo de evento (SPEC-200): el cliente lo
+        # envia como dict; DynamoDB lo guarda como Map y el TypeDeserializer
+        # lo devuelve como dict Python. Se replica a la columna jsonb de Neon.
+        'event_props': image.get('event_props'),
         'ip': image.get('ip'),
         'country': image.get('country'),
         'user_agent': image.get('user_agent'),

--- a/serverless/src/tracking_pixel/enrichment.py
+++ b/serverless/src/tracking_pixel/enrichment.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import re
 
+from common.cache import cached
+
+# TTL del cache de UA parsing: 24h. Un mismo User-Agent string repetido en
+# invocaciones warm no re-ejecuta el regex (SPEC-204).
+_UA_CACHE_TTL_SECONDS = 24 * 60 * 60
+
 # Simple UA parser - regex patterns (sin dependencia externa para evitar bloat)
 _BROWSER_PATTERNS = (
     ('Chrome', re.compile(r'Chrome/(\d+)')),
@@ -21,9 +27,14 @@ _OS_PATTERNS = (
 )
 
 
+@cached(ttl=_UA_CACHE_TTL_SECONDS, namespace='ua', tags=['user-agent'])
 def parse_user_agent(user_agent: str | None) -> dict[str, str]:
     """
     Parse User-Agent minimalista: browser + os + device type.
+
+    El resultado se cachea 24h via DynamoDB (`@cached`): la cache key se
+    deriva del string User-Agent, asi UA repetidos en invocaciones warm no
+    re-ejecutan el regex y UA distintos no colisionan (SPEC-204).
 
     Returns:
         Dict con `browser`, `browser_version`, `os`, `device_type`.

--- a/serverless/src/tracking_pixel/persistence.py
+++ b/serverless/src/tracking_pixel/persistence.py
@@ -84,6 +84,12 @@ def save_tracking_event(payload: dict[str, Any]) -> dict[str, Any]:
         if payload.get(meta_field):
             item[meta_field] = payload[meta_field]
 
+    # event_props (SPEC-200): datos especificos por tipo de evento. Se guarda
+    # como atributo Map de DynamoDB. Nullable: solo si el cliente lo envio.
+    event_props = payload.get('event_props')
+    if event_props:
+        item['event_props'] = event_props
+
     table.put_item(Item=item)
 
     return {

--- a/serverless/src/tracking_pixel/schemas.py
+++ b/serverless/src/tracking_pixel/schemas.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
+
+# Tamano maximo del event_props serializado a JSON. event_props es un dict
+# libre con datos especificos por tipo de evento (href del link, scroll %,
+# campo del form). 2 KB acota el volumen y evita payloads abusivos.
+EVENT_PROPS_MAX_BYTES = 2048
 
 
 class TrackingEventInput(BaseModel):
@@ -43,6 +50,36 @@ class TrackingEventInput(BaseModel):
 
     # Opcional: cf_token de Turnstile invisible (best-effort, no enforced)
     cf_token: str | None = Field(default=None, max_length=2048)
+
+    # Datos especificos por tipo de evento (SPEC-200): href del link
+    # clickeado, profundidad de scroll, campo del form, codigo de error.
+    # Dict libre acotado en tamano; se replica a la columna jsonb de Neon.
+    event_props: dict[str, Any] | None = Field(default=None)
+
+    @field_validator('event_props')
+    @classmethod
+    def validate_event_props_size(
+        cls, v: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        """
+        Valida que event_props serializado a JSON no exceda el limite.
+
+        event_props es un dict libre; un payload abusivo inflaria el item de
+        DynamoDB y la fila de Neon. Se serializa a JSON y se mide en bytes.
+        Si excede EVENT_PROPS_MAX_BYTES, lanza ValueError que Pydantic
+        convierte en ValidationError -> el handler responde 400 INVALID_INPUT.
+        """
+        if v is None:
+            return None
+        serialized = json.dumps(v, separators=(',', ':'))
+        size = len(serialized.encode('utf-8'))
+        if size > EVENT_PROPS_MAX_BYTES:
+            msg = (
+                f'event_props excede el tamano maximo '
+                f'({size} > {EVENT_PROPS_MAX_BYTES} bytes)'
+            )
+            raise ValueError(msg)
+        return v
 
     @field_validator('event_id', 'event_type_id')
     @classmethod

--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -89,7 +89,9 @@ Globals:
         # turnstile-secret es por stage: cada ambiente tiene su widget
         # Cloudflare Turnstile (limite de 10 dominios por widget).
         SSM_TURNSTILE_SECRET_PATH: !Sub /portfolio/${Stage}/turnstile-secret
-        SSM_NEON_URL_PATH: /portfolio/neon-url
+        # neon-url es por stage: cada ambiente apunta a su propio branch Neon
+        # (aislamiento dev/prod a nivel DB).
+        SSM_NEON_URL_PATH: !Sub /portfolio/${Stage}/neon-url
         SSM_OWNER_EMAIL_PATH: /portfolio/owner-email
         SSM_SES_FROM_PATH: /portfolio/ses-from-address
         # KMS key alias para decryption de SSM SecureStrings
@@ -381,7 +383,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: stream-processor
-          SSM_NEON_URL_PATH: /portfolio/neon-url
+          SSM_NEON_URL_PATH: !Sub /portfolio/${Stage}/neon-url
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt StreamProcessorDLQ.Arn
@@ -389,7 +391,7 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !GetAtt StreamProcessorDLQ.QueueName
         - SSMParameterReadPolicy:
-            ParameterName: 'portfolio/neon-url'
+            ParameterName: !Sub 'portfolio/${Stage}/neon-url'
         - Statement:
             - Effect: Allow
               Action: kms:Decrypt

--- a/serverless/tests/unit/contact_form/test_persistence.py
+++ b/serverless/tests/unit/contact_form/test_persistence.py
@@ -90,3 +90,75 @@ class TestSaveContact:
         item = table.get_item(Key={'id': result['contact_id']}).get('Item')
         assert 'company' not in item  # type: ignore[operator]
         assert 'role' not in item  # type: ignore[operator]
+
+    def test_when_session_id_present_then_stored(
+        self, contact_form_aws: None
+    ) -> None:
+        """
+        Given payload con session_id valido [AC-3],
+        When save_contact,
+        Then el item de contacts incluye session_id con ese valor.
+        """
+        session_id = 'a' * 32
+
+        result = save_contact({
+            'name': 'Pablo',
+            'email': 'p@example.com',
+            'message': 'Test',
+            'session_id': session_id,
+        })
+
+        table = boto3.resource('dynamodb', region_name='us-east-1').Table(
+            'portfolio-contacts-test'
+        )
+        item = table.get_item(Key={'id': result['contact_id']}).get('Item')
+        assert item is not None
+        assert item['session_id'] == session_id
+
+    def test_when_session_id_absent_then_not_stored(
+        self, contact_form_aws: None
+    ) -> None:
+        """
+        Given payload sin session_id [AC-2],
+        When save_contact,
+        Then el item de contacts NO incluye session_id (se guarda igual).
+        """
+        result = save_contact({
+            'name': 'Pablo',
+            'email': 'p@example.com',
+            'message': 'Test sin sesion',
+        })
+
+        table = boto3.resource('dynamodb', region_name='us-east-1').Table(
+            'portfolio-contacts-test'
+        )
+        item = table.get_item(Key={'id': result['contact_id']}).get('Item')
+        assert item is not None
+        assert 'session_id' not in item
+
+    def test_when_payload_has_origin_metadata_then_not_stored(
+        self, contact_form_aws: None
+    ) -> None:
+        """
+        Given payload que aun trae ip/country/user_agent [AC-3],
+        When save_contact,
+        Then el item de contacts NO incluye ninguno: contacts deja de
+        duplicar datos de origen (se consultan via tracking_events).
+        """
+        result = save_contact({
+            'name': 'Pablo',
+            'email': 'p@example.com',
+            'message': 'Test sin metadata de origen',
+            'ip': '203.0.113.7',
+            'country': 'CL',
+            'user_agent': 'Mozilla/5.0',
+        })
+
+        table = boto3.resource('dynamodb', region_name='us-east-1').Table(
+            'portfolio-contacts-test'
+        )
+        item = table.get_item(Key={'id': result['contact_id']}).get('Item')
+        assert item is not None
+        assert 'ip' not in item
+        assert 'country' not in item
+        assert 'user_agent' not in item

--- a/serverless/tests/unit/contact_form/test_schemas.py
+++ b/serverless/tests/unit/contact_form/test_schemas.py
@@ -80,3 +80,74 @@ class TestContactFormInput:
         assert parsed.budget is None
         assert parsed.timeline is None
         assert parsed.niche is None
+        assert parsed.session_id is None
+
+    def test_when_session_id_omitted_then_none(self) -> None:
+        """
+        Given payload sin session_id [AC-2],
+        When ContactFormInput parsea,
+        Then session_id queda None (un visitante sin cf_session se acepta).
+        """
+        parsed = ContactFormInput(**self._valid_payload())
+
+        assert parsed.session_id is None
+
+    def test_when_session_id_valid_then_accepted(self) -> None:
+        """
+        Given un session_id de 32 chars (formato valido) [AC-1],
+        When ContactFormInput parsea,
+        Then session_id se acepta con ese valor exacto.
+        """
+        session_id = 'a' * 32
+
+        parsed = ContactFormInput(
+            **self._valid_payload(session_id=session_id)
+        )
+
+        assert parsed.session_id == session_id
+
+    def test_when_session_id_min_length_then_accepted(self) -> None:
+        """
+        Given un session_id de exactamente 20 chars (limite inferior) [AC-1],
+        When ContactFormInput parsea,
+        Then se acepta.
+        """
+        session_id = 'b' * 20
+
+        parsed = ContactFormInput(
+            **self._valid_payload(session_id=session_id)
+        )
+
+        assert parsed.session_id == session_id
+
+    def test_when_session_id_max_length_then_accepted(self) -> None:
+        """
+        Given un session_id de exactamente 64 chars (limite superior) [AC-1],
+        When ContactFormInput parsea,
+        Then se acepta.
+        """
+        session_id = 'c' * 64
+
+        parsed = ContactFormInput(
+            **self._valid_payload(session_id=session_id)
+        )
+
+        assert parsed.session_id == session_id
+
+    def test_when_session_id_too_short_then_raises(self) -> None:
+        """
+        Given un session_id de 19 chars (< 20, formato invalido) [AC-4],
+        When ContactFormInput parsea,
+        Then ValidationError.
+        """
+        with pytest.raises(PydanticValidationError):
+            ContactFormInput(**self._valid_payload(session_id='d' * 19))
+
+    def test_when_session_id_too_long_then_raises(self) -> None:
+        """
+        Given un session_id de 65 chars (> 64, formato invalido) [AC-4],
+        When ContactFormInput parsea,
+        Then ValidationError.
+        """
+        with pytest.raises(PydanticValidationError):
+            ContactFormInput(**self._valid_payload(session_id='e' * 65))

--- a/serverless/tests/unit/contact_form/test_service.py
+++ b/serverless/tests/unit/contact_form/test_service.py
@@ -89,3 +89,83 @@ class TestProcessContactFormEmailMetric:
 
         assert result == saved
         assert 'OwnerEmailFailed' not in captured
+
+
+class TestProcessContactFormPayload:
+    """process_contact_form - shape del payload que llega a save_contact."""
+
+    def test_when_processed_then_payload_omits_origin_metadata(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _no_turnstile: None,
+    ) -> None:
+        """
+        Given un contacto con ip/country/user_agent en la request [AC-3],
+        When process_contact_form arma el payload,
+        Then save_contact NO recibe ip/country/user_agent: contacts deja
+        de duplicar datos de origen.
+        """
+        captured_payload: dict = {}
+
+        def _capture(payload: dict) -> dict:
+            captured_payload.update(payload)
+            return {'contact_id': 'c-1', 'created_at': '2026-05-17T00:00:00Z'}
+
+        monkeypatch.setattr(service, 'save_contact', _capture)
+        monkeypatch.setattr(
+            service, 'send_owner_email', lambda _contact: 'msg-id'
+        )
+        service.metrics.clear_metrics()
+
+        process_contact_form(
+            validated_input={
+                'name': 'Pablo',
+                'email': 'p@example.com',
+                'message': 'Hola mundo largo',
+            },
+            cf_response='token',
+            ip='203.0.113.9',
+            country='CL',
+            user_agent='Mozilla/5.0',
+        )
+
+        assert 'ip' not in captured_payload
+        assert 'country' not in captured_payload
+        assert 'user_agent' not in captured_payload
+
+    def test_when_session_id_present_then_payload_keeps_it(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _no_turnstile: None,
+    ) -> None:
+        """
+        Given validated_input con session_id [AC-3],
+        When process_contact_form arma el payload,
+        Then save_contact recibe session_id con ese valor (clave de
+        correlacion con tracking_events).
+        """
+        captured_payload: dict = {}
+
+        def _capture(payload: dict) -> dict:
+            captured_payload.update(payload)
+            return {'contact_id': 'c-2', 'created_at': '2026-05-17T00:00:00Z'}
+
+        monkeypatch.setattr(service, 'save_contact', _capture)
+        monkeypatch.setattr(
+            service, 'send_owner_email', lambda _contact: 'msg-id'
+        )
+        service.metrics.clear_metrics()
+
+        session_id = 'a' * 32
+        process_contact_form(
+            validated_input={
+                'name': 'Pablo',
+                'email': 'p@example.com',
+                'message': 'Hola mundo largo',
+                'session_id': session_id,
+            },
+            cf_response='token',
+            ip='203.0.113.9',
+        )
+
+        assert captured_payload['session_id'] == session_id

--- a/serverless/tests/unit/stream_processor/test_handler.py
+++ b/serverless/tests/unit/stream_processor/test_handler.py
@@ -1,0 +1,389 @@
+"""Tests del handler stream_processor (batch + batchItemFailures)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from stream_processor import handler
+from stream_processor.handler import lambda_handler
+
+pytestmark = pytest.mark.unit
+
+_CONTACTS_ARN = (
+    'arn:aws:dynamodb:us-east-1:123:table/portfolio-contacts-dev/stream/x'
+)
+_TRACKING_ARN = (
+    'arn:aws:dynamodb:us-east-1:123:table/portfolio-tracking-dev/stream/x'
+)
+
+
+@dataclass
+class MockLambdaContext:
+    """Context minimo para inject_lambda_context de Powertools."""
+
+    function_name: str = 'test-stream'
+    memory_limit_in_mb: int = 256
+    invoked_function_arn: str = (
+        'arn:aws:lambda:us-east-1:000000000000:function:stream'
+    )
+    aws_request_id: str = 'test-req-id'
+
+    def get_remaining_time_in_millis(self) -> int:
+        return 10000
+
+
+def _ctx() -> Any:
+    return MockLambdaContext()
+
+
+def _contact_record(event_id: str) -> dict[str, Any]:
+    """Stream record INSERT de la tabla contacts."""
+    return {
+        'eventID': event_id,
+        'eventName': 'INSERT',
+        'eventSourceARN': _CONTACTS_ARN,
+        'dynamodb': {
+            'NewImage': {
+                'id': {'S': f'contact-{event_id}'},
+                'name': {'S': 'Pablo'},
+                'email': {'S': 'p@example.com'},
+                'message': {'S': 'hola'},
+                'created_at': {'S': '2026-05-17T00:00:00Z'},
+            },
+        },
+    }
+
+
+def _tracking_record(event_id: str) -> dict[str, Any]:
+    """Stream record INSERT de la tabla tracking."""
+    return {
+        'eventID': event_id,
+        'eventName': 'INSERT',
+        'eventSourceARN': _TRACKING_ARN,
+        'dynamodb': {
+            'NewImage': {
+                'session_id': {'S': f'sess-{event_id}'},
+                'page_id': {'S': f'page-{event_id}'},
+                'page_url': {'S': 'https://the-full-stack.com/'},
+                'created_at': {'S': '2026-05-17T00:00:00Z'},
+            },
+        },
+    }
+
+
+class _Recorder:
+    """Captura las llamadas a pg_writer mockeadas + simula fallos."""
+
+    def __init__(self, fail_on: set[str] | None = None) -> None:
+        self.processed_log: set[str] = set()
+        self.upserts: list[dict[str, Any]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.marked: list[str] = []
+        self._fail_on = fail_on or set()
+
+    def is_event_processed(self, event_id: str) -> bool:
+        return event_id in self.processed_log
+
+    def upsert_contact(self, payload: dict[str, Any]) -> None:
+        if payload.get('id') in self._fail_on:
+            raise RuntimeError('simulated contact write failure')
+        self.upserts.append(payload)
+
+    def upsert_tracking(self, payload: dict[str, Any]) -> None:
+        if payload.get('session_id') in self._fail_on:
+            raise RuntimeError('simulated tracking write failure')
+        self.upserts.append(payload)
+
+    def mark_event_processed(
+        self, event_id: str, *, event_type: str, table_name: str
+    ) -> None:
+        _ = (event_type, table_name)
+        self.marked.append(event_id)
+        self.processed_log.add(event_id)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def _wire_recorder(
+    monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+) -> None:
+    """Sustituye las funciones pg_writer importadas por el handler."""
+    monkeypatch.setattr(
+        handler, 'is_event_processed', recorder.is_event_processed
+    )
+    monkeypatch.setattr(handler, 'upsert_contact', recorder.upsert_contact)
+    monkeypatch.setattr(handler, 'upsert_tracking', recorder.upsert_tracking)
+    monkeypatch.setattr(
+        handler, 'mark_event_processed', recorder.mark_event_processed
+    )
+    monkeypatch.setattr(handler, 'commit', recorder.commit)
+    monkeypatch.setattr(handler, 'rollback', recorder.rollback)
+
+
+class TestStreamHandlerHappyPath:
+    """lambda_handler - batch sin fallos."""
+
+    def test_when_contact_record_then_processed_and_committed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un batch con un record INSERT de contacts [AC-4],
+        When lambda_handler lo procesa,
+        Then el contacto se upsertea, se commitea y no hay batchItemFailures.
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+        event = {'Records': [_contact_record('evt-1')]}
+
+        # Act
+        response = lambda_handler(event, _ctx())
+
+        # Assert
+        assert response == {'batchItemFailures': []}
+        assert recorder.commits == 1
+        assert recorder.marked == ['evt-1']
+
+    def test_when_tracking_record_then_processed_and_committed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un batch con un record INSERT de tracking [AC-4],
+        When lambda_handler lo procesa,
+        Then el evento se upsertea, se commitea y no hay batchItemFailures.
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+        event = {'Records': [_tracking_record('evt-2')]}
+
+        # Act
+        response = lambda_handler(event, _ctx())
+
+        # Assert
+        assert response == {'batchItemFailures': []}
+        assert recorder.commits == 1
+        assert len(recorder.upserts) == 1
+
+    def test_when_empty_batch_then_no_failures(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un batch sin records [AC-4],
+        When lambda_handler lo procesa,
+        Then retorna batchItemFailures vacio y no hay commits.
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+
+        # Act
+        response = lambda_handler({'Records': []}, _ctx())
+
+        # Assert
+        assert response == {'batchItemFailures': []}
+        assert recorder.commits == 0
+
+
+class TestStreamHandlerIdempotency:
+    """lambda_handler - idempotencia: evento ya procesado se saltea."""
+
+    def test_when_event_already_processed_then_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un event_id ya registrado en processed_stream_events [AC-5],
+        When el handler lo recibe de nuevo,
+        Then NO se upsertea de nuevo (la fila no se duplica).
+        """
+        # Arrange
+        recorder = _Recorder()
+        recorder.processed_log.add('evt-dup')
+        _wire_recorder(monkeypatch, recorder)
+        event = {'Records': [_tracking_record('evt-dup')]}
+
+        # Act
+        response = lambda_handler(event, _ctx())
+
+        # Assert: ningun upsert, ningun commit -> sin duplicado
+        assert response == {'batchItemFailures': []}
+        assert recorder.upserts == []
+        assert recorder.commits == 0
+
+    def test_when_same_record_twice_then_second_pass_does_not_duplicate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given el mismo record entregado en dos invocaciones [AC-5],
+        When lambda_handler procesa la 2a vez,
+        Then solo hay un upsert total (la 2a pasada lo saltea por idempotencia).
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+        event = {'Records': [_contact_record('evt-once')]}
+
+        # Act: dos invocaciones con el mismo record
+        lambda_handler(event, _ctx())
+        lambda_handler(event, _ctx())
+
+        # Assert: el mark de la 1a pasada hace que la 2a lo saltee
+        assert len(recorder.upserts) == 1
+        assert recorder.commits == 1
+
+
+class TestStreamHandlerBatchFailures:
+    """lambda_handler - un record OK + uno que falla -> batchItemFailures."""
+
+    def test_when_one_record_fails_then_only_failed_reported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un batch con un record OK y otro que falla al escribir [AC-4],
+        When lambda_handler procesa el batch,
+        Then batchItemFailures reporta solo el itemIdentifier del fallido.
+        """
+        # Arrange: el record 'evt-bad' falla; 'evt-ok' procesa bien
+        recorder = _Recorder(fail_on={'contact-evt-bad'})
+        _wire_recorder(monkeypatch, recorder)
+        event = {
+            'Records': [
+                _contact_record('evt-ok'),
+                _contact_record('evt-bad'),
+            ]
+        }
+
+        # Act
+        response = lambda_handler(event, _ctx())
+
+        # Assert: solo el fallido en batchItemFailures
+        assert response == {
+            'batchItemFailures': [{'itemIdentifier': 'evt-bad'}]
+        }
+        # el OK avanzo: 1 upsert + 1 commit; el fallido hizo rollback
+        assert len(recorder.upserts) == 1
+        assert recorder.commits == 1
+        assert recorder.rollbacks == 1
+
+    def test_when_record_fails_then_rollback_called(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un record cuya escritura a PG lanza excepcion [AC-4],
+        When lambda_handler lo procesa,
+        Then se invoca rollback() y el record entra en batchItemFailures.
+        """
+        # Arrange
+        recorder = _Recorder(fail_on={'sess-evt-fail'})
+        _wire_recorder(monkeypatch, recorder)
+        event = {'Records': [_tracking_record('evt-fail')]}
+
+        # Act
+        response = lambda_handler(event, _ctx())
+
+        # Assert
+        assert response == {
+            'batchItemFailures': [{'itemIdentifier': 'evt-fail'}]
+        }
+        assert recorder.rollbacks == 1
+        assert recorder.commits == 0
+
+
+class TestStreamHandlerSkippedRecords:
+    """lambda_handler - records que se saltean (sin eventID, MODIFY, ARN)."""
+
+    def test_when_record_has_no_event_id_then_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un record sin eventID [AC-4],
+        When lambda_handler lo procesa,
+        Then se saltea (no se procesa) y no entra en batchItemFailures.
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+        record = _contact_record('')
+        record['eventID'] = ''
+
+        # Act
+        response = lambda_handler({'Records': [record]}, _ctx())
+
+        # Assert
+        assert response == {'batchItemFailures': []}
+        assert recorder.commits == 0
+
+    def test_when_record_is_modify_then_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un record MODIFY de contacts [AC-4],
+        When lambda_handler lo procesa,
+        Then parse_contact_record devuelve None y el record se saltea.
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+        record = _contact_record('evt-modify')
+        record['eventName'] = 'MODIFY'
+
+        # Act
+        response = lambda_handler({'Records': [record]}, _ctx())
+
+        # Assert: MODIFY -> parse devuelve None -> sin upsert ni commit
+        assert response == {'batchItemFailures': []}
+        assert recorder.upserts == []
+        assert recorder.commits == 0
+
+    def test_when_record_arn_unknown_then_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un record cuyo ARN no es contacts ni tracking [AC-4],
+        When lambda_handler lo procesa,
+        Then detect_table devuelve 'unknown' y el record se saltea.
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+        record = _contact_record('evt-unknown')
+        record['eventSourceARN'] = (
+            'arn:aws:dynamodb:us-east-1:123:table/other-table/stream/x'
+        )
+
+        # Act
+        response = lambda_handler({'Records': [record]}, _ctx())
+
+        # Assert
+        assert response == {'batchItemFailures': []}
+        assert recorder.commits == 0
+
+    def test_when_tracking_record_missing_keys_then_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un record tracking sin session_id en el NewImage [AC-4],
+        When lambda_handler lo procesa,
+        Then parse_tracking_record devuelve None y el record se saltea.
+        """
+        # Arrange
+        recorder = _Recorder()
+        _wire_recorder(monkeypatch, recorder)
+        record = _tracking_record('evt-nokeys')
+        del record['dynamodb']['NewImage']['session_id']
+
+        # Act
+        response = lambda_handler({'Records': [record]}, _ctx())
+
+        # Assert
+        assert response == {'batchItemFailures': []}
+        assert recorder.upserts == []
+        assert recorder.commits == 0

--- a/serverless/tests/unit/stream_processor/test_pg_writer.py
+++ b/serverless/tests/unit/stream_processor/test_pg_writer.py
@@ -87,8 +87,43 @@ class TestGetConnection:
         assert calls == ['postgres://x']
 
 
+def _tracking_payload(**overrides: Any) -> dict[str, Any]:
+    """Payload de tracking minimo para upsert_tracking, con overrides."""
+    payload: dict[str, Any] = {
+        'session_id': 'sess-3',
+        'page_id': 'page-uuid-3',
+        'stream_event_id': 'evt-200',
+        'created_at': '2026-05-17T00:00:00Z',
+        'expires_at': 1750000000,
+        'page_url': 'https://the-full-stack.com/',
+        'page_title': None,
+        'page_path': None,
+        'referrer': None,
+        'utm_source': None,
+        'utm_medium': None,
+        'utm_campaign': None,
+        'utm_content': None,
+        'utm_term': None,
+        'viewport_width': None,
+        'viewport_height': None,
+        'niche': 'generic',
+        'event_id': 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+        'event_type_id': '019e372b-e0a7-7154-8279-8829bcf6a08c',
+        'event_props': None,
+        'ip': None,
+        'country': None,
+        'user_agent': None,
+        'browser': None,
+        'browser_version': None,
+        'os': None,
+        'device_type': None,
+    }
+    payload.update(overrides)
+    return payload
+
+
 class TestUpsertTracking:
-    """upsert_tracking - el INSERT incluye event_id y event_type_id."""
+    """upsert_tracking - el INSERT incluye event_id, event_type_id, props."""
 
     def test_when_payload_has_event_ids_then_insert_includes_columns(
         self, monkeypatch: pytest.MonkeyPatch
@@ -101,43 +136,74 @@ class TestUpsertTracking:
         fake_conn = _FakeConnection()
         monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
 
-        payload = {
-            'session_id': 'sess-3',
-            'page_id': 'page-uuid-3',
-            'stream_event_id': 'evt-200',
-            'created_at': '2026-05-17T00:00:00Z',
-            'expires_at': 1750000000,
-            'page_url': 'https://the-full-stack.com/',
-            'page_title': None,
-            'page_path': None,
-            'referrer': None,
-            'utm_source': None,
-            'utm_medium': None,
-            'utm_campaign': None,
-            'utm_content': None,
-            'utm_term': None,
-            'viewport_width': None,
-            'viewport_height': None,
-            'niche': 'generic',
-            'event_id': 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
-            'event_type_id': '019e372b-e0a7-7154-8279-8829bcf6a08c',
-            'ip': None,
-            'country': None,
-            'user_agent': None,
-            'browser': None,
-            'browser_version': None,
-            'os': None,
-            'device_type': None,
-        }
+        payload = _tracking_payload()
 
         pg_writer.upsert_tracking(payload)
 
         sql = fake_conn.cursor_obj.sql
+        params = fake_conn.cursor_obj.params
         assert 'event_id' in sql
         assert 'event_type_id' in sql
         assert '%(event_id)s' in sql
         assert '%(event_type_id)s' in sql
-        assert fake_conn.cursor_obj.params == payload
+        assert params['event_id'] == 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+        assert params['event_type_id'] == (
+            '019e372b-e0a7-7154-8279-8829bcf6a08c'
+        )
+
+    def test_when_payload_has_event_props_then_insert_includes_column(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un payload de tracking con event_props (dict de contexto) [AC-10],
+        When upsert_tracking arma el INSERT,
+        Then la sentencia nombra la columna event_props con su placeholder.
+        """
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        pg_writer.upsert_tracking(
+            _tracking_payload(event_props={'href': 'https://x.com'})
+        )
+
+        sql = fake_conn.cursor_obj.sql
+        assert 'event_props' in sql
+        assert '%(event_props)s' in sql
+
+    def test_when_event_props_present_then_param_wrapped_as_jsonb(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given event_props como dict en el payload [AC-10],
+        When upsert_tracking adapta los params,
+        Then event_props viaja envuelto en psycopg Jsonb (adaptacion jsonb).
+        """
+        from psycopg.types.json import Jsonb
+
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+        props = {'depth': 50, 'href': 'https://x.com'}
+
+        pg_writer.upsert_tracking(_tracking_payload(event_props=props))
+
+        param = fake_conn.cursor_obj.params['event_props']
+        assert isinstance(param, Jsonb)
+        assert param.obj == props
+
+    def test_when_event_props_none_then_param_stays_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un payload sin event_props (None) [AC-10],
+        When upsert_tracking adapta los params,
+        Then event_props se pasa como None (columna jsonb nullable).
+        """
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        pg_writer.upsert_tracking(_tracking_payload(event_props=None))
+
+        assert fake_conn.cursor_obj.params['event_props'] is None
 
 
 class TestUpsertContact:
@@ -157,6 +223,65 @@ class TestUpsertContact:
         pg_writer.upsert_contact({'id': 'contact-uuid'})
 
         assert 'ON CONFLICT (id) DO NOTHING' in fake_conn.cursor_obj.sql
+
+    def test_when_payload_has_session_id_then_insert_includes_column(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un payload de contacto con session_id [AC-6],
+        When upsert_contact arma el INSERT,
+        Then la sentencia nombra la columna session_id y su placeholder.
+        """
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        pg_writer.upsert_contact({
+            'id': 'contact-uuid',
+            'session_id': 'a' * 32,
+        })
+
+        sql = fake_conn.cursor_obj.sql
+        assert 'session_id' in sql
+        assert '%(session_id)s' in sql
+
+    def test_when_legacy_fields_null_then_insert_keeps_columns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given un payload de contacto con ip/country/user_agent en NULL [AC-6],
+        When upsert_contact arma el INSERT,
+        Then las columnas legacy siguen en la sentencia (no se eliminan) y
+        los params se pasan con valor None.
+        """
+        fake_conn = _FakeConnection()
+        monkeypatch.setattr(pg_writer, '_get_connection', lambda: fake_conn)
+
+        payload = {
+            'id': 'contact-uuid',
+            'stream_event_id': 'evt-1',
+            'created_at': '2026-05-17T00:00:00Z',
+            'name': 'Pablo',
+            'email': 'p@example.com',
+            'message': 'hola',
+            'company': None,
+            'role': None,
+            'service_type': None,
+            'budget': None,
+            'timeline': None,
+            'niche': 'generic',
+            'session_id': 'a' * 32,
+            'ip': None,
+            'country': None,
+            'user_agent': None,
+        }
+
+        pg_writer.upsert_contact(payload)
+
+        sql = fake_conn.cursor_obj.sql
+        assert 'ip' in sql
+        assert 'country' in sql
+        assert 'user_agent' in sql
+        assert fake_conn.cursor_obj.params == payload
 
 
 class TestIdempotencyLog:

--- a/serverless/tests/unit/stream_processor/test_transformers.py
+++ b/serverless/tests/unit/stream_processor/test_transformers.py
@@ -72,6 +72,83 @@ class TestParseContactRecord:
         }
         assert parse_contact_record(record) is None
 
+    def test_when_insert_with_session_id_then_payload_includes_it(
+        self,
+    ) -> None:
+        """
+        Given INSERT contacts con session_id en el image [AC-6],
+        When parse_contact_record,
+        Then el payload incluye session_id con ese valor (correlacion).
+        """
+        record = {
+            'eventID': 'evt-003',
+            'eventName': 'INSERT',
+            'dynamodb': {
+                'NewImage': {
+                    'id': {'S': 'abc-uuid'},
+                    'name': {'S': 'Pablo'},
+                    'email': {'S': 'p@example.com'},
+                    'message': {'S': 'hola'},
+                    'session_id': {'S': 'a' * 32},
+                },
+            },
+        }
+        result = parse_contact_record(record)
+        assert result is not None
+        assert result['session_id'] == 'a' * 32
+
+    def test_when_insert_then_legacy_origin_fields_are_null(self) -> None:
+        """
+        Given INSERT contacts (un image que aun trae ip/country/UA) [AC-6],
+        When parse_contact_record,
+        Then ip/country/user_agent del payload quedan None: contacts deja
+        de poblar las columnas legacy para contactos nuevos.
+        """
+        record = {
+            'eventID': 'evt-004',
+            'eventName': 'INSERT',
+            'dynamodb': {
+                'NewImage': {
+                    'id': {'S': 'abc-uuid'},
+                    'name': {'S': 'Pablo'},
+                    'email': {'S': 'p@example.com'},
+                    'message': {'S': 'hola'},
+                    'ip': {'S': '203.0.113.7'},
+                    'country': {'S': 'CL'},
+                    'user_agent': {'S': 'Mozilla/5.0'},
+                },
+            },
+        }
+        result = parse_contact_record(record)
+        assert result is not None
+        assert result['ip'] is None
+        assert result['country'] is None
+        assert result['user_agent'] is None
+
+    def test_when_insert_without_session_id_then_payload_session_id_none(
+        self,
+    ) -> None:
+        """
+        Given INSERT contacts sin session_id en el image [AC-6],
+        When parse_contact_record,
+        Then session_id del payload queda None (contacto sin correlacion).
+        """
+        record = {
+            'eventID': 'evt-005',
+            'eventName': 'INSERT',
+            'dynamodb': {
+                'NewImage': {
+                    'id': {'S': 'abc-uuid'},
+                    'name': {'S': 'Pablo'},
+                    'email': {'S': 'p@example.com'},
+                    'message': {'S': 'hola'},
+                },
+            },
+        }
+        result = parse_contact_record(record)
+        assert result is not None
+        assert result['session_id'] is None
+
 
 class TestParseTrackingRecord:
     def test_when_insert_then_returns_payload(self) -> None:
@@ -134,6 +211,55 @@ class TestParseTrackingRecord:
         assert result['event_type_id'] == (
             '019e372b-e0a7-7154-8279-8829bcf6a08c'
         )
+
+    def test_when_insert_with_event_props_then_payload_includes_them(
+        self,
+    ) -> None:
+        """
+        Given INSERT tracking con event_props (Map de DynamoDB) [AC-10],
+        When parse_tracking_record,
+        Then el payload incluye event_props como dict Python.
+        """
+        record = {
+            'eventID': 'evt-102',
+            'eventName': 'INSERT',
+            'dynamodb': {
+                'NewImage': {
+                    'session_id': {'S': 'sess-4'},
+                    'page_id': {'S': 'page-uuid-4'},
+                    'page_url': {'S': 'https://x.com'},
+                    'event_props': {
+                        'M': {'href': {'S': 'https://github.com/bypabloc'}}
+                    },
+                },
+            },
+        }
+        result = parse_tracking_record(record)
+        assert result is not None
+        assert result['event_props'] == {'href': 'https://github.com/bypabloc'}
+
+    def test_when_insert_without_event_props_then_payload_has_none(
+        self,
+    ) -> None:
+        """
+        Given INSERT tracking sin event_props en el image [AC-10],
+        When parse_tracking_record,
+        Then el payload tiene event_props en None (columna jsonb nullable).
+        """
+        record = {
+            'eventID': 'evt-103',
+            'eventName': 'INSERT',
+            'dynamodb': {
+                'NewImage': {
+                    'session_id': {'S': 'sess-5'},
+                    'page_id': {'S': 'page-uuid-5'},
+                    'page_url': {'S': 'https://x.com'},
+                },
+            },
+        }
+        result = parse_tracking_record(record)
+        assert result is not None
+        assert result['event_props'] is None
 
 
 class TestDetectTable:

--- a/serverless/tests/unit/tracking_pixel/test_enrichment.py
+++ b/serverless/tests/unit/tracking_pixel/test_enrichment.py
@@ -1,58 +1,263 @@
-"""Tests para tracking_pixel.enrichment."""
+"""Tests para tracking_pixel.enrichment (parse UA + cache @cached SPEC-204)."""
 
 from __future__ import annotations
 
 import pytest
 
+from tracking_pixel import enrichment
 from tracking_pixel.enrichment import parse_user_agent
 
 pytestmark = pytest.mark.unit
+
+_CHROME_UA = (
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+    'Chrome/118.0.0.0 Safari/537.36'
+)
+_FIREFOX_UA = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64) Gecko/20100101 Firefox/120.0'
+)
+_IPHONE_UA = (
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
+    'AppleWebKit/605.1 Version/17.0 Mobile/15E148 Safari/604.1'
+)
 
 
 class TestParseUserAgent:
     """parse_user_agent - browser/os/device detection."""
 
-    def test_when_chrome_desktop_then_detects(self) -> None:
-        """Given Chrome UA, When parse, Then browser=Chrome + desktop."""
-        ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/118.0.0.0 Safari/537.36'
+    def test_when_chrome_desktop_then_detects(self, tracking_aws: None) -> None:
+        """
+        Given un User-Agent de Chrome en desktop,
+        When se invoca parse_user_agent,
+        Then detecta browser=Chrome, version=118, os=Linux, device=desktop.
+        """
+        # Arrange / Act
+        result = parse_user_agent(_CHROME_UA)
 
-        result = parse_user_agent(ua)
+        # Assert
+        assert result == {
+            'browser': 'Chrome',
+            'browser_version': '118',
+            'os': 'Linux',
+            'device_type': 'desktop',
+        }
 
-        assert result['browser'] == 'Chrome'
-        assert result['browser_version'] == '118'
-        assert result['os'] == 'Linux'
-        assert result['device_type'] == 'desktop'
+    def test_when_iphone_then_detects_ios_mobile(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un User-Agent de iPhone,
+        When se invoca parse_user_agent,
+        Then detecta os=iOS y device_type=mobile.
+        """
+        # Arrange / Act
+        result = parse_user_agent(_IPHONE_UA)
 
-    def test_when_iphone_then_detects_ios_mobile(self) -> None:
-        """Given iPhone UA, When parse, Then os=iOS + device=mobile."""
-        ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1 Version/17.0 Mobile/15E148 Safari/604.1'
-
-        result = parse_user_agent(ua)
-
+        # Assert
         assert result['os'] == 'iOS'
         assert result['device_type'] == 'mobile'
 
-    def test_when_bot_then_detects_bot(self) -> None:
-        """Given UA con 'bot', When parse, Then device_type=bot."""
+    def test_when_ipad_then_detects_tablet(self, tracking_aws: None) -> None:
+        """
+        Given un User-Agent de iPad,
+        When se invoca parse_user_agent,
+        Then device_type=tablet.
+        """
+        # Arrange
+        ua = (
+            'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) '
+            'AppleWebKit/605.1 Version/17.0 Safari/604.1'
+        )
+
+        # Act
+        result = parse_user_agent(ua)
+
+        # Assert
+        assert result['device_type'] == 'tablet'
+
+    def test_when_bot_then_detects_bot(self, tracking_aws: None) -> None:
+        """
+        Given un User-Agent que contiene 'bot',
+        When se invoca parse_user_agent,
+        Then device_type=bot.
+        """
+        # Arrange
         ua = 'Googlebot/2.1 (+http://www.google.com/bot.html)'
 
+        # Act
         result = parse_user_agent(ua)
 
+        # Assert
         assert result['device_type'] == 'bot'
 
-    def test_when_none_then_returns_unknowns(self) -> None:
-        """Given UA=None, When parse, Then todos unknown."""
-        result = parse_user_agent(None)
+    def test_when_macos_safari_then_detects(self, tracking_aws: None) -> None:
+        """
+        Given un User-Agent de Safari en macOS,
+        When se invoca parse_user_agent,
+        Then browser=Safari y os=macOS.
+        """
+        # Arrange
+        ua = (
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) '
+            'AppleWebKit/605.1 Version/17.0 Safari/605.1.15'
+        )
 
-        assert result['browser'] == 'unknown'
-        assert result['os'] == 'unknown'
-        assert result['device_type'] == 'unknown'
-
-    def test_when_firefox_windows_then_detects(self) -> None:
-        """Given Firefox Windows UA, When parse, Then ambos detectados."""
-        ua = 'Mozilla/5.0 (Windows NT 10.0; Win64) Gecko/20100101 Firefox/120.0'
-
+        # Act
         result = parse_user_agent(ua)
 
+        # Assert
+        assert result['browser'] == 'Safari'
+        assert result['os'] == 'macOS'
+
+    def test_when_none_then_returns_unknowns(self, tracking_aws: None) -> None:
+        """
+        Given user_agent=None,
+        When se invoca parse_user_agent,
+        Then todos los campos son 'unknown' / ''.
+        """
+        # Arrange / Act
+        result = parse_user_agent(None)
+
+        # Assert
+        assert result == {
+            'browser': 'unknown',
+            'browser_version': '',
+            'os': 'unknown',
+            'device_type': 'unknown',
+        }
+
+    def test_when_empty_string_then_returns_unknowns(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given user_agent='' (string vacio),
+        When se invoca parse_user_agent,
+        Then todos los campos son 'unknown' / ''.
+        """
+        # Arrange / Act
+        result = parse_user_agent('')
+
+        # Assert
+        assert result == {
+            'browser': 'unknown',
+            'browser_version': '',
+            'os': 'unknown',
+            'device_type': 'unknown',
+        }
+
+    def test_when_firefox_windows_then_detects(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un User-Agent de Firefox en Windows,
+        When se invoca parse_user_agent,
+        Then browser=Firefox y os=Windows.
+        """
+        # Arrange / Act
+        result = parse_user_agent(_FIREFOX_UA)
+
+        # Assert
         assert result['browser'] == 'Firefox'
         assert result['os'] == 'Windows'
+
+
+class TestParseUserAgentCache:
+    """parse_user_agent - el @cached evita re-ejecutar el regex (SPEC-204)."""
+
+    def test_when_same_ua_twice_then_second_call_skips_regex(
+        self, tracking_aws: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Given el mismo User-Agent procesado dos veces en una Lambda warm [AC-1],
+        When se invoca parse_user_agent la segunda vez,
+        Then el resultado viene del cache y el regex de browser no se
+        re-ejecuta (el .search del patron Chrome solo corre una vez).
+        """
+
+        # Arrange: proxy contador alrededor del patron Chrome (re.Pattern
+        # tiene atributos read-only, asi que se sustituye el patron entero).
+        class _CountingPattern:
+            def __init__(self, real: object) -> None:
+                self._real = real
+                self.calls: list[str] = []
+
+            def search(self, text: str) -> object:
+                self.calls.append(text)
+                return self._real.search(text)
+
+        chrome_name, chrome_pattern = enrichment._BROWSER_PATTERNS[0]
+        counter = _CountingPattern(chrome_pattern)
+        patched = (
+            (chrome_name, counter),
+            *enrichment._BROWSER_PATTERNS[1:],
+        )
+        monkeypatch.setattr(enrichment, '_BROWSER_PATTERNS', patched)
+
+        # Act: dos invocaciones con el MISMO User-Agent
+        first = parse_user_agent(_CHROME_UA)
+        second = parse_user_agent(_CHROME_UA)
+
+        # Assert: la 2a invocacion sirvio del cache, sin re-ejecutar el regex
+        assert first == second
+        assert counter.calls == [_CHROME_UA]
+
+    def test_when_same_ua_twice_then_same_result(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given el mismo User-Agent procesado dos veces [AC-1],
+        When se invoca parse_user_agent,
+        Then ambas invocaciones devuelven exactamente el mismo dict.
+        """
+        # Arrange / Act
+        first = parse_user_agent(_IPHONE_UA)
+        second = parse_user_agent(_IPHONE_UA)
+
+        # Assert
+        assert first == second
+        assert second == {
+            'browser': 'Safari',
+            'browser_version': '17',
+            'os': 'iOS',
+            'device_type': 'mobile',
+        }
+
+    def test_when_distinct_ua_then_no_cache_collision(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given dos User-Agent distintos [AC-2],
+        When se procesan ambos,
+        Then cada uno produce su propio resultado (la cache no colisiona keys).
+        """
+        # Arrange / Act
+        chrome = parse_user_agent(_CHROME_UA)
+        firefox = parse_user_agent(_FIREFOX_UA)
+
+        # Assert: keys distintas -> resultados distintos, sin contaminacion
+        assert chrome['browser'] == 'Chrome'
+        assert firefox['browser'] == 'Firefox'
+
+    def test_when_ua_cached_then_entry_persisted_in_cache_table(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un User-Agent procesado una vez [AC-1],
+        When se inspecciona la tabla de cache,
+        Then existe una entry bajo el namespace 'ua' con el resultado.
+        """
+        # Arrange
+        from common.cache import DynamoDBCache
+
+        # Act
+        parse_user_agent(_FIREFOX_UA)
+        cache = DynamoDBCache()
+
+        # Assert: la entry vive bajo el namespace 'ua' del decorator
+        scan = cache.table.scan()['Items']
+        ua_keys = [
+            item['cache_key']
+            for item in scan
+            if str(item['cache_key']).startswith('ua:parse_user_agent:')
+        ]
+        assert len(ua_keys) == 1

--- a/serverless/tests/unit/tracking_pixel/test_schemas.py
+++ b/serverless/tests/unit/tracking_pixel/test_schemas.py
@@ -1,11 +1,11 @@
-"""Tests del schema TrackingEventInput (event_id + event_type_id)."""
+"""Tests del schema TrackingEventInput (campos requeridos, limites, UUID)."""
 
 from __future__ import annotations
 
 import pytest
 from pydantic import ValidationError
 
-from tracking_pixel.schemas import TrackingEventInput
+from tracking_pixel.schemas import EVENT_PROPS_MAX_BYTES, TrackingEventInput
 
 pytestmark = pytest.mark.unit
 
@@ -31,48 +31,53 @@ class TestTrackingEventInputEventIds:
 
     def test_when_valid_event_ids_then_accepted(self) -> None:
         """
-        Given un body con event_id y event_type_id UUID validos [AC-4],
+        Given un body con event_id y event_type_id UUID validos [AC-3],
         When se valida con Pydantic,
         Then ambos campos quedan en el modelo con su valor.
         """
+        # Arrange / Act
         model = TrackingEventInput(**_base_body())
 
+        # Assert
         assert model.event_id == _EVENT_ID
         assert model.event_type_id == _PAGE_LOAD
 
     def test_when_event_type_id_hyphenated_uuid_then_accepted(self) -> None:
         """
-        Given event_id en forma con guiones (UUID4 de 36 chars) [AC-4],
+        Given event_id en forma con guiones (UUID4 de 36 chars) [AC-3],
         When se valida,
         Then se acepta (el validador tolera con/sin guiones).
         """
+        # Arrange / Act
         model = TrackingEventInput(
             **_base_body(event_id='a1b2c3d4-e5f6-4718-a93a-4b5c6d7e8f90')
         )
 
+        # Assert
         assert model.event_id == 'a1b2c3d4-e5f6-4718-a93a-4b5c6d7e8f90'
 
     def test_when_missing_event_type_id_then_validation_error(self) -> None:
         """
-        Given un body sin event_type_id [AC-5],
+        Given un body sin event_type_id [AC-3],
         When se valida,
         Then Pydantic lanza ValidationError (el handler -> 400 INVALID_INPUT).
         """
+        # Arrange
         body = _base_body()
         del body['event_type_id']
 
+        # Act / Assert
         with pytest.raises(ValidationError) as exc_info:
             TrackingEventInput(**body)
-
         assert 'event_type_id' in str(exc_info.value)
 
     def test_when_event_type_id_malformed_then_validation_error(self) -> None:
         """
-        Given event_type_id con la longitud correcta pero no-UUID [AC-6],
+        Given event_type_id con la longitud correcta pero no-UUID [AC-3],
         When se valida,
         Then Pydantic lanza ValidationError (el validador UUID() rechaza).
         """
-        # 36 chars, formato de guiones correcto, pero 'zzzz' no es hex.
+        # Arrange / Act / Assert: 36 chars con guiones, pero 'zzzz' no es hex
         with pytest.raises(ValidationError):
             TrackingEventInput(
                 **_base_body(
@@ -82,12 +87,227 @@ class TestTrackingEventInputEventIds:
 
     def test_when_event_id_malformed_then_validation_error(self) -> None:
         """
-        Given event_id con la longitud correcta pero no-UUID [AC-6],
+        Given event_id con la longitud correcta pero no-UUID [AC-3],
         When se valida,
         Then Pydantic lanza ValidationError.
         """
-        # 32 chars pero 'g' no es un digito hexadecimal valido.
+        # Arrange / Act / Assert: 32 chars pero 'g' no es hex valido
         with pytest.raises(ValidationError):
             TrackingEventInput(
                 **_base_body(event_id='gggggggggggggggggggggggggggggggg')
             )
+
+
+class TestTrackingEventInputRequiredFields:
+    """TrackingEventInput - campos requeridos."""
+
+    def test_when_missing_session_id_then_validation_error(self) -> None:
+        """
+        Given un body sin session_id [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError mencionando session_id.
+        """
+        # Arrange
+        body = _base_body()
+        del body['session_id']
+
+        # Act / Assert
+        with pytest.raises(ValidationError) as exc_info:
+            TrackingEventInput(**body)
+        assert 'session_id' in str(exc_info.value)
+
+    def test_when_missing_event_id_then_validation_error(self) -> None:
+        """
+        Given un body sin event_id [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError mencionando event_id.
+        """
+        # Arrange
+        body = _base_body()
+        del body['event_id']
+
+        # Act / Assert
+        with pytest.raises(ValidationError) as exc_info:
+            TrackingEventInput(**body)
+        assert 'event_id' in str(exc_info.value)
+
+    def test_when_missing_page_url_then_validation_error(self) -> None:
+        """
+        Given un body sin page_url [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError mencionando page_url.
+        """
+        # Arrange
+        body = _base_body()
+        del body['page_url']
+
+        # Act / Assert
+        with pytest.raises(ValidationError) as exc_info:
+            TrackingEventInput(**body)
+        assert 'page_url' in str(exc_info.value)
+
+
+class TestTrackingEventInputLimits:
+    """TrackingEventInput - limites de longitud y rango."""
+
+    def test_when_session_id_too_short_then_validation_error(self) -> None:
+        """
+        Given session_id de 19 chars (min_length=20) [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError.
+        """
+        # Arrange / Act / Assert
+        with pytest.raises(ValidationError):
+            TrackingEventInput(**_base_body(session_id='x' * 19))
+
+    def test_when_session_id_too_long_then_validation_error(self) -> None:
+        """
+        Given session_id de 65 chars (max_length=64) [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError.
+        """
+        # Arrange / Act / Assert
+        with pytest.raises(ValidationError):
+            TrackingEventInput(**_base_body(session_id='x' * 65))
+
+    def test_when_page_url_too_long_then_validation_error(self) -> None:
+        """
+        Given page_url de 501 chars (max_length=500) [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError.
+        """
+        # Arrange
+        long_url = 'https://x.com/' + 'a' * 500
+
+        # Act / Assert
+        with pytest.raises(ValidationError):
+            TrackingEventInput(**_base_body(page_url=long_url))
+
+    def test_when_viewport_width_negative_then_validation_error(self) -> None:
+        """
+        Given viewport_width=-1 (ge=0) [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError.
+        """
+        # Arrange / Act / Assert
+        with pytest.raises(ValidationError):
+            TrackingEventInput(**_base_body(viewport_width=-1))
+
+    def test_when_viewport_height_above_max_then_validation_error(
+        self,
+    ) -> None:
+        """
+        Given viewport_height=10001 (le=10000) [AC-3],
+        When se valida,
+        Then Pydantic lanza ValidationError.
+        """
+        # Arrange / Act / Assert
+        with pytest.raises(ValidationError):
+            TrackingEventInput(**_base_body(viewport_height=10001))
+
+
+class TestTrackingEventInputOptionalFields:
+    """TrackingEventInput - campos opcionales y defaults."""
+
+    def test_when_only_required_fields_then_optionals_are_none(self) -> None:
+        """
+        Given un body solo con los campos requeridos [AC-3],
+        When se valida,
+        Then los campos opcionales quedan en None por default.
+        """
+        # Arrange / Act
+        model = TrackingEventInput(**_base_body())
+
+        # Assert
+        assert model.page_title is None
+        assert model.utm_source is None
+        assert model.niche is None
+        assert model.cf_token is None
+
+    def test_when_all_optionals_given_then_accepted(self) -> None:
+        """
+        Given un body con todos los campos opcionales poblados [AC-3],
+        When se valida,
+        Then el modelo conserva cada valor.
+        """
+        # Arrange / Act
+        model = TrackingEventInput(
+            **_base_body(
+                page_title='Home',
+                page_path='/',
+                referrer='https://google.com',
+                utm_source='twitter',
+                utm_medium='social',
+                utm_campaign='launch',
+                utm_content='hero',
+                utm_term='portfolio',
+                viewport_width=1920,
+                viewport_height=1080,
+                niche='vibe',
+                cf_token='token-abc',  # noqa: S106 - Turnstile token, no es password
+            )
+        )
+
+        # Assert
+        assert model.page_title == 'Home'
+        assert model.utm_medium == 'social'
+        assert model.viewport_width == 1920
+        assert model.niche == 'vibe'
+        assert model.cf_token == 'token-abc'  # noqa: S105 - Turnstile token, no es password
+
+
+class TestTrackingEventInputEventProps:
+    """TrackingEventInput - validacion del campo opcional event_props."""
+
+    def test_when_event_props_omitted_then_defaults_to_none(self) -> None:
+        """
+        Given un body de /track sin event_props [AC-10],
+        When se valida,
+        Then event_props queda en None (campo opcional).
+        """
+        model = TrackingEventInput(**_base_body())
+        assert model.event_props is None
+
+    def test_when_event_props_explicit_none_then_accepted(self) -> None:
+        """
+        Given un body con event_props pasado explicitamente como None [AC-10],
+        When se valida (el validador de tamano corre sobre el valor None),
+        Then event_props queda en None sin lanzar error.
+        """
+        model = TrackingEventInput(**_base_body(event_props=None))
+        assert model.event_props is None
+
+    def test_when_event_props_dict_then_accepted(self) -> None:
+        """
+        Given un body con event_props como dict de contexto del evento [AC-10],
+        When se valida,
+        Then event_props queda en el modelo con su contenido.
+        """
+        props = {'href': 'https://github.com/bypabloc', 'depth': 75}
+        model = TrackingEventInput(**_base_body(event_props=props))
+        assert model.event_props == props
+
+    def test_when_event_props_within_size_limit_then_accepted(self) -> None:
+        """
+        Given event_props serializado justo en el limite de tamano [AC-11],
+        When se valida,
+        Then se acepta (el limite es inclusivo).
+        """
+        overhead = len('{"k":""}')
+        filler = 'x' * (EVENT_PROPS_MAX_BYTES - overhead)
+        model = TrackingEventInput(**_base_body(event_props={'k': filler}))
+        assert model.event_props == {'k': filler}
+
+    def test_when_event_props_exceeds_size_limit_then_validation_error(
+        self,
+    ) -> None:
+        """
+        Given event_props serializado que supera el tamano maximo [AC-11],
+        When se valida,
+        Then Pydantic lanza ValidationError (el handler -> 400 INVALID_INPUT).
+        """
+        overhead = len('{"k":""}')
+        filler = 'x' * (EVENT_PROPS_MAX_BYTES - overhead + 1)
+        with pytest.raises(ValidationError) as exc_info:
+            TrackingEventInput(**_base_body(event_props={'k': filler}))
+        assert 'event_props' in str(exc_info.value)

--- a/serverless/tests/unit/tracking_pixel/test_service.py
+++ b/serverless/tests/unit/tracking_pixel/test_service.py
@@ -1,0 +1,189 @@
+"""Tests de tracking_pixel.service (orquestacion enrichment + persist)."""
+
+from __future__ import annotations
+
+import boto3
+import pytest
+
+from tracking_pixel.service import process_tracking_event
+
+pytestmark = pytest.mark.unit
+
+_SESSION_ID = 'session-uuid-1234567890abcdef'
+_EVENT_ID = 'a1b2c3d4e5f60718293a4b5c6d7e8f90'
+_PAGE_LOAD = '019e372b-e0a7-7154-8279-8829bcf6a08c'
+_CHROME_UA = (
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+    'Chrome/118.0.0.0 Safari/537.36'
+)
+
+
+def _validated_input(**overrides: object) -> dict[str, object]:
+    """dict minimo del TrackingEventInput validado (sin cf_token)."""
+    payload: dict[str, object] = {
+        'session_id': _SESSION_ID,
+        'event_id': _EVENT_ID,
+        'event_type_id': _PAGE_LOAD,
+        'page_url': 'https://the-full-stack.com/',
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _tracking_table() -> object:
+    """Devuelve el boto3 Table de tracking del entorno de test."""
+    return boto3.resource('dynamodb', region_name='us-east-1').Table(
+        'portfolio-tracking-test'
+    )
+
+
+class TestProcessTrackingEvent:
+    """process_tracking_event - enrichment + persistencia."""
+
+    def test_when_valid_input_then_returns_identifiers(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un input validado, una IP y un User-Agent [AC-3],
+        When se invoca process_tracking_event,
+        Then retorna session_id, page_id y expires_at del item persistido.
+        """
+        # Arrange / Act
+        result = process_tracking_event(
+            validated_input=_validated_input(),
+            ip='1.2.3.4',
+            user_agent=_CHROME_UA,
+        )
+
+        # Assert
+        assert result['session_id'] == _SESSION_ID
+        assert isinstance(result['page_id'], str)
+        assert isinstance(result['expires_at'], int)
+
+    def test_when_processed_then_enrichment_persisted(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un User-Agent de Chrome [AC-3],
+        When process_tracking_event orquesta enrichment + persist,
+        Then el item de DynamoDB contiene el browser/os/device parseados.
+        """
+        # Arrange / Act
+        result = process_tracking_event(
+            validated_input=_validated_input(),
+            ip='1.2.3.4',
+            user_agent=_CHROME_UA,
+        )
+
+        # Assert: el enrichment del UA quedo escrito en el item
+        item = _tracking_table().get_item(
+            Key={
+                'session_id': result['session_id'],
+                'page_id': result['page_id'],
+            }
+        )['Item']
+        assert item['browser'] == 'Chrome'
+        assert item['os'] == 'Linux'
+        assert item['device_type'] == 'desktop'
+        assert item['ip'] == '1.2.3.4'
+
+    def test_when_country_given_then_persisted(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un country code provisto por CF-IPCountry [AC-3],
+        When process_tracking_event lo recibe,
+        Then el item persistido incluye el atributo country.
+        """
+        # Arrange / Act
+        result = process_tracking_event(
+            validated_input=_validated_input(),
+            ip='1.2.3.4',
+            user_agent=_CHROME_UA,
+            country='CL',
+        )
+
+        # Assert
+        item = _tracking_table().get_item(
+            Key={
+                'session_id': result['session_id'],
+                'page_id': result['page_id'],
+            }
+        )['Item']
+        assert item['country'] == 'CL'
+
+    def test_when_no_country_then_attribute_absent(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given country=None (default) [AC-3],
+        When process_tracking_event persiste el evento,
+        Then el item no contiene el atributo country.
+        """
+        # Arrange / Act
+        result = process_tracking_event(
+            validated_input=_validated_input(),
+            ip='1.2.3.4',
+            user_agent=_CHROME_UA,
+        )
+
+        # Assert
+        item = _tracking_table().get_item(
+            Key={
+                'session_id': result['session_id'],
+                'page_id': result['page_id'],
+            }
+        )['Item']
+        assert 'country' not in item
+
+    def test_when_user_agent_none_then_enrichment_is_unknown(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given user_agent=None [AC-3],
+        When process_tracking_event arma el payload,
+        Then el item no escribe user_agent (string vacio es falsy y se omite)
+        pero el enrichment queda como 'unknown'.
+        """
+        # Arrange / Act
+        result = process_tracking_event(
+            validated_input=_validated_input(),
+            ip='1.2.3.4',
+            user_agent=None,
+        )
+
+        # Assert: user_agent vacio no se escribe; enrichment queda 'unknown'
+        item = _tracking_table().get_item(
+            Key={
+                'session_id': result['session_id'],
+                'page_id': result['page_id'],
+            }
+        )['Item']
+        assert 'user_agent' not in item
+        assert item['browser'] == 'unknown'
+        assert item['device_type'] == 'unknown'
+
+    def test_when_event_ids_given_then_persisted(
+        self, tracking_aws: None
+    ) -> None:
+        """
+        Given un input con event_id y event_type_id [AC-3],
+        When process_tracking_event persiste el evento,
+        Then el item conserva ambos identificadores del evento.
+        """
+        # Arrange / Act
+        result = process_tracking_event(
+            validated_input=_validated_input(),
+            ip='1.2.3.4',
+            user_agent=_CHROME_UA,
+        )
+
+        # Assert
+        item = _tracking_table().get_item(
+            Key={
+                'session_id': result['session_id'],
+                'page_id': result['page_id'],
+            }
+        )['Item']
+        assert item['event_id'] == _EVENT_ID
+        assert item['event_type_id'] == _PAGE_LOAD

--- a/tests/feature/contact/contact-funnel.spec.ts
+++ b/tests/feature/contact/contact-funnel.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * @feature Embudo de contacto (SPEC-200 AC-4..AC-7)
+ * @description Verifica que el formulario de contacto emite los 5 eventos del
+ *   embudo via `trackEvent`:
+ *   - `contact_view` al cargar /contact [AC-4]
+ *   - `contact_form_start` en el primer foco de un campo [AC-5]
+ *   - `contact_form_submit` + `contact_form_success` al enviar con exito [AC-6]
+ *   - `contact_form_error` con el codigo del error si el envio falla [AC-7]
+ *
+ *   El gating de consentimiento se fuerza con `?cf_track=force` (flag de QA).
+ *   Los eventos viajan por `navigator.sendBeacon`; el test lo neutraliza con
+ *   `addInitScript` para que `trackEvent` caiga al path `fetch`, cuyo
+ *   `postData` SI es legible por Playwright.
+ */
+import { expect, type Page, subdomainUrl, test } from '../fixtures/index.js'
+
+const BYPASS_SECRET = process.env.TURNSTILE_BYPASS_SECRET ?? ''
+
+const EVENT_TYPES = {
+  CONTACT_VIEW: '019e372b-e0a7-7f8f-b568-3fbdb8a91756',
+  CONTACT_FORM_START: '019e372b-e0a7-7467-a074-603b7e294cf8',
+  CONTACT_FORM_SUBMIT: '019e372b-e0a7-7a02-b754-606a5fe38afc',
+  CONTACT_FORM_SUCCESS: '019e372b-e0a7-7d1b-9bd3-3cb2ee92b4d7',
+  CONTACT_FORM_ERROR: '019e372b-e0a7-77f6-897f-17f41a06b2c0',
+} as const
+
+interface TrackPayload {
+  session_id: string
+  event_id: string
+  event_type_id: string
+  page_url: string
+  event_props?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/**
+ * Deshabilita `navigator.sendBeacon` para forzar el fallback a `fetch()`
+ * (cuyo postData Playwright SI expone de forma fiable).
+ */
+async function disableSendBeacon(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    })
+  })
+}
+
+/**
+ * Intercepta los POST a `/track`, los responde 204 y acumula sus payloads.
+ */
+async function captureTrackRequests(page: Page): Promise<TrackPayload[]> {
+  const captured: TrackPayload[] = []
+  await page.route('**/track', async (route) => {
+    const request = route.request()
+    if (request.method() === 'POST') {
+      try {
+        captured.push(JSON.parse(request.postData() ?? '{}') as TrackPayload)
+      } catch {
+        // payload no JSON: lo ignoramos
+      }
+    }
+    await route.fulfill({ status: 204, body: '' })
+  })
+  return captured
+}
+
+/**
+ * Devuelve los `event_type_id` capturados, en orden de emision.
+ */
+function emittedTypes(captured: TrackPayload[]): string[] {
+  return captured.map((p) => p.event_type_id)
+}
+
+/**
+ * Navega a /contact y espera a que el island este interactivo de forma
+ * estable. En dev (Vite HMR) la primera carga del island puede disparar una
+ * re-optimizacion de dependencias que recarga la pagina; esperar el evento
+ * `contact_view` capturado garantiza que el island ya monto definitivamente
+ * (su effect de montaje ya corrio) — recien ahi es seguro interactuar.
+ */
+async function gotoContactFunnel(
+  page: Page,
+  captured: TrackPayload[],
+): Promise<void> {
+  await page.goto(`${subdomainUrl()}/contact?cf_track=force`, {
+    waitUntil: 'domcontentloaded',
+  })
+  await expect(page.locator('input[name="name"]')).toBeVisible()
+  await expect
+    .poll(() => emittedTypes(captured).includes(EVENT_TYPES.CONTACT_VIEW), {
+      timeout: 15000,
+    })
+    .toBe(true)
+}
+
+test.describe('Feature: embudo de contacto (SPEC-200)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (BYPASS_SECRET) {
+      await page.addInitScript((secret: string) => {
+        ;(
+          window as Window & { __playwrightTurnstileBypass?: string }
+        ).__playwrightTurnstileBypass = secret
+      }, BYPASS_SECRET)
+    }
+  })
+
+  test('Given /contact con ?cf_track=force When carga Then emite contact_view [AC-4]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+
+    // Act
+    await page.goto(`${subdomainUrl()}/contact?cf_track=force`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await expect(page.getByTestId('contact-form')).toBeVisible()
+    // 15s de margen: en dev la primera carga del island puede recargar por
+    // la re-optimizacion de dependencias de Vite.
+    await expect
+      .poll(() => emittedTypes(captured).includes(EVENT_TYPES.CONTACT_VIEW), {
+        timeout: 15000,
+      })
+      .toBe(true)
+
+    // Assert
+    const viewEvent = captured.find(
+      (p) => p.event_type_id === EVENT_TYPES.CONTACT_VIEW,
+    )
+    expect(viewEvent?.page_url).toContain('/contact')
+  })
+
+  test('Given el form When foco el primer campo Then emite contact_form_start una vez [AC-5]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+    await gotoContactFunnel(page, captured)
+
+    // Act: focar dos campos distintos -> contact_form_start solo una vez
+    await page.locator('input[name="name"]').focus()
+    await page.locator('input[name="email"]').focus()
+    await expect
+      .poll(
+        () =>
+          emittedTypes(captured).filter(
+            (t) => t === EVENT_TYPES.CONTACT_FORM_START,
+          ).length,
+        { timeout: 10000 },
+      )
+      .toBe(1)
+
+    // Assert: exactamente un contact_form_start pese a multiples focos
+    const starts = emittedTypes(captured).filter(
+      (t) => t === EVENT_TYPES.CONTACT_FORM_START,
+    )
+    expect(starts.length).toBe(1)
+  })
+
+  // ------------------------------------------------------------------
+  // Tests que envian el form (AC-6, AC-7): requieren el bypass de Turnstile
+  // para superar el preflight del captcha. Se skipean si el secret no esta
+  // seteado (mismo patron que contact-form.spec.ts).
+  // ------------------------------------------------------------------
+  test.describe('with Turnstile bypass (skipped if TURNSTILE_BYPASS_SECRET not set)', () => {
+    test.skip(
+      !BYPASS_SECRET,
+      'TURNSTILE_BYPASS_SECRET no esta seteada en el entorno',
+    )
+
+    test('Given un envio que falla 429 When submit Then emite submit + error con el codigo [AC-7]', async ({
+      page,
+    }) => {
+      // Arrange
+      await disableSendBeacon(page)
+      const captured = await captureTrackRequests(page)
+      await page.route(
+        /https:\/\/[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com\/[a-z]+\/contact$/,
+        async (route) => {
+          await route.fulfill({
+            status: 429,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'Too many requests' }),
+          })
+        },
+      )
+      await gotoContactFunnel(page, captured)
+
+      // Act
+      await page.locator('input[name="name"]').fill('Pablo Test')
+      await page.locator('input[name="email"]').fill('pacg1991@gmail.com')
+      await page
+        .locator('textarea[name="message"]')
+        .fill('Mensaje suficientemente largo para pasar Zod cliente.')
+      await page.getByTestId('contact-submit').click()
+      await expect
+        .poll(
+          () => emittedTypes(captured).includes(EVENT_TYPES.CONTACT_FORM_ERROR),
+          { timeout: 10000 },
+        )
+        .toBe(true)
+
+      // Assert: submit precede al error, y el error lleva code 429 en props
+      const types = emittedTypes(captured)
+      expect(types.includes(EVENT_TYPES.CONTACT_FORM_SUBMIT)).toBe(true)
+      const errorEvent = captured.find(
+        (p) => p.event_type_id === EVENT_TYPES.CONTACT_FORM_ERROR,
+      )
+      expect(errorEvent?.event_props).toEqual({ code: '429' })
+    })
+
+    test('Given un envio 201 When submit Then emite submit seguido de success [AC-6]', async ({
+      page,
+    }) => {
+      // Arrange: el POST /contact se mockea con 201 para no depender del
+      // backend AWS (el embudo se mide en el cliente, no en el Lambda).
+      await disableSendBeacon(page)
+      const captured = await captureTrackRequests(page)
+      await page.route(
+        /https:\/\/[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com\/[a-z]+\/contact$/,
+        async (route) => {
+          await route.fulfill({
+            status: 201,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              contact_id: '019e28fc-b97d-7d79-91a5-44c9b19465b4',
+              created_at: new Date().toISOString(),
+            }),
+          })
+        },
+      )
+      await gotoContactFunnel(page, captured)
+
+      // Act
+      const uniqueMsg = `[E2E funnel] ${new Date().toISOString()} - mensaje largo.`
+      await page.locator('input[name="name"]').fill('Playwright Funnel')
+      await page.locator('input[name="email"]').fill('pacg1991@gmail.com')
+      await page.locator('textarea[name="message"]').fill(uniqueMsg)
+      await page.getByTestId('contact-submit').click()
+      await expect(page.getByTestId('contact-sent-card')).toBeVisible()
+      await expect
+        .poll(
+          () =>
+            emittedTypes(captured).includes(EVENT_TYPES.CONTACT_FORM_SUCCESS),
+          { timeout: 10000 },
+        )
+        .toBe(true)
+
+      // Assert: submit emitido antes que success
+      const types = emittedTypes(captured)
+      const submitIdx = types.indexOf(EVENT_TYPES.CONTACT_FORM_SUBMIT)
+      const successIdx = types.indexOf(EVENT_TYPES.CONTACT_FORM_SUCCESS)
+      expect(submitIdx).toBeGreaterThanOrEqual(0)
+      expect(successIdx).toBeGreaterThan(submitIdx)
+    })
+  })
+})

--- a/tests/feature/contact/contact-session-link.spec.ts
+++ b/tests/feature/contact/contact-session-link.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * @feature Enlace contacto <-> tracking via session_id (SPEC-202 AC-1/AC-2)
+ * @description Verifica que el formulario de contacto envia el `session_id`
+ *   de tracking en el body del `POST /contact`:
+ *   - Con tracking aceptado: el `session_id` del `POST /contact` es el MISMO
+ *     que el de los eventos de `/track` (misma `localStorage.cf_session`)
+ *     [AC-1].
+ *   - Con tracking rechazado (sin `cf_session`): el contacto se envia SIN la
+ *     clave `session_id` y el form igual funciona [AC-2].
+ *
+ *   El `POST /contact` se intercepta con `page.route` para inspeccionar el
+ *   body sin depender del backend AWS. El bypass de Turnstile se inyecta solo
+ *   si `TURNSTILE_BYPASS_SECRET` esta seteada; sin el, el preflight del form
+ *   exige captcha y no llega a hacer el POST, asi que esos tests se skipean.
+ */
+import { expect, type Page, subdomainUrl, test } from '../fixtures/index.js'
+
+const BYPASS_SECRET = process.env.TURNSTILE_BYPASS_SECRET ?? ''
+
+const CONTACT_ROUTE =
+  /https:\/\/[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com\/[a-z]+\/contact$/
+
+interface ContactPayload {
+  name?: string
+  email?: string
+  message?: string
+  session_id?: string
+  [key: string]: unknown
+}
+
+interface TrackPayload {
+  session_id: string
+  event_type_id: string
+  [key: string]: unknown
+}
+
+/**
+ * Deshabilita `navigator.sendBeacon` para que los eventos de `/track`
+ * caigan al path `fetch` (postData legible).
+ */
+async function disableSendBeacon(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    })
+  })
+}
+
+/**
+ * Intercepta el `POST /contact` (al API Gateway), responde 201 y captura el
+ * body en el array devuelto.
+ */
+async function captureContactPosts(page: Page): Promise<ContactPayload[]> {
+  const captured: ContactPayload[] = []
+  await page.route(CONTACT_ROUTE, async (route) => {
+    if (route.request().method() === 'POST') {
+      try {
+        captured.push(
+          JSON.parse(route.request().postData() ?? '{}') as ContactPayload,
+        )
+      } catch {
+        // payload no JSON: lo ignoramos
+      }
+    }
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        contact_id: '019e28fc-b97d-7d79-91a5-44c9b19465b4',
+        created_at: new Date().toISOString(),
+      }),
+    })
+  })
+  return captured
+}
+
+/**
+ * Intercepta los POST a `/track` y captura sus payloads.
+ */
+async function captureTrackRequests(page: Page): Promise<TrackPayload[]> {
+  const captured: TrackPayload[] = []
+  await page.route('**/track', async (route) => {
+    if (route.request().method() === 'POST') {
+      try {
+        captured.push(
+          JSON.parse(route.request().postData() ?? '{}') as TrackPayload,
+        )
+      } catch {
+        // payload no JSON: lo ignoramos
+      }
+    }
+    await route.fulfill({ status: 204, body: '' })
+  })
+  return captured
+}
+
+const MESSAGE = 'Mensaje suficientemente largo para pasar Zod cliente.'
+
+/**
+ * Rellena los campos obligatorios del form con datos validos y verifica que
+ * los valores se mantienen. En dev (Vite HMR) la primera carga del island
+ * puede recargar la pagina por la re-optimizacion de dependencias, lo que
+ * borraria los valores controlados por React; el poll re-rellena hasta que
+ * el form queda estable.
+ */
+async function fillContactForm(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        await page.locator('input[name="name"]').fill('Pablo Session')
+        await page.locator('input[name="email"]').fill('pacg1991@gmail.com')
+        await page.locator('textarea[name="message"]').fill(MESSAGE)
+        return page.locator('input[name="name"]').inputValue()
+      },
+      { timeout: 15000 },
+    )
+    .toBe('Pablo Session')
+}
+
+/**
+ * Espera a que el island este interactivo de forma estable. Sin
+ * consentimiento el island no emite `/track`: la estabilidad se verifica con
+ * `fillContactForm`, que re-rellena hasta que los valores se mantienen.
+ */
+async function waitIslandReady(page: Page): Promise<void> {
+  await expect(page.locator('input[name="name"]')).toBeVisible()
+}
+
+test.describe('Feature: enlace contacto <-> tracking por session_id (SPEC-202)', () => {
+  test.skip(
+    !BYPASS_SECRET,
+    'TURNSTILE_BYPASS_SECRET no esta seteada: el form exige captcha',
+  )
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((secret: string) => {
+      ;(
+        window as Window & { __playwrightTurnstileBypass?: string }
+      ).__playwrightTurnstileBypass = secret
+    }, BYPASS_SECRET)
+  })
+
+  test('Given tracking aceptado When envio el form Then el POST /contact lleva el mismo session_id que /track [AC-1]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const contactPosts = await captureContactPosts(page)
+    const trackPosts = await captureTrackRequests(page)
+
+    // Act: con ?cf_track=force el tracking emite eventos -> hay cf_session
+    await page.goto(`${subdomainUrl()}/contact?cf_track=force`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await waitIslandReady(page)
+    // fillContactForm re-rellena si Vite recarga el island; tras completarse,
+    // el form esta estable y el embudo ya emitio al menos un /track.
+    await fillContactForm(page)
+    await expect
+      .poll(() => trackPosts.length, { timeout: 15000 })
+      .toBeGreaterThanOrEqual(1)
+    await page.getByTestId('contact-submit').click()
+    await expect.poll(() => contactPosts.length, { timeout: 10000 }).toBe(1)
+
+    // Assert: el session_id del contacto coincide con el de los eventos
+    const trackingSessionId = trackPosts[0].session_id
+    expect(trackingSessionId.length).toBeGreaterThanOrEqual(20)
+    expect(contactPosts[0].session_id).toBe(trackingSessionId)
+  })
+
+  test('Given tracking rechazado When envio el form Then el POST /contact NO lleva session_id [AC-2]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const contactPosts = await captureContactPosts(page)
+
+    // Act: SIN ?cf_track=force y sin cf_consent -> no hay cf_session
+    await page.goto(`${subdomainUrl()}/contact`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await waitIslandReady(page)
+    // fillContactForm re-rellena si Vite recarga el island; al terminar el
+    // form esta estable. Recien entonces se limpia el storage de tracking.
+    await fillContactForm(page)
+    await page.evaluate(() => {
+      window.localStorage.removeItem('cf_session')
+      window.localStorage.removeItem('cf_consent')
+    })
+    await page.getByTestId('contact-submit').click()
+    await expect.poll(() => contactPosts.length, { timeout: 10000 }).toBe(1)
+
+    // Assert: el contacto se envia y NO incluye la clave session_id
+    expect('session_id' in contactPosts[0]).toBe(false)
+    expect(contactPosts[0].name).toBe('Pablo Session')
+  })
+})

--- a/tests/feature/smoke/cv-filters.spec.ts
+++ b/tests/feature/smoke/cv-filters.spec.ts
@@ -23,12 +23,22 @@ const APPS_WITH_FILTERS = [
 ] as const
 
 test.describe('Feature: CV filters via query params', () => {
-  // biome-ignore lint/correctness/noEmptyPattern: Playwright beforeEach requires destructuring pattern as first arg even when no fixtures used
-  test.beforeEach(({}, testInfo) => {
+  test.beforeEach(async ({ page }, testInfo) => {
     test.skip(
       testInfo.project.name !== 'desktop-chromium',
       'Spec corre solo en desktop-chromium',
     )
+    // El CookieBanner (SPEC-201) es un overlay fixed bottom z-index 9999 que
+    // aparece en la primera visita e intercepta clicks en los controles del
+    // filtro. Pre-sembrar cf_consent en localStorage evita que se muestre y
+    // mantiene estas pruebas de filtros aisladas del flujo de consentimiento.
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('cf_consent', 'rejected')
+      } catch {
+        /* private mode: el banner igual no bloquea si storage falla */
+      }
+    })
   })
 
   test.describe('AC-4: tech filter hides non-matching items', () => {

--- a/tests/feature/tracking/consent.spec.ts
+++ b/tests/feature/tracking/consent.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * @feature CookieBanner - consentimiento GDPR (SPEC-201)
+ * @description Verifica el flujo de consentimiento end-to-end:
+ *   - primera visita muestra el banner [AC-1]
+ *   - Rechazar persiste 'rejected' y NO emite POST /track [AC-2]
+ *   - Aceptar persiste 'accepted' y emite page_load [AC-3]
+ *   - segunda visita tras responder NO muestra el banner [AC-4]
+ *   - el enlace del Footer reabre el banner [AC-5]
+ *   - reabrir y rechazar tras aceptar cesa el tracking [AC-6]
+ *   - el banner es navegable con teclado (Tab alcanza ambos botones) [AC-7]
+ *
+ *   El pixel envia por navigator.sendBeacon; Playwright no expone su
+ *   postData de forma fiable, asi que se neutraliza sendBeacon con
+ *   addInitScript para que el pixel caiga al path fetch (interceptable).
+ */
+import { expect, type Page, subdomainUrl, test } from '../fixtures/index.js'
+
+/**
+ * Deshabilita navigator.sendBeacon para forzar el fallback a fetch() del
+ * pixel. fetch expone postData de forma fiable; sendBeacon (Blob) no.
+ */
+async function disableSendBeacon(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: undefined,
+    })
+  })
+}
+
+interface TrackPayload {
+  event_type_id: string
+  [key: string]: unknown
+}
+
+/**
+ * Intercepta los POST a /track, los responde 204 (sin depender del backend
+ * AWS) y acumula los payloads en el array devuelto.
+ */
+async function captureTrackRequests(page: Page): Promise<TrackPayload[]> {
+  const captured: TrackPayload[] = []
+  await page.route('**/track', async (route) => {
+    const request = route.request()
+    if (request.method() === 'POST') {
+      try {
+        captured.push(JSON.parse(request.postData() ?? '{}') as TrackPayload)
+      } catch {
+        // payload no JSON: lo ignoramos
+      }
+    }
+    await route.fulfill({ status: 204, body: '' })
+  })
+  return captured
+}
+
+const PAGE_LOAD_TYPE = '019e372b-e0a7-7154-8279-8829bcf6a08c'
+
+test.describe('Feature: CookieBanner consentimiento GDPR (SPEC-201)', () => {
+  test('Given primera visita When carga Then el banner es visible con dos botones [AC-1]', async ({
+    page,
+  }) => {
+    // Act
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+
+    // Assert
+    const banner = page.getByRole('dialog', {
+      name: 'Consentimiento de analytics',
+    })
+    await expect(banner).toBeVisible()
+    await expect(page.getByTestId('cookie-accept')).toBeVisible()
+    await expect(page.getByTestId('cookie-reject')).toBeVisible()
+  })
+
+  test('Given el banner visible When click Rechazar Then cf_consent=rejected, banner oculto y sin POST /track [AC-2]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+
+    // Act
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+    await page.getByTestId('cookie-reject').click()
+    await page.waitForTimeout(4000)
+
+    // Assert
+    const consent = await page.evaluate(() =>
+      localStorage.getItem('cf_consent'),
+    )
+    expect(consent).toBe('rejected')
+    await expect(page.getByRole('dialog')).toBeHidden()
+    expect(captured.length).toBe(0)
+  })
+
+  test('Given el banner visible When click Aceptar Then cf_consent=accepted, banner oculto y emite page_load [AC-3]', async ({
+    page,
+  }) => {
+    // Arrange
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+
+    // Act
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+    await page.getByTestId('cookie-accept').click()
+    await expect.poll(() => captured.length, { timeout: 5000 }).toBe(1)
+
+    // Assert
+    const consent = await page.evaluate(() =>
+      localStorage.getItem('cf_consent'),
+    )
+    expect(consent).toBe('accepted')
+    await expect(page.getByRole('dialog')).toBeHidden()
+    expect(captured[0].event_type_id).toBe(PAGE_LOAD_TYPE)
+  })
+
+  test('Given un usuario que ya respondio When vuelve a abrir Then el banner NO se muestra [AC-4]', async ({
+    page,
+  }) => {
+    // Arrange: primera visita + rechazar
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+    await page.getByTestId('cookie-reject').click()
+    await expect(page.getByRole('dialog')).toBeHidden()
+
+    // Act: segunda visita en la misma sesion del browser
+    await page.goto(`${subdomainUrl()}/about`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await page.waitForTimeout(1000)
+
+    // Assert
+    await expect(page.getByRole('dialog')).toBeHidden()
+  })
+
+  test('Given el enlace del Footer When lo activo Then el banner se reabre [AC-5]', async ({
+    page,
+  }) => {
+    // Arrange: aceptar para que el banner quede cerrado
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+    await page.getByTestId('cookie-accept').click()
+    await expect(page.getByRole('dialog')).toBeHidden()
+
+    // Act: activar "Gestionar consentimiento" en el Footer
+    await page.getByTestId('manage-consent').click()
+
+    // Assert: el banner reaparece
+    await expect(page.getByRole('dialog')).toBeVisible()
+  })
+
+  test('Given cf_consent=accepted When reabro y rechazo Then cf_consent=rejected y cesa el tracking [AC-6]', async ({
+    page,
+  }) => {
+    // Arrange: aceptar primero
+    await disableSendBeacon(page)
+    const captured = await captureTrackRequests(page)
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+    await page.getByTestId('cookie-accept').click()
+    await expect.poll(() => captured.length, { timeout: 5000 }).toBe(1)
+
+    // Act: reabrir desde el Footer y rechazar
+    await page.getByTestId('manage-consent').click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await page.getByTestId('cookie-reject').click()
+
+    // Assert: el consentimiento quedo revocado y un reload no emite mas
+    const consent = await page.evaluate(() =>
+      localStorage.getItem('cf_consent'),
+    )
+    expect(consent).toBe('rejected')
+    const before = captured.length
+    await page.goto(`${subdomainUrl()}/about`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await page.waitForTimeout(4000)
+    expect(captured.length).toBe(before)
+  })
+
+  test('Given el banner When navego con teclado Then Tab alcanza ambos botones con foco visible [AC-7]', async ({
+    page,
+  }) => {
+    // Act
+    await page.goto(`${subdomainUrl()}/`, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    // Assert: al abrir el foco entra al boton Aceptar
+    const accept = page.getByTestId('cookie-accept')
+    const reject = page.getByTestId('cookie-reject')
+    await expect(accept).toBeFocused()
+
+    // Tab mueve el foco al boton Rechazar
+    await page.keyboard.press('Tab')
+    await expect(reject).toBeFocused()
+
+    // Enter sobre el boton enfocado activa el rechazo
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('dialog')).toBeHidden()
+    const consent = await page.evaluate(() =>
+      localStorage.getItem('cf_consent'),
+    )
+    expect(consent).toBe('rejected')
+  })
+
+  test('Given el layout en ingles When carga /en/ Then el banner muestra textos en ingles [AC-8]', async ({
+    page,
+  }) => {
+    // Act
+    await page.goto(`${subdomainUrl()}/en/`, {
+      waitUntil: 'domcontentloaded',
+    })
+
+    // Assert
+    await expect(page.getByTestId('cookie-accept')).toHaveText('Accept')
+    await expect(page.getByTestId('cookie-reject')).toHaveText('Reject')
+  })
+})

--- a/tests/feature/tracking/track-pageload.spec.ts
+++ b/tests/feature/tracking/track-pageload.spec.ts
@@ -152,12 +152,22 @@ test.describe('Feature: TrackingPixel page_load (SPEC-102)', () => {
         window.location.href = '/about?cf_track=force'
       }
     })
-    await waitForCount(captured, 2)
 
-    // Assert: el ultimo evento es de /about, con event_id propio
-    const last = captured[captured.length - 1]
-    expect(last.page_url).toContain('/about')
-    expect(last.event_id).not.toBe(captured[0].event_id)
+    // Esperar el evento de /about. Segun el browser, entre el page_load del
+    // home y el evento de /about puede colarse un spa_navigation intermedio
+    // (ClientRouter dispara astro:after-swap antes de que location refleje la
+    // ruta nueva en WebKit). Por eso se poll-ea por el evento cuya page_url ya
+    // apunta a /about en vez de asumir un orden/conteo fijo.
+    await expect
+      .poll(() => captured.some((p) => p.page_url.includes('/about')), {
+        timeout: 10000,
+      })
+      .toBe(true)
+
+    // Assert: existe un evento de /about con event_id propio
+    const aboutEvent = captured.find((p) => p.page_url.includes('/about'))
+    expect(aboutEvent?.page_url).toContain('/about')
+    expect(aboutEvent?.event_id).not.toBe(captured[0].event_id)
   })
 
   test('Given pagina sin consentimiento y sin flag When carga Then NO se emite /track [AC-8]', async ({


### PR DESCRIPTION
## Problema

Promocion en cadena de la Fase 2 (tracking de eventos + SES) hacia el entorno de release.

## Solucion

Merge de `dev` a `stage`: 8 commits de la Fase 2 (SPEC-200/201/202/203/204 + fix de aislamiento Neon stage-aware). Sin cambios nuevos — es una promocion de entorno.

## Como probar

CI corre los quality gates. Tras el merge, deploy del backend serverless a stage:
```bash
python devtools/run.py serverless db-migrate --stage=stage
python devtools/run.py serverless deploy --stage=stage
python devtools/run.py serverless smoke --stage=stage
```

## TODO

- Rotar `/portfolio/stage/neon-url` a un branch Neon propio (hoy es copia del legacy = branch production).