### PR TITLE
fix(serverless): unifica AllowOrigin del preflight CORS a '*' en todos los stages

### DIFF
--- a/serverless/template.yaml
+++ b/serverless/template.yaml
@@ -110,22 +110,6 @@ Globals:
   # metodos (HandlerErrorCode: InvalidRequest "REST API doesn't contain any
   # methods"). El API se materializa cuando aparece el primer endpoint.
 
-# ============================================================================
-# Conditions: stage-based behavior
-# ============================================================================
-# IsDev: en dev permitimos CORS '*' en preflight para poder testear desde
-# localhost:9970-9973 (Docker stack del frontend). Prod mantiene whitelist
-# estricta. La Lambda igual valida Turnstile token, asi que '*' en preflight
-# no permite enviar form sin captcha resuelto.
-# ============================================================================
-Conditions:
-  # IsNotProd: dev y stage. Usado para el AllowOrigin del preflight CORS:
-  # ambos permiten '*' en OPTIONS porque la Lambda valida el Origin real
-  # (CORS_ALLOWED_ORIGINS) + el token Turnstile. Prod mantiene whitelist.
-  # El bypass de Turnstile NO usa una Condition CloudFormation: se gatea
-  # en codigo (turnstile.py _BYPASS_ALLOWED_STAGES = {dev, local}).
-  IsNotProd: !Not [!Equals [!Ref Stage, 'prod']]
-
 Resources:
   # ==========================================================================
   # Lambda Layer compartido: Powertools v3 + httpx + pydantic
@@ -205,15 +189,15 @@ Resources:
           "integrationLatency":"$context.integrationLatency",
           "latency":"$context.responseLatency"}
       Cors:
-        # En dev/stage permitimos '*' para el preflight OPTIONS (testear desde
-        # localhost y desde *.portfolio.{env}.the-full-stack.com). En prod
-        # mantenemos whitelist estricta (apex). La Lambda igual valida el Origin
-        # real (CORS_ALLOWED_ORIGINS) + el token Turnstile, asi que '*' en
-        # preflight no permite spammear el form sin captcha resuelto.
-        AllowOrigin: !If
-          - IsNotProd
-          - "'*'"
-          - "'https://the-full-stack.com'"
+        # AllowOrigin '*' en TODOS los stages para el preflight OPTIONS. El
+        # preflight de API Gateway no puede hacer echo dinamico del Origin
+        # (es un valor estatico), asi que un valor fijo (ej. el apex) rompe
+        # cualquier otro origin valido — incluido www.the-full-stack.com.
+        # '*' es seguro: la Lambda valida el Origin real contra
+        # CORS_ALLOWED_ORIGINS en la respuesta del POST, el form de contacto
+        # exige token Turnstile y /track esta protegido por rate-limit per-IP.
+        # El preflight '*' solo afecta a OPTIONS, no autoriza el POST.
+        AllowOrigin: "'*'"
         AllowHeaders: "'Content-Type,X-Turnstile-Token,X-Turnstile-Bypass-Secret'"
         AllowMethods: "'GET,POST,OPTIONS'"
         MaxAge: "'600'"


### PR DESCRIPTION
## Problema

El tracking pixel del frontend prod (`https://www.the-full-stack.com`) falla con error CORS al pegarle a `https://api.portfolio.the-full-stack.com/track`:

> Response to preflight request doesn't pass access control check: The 'Access-Control-Allow-Origin' header has a value 'https://the-full-stack.com' that is not equal to the supplied origin.

Causa raiz: el bloque `Cors` del `AWS::Serverless::Api` configuraba el preflight OPTIONS con `AllowOrigin` estatico — en prod, `'https://the-full-stack.com'` hardcodeado. El preflight de API Gateway no puede hacer echo dinamico del Origin, asi que cualquier origin valido distinto del apex (incluido `www.the-full-stack.com`) rompe el preflight. El env var `CORS_ALLOWED_ORIGINS` de la Lambda si incluye `www`, pero ese valor solo aplica a la respuesta del POST, no al preflight.

## Solucion

- El bloque `Cors` ahora usa `AllowOrigin: '*'` en TODOS los stages (antes `!If [IsNotProd, "'*'", "'https://the-full-stack.com'"]`).
- Eliminada la `Condition IsNotProd` (ya sin uso) y el comentario huerfano del bloque `Conditions`.
- Es seguro: la Lambda sigue validando el Origin real contra `CORS_ALLOWED_ORIGINS` en la respuesta del POST; `/contact` exige token Turnstile y `/track` esta protegido por rate-limit per-IP. El `'*'` solo afecta a OPTIONS, no autoriza el POST.

## Como probar

1. `python devtools/run.py serverless validate` — `sam validate --lint` debe pasar.
2. Tras desplegar el backend del stage afectado, hacer un preflight desde un origin con `www`:
   ```bash
   curl -i -X OPTIONS https://api.portfolio.the-full-stack.com/track \
     -H 'Origin: https://www.the-full-stack.com' \
     -H 'Access-Control-Request-Method: POST'
   ```
   La respuesta debe traer `Access-Control-Allow-Origin: *` (antes: `https://the-full-stack.com`).
3. En `https://www.the-full-stack.com`, aceptar el banner de tracking: el `POST /track` ya no debe fallar por CORS.

## TODO

- Desplegar el backend del stage de produccion (requiere credenciales con permiso de CloudFormation; las credenciales SSO de desarrollo no alcanzan).
- Cloudflare: agregar Redirect Rule `301` de `www.the-full-stack.com` -> apex `the-full-stack.com` (el apex es el dominio canonico; `www` no deberia servir contenido). Defensa en profundidad complementaria a este fix.