### PR TITLE
chore(release): promueve stage a main — fix Vary: Origin sendBeacon

### DIFF
--- a/serverless/src/common/cors.py
+++ b/serverless/src/common/cors.py
@@ -150,19 +150,25 @@ def cors_headers(origin: str) -> dict[str, str]:
     Build headers CORS para una respuesta JSON.
 
     Args:
-        origin: el origin a echo en Access-Control-Allow-Origin (debe
-                ser uno valido, no se valida aqui — se asume llamada via
-                resolve_origin()).
+        origin: el origin a echo en Access-Control-Allow-Origin. Puede ser
+                un origin concreto (echo via `resolve_origin()`) o `'*'`
+                (endpoints publicos via `public_cors_origin()`).
 
     Returns:
-        Dict con los 5 headers CORS estandar.
+        Dict con los headers CORS. `Vary: Origin` se incluye SOLO cuando el
+        origin es un echo concreto — la respuesta varia segun el Origin. Con
+        `'*'` la respuesta NO varia, y mandar `Vary: Origin` junto a `'*'`
+        es contradictorio: `navigator.sendBeacon` (modo `ping`) rechaza esa
+        combinacion con CORS error. Por eso con `'*'` se omite el `Vary`.
     """
-    return {
+    headers = {
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
         'Access-Control-Allow-Headers': (
             'Content-Type,X-Turnstile-Token,X-Turnstile-Bypass-Secret'
         ),
         'Access-Control-Max-Age': '600',
-        'Vary': 'Origin',
     }
+    if origin != '*':
+        headers['Vary'] = 'Origin'
+    return headers

--- a/serverless/tests/unit/common/test_cors.py
+++ b/serverless/tests/unit/common/test_cors.py
@@ -168,3 +168,25 @@ class TestCorsHeaders:
         assert 'X-Turnstile-Token' in headers['Access-Control-Allow-Headers']
         assert headers['Access-Control-Max-Age'] == '600'
         assert headers['Vary'] == 'Origin'
+
+    def test_concrete_origin_includes_vary_origin(self) -> None:
+        """
+        Given un origin concreto (echo),
+        When cors_headers,
+        Then incluye Vary: Origin (la respuesta varia segun el Origin).
+        """
+        headers = cors_headers('https://hub.the-full-stack.com')
+
+        assert headers['Vary'] == 'Origin'
+
+    def test_wildcard_origin_omits_vary_origin(self) -> None:
+        """
+        Given origin '*' (endpoint publico),
+        When cors_headers,
+        Then NO incluye Vary: Origin — la combinacion '*' + Vary: Origin
+        rompe navigator.sendBeacon (modo ping) con CORS error.
+        """
+        headers = cors_headers('*')
+
+        assert headers['Access-Control-Allow-Origin'] == '*'
+        assert 'Vary' not in headers


### PR DESCRIPTION
## Problema

Promocion `stage -> main` (produccion) en cadena. `stage` incluye el fix de `Vary: Origin` para `sendBeacon` (PR #78/#79) que aun no esta en `main`.

## Solucion

Promueve a `main`:
- `fix(serverless)`: `cors_headers()` omite `Vary: Origin` cuando el `Allow-Origin` es `'*'`. La combinacion `'*'` + `Vary: Origin` rompia `navigator.sendBeacon` con CORS error.

## Como probar

Tras el merge y el deploy de produccion, verificar que `POST /track` responde `access-control-allow-origin: *` sin header `Vary`, y que el `ping` del tracking pixel ya no da CORS error en el sitio.

## TODO

- Desplegar el backend de produccion tras el merge.