### PR TITLE
feat(devtools): agrega flag --aws-profile al script serverless

### DIFF
--- a/.claude/docs/lambda-controller/06-devtools-operations.md
+++ b/.claude/docs/lambda-controller/06-devtools-operations.md
@@ -78,9 +78,9 @@ lambda.
 ### Deployar a un entorno
 
 ```bash
-python devtools/run.py serverless deploy --lambda=<nombre> --stage=dev
-python devtools/run.py serverless deploy --lambda=<nombre> --stage=stage
-python devtools/run.py serverless deploy --lambda=<nombre> --stage=prod
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=dev --aws-profile=<perfil>
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=stage --aws-profile=<perfil>
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=prod --aws-profile=<perfil>
 ```
 
 Regenera el SAM para ese stage (selecciona su bloque de env vars), corre
@@ -91,11 +91,22 @@ Regenera el SAM para ese stage (selecciona su bloque de env vars), corre
 
 ```bash
 python devtools/run.py serverless invoke-remote \
-  --lambda=<nombre> --stage=dev --event=events/create.json
+  --lambda=<nombre> --stage=dev --event=events/create.json --aws-profile=<perfil>
 ```
 
 Invoca via `aws lambda invoke` la funcion `<name>-<stage>` ya desplegada
 e imprime el payload de respuesta. Requiere AWS CLI + credenciales.
+
+### Flag `--aws-profile` (perfil AWS CLI)
+
+`deploy` e `invoke-remote` ejecutan `aws`/`sam` por debajo. Sin
+`--aws-profile`, usan el perfil del shell (`AWS_PROFILE` o `[default]`),
+que puede apuntar a OTRA cuenta AWS o tener el token SSO expirado —
+sintoma: `Error when retrieving token from sso` aunque hayas hecho
+`aws sso login`. Pasar SIEMPRE `--aws-profile=<perfil>` para fijar el
+perfil correcto en los comandos `aws`/`sam`. Alternativa:
+`export AWS_PROFILE=<perfil>` en la sesion de trabajo. El nombre del
+perfil es especifico del backend (en el portfolio: `tfs-dev`).
 
 ### Tests
 

--- a/.claude/docs/serverless-backend/04-deploy-operacion.md
+++ b/.claude/docs/serverless-backend/04-deploy-operacion.md
@@ -27,11 +27,28 @@ python devtools/run.py serverless init    # uv sync + verifica sam + aws CLI
 
 ### 2.1. Profile SSO
 
+El backend del portfolio vive en la cuenta AWS `637423614564`, accesible
+con el perfil `tfs-dev` (SSO start URL `https://tfs-tech.awsapps.com/start`,
+role `AdministratorAccess`).
+
 ```bash
 aws configure sso
 # SSO start URL, region us-east-1, role AdministratorAccess, profile tfs-dev
 aws sts get-caller-identity --profile tfs-dev
 ```
+
+> **CRITICO — el perfil AWS de los comandos `serverless`.** Los comandos
+> `deploy`, `deploy-infra` e `invoke-remote` ejecutan `aws`/`sam` por
+> debajo. Por defecto usan el perfil del shell (`AWS_PROFILE` o
+> `[default]`), que puede apuntar a OTRA cuenta (ej. un perfil de otro
+> proyecto) o tener el token SSO expirado. Por eso estos comandos aceptan
+> `--aws-profile=tfs-dev`: inyecta `--profile tfs-dev` en los comandos
+> `aws`/`sam` y garantiza que se opera sobre la cuenta del portfolio.
+>
+> SIEMPRE pasar `--aws-profile=tfs-dev` (o `export AWS_PROFILE=tfs-dev`
+> en la sesion de trabajo del portfolio). Sin esto, un
+> `aws sso login --profile tfs-dev` refresca el perfil equivocado y el
+> comando sigue fallando con `Error when retrieving token from sso`.
 
 ### 2.2. KMS key para los SSM SecureString
 
@@ -70,13 +87,13 @@ El stack de infra va PRIMERO; los 4 Lambdas lo importan.
 
 ```bash
 # 1. Stack de infra (idempotente: CREATE si no existe, UPDATE si existe)
-python devtools/run.py serverless deploy-infra --stage=dev --profile=tfs-dev
+python devtools/run.py serverless deploy-infra --stage=dev --aws-profile=tfs-dev
 
 # 2. Los 4 stacks de Lambda (en cualquier orden entre si)
-python devtools/run.py serverless deploy --lambda=db --stage=dev --profile=tfs-dev
-python devtools/run.py serverless deploy --lambda=contact_form --stage=dev --profile=tfs-dev
-python devtools/run.py serverless deploy --lambda=tracking_pixel --stage=dev --profile=tfs-dev
-python devtools/run.py serverless deploy --lambda=stream_processor --stage=dev --profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=db --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=contact_form --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=tracking_pixel --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=stream_processor --stage=dev --aws-profile=tfs-dev
 
 # 3. Aplicar el schema PostgreSQL (via la Lambda db)
 python devtools/run.py serverless db-migrate --stage=dev
@@ -110,7 +127,7 @@ python devtools/run.py serverless run-local \
 
 # Invocar un Lambda ya deployado
 python devtools/run.py serverless invoke-remote \
-  --lambda=db --stage=dev --event=events/current.json --profile=tfs-dev
+  --lambda=db --stage=dev --event=events/current.json --aws-profile=tfs-dev
 
 # Tests de un Lambda (viven dentro del Lambda)
 python devtools/run.py serverless test-unit --lambda=db
@@ -141,11 +158,15 @@ directorio explicito (`--module` es alias de `--path`).
 | `test-unit` | `pytest <lambda>/tests/unit` |
 | `test-integration` | `pytest <lambda>/tests/integration` |
 
+`deploy` e `invoke-remote` aceptan `--aws-profile=<perfil>` para fijar el
+perfil AWS CLI de los comandos `aws`/`sam`. Usar SIEMPRE
+`--aws-profile=tfs-dev` (ver seccion 2.1).
+
 ### Infra
 
 | Comando | Que hace |
 |---------|----------|
-| `deploy-infra` | Deploya `portfolio-infra-<stage>` (idempotente) |
+| `deploy-infra` | Deploya `portfolio-infra-<stage>` (idempotente). Acepta `--aws-profile=tfs-dev` |
 
 ### Setup / mantenimiento / calidad
 
@@ -221,7 +242,8 @@ python devtools/run.py serverless rotate-secret \
 
 | Sintoma | Causa probable | Solucion |
 |---------|----------------|----------|
-| `UnauthorizedOperation` en el deploy | Token SSO expirado | `aws sso login --profile tfs-dev` |
+| `Error when retrieving token from sso` aunque hiciste `aws sso login` | El comando usa el perfil del shell (`AWS_PROFILE`/`[default]`), no `tfs-dev` — refrescaste el perfil equivocado | Pasar `--aws-profile=tfs-dev` al comando `serverless` (o `export AWS_PROFILE=tfs-dev`). Ver seccion 2.1 |
+| `UnauthorizedOperation` en el deploy | Token SSO de `tfs-dev` expirado | `aws sso login --profile tfs-dev` + `--aws-profile=tfs-dev` |
 | `Export ... cannot be deleted` | Se intenta borrar infra antes que los Lambdas | Borrar los 4 stacks de Lambda primero |
 | `No export named portfolio-infra-...` al deployar un Lambda | El stack de infra no esta deployado en ese stage | `deploy-infra --stage=<stage>` primero |
 | Stack en `ROLLBACK_COMPLETE` | Recurso no creado en un deploy previo | `aws cloudformation delete-stack` + re-deploy |

--- a/.claude/rules/lambda-controller.md
+++ b/.claude/rules/lambda-controller.md
@@ -246,20 +246,20 @@ python devtools/run.py serverless run-local \
   --lambda=<nombre> --event=events/create.json
 
 # Deployar a un entorno (uv arma el zip en build/, luego sam deploy)
-python devtools/run.py serverless deploy --lambda=<nombre> --stage=dev
-python devtools/run.py serverless deploy --lambda=<nombre> --stage=stage
-python devtools/run.py serverless deploy --lambda=<nombre> --stage=prod
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=dev --aws-profile=<perfil>
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=stage --aws-profile=<perfil>
+python devtools/run.py serverless deploy --lambda=<nombre> --stage=prod --aws-profile=<perfil>
 
 # Invocar el Lambda ya deployado (aws lambda invoke)
 python devtools/run.py serverless invoke-remote \
-  --lambda=<nombre> --stage=dev --event=events/create.json
+  --lambda=<nombre> --stage=dev --event=events/create.json --aws-profile=<perfil>
 
 # Tests
 python devtools/run.py serverless test-unit --lambda=<nombre>
 python devtools/run.py serverless test-integration --lambda=<nombre>
 
 # Alternativa: apuntar a un directorio explicito con --path
-python devtools/run.py serverless deploy --path=<dir> --stage=dev
+python devtools/run.py serverless deploy --path=<dir> --stage=dev --aws-profile=<perfil>
 ```
 
 `lambda.yaml` es la unica fuente de verdad de la config; el
@@ -267,6 +267,14 @@ python devtools/run.py serverless deploy --path=<dir> --stage=dev
 Sin `--lambda` ni `--path`, los comandos `deploy`/`test-unit`/
 `test-integration` operan sobre el backend SAM del portfolio (modo
 legacy).
+
+**`--aws-profile` (perfil AWS CLI)**: `deploy`, `deploy-infra` e
+`invoke-remote` ejecutan `aws`/`sam` por debajo. Sin `--aws-profile`
+usan el perfil del shell (`AWS_PROFILE` o `[default]`), que puede
+apuntar a otra cuenta AWS o tener el token SSO expirado — sintoma:
+`Error when retrieving token from sso` aun despues de `aws sso login`.
+SIEMPRE pasar `--aws-profile=<perfil>` (en el portfolio: `tfs-dev`) o
+`export AWS_PROFILE=<perfil>` en la sesion de trabajo.
 
 Detalle completo:
 [.claude/docs/lambda-controller/06-devtools-operations.md](../docs/lambda-controller/06-devtools-operations.md).

--- a/.claude/rules/serverless-secrets.md
+++ b/.claude/rules/serverless-secrets.md
@@ -178,6 +178,16 @@ Las credenciales que devtools usa para `sam deploy` NO viven en AWS:
   borrar la antigua tras 24h sin uso.
 - Alternativa SSO para uso manual: `aws sso login --profile tfs-dev`.
 
+> **Perfil AWS de los comandos `serverless`.** El backend del portfolio vive
+> en la cuenta `637423614564`, accesible con el perfil `tfs-dev`. Los
+> comandos `deploy`, `deploy-infra` e `invoke-remote` del script
+> `serverless` aceptan `--aws-profile=tfs-dev` para fijar ese perfil en los
+> comandos `aws`/`sam` que ejecutan. Sin el flag usan el perfil del shell
+> (`AWS_PROFILE`/`[default]`), que puede apuntar a otra cuenta o tener el
+> token SSO expirado — sintoma: `Error when retrieving token from sso` aun
+> tras `aws sso login`. SIEMPRE pasar `--aws-profile=tfs-dev` o
+> `export AWS_PROFILE=tfs-dev` en la sesion de trabajo del portfolio.
+
 `CLOUDFLARE_API_TOKEN` no se necesita en runtime de las Lambdas; solo lo usa
 devtools en local.
 

--- a/.claude/skills/lambda-controller/SKILL.md
+++ b/.claude/skills/lambda-controller/SKILL.md
@@ -176,11 +176,11 @@ python devtools/run.py serverless run-local \
   --path=<dir> --event=events/create.json
 
 # Deployar a un entorno (sam build + sam deploy)
-python devtools/run.py serverless deploy --path=<dir> --stage=dev
+python devtools/run.py serverless deploy --path=<dir> --stage=dev --aws-profile=<perfil>
 
 # Invocar el Lambda ya deployado (aws lambda invoke)
 python devtools/run.py serverless invoke-remote \
-  --path=<dir> --stage=dev --event=events/create.json
+  --path=<dir> --stage=dev --event=events/create.json --aws-profile=<perfil>
 
 # Tests
 python devtools/run.py serverless test-unit --path=<dir>
@@ -191,6 +191,14 @@ python devtools/run.py serverless test-integration --path=<dir>
 commitear el `template.yaml` generado: se cambia `lambda.yaml` y se
 regenera. Detalle:
 `.claude/docs/lambda-controller/06-devtools-operations.md`.
+
+**`--aws-profile`**: `deploy`, `deploy-infra` e `invoke-remote` ejecutan
+`aws`/`sam` por debajo. Sin `--aws-profile` usan el perfil del shell
+(`AWS_PROFILE` o `[default]`), que puede apuntar a otra cuenta AWS o
+tener el token SSO expirado — sintoma: `Error when retrieving token
+from sso` aun despues de `aws sso login`. SIEMPRE pasar
+`--aws-profile=<perfil>` (en el portfolio: `tfs-dev`) o
+`export AWS_PROFILE=<perfil>` en la sesion de trabajo.
 
 ## Verificacion (antes de declarar listo)
 

--- a/devtools/serverless/flags.py
+++ b/devtools/serverless/flags.py
@@ -118,7 +118,7 @@ ALLOWED_FLAGS = [
     # Cross-cutting
     'output',  # json|text
     'since',  # --since=10m|1h|24h (ventana de metrics / rate-limit stats)
-    'profile',  # --profile=tfs-dev (perfil AWS CLI)
+    'aws_profile',  # --aws-profile=tfs-dev (perfil AWS CLI)
     # Internal
     'command',
     'subcommands',
@@ -214,13 +214,20 @@ _COMMAND_FLAGS: dict[str, list[str]] = {
         'module',
         'stage',
         'guided',
-        'profile',
+        'aws_profile',
         'dry_run',
     ],
-    'invoke-remote': ['lambda', 'path', 'module', 'stage', 'event', 'profile'],
+    'invoke-remote': [
+        'lambda',
+        'path',
+        'module',
+        'stage',
+        'event',
+        'aws_profile',
+    ],
     'test-unit': ['lambda', 'path', 'module', 'verbose'],
     'test-integration': ['lambda', 'path', 'module', 'verbose'],
-    'deploy-infra': ['stage', 'profile', 'dry_run'],
+    'deploy-infra': ['stage', 'aws_profile', 'dry_run'],
     'setup-ssm': ['stage', 'name', 'value', 'key_id'],
     'rotate-secret': ['stage', 'name', 'value', 'confirm'],
     'verify-ses-dns': [],
@@ -396,9 +403,13 @@ def describe() -> ScriptDescribe:
                 'type': 'string',
                 'summary': 'Path a event JSON (events/<X>.json)',
             },
-            'profile': {
+            'aws_profile': {
                 'type': 'string',
-                'summary': 'Perfil AWS CLI (ej. tfs-dev)',
+                'summary': (
+                    'Perfil AWS CLI a inyectar en los comandos aws/sam '
+                    '(ej. --aws-profile=tfs-dev). Si se omite, se usa el '
+                    'perfil por defecto (AWS_PROFILE o [default])'
+                ),
             },
             'since': {
                 'type': 'string',

--- a/devtools/serverless/help.py
+++ b/devtools/serverless/help.py
@@ -92,8 +92,13 @@ def cmd_help(flags: dict[str, Any]) -> int:
             destructive_marker = (
                 _c(RED, ' [destructivo]') if cmd in DESTRUCTIVE_COMMANDS else ''
             )
+            # flags_to_dict normaliza --foo-bar -> key 'foo_bar'; el help
+            # muestra la forma con guion (la que el usuario tipea).
             flag_hint = (
-                _c(DIM, f'  ({", ".join("--" + f for f in flag_list)})')
+                _c(
+                    DIM,
+                    f'  ({", ".join("--" + f.replace("_", "-") for f in flag_list)})',
+                )
                 if flag_list
                 else ''
             )

--- a/devtools/serverless/infra_deploy.py
+++ b/devtools/serverless/infra_deploy.py
@@ -154,16 +154,16 @@ def cmd_deploy_infra(flags: dict[str, Any]) -> int:
     """Deploya el stack de infra compartida (idempotente).
 
     Flags:
-      --stage   : dev | stage | prod (default dev).
-      --profile : perfil AWS CLI (opcional).
-      --dry-run : muestra que haria sin ejecutar.
+      --stage       : dev | stage | prod (default dev).
+      --aws-profile : perfil AWS CLI (opcional).
+      --dry-run     : muestra que haria sin ejecutar.
     """
     stage = flags.get('stage', 'dev')
     if stage == 'local':
         _err('El stack de infra no aplica al stage `local`.')
         return 1
 
-    profile = flags.get('profile')
+    profile = flags.get('aws_profile')
     region = 'us-east-1'
     stack = f'portfolio-infra-{stage}'
 

--- a/devtools/serverless/lambda_controller.py
+++ b/devtools/serverless/lambda_controller.py
@@ -217,9 +217,9 @@ def cmd_deploy_lambda(flags: dict[str, Any]) -> int:
         '--region',
         str(resolved.manifest.get('region', 'us-east-1')),
     ]
-    profile = flags.get('profile')
-    if profile:
-        deploy_args += ['--profile', str(profile)]
+    aws_profile = flags.get('aws_profile')
+    if aws_profile:
+        deploy_args += ['--profile', str(aws_profile)]
     if flags.get('guided'):
         deploy_args.append('--guided')
 
@@ -284,9 +284,9 @@ def cmd_invoke_remote(flags: dict[str, Any]) -> int:
         '--cli-binary-format',
         'raw-in-base64-out',
     ]
-    profile = flags.get('profile')
-    if profile:
-        args += ['--profile', str(profile)]
+    aws_profile = flags.get('aws_profile')
+    if aws_profile:
+        args += ['--profile', str(aws_profile)]
 
     event = flags.get('event')
     if event:


### PR DESCRIPTION
## Problema

Los comandos del script `serverless` de devtools (`deploy`, `deploy-infra`, `invoke-remote`) ejecutan `aws`/`sam` por debajo sin forzar un perfil AWS. Usan el perfil del shell (`AWS_PROFILE` o `[default]`), que puede apuntar a OTRA cuenta AWS o tener el token SSO expirado.

Sintoma concreto: `invoke-remote` fallaba con `Error when retrieving token from sso: Token has expired and refresh failed` aun despues de correr `aws sso login --profile tfs-dev` — porque se refrescaba el perfil equivocado (el del shell, no el de la cuenta del portfolio `637423614564`).

## Solucion

- Renombra el flag `--profile` a `--aws-profile` en el script `serverless`, aplicado a `deploy`, `deploy-infra` e `invoke-remote`: inyecta `--profile <perfil>` en los comandos `aws`/`sam`.
- `flags.py`: key `aws_profile` en `ALLOWED_FLAGS`, `_COMMAND_FLAGS` y `describe()` con summary explicito.
- `lambda_controller.py` e `infra_deploy.py`: leen `flags.get('aws_profile')`.
- `help.py`: el help colorizado ahora renderiza los flags con guion (`--aws-profile`, `--dry-run`) en vez de underscore — alineado con lo que el usuario tipea.
- Documenta el flag y la trampa del perfil del shell en: rule `serverless-secrets`, rule `lambda-controller`, skill `lambda-controller`, docs `04-deploy-operacion` y `06-devtools-operations`.

## Como probar

```bash
# El help muestra --aws-profile en deploy / invoke-remote / deploy-infra
python devtools/run.py serverless help | grep -E "deploy|invoke-remote"

# invoke-remote inyecta --profile tfs-dev y la Lambda corre (StatusCode 200)
python devtools/run.py serverless invoke-remote \
  --lambda=contact_form --stage=dev --event=events/create.json --aws-profile=tfs-dev

# Tests del parser de flags (25 tests, todos verdes)
cd devtools && .venv/bin/python -m pytest tests/unit/src/serverless/flags.py -q
```

Verificado en la sesion: el comando `invoke-remote` con `--aws-profile=tfs-dev` ejecuto con `StatusCode: 200`.

## TODO

Vacio.