### PR TITLE
feat(devtools): agrega flag --lambda para resolver lambdas por nombre corto

### DIFF
--- a/.claude/docs/lambda-controller/06-devtools-operations.md
+++ b/.claude/docs/lambda-controller/06-devtools-operations.md
@@ -4,7 +4,8 @@
 
 Un lambda-controller se opera con el script `serverless` de devtools:
 ejecutar en local, deployar a los entornos, invocar el Lambda deployado
-y correr los tests. El comando resuelve el lambda objetivo via `--path`.
+y correr los tests. El comando resuelve el lambda objetivo via
+`--lambda=<nombre>` (o `--path=<dir>`).
 
 ## El manifiesto `lambda.yaml`
 
@@ -50,20 +51,24 @@ lambda.yaml  --(devtools sam-generate)-->  template.yaml  --(sam)-->  AWS
 Si necesitas ver el SAM que se va a usar:
 
 ```bash
-python devtools/run.py serverless sam-generate --path=<dir> --stage=dev
+python devtools/run.py serverless sam-generate --lambda=<nombre> --stage=dev
 ```
 
 ## Comandos
 
-Todos los comandos de lambda-controller requieren `--path=<dir>` (el
-directorio raiz del lambda, el que contiene `lambda.yaml`). `--module`
-es alias de `--path`.
+Todos los comandos de lambda-controller requieren apuntar al lambda.
+La forma recomendada es `--lambda=<nombre>`: el nombre corto se resuelve
+contra `serverless/src/<nombre>/` y devtools valida que la carpeta cumpla
+la estructura lambda-controller (que exista y traiga `lambda.yaml`); si
+no, lanza un error listando los lambdas validos. Como alternativa,
+`--path=<dir>` apunta a un directorio explicito en cualquier ubicacion
+(`--module` es alias de `--path`).
 
 ### Ejecutar en local
 
 ```bash
 python devtools/run.py serverless run-local \
-  --path=<dir> --event=events/create.json
+  --lambda=<nombre> --event=events/create.json
 ```
 
 Regenera el SAM y corre `sam local invoke` con el event JSON indicado.
@@ -73,9 +78,9 @@ lambda.
 ### Deployar a un entorno
 
 ```bash
-python devtools/run.py serverless deploy --path=<dir> --stage=dev
-python devtools/run.py serverless deploy --path=<dir> --stage=stage
-python devtools/run.py serverless deploy --path=<dir> --stage=prod
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=dev
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=stage
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=prod
 ```
 
 Regenera el SAM para ese stage (selecciona su bloque de env vars), corre
@@ -86,7 +91,7 @@ Regenera el SAM para ese stage (selecciona su bloque de env vars), corre
 
 ```bash
 python devtools/run.py serverless invoke-remote \
-  --path=<dir> --stage=dev --event=events/create.json
+  --lambda=<nombre> --stage=dev --event=events/create.json
 ```
 
 Invoca via `aws lambda invoke` la funcion `<name>-<stage>` ya desplegada
@@ -95,48 +100,49 @@ e imprime el payload de respuesta. Requiere AWS CLI + credenciales.
 ### Tests
 
 ```bash
-python devtools/run.py serverless test-unit --path=<dir>
-python devtools/run.py serverless test-integration --path=<dir>
+python devtools/run.py serverless test-unit --lambda=<nombre>
+python devtools/run.py serverless test-integration --lambda=<nombre>
 ```
 
 `test-unit` corre `pytest tests/unit` y `test-integration` corre
 `pytest tests/integration`, ambos con cwd en la raiz del lambda. Sin
-`--path`, estos comandos operan sobre el backend SAM del portfolio
-(modo legacy).
+`--lambda` ni `--path`, estos comandos operan sobre el backend SAM del
+portfolio (modo legacy).
 
 ## Ciclo de trabajo tipico
 
 ```bash
 # 1. Desarrollar + tests
-python devtools/run.py serverless test-unit --path=<dir>
+python devtools/run.py serverless test-unit --lambda=<nombre>
 
 # 2. Probar en local
 python devtools/run.py serverless run-local \
-  --path=<dir> --event=events/create.json
+  --lambda=<nombre> --event=events/create.json
 
 # 3. Deployar a dev y verificar
-python devtools/run.py serverless deploy --path=<dir> --stage=dev
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=dev
 python devtools/run.py serverless invoke-remote \
-  --path=<dir> --stage=dev --event=events/create.json
+  --lambda=<nombre> --stage=dev --event=events/create.json
 
 # 4. Promover a stage y prod
-python devtools/run.py serverless deploy --path=<dir> --stage=stage
-python devtools/run.py serverless deploy --path=<dir> --stage=prod
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=stage
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=prod
 ```
 
 ## Modo legacy vs lambda-controller
 
-El script `serverless` opera en dos modos segun la presencia de `--path`:
+El script `serverless` opera en dos modos segun la presencia de
+`--lambda` (o `--path`):
 
-| Sin `--path` | Con `--path=<dir>` |
-|--------------|--------------------|
-| Backend SAM del portfolio (`serverless/`) | lambda-controller en `<dir>` |
+| Sin `--lambda` ni `--path` | Con `--lambda=<nombre>` (o `--path=<dir>`) |
+|----------------------------|--------------------------------------------|
+| Backend SAM del portfolio (`serverless/`) | lambda-controller resuelto |
 | `template.yaml` escrito a mano | `template.yaml` generado de `lambda.yaml` |
 | 3 funciones fijas | cualquier lambda con `lambda.yaml` |
 
 Los comandos `sam-generate`, `run-local`, `invoke-remote` SOLO existen
-en modo lambda-controller (exigen `--path`). `deploy`, `test-unit`,
-`test-integration` funcionan en ambos modos.
+en modo lambda-controller (exigen `--lambda` o `--path`). `deploy`,
+`test-unit`, `test-integration` funcionan en ambos modos.
 
 ---
 

--- a/.claude/docs/serverless-backend/04-deploy-operacion.md
+++ b/.claude/docs/serverless-backend/04-deploy-operacion.md
@@ -73,10 +73,10 @@ El stack de infra va PRIMERO; los 4 Lambdas lo importan.
 python devtools/run.py serverless deploy-infra --stage=dev --profile=tfs-dev
 
 # 2. Los 4 stacks de Lambda (en cualquier orden entre si)
-python devtools/run.py serverless deploy --path=serverless/src/db --stage=dev --profile=tfs-dev
-python devtools/run.py serverless deploy --path=serverless/src/contact_form --stage=dev --profile=tfs-dev
-python devtools/run.py serverless deploy --path=serverless/src/tracking_pixel --stage=dev --profile=tfs-dev
-python devtools/run.py serverless deploy --path=serverless/src/stream_processor --stage=dev --profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=db --stage=dev --profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=contact_form --stage=dev --profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=tracking_pixel --stage=dev --profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=stream_processor --stage=dev --profile=tfs-dev
 
 # 3. Aplicar el schema PostgreSQL (via la Lambda db)
 python devtools/run.py serverless db-migrate --stage=dev
@@ -102,19 +102,19 @@ Lambda primero, el de infra al final.
 
 ```bash
 # Generar el SAM efimero desde lambda.yaml
-python devtools/run.py serverless sam-generate --path=serverless/src/db --stage=dev
+python devtools/run.py serverless sam-generate --lambda=db --stage=dev
 
 # Ejecutar el Lambda en local (sam local invoke, sin AWS)
 python devtools/run.py serverless run-local \
-  --path=serverless/src/db --event=events/current.json
+  --lambda=db --event=events/current.json
 
 # Invocar un Lambda ya deployado
 python devtools/run.py serverless invoke-remote \
-  --path=serverless/src/db --stage=dev --event=events/current.json --profile=tfs-dev
+  --lambda=db --stage=dev --event=events/current.json --profile=tfs-dev
 
 # Tests de un Lambda (viven dentro del Lambda)
-python devtools/run.py serverless test-unit --path=serverless/src/db
-python devtools/run.py serverless test-integration --path=serverless/src/db
+python devtools/run.py serverless test-unit --lambda=db
+python devtools/run.py serverless test-integration --lambda=db
 
 # Tests de la libreria comun shared/
 python devtools/run.py serverless test --coverage-threshold=80
@@ -125,10 +125,12 @@ python devtools/run.py serverless test --coverage-threshold=80
 `python devtools/run.py serverless <command> [flags]`. Inventario
 colorizado: `serverless help`.
 
-### Lambda (modo `lambda-controller`, `--path` requerido)
+### Lambda (modo `lambda-controller`, `--lambda` requerido)
 
-`--path=<dir>` es la raiz del Lambda (el directorio con `lambda.yaml`);
-`--module` es alias de `--path`.
+`--lambda=<nombre>` resuelve el lambda contra `serverless/src/<nombre>/`
+(forma recomendada) y valida que la carpeta cumpla la estructura
+lambda-controller. Como alternativa, `--path=<dir>` apunta a un
+directorio explicito (`--module` es alias de `--path`).
 
 | Comando | Que hace |
 |---------|----------|
@@ -187,7 +189,7 @@ colorizado: `serverless help`.
 
 > No existe ya el modo SAM monolitico: los comandos `build`, `validate`,
 > `start-api`, `logs` y `smoke` fueron eliminados. Cada Lambda es su
-> propio stack y se opera con `--path`.
+> propio stack y se opera con `--lambda=<nombre>`.
 
 ## 6. Rotar secrets
 

--- a/.claude/docs/serverless-backend/README.md
+++ b/.claude/docs/serverless-backend/README.md
@@ -21,7 +21,8 @@
   `Fn::ImportValue`. Para borrar, los Lambdas primero (CloudFormation
   bloquea borrar un export en uso).
 - **SIEMPRE** cada Lambda se opera con `python devtools/run.py serverless
-  <cmd> --path=serverless/src/<lambda>` (formato `lambda-controller`).
+  <cmd> --lambda=<nombre>` (formato `lambda-controller`); el nombre corto
+  se resuelve contra `serverless/src/<nombre>/`.
 - **SIEMPRE** el `lambda.yaml` de cada Lambda es la fuente de verdad de
   su config; el `template.yaml` SAM se genera y es efimero (`.gitignore`).
 - **SIEMPRE** Python 3.13 (managed runtime), arm64 Graviton2, Powertools v3.
@@ -38,10 +39,10 @@
 | Stack | Contenido | Operacion |
 |-------|-----------|-----------|
 | `portfolio-infra-<stage>` | API Gateway REST + 5 tablas DynamoDB + DLQ SQS | `serverless deploy-infra` |
-| `portfolio-db-<stage>` | Lambda `db` (schema Alembic, invoke directo) | `serverless deploy --path=serverless/src/db` |
-| `portfolio-contact-form-<stage>` | Lambda `contact_form` + `POST /contact` | `serverless deploy --path=serverless/src/contact_form` |
-| `portfolio-tracking-pixel-<stage>` | Lambda `tracking_pixel` + `POST /track` | `serverless deploy --path=serverless/src/tracking_pixel` |
-| `portfolio-stream-processor-<stage>` | Lambda `stream_processor` + Event Source Mappings | `serverless deploy --path=serverless/src/stream_processor` |
+| `portfolio-db-<stage>` | Lambda `db` (schema Alembic, invoke directo) | `serverless deploy --lambda=db` |
+| `portfolio-contact-form-<stage>` | Lambda `contact_form` + `POST /contact` | `serverless deploy --lambda=contact_form` |
+| `portfolio-tracking-pixel-<stage>` | Lambda `tracking_pixel` + `POST /track` | `serverless deploy --lambda=tracking_pixel` |
+| `portfolio-stream-processor-<stage>` | Lambda `stream_processor` + Event Source Mappings | `serverless deploy --lambda=stream_processor` |
 
 ## Que NO esta aqui (referencias)
 

--- a/.claude/rules/lambda-controller.md
+++ b/.claude/rules/lambda-controller.md
@@ -229,35 +229,44 @@ Receta detallada + checklist Definition of Done:
 ## Operacion con devtools
 
 El lambda-controller se opera con el script `serverless` de devtools.
-Todos los comandos requieren `--path=<dir>` (la raiz del lambda, con
-`lambda.yaml`). `--module` es alias de `--path`.
+Todos los comandos requieren apuntar al lambda con `--lambda=<nombre>`
+(forma recomendada): el nombre corto se resuelve contra
+`serverless/src/<nombre>/` y devtools valida que la carpeta cumpla la
+estructura lambda-controller (que exista y traiga `lambda.yaml`); si no,
+lanza un error listando los lambdas validos. Como alternativa,
+`--path=<dir>` (o su alias `--module=<dir>`) apunta a un directorio
+explicito en cualquier ubicacion.
 
 ```bash
 # Generar el SAM template desde lambda.yaml (efimero)
-python devtools/run.py serverless sam-generate --path=<dir> --stage=dev
+python devtools/run.py serverless sam-generate --lambda=<nombre> --stage=dev
 
 # Ejecutar en local (sam local invoke)
 python devtools/run.py serverless run-local \
-  --path=<dir> --event=events/create.json
+  --lambda=<nombre> --event=events/create.json
 
 # Deployar a un entorno (uv arma el zip en build/, luego sam deploy)
-python devtools/run.py serverless deploy --path=<dir> --stage=dev
-python devtools/run.py serverless deploy --path=<dir> --stage=stage
-python devtools/run.py serverless deploy --path=<dir> --stage=prod
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=dev
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=stage
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=prod
 
 # Invocar el Lambda ya deployado (aws lambda invoke)
 python devtools/run.py serverless invoke-remote \
-  --path=<dir> --stage=dev --event=events/create.json
+  --lambda=<nombre> --stage=dev --event=events/create.json
 
 # Tests
-python devtools/run.py serverless test-unit --path=<dir>
-python devtools/run.py serverless test-integration --path=<dir>
+python devtools/run.py serverless test-unit --lambda=<nombre>
+python devtools/run.py serverless test-integration --lambda=<nombre>
+
+# Alternativa: apuntar a un directorio explicito con --path
+python devtools/run.py serverless deploy --path=<dir> --stage=dev
 ```
 
 `lambda.yaml` es la unica fuente de verdad de la config; el
 `template.yaml` SAM se regenera desde el en cada `run-local`/`deploy`.
-Sin `--path`, los comandos `deploy`/`test-unit`/`test-integration`
-operan sobre el backend SAM del portfolio (modo legacy).
+Sin `--lambda` ni `--path`, los comandos `deploy`/`test-unit`/
+`test-integration` operan sobre el backend SAM del portfolio (modo
+legacy).
 
 Detalle completo:
 [.claude/docs/lambda-controller/06-devtools-operations.md](../docs/lambda-controller/06-devtools-operations.md).
@@ -271,7 +280,7 @@ pytest tests/unit                        # suite unitaria verde
 pytest tests/unit --cov=core --cov-report=term-missing
 
 # o via devtools (resuelve cwd + deps con uv):
-python devtools/run.py serverless test-unit --path=<dir>
+python devtools/run.py serverless test-unit --lambda=<nombre>
 ```
 
 ## Anti-patrones

--- a/devtools/serverless/flags.py
+++ b/devtools/serverless/flags.py
@@ -78,8 +78,9 @@ VALID_COMMANDS = [
 ALLOWED_FLAGS = [
     # Stage
     'stage',
-    # lambda-controller: --path=<dir> del lambda (dir con lambda.yaml)
-    'path',
+    # lambda-controller: como apuntar al lambda objetivo
+    'lambda',  # --lambda=<nombre> resuelto contra serverless/src/* (recomendado)
+    'path',  # --path=<dir> del lambda (dir con lambda.yaml, cualquier ubicacion)
     'module',  # alias de --path
     # Deploy
     'guided',  # sam deploy --guided
@@ -135,8 +136,8 @@ DESTRUCTIVE_COMMANDS = frozenset(
 )
 
 
-# Comandos del modo lambda-controller: requieren --path=<dir> (la raiz
-# del lambda, con lambda.yaml).
+# Comandos del modo lambda-controller: requieren apuntar a un lambda con
+# --lambda=<nombre> (resuelto contra serverless/src/*) o --path=<dir>.
 PATH_REQUIRED_COMMANDS = frozenset(
     {
         'sam-generate',
@@ -169,12 +170,12 @@ _COMMAND_SUMMARIES: dict[str, str] = {
     'typecheck': 'mypy strict sobre shared/ y src/',
     'test': 'pytest tests/ (cubre la libreria comun shared/)',
     'test-coverage': 'pytest --cov + HTML report (threshold 80%)',
-    'sam-generate': 'Genera template.yaml SAM desde lambda.yaml (--path)',
-    'run-local': 'sam local invoke de un lambda (--path)',
-    'deploy': 'sam build + sam deploy del lambda a un stage (--path)',
-    'invoke-remote': 'aws lambda invoke contra un stage deployado (--path)',
-    'test-unit': 'pytest <lambda>/tests/unit (--path)',
-    'test-integration': 'pytest <lambda>/tests/integration (--path)',
+    'sam-generate': 'Genera template.yaml SAM desde lambda.yaml (--lambda)',
+    'run-local': 'sam local invoke de un lambda (--lambda)',
+    'deploy': 'Empaqueta con uv + sam deploy del lambda a un stage (--lambda)',
+    'invoke-remote': 'aws lambda invoke contra un stage deployado (--lambda)',
+    'test-unit': 'pytest <lambda>/tests/unit (--lambda)',
+    'test-integration': 'pytest <lambda>/tests/integration (--lambda)',
     'deploy-infra': 'Deploya el stack de infra compartida (idempotente)',
     'setup-ssm': 'Crear SSM Parameters con KMS (turnstile, neon-url)',
     'rotate-secret': 'Rotar valor de un SSM Parameter (DESTRUCTIVO)',
@@ -205,12 +206,20 @@ _COMMAND_FLAGS: dict[str, list[str]] = {
     'typecheck': ['module_path'],
     'test': ['verbose', 'coverage_threshold'],
     'test-coverage': ['coverage_threshold'],
-    'sam-generate': ['path', 'module', 'stage'],
-    'run-local': ['path', 'module', 'stage', 'event', 'debug'],
-    'deploy': ['path', 'module', 'stage', 'guided', 'profile', 'dry_run'],
-    'invoke-remote': ['path', 'module', 'stage', 'event', 'profile'],
-    'test-unit': ['path', 'module', 'verbose'],
-    'test-integration': ['path', 'module', 'verbose'],
+    'sam-generate': ['lambda', 'path', 'module', 'stage'],
+    'run-local': ['lambda', 'path', 'module', 'stage', 'event', 'debug'],
+    'deploy': [
+        'lambda',
+        'path',
+        'module',
+        'stage',
+        'guided',
+        'profile',
+        'dry_run',
+    ],
+    'invoke-remote': ['lambda', 'path', 'module', 'stage', 'event', 'profile'],
+    'test-unit': ['lambda', 'path', 'module', 'verbose'],
+    'test-integration': ['lambda', 'path', 'module', 'verbose'],
     'deploy-infra': ['stage', 'profile', 'dry_run'],
     'setup-ssm': ['stage', 'name', 'value', 'key_id'],
     'rotate-secret': ['stage', 'name', 'value', 'confirm'],
@@ -326,11 +335,14 @@ def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
         )
 
     if command in PATH_REQUIRED_COMMANDS and not (
-        flags_dict.get('path') or flags_dict.get('module')
+        flags_dict.get('lambda')
+        or flags_dict.get('path')
+        or flags_dict.get('module')
     ):
         raise ValueError(
             f'{command!r} opera sobre un lambda-controller: requiere '
-            f'--path=<dir> (directorio con lambda.yaml).',
+            f'--lambda=<nombre> (resuelto contra serverless/src/*) '
+            f'o --path=<dir> (directorio con lambda.yaml).',
         )
 
     validate_allowed_flags(flags_dict, ALLOWED_FLAGS)
@@ -346,7 +358,7 @@ def describe() -> ScriptDescribe:
         'kind': 'subcommand',
         'summary': (
             'Backend serverless del portfolio: 5 stacks (infra + 4 Lambdas '
-            'lambda-controller). Cada Lambda se opera con --path=<dir>'
+            'lambda-controller). Cada Lambda se opera con --lambda=<nombre>'
         ),
         'commands': [
             {
@@ -365,11 +377,19 @@ def describe() -> ScriptDescribe:
                 'default': 'local',
                 'summary': 'Stage objetivo (local|dev|prod)',
             },
+            'lambda': {
+                'type': 'string',
+                'summary': (
+                    'Nombre corto de un lambda, resuelto contra '
+                    'serverless/src/<nombre>/. Forma recomendada de '
+                    'apuntar a un lambda-controller'
+                ),
+            },
             'path': {
                 'type': 'string',
                 'summary': (
-                    'Directorio de un lambda (dir con lambda.yaml). '
-                    'Requerido por los comandos del modo lambda-controller'
+                    'Directorio de un lambda (dir con lambda.yaml), '
+                    'cualquier ubicacion. Alternativa a --lambda'
                 ),
             },
             'event': {

--- a/devtools/serverless/resolve.py
+++ b/devtools/serverless/resolve.py
@@ -23,6 +23,10 @@ from typing import Any
 # Path al backend SAM del portfolio (modo legacy).
 _PORTFOLIO_SERVERLESS_DIR = Path(__file__).resolve().parents[2] / 'serverless'
 
+# Directorio donde viven los lambda-controller del portfolio. El flag
+# `--lambda=<nombre>` resuelve un nombre corto contra `serverless/src/*`.
+_PORTFOLIO_LAMBDAS_DIR = _PORTFOLIO_SERVERLESS_DIR / 'src'
+
 # Campos obligatorios del manifiesto lambda.yaml.
 _REQUIRED_FIELDS = ('name', 'runtime', 'handler')
 
@@ -121,17 +125,82 @@ def _read_manifest(manifest_path: Path) -> dict[str, Any]:
     return manifest
 
 
+def available_lambdas() -> list[str]:
+    """Lista los nombres cortos de lambdas validos en `serverless/src/*`.
+
+    Un lambda valido es un subdirectorio de `serverless/src/` que trae un
+    `lambda.yaml`. Sirve para los mensajes de error de `--lambda`.
+    """
+    if not _PORTFOLIO_LAMBDAS_DIR.is_dir():
+        return []
+    return sorted(
+        child.name
+        for child in _PORTFOLIO_LAMBDAS_DIR.iterdir()
+        if child.is_dir() and (child / 'lambda.yaml').is_file()
+    )
+
+
+def _resolve_lambda_dir(name: str) -> Path:
+    """Resuelve un nombre corto de lambda a su directorio en `src/`.
+
+    `--lambda=contact_form` -> `serverless/src/contact_form/`. Valida que
+    la carpeta exista Y que cumpla la estructura lambda-controller (tenga
+    `lambda.yaml`); si no, lanza un error que advierte que no cumple lo
+    necesario y lista los lambdas validos.
+
+    Parameters
+    ----------
+    name : str
+        Nombre corto del lambda (subdirectorio de `serverless/src/`).
+
+    Returns
+    -------
+    Path
+        Directorio raiz del lambda.
+
+    Raises
+    ------
+    ManifestError
+        Si el directorio no existe o no es un lambda-controller valido.
+    """
+    candidate = _PORTFOLIO_LAMBDAS_DIR / name
+    valid = available_lambdas()
+
+    if not candidate.is_dir():
+        listed = ', '.join(valid) if valid else '(ninguno)'
+        raise ManifestError(
+            f'No existe el lambda {name!r} en {_PORTFOLIO_LAMBDAS_DIR}. '
+            f'Lambdas validos: {listed}.',
+        )
+
+    if not (candidate / 'lambda.yaml').is_file():
+        raise ManifestError(
+            f'El directorio {candidate} existe pero NO cumple la '
+            f'estructura lambda-controller: falta lambda.yaml. '
+            f'Un lambda valido debe traer su manifiesto lambda.yaml.',
+        )
+
+    return candidate
+
+
 def resolve_lambda(flags: dict[str, Any]) -> ResolvedLambda:
     """Resuelve el lambda objetivo a partir de los flags.
 
-    Si `--path` o `--module` esta presente, busca `lambda.yaml` en ese
-    directorio (modo lambda-controller). Sin esos flags, devuelve el
-    backend SAM del portfolio (modo legacy).
+    Tres formas de apuntar a un lambda-controller, en orden de
+    precedencia:
+
+      - `--lambda=<nombre>`: nombre corto resuelto contra
+        `serverless/src/<nombre>/` (forma recomendada).
+      - `--path=<dir>` / `--module=<dir>`: directorio explicito del
+        lambda (cualquier ubicacion, no solo `serverless/src/`).
+
+    Sin ninguno de esos flags, devuelve el backend SAM del portfolio
+    (modo legacy).
 
     Parameters
     ----------
     flags : dict[str, Any]
-        Flags ya parseados; se leen `path` y `module`.
+        Flags ya parseados; se leen `lambda`, `path` y `module`.
 
     Returns
     -------
@@ -141,19 +210,22 @@ def resolve_lambda(flags: dict[str, Any]) -> ResolvedLambda:
     Raises
     ------
     ManifestError
-        Si el path no existe o el manifiesto es invalido.
+        Si el lambda no existe, no cumple la estructura, o el manifiesto
+        es invalido.
     """
-    target = flags.get('path') or flags.get('module')
-
-    if not target:
-        return ResolvedLambda(
-            mode='legacy',
-            root=_PORTFOLIO_SERVERLESS_DIR,
-        )
-
-    root = Path(target).expanduser().resolve()
-    if not root.is_dir():
-        raise ManifestError(f'El path del lambda no existe: {root}')
+    lambda_name = flags.get('lambda')
+    if lambda_name:
+        root = _resolve_lambda_dir(str(lambda_name))
+    else:
+        target = flags.get('path') or flags.get('module')
+        if not target:
+            return ResolvedLambda(
+                mode='legacy',
+                root=_PORTFOLIO_SERVERLESS_DIR,
+            )
+        root = Path(target).expanduser().resolve()
+        if not root.is_dir():
+            raise ManifestError(f'El path del lambda no existe: {root}')
 
     manifest_path = root / 'lambda.yaml'
     if not manifest_path.is_file():

--- a/devtools/tests/unit/src/serverless/flags.py
+++ b/devtools/tests/unit/src/serverless/flags.py
@@ -88,6 +88,22 @@ class TestPathRequired:
 
         assert result['command'] == 'run-local'
 
+    def test_lambda_flag_satisfies_path_requirement(self, monkeypatch):
+        _argv(monkeypatch, 'deploy', '--stage=dev')
+        from serverless.flags import flag
+
+        result = flag({'lambda': 'contact_form'})
+
+        assert result['command'] == 'deploy'
+        assert result['lambda'] == 'contact_form'
+
+    def test_error_message_mentions_lambda_flag(self, monkeypatch):
+        _argv(monkeypatch, 'deploy', '--stage=dev')
+        from serverless.flags import flag
+
+        with pytest.raises(ValueError, match='--lambda'):
+            flag({})
+
 
 class TestDeployRequiresPath:
     """deploy y test-unit operan un Lambda: exigen --path (no hay legacy)."""

--- a/devtools/tests/unit/src/serverless/resolve.py
+++ b/devtools/tests/unit/src/serverless/resolve.py
@@ -67,6 +67,58 @@ class TestResolveMode:
         assert resolved.is_lambda_controller is True
 
 
+class TestResolveByLambdaName:
+    """resolve_lambda con --lambda resuelve un nombre corto contra src/."""
+
+    def test_lambda_name_resolves_to_src_directory(self):
+        from serverless.resolve import resolve_lambda
+
+        resolved = resolve_lambda({'lambda': 'contact_form'})
+
+        assert resolved.mode == 'lambda-controller'
+        assert resolved.root.name == 'contact_form'
+
+    def test_lambda_name_reads_the_manifest(self):
+        from serverless.resolve import resolve_lambda
+
+        resolved = resolve_lambda({'lambda': 'db'})
+
+        assert resolved.manifest['name'] == 'db'
+
+    def test_unknown_lambda_name_raises_listing_valid_ones(self):
+        from serverless.resolve import ManifestError
+        from serverless.resolve import resolve_lambda
+
+        with pytest.raises(ManifestError, match='No existe el lambda'):
+            resolve_lambda({'lambda': 'nonexistent-lambda'})
+
+    def test_directory_without_manifest_raises_structure_error(
+        self, monkeypatch, tmp_path
+    ):
+        from serverless import resolve
+
+        # Apunta el resolver a un src/ de prueba con una carpeta que NO
+        # cumple la estructura lambda-controller (sin lambda.yaml).
+        fake_src = tmp_path / 'src'
+        (fake_src / 'broken').mkdir(parents=True)
+        monkeypatch.setattr(resolve, '_PORTFOLIO_LAMBDAS_DIR', fake_src)
+
+        with pytest.raises(resolve.ManifestError, match='NO cumple'):
+            resolve.resolve_lambda({'lambda': 'broken'})
+
+    def test_available_lambdas_lists_real_lambdas(self):
+        from serverless.resolve import available_lambdas
+
+        names = available_lambdas()
+
+        assert names == [
+            'contact_form',
+            'db',
+            'stream_processor',
+            'tracking_pixel',
+        ]
+
+
 class TestManifestValidation:
     """_read_manifest valida campos obligatorios, runtime y defaults."""
 


### PR DESCRIPTION
## Problema

Para operar un Lambda del backend serverless con el script `serverless` de
devtools habia que pasar el path completo del directorio:

```bash
python devtools/run.py serverless deploy --path=serverless/src/contact_form --stage=dev
```

Es verboso, repetitivo y propenso a error de tipeo en el path.

## Solucion

Se agrega el flag `--lambda=<nombre>` que resuelve el nombre corto contra
`serverless/src/<nombre>/`:

```bash
python devtools/run.py serverless deploy --lambda=contact_form --stage=dev
```

- `--lambda` valida que la carpeta exista Y cumpla la estructura
  lambda-controller (que traiga `lambda.yaml`); si no, lanza un error que
  lista los lambdas validos.
- `--path=<dir>` y `--module=<dir>` se mantienen como alternativa para
  apuntar a un directorio explicito en cualquier ubicacion.
- Aplica a los 6 comandos del modo lambda-controller: `sam-generate`,
  `run-local`, `deploy`, `invoke-remote`, `test-unit`, `test-integration`.
- `resolve.py` gana `available_lambdas()` y `_resolve_lambda_dir()`.

## Como probar

```bash
# Resuelve por nombre corto (dry-run, no toca AWS)
python devtools/run.py serverless deploy --lambda=contact_form --stage=dev --dry-run

# Error claro si el lambda no existe
python devtools/run.py serverless deploy --lambda=noexiste --stage=dev

# Tests del resolver y los flags
python devtools/run.py test_runner --module=devtools --type=unit
```

## TODO

- `RET504` de ruff preexistente en `devtools/serverless/flags.py` (patron
  `flags_dict = ...; return flags_dict`) — deuda anterior, fuera del scope
  de este PR.