### PR TITLE
fix(serverless): omite Vary: Origin cuando Allow-Origin es '*' (rompe sendBeacon)

### DIFF
--- a/serverless/src/common/cors.py
+++ b/serverless/src/common/cors.py
@@ -150,19 +150,25 @@ def cors_headers(origin: str) -> dict[str, str]:
     Build headers CORS para una respuesta JSON.
 
     Args:
-        origin: el origin a echo en Access-Control-Allow-Origin (debe
-                ser uno valido, no se valida aqui — se asume llamada via
-                resolve_origin()).
+        origin: el origin a echo en Access-Control-Allow-Origin. Puede ser
+                un origin concreto (echo via `resolve_origin()`) o `'*'`
+                (endpoints publicos via `public_cors_origin()`).
 
     Returns:
-        Dict con los 5 headers CORS estandar.
+        Dict con los headers CORS. `Vary: Origin` se incluye SOLO cuando el
+        origin es un echo concreto — la respuesta varia segun el Origin. Con
+        `'*'` la respuesta NO varia, y mandar `Vary: Origin` junto a `'*'`
+        es contradictorio: `navigator.sendBeacon` (modo `ping`) rechaza esa
+        combinacion con CORS error. Por eso con `'*'` se omite el `Vary`.
     """
-    return {
+    headers = {
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
         'Access-Control-Allow-Headers': (
             'Content-Type,X-Turnstile-Token,X-Turnstile-Bypass-Secret'
         ),
         'Access-Control-Max-Age': '600',
-        'Vary': 'Origin',
     }
+    if origin != '*':
+        headers['Vary'] = 'Origin'
+    return headers

--- a/serverless/tests/unit/common/test_cors.py
+++ b/serverless/tests/unit/common/test_cors.py
@@ -168,3 +168,25 @@ class TestCorsHeaders:
         assert 'X-Turnstile-Token' in headers['Access-Control-Allow-Headers']
         assert headers['Access-Control-Max-Age'] == '600'
         assert headers['Vary'] == 'Origin'
+
+    def test_concrete_origin_includes_vary_origin(self) -> None:
+        """
+        Given un origin concreto (echo),
+        When cors_headers,
+        Then incluye Vary: Origin (la respuesta varia segun el Origin).
+        """
+        headers = cors_headers('https://hub.the-full-stack.com')
+
+        assert headers['Vary'] == 'Origin'
+
+    def test_wildcard_origin_omits_vary_origin(self) -> None:
+        """
+        Given origin '*' (endpoint publico),
+        When cors_headers,
+        Then NO incluye Vary: Origin — la combinacion '*' + Vary: Origin
+        rompe navigator.sendBeacon (modo ping) con CORS error.
+        """
+        headers = cors_headers('*')
+
+        assert headers['Access-Control-Allow-Origin'] == '*'
+        assert 'Vary' not in headers


### PR DESCRIPTION
## Problema

Tras el fix #75 (`/track` responde `Access-Control-Allow-Origin: '*'`), el tracking pixel **seguia** dando `CORS error` en la request `ping`. El `curl` confirmaba `access-control-allow-origin: *`, pero el navegador lo rechazaba igual.

Causa raiz: la respuesta del POST traia `Access-Control-Allow-Origin: '*'` **junto con** `Vary: Origin`. Esa combinacion es contradictoria — `*` significa "la respuesta no varia segun el Origin", y `Vary: Origin` dice lo contrario. `navigator.sendBeacon` (modo `ping`) es estricto y rechaza la respuesta con CORS error. `fetch` la tolera; `ping` no.

`cors_headers()` agregaba `Vary: Origin` siempre, sin distinguir si el origin era un echo concreto o `*`.

## Solucion

- `cors_headers()` agrega `Vary: Origin` **solo** cuando el origin es un echo concreto (`resolve_origin`). Con `'*'` lo omite.
- `/track` (publico, `public_cors_origin` -> `'*'`) responde sin `Vary` -> `sendBeacon` ya no falla.
- `/contact` (echo via `resolve_origin`) mantiene `Vary: Origin` — ahi la respuesta si varia segun el Origin, es correcto.
- 2 tests nuevos: `Vary` presente con origin concreto, ausente con `'*'`.

## Como probar

1. Tests del backend: suite completa verde (313 passed, coverage 92.7%).
2. Tras desplegar, la respuesta de `POST /track` NO debe traer el header `Vary`:
   ```bash
   curl -s -i -X POST https://api.portfolio.the-full-stack.com/track \
     -H 'Origin: https://the-full-stack.com' -H 'Content-Type: application/json' \
     --data '{"session_id":"...","event_id":"...","event_type_id":"...","page_url":"https://the-full-stack.com/","niche":"generic"}' \
     | grep -i 'vary\|allow-origin'
   ```
   Debe mostrar `access-control-allow-origin: *` y NINGUN `vary`.
3. En el sitio, aceptar el banner: el `ping` a `/track` ya no debe dar CORS error.

## TODO

- Desplegar el backend en los 3 stages tras el merge.