### PR TITLE
fix(serverless): /track responde Access-Control-Allow-Origin '*' para sendBeacon

### DIFF
--- a/serverless/src/common/cors.py
+++ b/serverless/src/common/cors.py
@@ -125,6 +125,26 @@ def resolve_origin(headers: dict[str, str] | None) -> str:
     return _DEFAULT_WHITELIST[0]
 
 
+def public_cors_origin() -> str:
+    """
+    Origin para endpoints publicos sin credenciales: siempre `'*'`.
+
+    `navigator.sendBeacon` (modo `ping`) — usado por el tracking pixel —
+    exige `Access-Control-Allow-Origin: *` literal en la respuesta. Un echo
+    del Origin (aunque este en whitelist) hace fallar la request `ping` con
+    CORS error. El endpoint `/track` es tracking anonimo: NUNCA usa cookies
+    ni `credentials: include`, asi que `'*'` es correcto y seguro.
+
+    NO usar en `/contact`: ese endpoint hace `fetch` normal y podria
+    necesitar credentials a futuro — ahi va `resolve_origin()` (echo).
+
+    Examples:
+        >>> public_cors_origin()
+        '*'
+    """
+    return '*'
+
+
 def cors_headers(origin: str) -> dict[str, str]:
     """
     Build headers CORS para una respuesta JSON.

--- a/serverless/src/tracking_pixel/handler.py
+++ b/serverless/src/tracking_pixel/handler.py
@@ -16,7 +16,7 @@ from typing import Any
 from aws_lambda_powertools.metrics import MetricUnit
 from pydantic import ValidationError as PydanticValidationError
 
-from common.cors import resolve_origin
+from common.cors import public_cors_origin
 from common.exceptions import ApplicationError, ValidationError
 from common.ip_extractor import extract_country, extract_ip
 from common.logger import logger
@@ -34,7 +34,11 @@ from tracking_pixel.service import process_tracking_event
 def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
     """Entry point Lambda tracking_pixel."""
     headers = event.get('headers') or {}
-    origin = resolve_origin(headers)
+    # /track lo invoca navigator.sendBeacon (modo `ping`), que exige
+    # Access-Control-Allow-Origin: '*' literal. Un echo del Origin hace
+    # fallar la request con CORS error. /track es tracking anonimo sin
+    # credenciales, asi que '*' es correcto (ver common.cors).
+    origin = public_cors_origin()
     ip = extract_ip(event)
     country = extract_country(event)
     user_agent = next(

--- a/serverless/tests/unit/common/test_cors.py
+++ b/serverless/tests/unit/common/test_cors.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from common.cors import cors_headers, is_allowed_origin, resolve_origin
+from common.cors import (
+    cors_headers,
+    is_allowed_origin,
+    public_cors_origin,
+    resolve_origin,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -136,6 +141,18 @@ class TestResolveOrigin:
         """Given headers vacios, When resolve, Then apex default."""
         assert resolve_origin(None) == 'https://the-full-stack.com'
         assert resolve_origin({}) == 'https://the-full-stack.com'
+
+
+class TestPublicCorsOrigin:
+    """public_cors_origin - siempre '*' para endpoints sin credenciales."""
+
+    def test_returns_wildcard(self) -> None:
+        """
+        Given un endpoint publico sin credenciales (ej. /track via sendBeacon),
+        When se invoca public_cors_origin,
+        Then retorna '*' literal (sendBeacon en modo ping lo exige).
+        """
+        assert public_cors_origin() == '*'
 
 
 class TestCorsHeaders:


### PR DESCRIPTION
## Problema

Tras el fix del preflight (#72), el tracking pixel **seguia fallando** con CORS. DevTools mostraba dos filas para `/track`: el `preflight` daba `200`, pero el request real (Type `ping`) daba `CORS error`.

Causa raiz: el tracking pixel envia `POST /track` via `navigator.sendBeacon` (Type `ping` en DevTools), no `fetch`. El modo `ping` exige que la respuesta del POST traiga `Access-Control-Allow-Origin: '*'` **literal**. El handler de `tracking_pixel` usaba `resolve_origin()`, que hace echo del Origin (`https://the-full-stack.com`) — valido para `fetch` normal, pero `sendBeacon` lo rechaza con CORS error.

## Solucion

- Nuevo helper `public_cors_origin()` en `common/cors.py`: devuelve `'*'` para endpoints publicos sin credenciales.
- El handler de `tracking_pixel` usa `public_cors_origin()` en vez de `resolve_origin()`. `/track` es tracking anonimo: NUNCA usa cookies ni `credentials: include`, asi que `'*'` es correcto y seguro.
- `/contact` mantiene `resolve_origin()` (echo): usa `fetch`, no `sendBeacon`, y podria necesitar `credentials` a futuro.
- Test `TestPublicCorsOrigin` en `test_cors.py`.

## Como probar

1. Backend: `python devtools/run.py serverless validate` — OK.
2. Tests: suite completa del backend verde (311 passed, coverage 92.6%); `cors.py` 98%, `tracking_pixel/handler.py` 92%.
3. Tras desplegar, verificar la respuesta del POST:
   ```bash
   curl -s -i -X POST https://api.portfolio.the-full-stack.com/track \
     -H 'Origin: https://the-full-stack.com' -H 'Content-Type: application/json' \
     --data '{"session_id":"...","event_id":"...","event_type_id":"...","page_url":"https://the-full-stack.com/","niche":"generic"}'
   ```
   Debe traer `access-control-allow-origin: *` (antes: echo del Origin).
4. En el sitio, aceptar el banner de tracking: el `ping` a `/track` ya no debe dar CORS error.

## TODO

- Desplegar el backend en los 3 stages tras el merge (requiere credenciales con permiso de CloudFormation).