### PR TITLE
fix(ui): envia el beacon de tracking como text/plain para evitar preflight CORS

### DIFF
--- a/packages/ui/src/lib/track-event.ts
+++ b/packages/ui/src/lib/track-event.ts
@@ -164,6 +164,13 @@ export function buildTrackPayload(
  *   (sigue funcionando si el usuario cierra la pestana), con fallback a
  *   `fetch` keepalive. Fire-and-forget: cualquier error se ignora.
  *
+ *   El Blob va con `type: 'text/plain'` a proposito: `text/plain` es un
+ *   Content-Type CORS-safelisted, asi que `sendBeacon` envia una request
+ *   SIMPLE (sin preflight). Con `application/json` el browser dispara
+ *   preflight y el modo `ping` de sendBeacon falla con CORS error tras el
+ *   preflight. El body sigue siendo JSON serializado; el backend `/track`
+ *   parsea con `json.loads()` sin mirar el Content-Type.
+ *
  * @returns {boolean} true si se entrego (a beacon o fetch), false si no
  */
 export function sendBeaconPayload(payload: TrackEventPayload): boolean {
@@ -172,16 +179,19 @@ export function sendBeaconPayload(payload: TrackEventPayload): boolean {
   const body = JSON.stringify(payload)
   try {
     if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
-      const blob = new Blob([body], { type: 'application/json' })
+      // text/plain evita el preflight CORS que rompe el modo `ping`.
+      const blob = new Blob([body], { type: 'text/plain' })
       return navigator.sendBeacon(url, blob)
     }
   } catch {
     // continua con el fallback fetch
   }
   try {
+    // El fallback fetch tambien usa text/plain: mismo motivo (request
+    // simple, sin preflight). El backend parsea el body como JSON.
     void fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'text/plain' },
       body,
       keepalive: true,
     }).catch(() => {

--- a/packages/ui/tests/unit/track-event.test.ts
+++ b/packages/ui/tests/unit/track-event.test.ts
@@ -202,6 +202,13 @@ describe('track-event', () => {
       expect(body.event_props).toEqual({ href: '/contact' })
     })
 
+    it('Given consent When trackEvent Then the beacon Blob is text/plain (CORS-safelisted, no preflight)', () => {
+      localStorage.setItem('cf_consent', 'accepted')
+      trackEvent(PAGE_LOAD)
+      const [, blob] = vi.mocked(navigator.sendBeacon).mock.calls[0] ?? []
+      expect((blob as Blob).type).toBe('text/plain')
+    })
+
     it('Given no consent but ?cf_track=force When trackEvent Then sends the beacon (QA bypass)', () => {
       setSearch('?cf_track=force')
       const result = trackEvent(PAGE_LOAD)


### PR DESCRIPTION
## Problema

Tras 3 fixes de CORS en el backend (#72, #75, #78), el tracking pixel **seguia** dando `CORS error` en la request `ping`. El `curl` confirmaba que el backend respondia perfecto: `access-control-allow-origin: *`, sin `Vary`, `204`. El problema estaba en el **frontend**.

`sendBeaconPayload` armaba el Blob con `type: 'application/json'`. `application/json` NO es un Content-Type CORS-safelisted: el browser dispara un preflight, y el modo `ping` de `navigator.sendBeacon` **falla con CORS error tras el preflight** — el preflight pasa `200`, pero el `ping` real es rechazado. `fetch` maneja bien el ciclo preflight->request; el modo `ping` de `sendBeacon` no.

## Solucion

- El Blob de `sendBeacon` ahora va con `type: 'text/plain'`. `text/plain` SI es CORS-safelisted: `sendBeacon` envia una **request simple**, sin preflight, y el `ping` ya no falla.
- El fallback `fetch` tambien pasa a `Content-Type: 'text/plain'` por el mismo motivo.
- El body sigue siendo JSON serializado. El backend `/track` parsea con `json.loads()` sin mirar el `Content-Type` (verificado: `POST` con `text/plain` responde `204`).
- Test nuevo: verifica que el Blob es `text/plain`.

## Como probar

1. `pnpm --filter @portfolio/ui exec vitest run` — 45 tests verdes (track-event + click-tracking + scroll-depth).
2. `pnpm --filter @portfolio/ui run typecheck` — OK.
3. Verificacion del backend (ya desplegado): `POST /track` con `Content-Type: text/plain` responde `204`.
4. Tras el deploy del frontend a Cloudflare Pages, en `https://the-full-stack.com` aceptar el banner de tracking: la request `ping` a `/track` ya no debe dar CORS error. Ahora deberia ser una request simple (sin la fila `preflight` separada).

## TODO

Vacio.