### PR TITLE
perf(serverless): reusa el resource DynamoDB entre invocaciones (cold start)

### DIFF
--- a/serverless/src/common/dynamodb_client.py
+++ b/serverless/src/common/dynamodb_client.py
@@ -2,14 +2,22 @@
 DynamoDB Resource API client.
 
 Decision (.claude/docs/aws-lambda/04-cold-start-optimization.md):
-boto3 Resource/Client en MODULE SCOPE (no en handler) reduce cold start
-~150ms en invocaciones warm. La conexion HTTPS + STS roles se reusan.
+boto3 Resource/Client SINGLETON reusado entre invocaciones reduce cold
+start ~150ms en invocaciones warm. La conexion HTTPS + STS roles se
+reusan.
+
+El resource se crea de forma LAZY (en el primer `get_table`/`get_resource`,
+no al importar el modulo). Motivo: crearlo en module scope lo ataria a las
+credenciales presentes en el import, lo que rompe `moto` en tests (el mock
+se activa DESPUES del import). Lazy + cache da el mismo beneficio en Lambda
+-el primer uso ocurre en el cold start, igual que un import- y deja que
+`moto` intercepte la creacion cuando el mock ya esta activo.
 
 Usar SIEMPRE `Resource` (mas alto nivel) para CRUD; Client crudo solo si
 no hay Resource equivalente.
 
 Uso:
-    from common.dynamodb_client import dynamodb, get_table
+    from common.dynamodb_client import get_table
 
     table = get_table('portfolio-contacts-dev')
     table.put_item(Item={...})
@@ -22,15 +30,32 @@ from typing import Any
 
 import boto3
 
-# Region desde env var AWS_REGION (default us-east-1 desde Settings).
-# NO usar boto3.Session() porque crea connection pool nuevo cada vez.
-dynamodb = boto3.resource('dynamodb', region_name=os.environ.get('AWS_REGION', 'us-east-1'))
+# Singleton cacheado. None hasta el primer get_resource().
+_dynamodb_resource: Any = None
+
+
+def get_resource() -> Any:
+    """
+    Resource DynamoDB singleton (creado lazy en el primer uso).
+
+    Se cachea a nivel de modulo: la primera llamada lo crea, las siguientes
+    reusan la misma instancia (conexion HTTPS + credenciales compartidas
+    entre invocaciones warm del mismo contenedor Lambda).
+
+    Returns:
+        boto3 DynamoDB ServiceResource.
+    """
+    global _dynamodb_resource
+    if _dynamodb_resource is None:
+        region = os.environ.get('AWS_REGION', 'us-east-1')
+        # NO usar boto3.Session(): crearia un connection pool nuevo.
+        _dynamodb_resource = boto3.resource('dynamodb', region_name=region)
+    return _dynamodb_resource
 
 
 def get_table(table_name: str) -> Any:
     """
-    Helper para obtener una Table reference. Es equivalente a
-    `dynamodb.Table(name)` pero centraliza la importacion.
+    Table reference sobre el resource singleton.
 
     Args:
         table_name: nombre fisico de la tabla DynamoDB.
@@ -38,4 +63,14 @@ def get_table(table_name: str) -> Any:
     Returns:
         boto3 DynamoDB Table reference.
     """
-    return dynamodb.Table(table_name)
+    return get_resource().Table(table_name)
+
+
+def reset_resource_cache() -> None:
+    """
+    Limpia el resource cacheado. Solo para aislamiento entre tests:
+    fuerza que el proximo `get_resource()` cree uno nuevo bajo el
+    `mock_aws()` activo del test.
+    """
+    global _dynamodb_resource
+    _dynamodb_resource = None

--- a/serverless/src/common/rate_limit/buckets.py
+++ b/serverless/src/common/rate_limit/buckets.py
@@ -27,15 +27,16 @@ import os
 import time
 from typing import Any
 
-import boto3
+from common.dynamodb_client import get_table
 
 
 def _buckets_table() -> Any:
-    region = os.environ.get('AWS_REGION', 'us-east-1')
+    # get_table reusa el resource DynamoDB module-scope (common.dynamodb_client)
+    # en vez de crear uno nuevo por llamada (~150ms cold start por invocacion).
     table_name = os.environ.get(
         'RATE_LIMIT_BUCKETS_TABLE_NAME', 'portfolio-rate-limit-buckets-dev'
     )
-    return boto3.resource('dynamodb', region_name=region).Table(table_name)
+    return get_table(table_name)
 
 
 def _window_start(now: int, window_seconds: int) -> int:

--- a/serverless/src/common/rate_limit/rules.py
+++ b/serverless/src/common/rate_limit/rules.py
@@ -21,9 +21,8 @@ import os
 import time
 from typing import Any, TypedDict
 
-import boto3
-
 from common.cache.decorator import cached
+from common.dynamodb_client import get_table
 
 
 class RateLimitRule(TypedDict, total=False):
@@ -40,12 +39,15 @@ class RateLimitRule(TypedDict, total=False):
 
 
 def _rules_table() -> Any:
-    """Lazy boto3 Resource para rate_limit_rules table."""
-    region = os.environ.get('AWS_REGION', 'us-east-1')
+    """Table reference de rate_limit_rules.
+
+    Usa get_table (resource DynamoDB module-scope, common.dynamodb_client):
+    se reusa entre invocaciones warm en vez de re-crearse por llamada.
+    """
     table_name = os.environ.get(
         'RATE_LIMIT_RULES_TABLE_NAME', 'portfolio-rate-limit-rules-dev'
     )
-    return boto3.resource('dynamodb', region_name=region).Table(table_name)
+    return get_table(table_name)
 
 
 @cached(ttl=60, stale_for=300, namespace='rate_limit', tags=['rate-limit-rules'])

--- a/serverless/src/tracking_pixel/persistence.py
+++ b/serverless/src/tracking_pixel/persistence.py
@@ -7,8 +7,7 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
-import boto3
-
+from common.dynamodb_client import get_table
 from common.ulid import new_uuidv7
 
 # 60 dias en segundos
@@ -33,9 +32,11 @@ def save_tracking_event(payload: dict[str, Any]) -> dict[str, Any]:
     created_at = datetime.now(UTC).isoformat()
     expires_at = int(time.time()) + TTL_SECONDS
 
-    region = os.environ.get('AWS_REGION', 'us-east-1')
+    # El resource DynamoDB vive en module scope (common.dynamodb_client):
+    # se reusa entre invocaciones warm del mismo contenedor Lambda en vez
+    # de re-crearse en cada save (~150ms de cold start por invocacion).
     table_name = os.environ.get('TRACKING_TABLE_NAME', 'portfolio-tracking-dev')
-    table = boto3.resource('dynamodb', region_name=region).Table(table_name)
+    table = get_table(table_name)
 
     item: dict[str, Any] = {
         'session_id': payload['session_id'],

--- a/serverless/tests/unit/common/rate_limit/conftest.py
+++ b/serverless/tests/unit/common/rate_limit/conftest.py
@@ -8,6 +8,8 @@ import boto3
 import pytest
 from moto import mock_aws
 
+from common.dynamodb_client import reset_resource_cache
+
 
 @pytest.fixture
 def rate_limit_tables() -> Generator[dict[str, str]]:
@@ -18,6 +20,8 @@ def rate_limit_tables() -> Generator[dict[str, str]]:
     - portfolio-rate-limit-buckets-test
     """
     with mock_aws():
+        # El resource DynamoDB singleton se recrea bajo este mock_aws().
+        reset_resource_cache()
         client = boto3.client('dynamodb', region_name='us-east-1')
 
         # Cache table

--- a/serverless/tests/unit/contact_form/conftest.py
+++ b/serverless/tests/unit/contact_form/conftest.py
@@ -8,6 +8,8 @@ import boto3
 import pytest
 from moto import mock_aws
 
+from common.dynamodb_client import reset_resource_cache
+
 
 @pytest.fixture
 def contact_form_aws(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
@@ -50,6 +52,8 @@ def contact_form_aws(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
     )
 
     with mock_aws():
+        # El resource DynamoDB singleton se recrea bajo este mock_aws().
+        reset_resource_cache()
         # DynamoDB tables
         ddb = boto3.client('dynamodb', region_name='us-east-1')
         ddb.create_table(

--- a/serverless/tests/unit/tracking_pixel/conftest.py
+++ b/serverless/tests/unit/tracking_pixel/conftest.py
@@ -8,6 +8,8 @@ import boto3
 import pytest
 from moto import mock_aws
 
+from common.dynamodb_client import reset_resource_cache
+
 
 @pytest.fixture
 def tracking_aws(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
@@ -22,6 +24,9 @@ def tracking_aws(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
     )
 
     with mock_aws():
+        # El resource DynamoDB singleton se recrea bajo este mock_aws():
+        # si quedo cacheado de un test anterior apuntaria a otro mock.
+        reset_resource_cache()
         ddb = boto3.client('dynamodb', region_name='us-east-1')
 
         ddb.create_table(


### PR DESCRIPTION
## Problema

`POST /track` tardaba 1-2s en produccion (visible en DevTools). El procesamiento del servidor warm es ~330ms; la latencia extra venia del **cold start**.

Causa raiz: `persistence.py`, `rate_limit/buckets.py` y `rate_limit/rules.py` creaban un `boto3.resource('dynamodb')` nuevo **dentro de la funcion**. Cada `POST /track` re-creaba **3 resources** (sesion boto3 + carga de modelos de servicio + cliente HTTP). Segun la decision documentada en `.claude/docs/aws-lambda/04-cold-start-optimization.md`, eso suma ~150ms por invocacion que se podrian reusar entre invocaciones warm del mismo contenedor.

El modulo `common/dynamodb_client.py` ya existia como la solucion (resource compartido + `get_table()`), pero estos 3 archivos no lo usaban — exactamente el anti-patron que `.claude/rules/neon-management.md` y la skill `aws-lambda-python` documentan.

## Solucion

- Los 3 archivos del path de `/track` usan `common.dynamodb_client.get_table()`, que reusa un unico resource cacheado.
- `dynamodb_client.py` pasa a **singleton lazy** (`get_resource()`): crea el resource en el primer uso, no al importar el modulo. Crearlo en module scope lo ataba a las credenciales del import y rompia `moto` en tests (el mock se activa despues del import). Lazy da el mismo beneficio en Lambda — el primer uso ocurre en el cold start, igual que un import.
- Nuevo `reset_resource_cache()` para aislamiento entre tests; las 3 fixtures con `mock_aws` (tracking / contact_form / rate_limit) lo invocan dentro del mock.
- Sin cambio funcional: misma salida, menos latencia en cold start.

## Como probar

1. Tests del backend: suite completa verde (313 passed, coverage 93.1%).
2. `ruff check` de los 7 archivos: limpio.
3. `serverless validate`: OK.
4. Tras desplegar, el primer `POST /track` tras un periodo de inactividad (cold start) deberia bajar de ~1-2s; las invocaciones warm siguen en ~300ms.

## TODO

- Desplegar el backend en los 3 stages tras el merge.