### PR TITLE
docs(rules): estandariza commits, worktrees y verificacion E2E en todo plan

### DIFF
--- a/.claude/docs/plan-format-large/README.md
+++ b/.claude/docs/plan-format-large/README.md
@@ -1,16 +1,64 @@
-# Plan Format - Seccion 8: Descomposicion para Paralelizacion
+# Estandar de Plan de Implementacion (formato extendido)
 
-> Documento referenciado desde `.claude/rules/plan-format.md`. Solo aplicar para
-> planes Large (11+ archivos) o cuando se planee implementar con multiples
-> agentes en git worktrees.
+> Documento maestro del formato de plan del portfolio. Detalla las tres
+> secciones de ejecucion que TODO plan debe incluir — commits, paralelizacion
+> con git worktrees y verificacion E2E iterativa — mas la descomposicion para
+> paralelizacion. Referenciado desde `.claude/rules/plan-format.md`.
+>
+> Plan de referencia que sigue este estandar al pie de la letra:
+> `docs/specs/serverless-drop-sam/` (README + 12 docs de fases).
 
-## Cuando incluir esta seccion
+## Que define este documento
 
-- Plan Large (11+ archivos) que se beneficie de paralelizacion
-- Implementacion con multiples agentes concurrentes (subagentes paralelos en git worktrees)
-- Refactors o migraciones cross-cutting con archivos independientes
+`.claude/rules/plan-format.md` define la estructura general y las secciones
+1-7. Este documento define en detalle las secciones de **ejecucion**, que son
+obligatorias en todo plan (Micro incluido, en forma minima):
 
-Para planes Small/Medium, OMITIR esta seccion (no es necesaria).
+| Seccion del plan | Que cubre | Detalle aqui |
+|------------------|-----------|--------------|
+| 8. Descomposicion para Paralelizacion | Tareas atomicas, checks de file-exclusivity | Capitulo 1 |
+| 9. Commits | Listado de commits incrementales, cada uno verde | Capitulo 2 |
+| 10. Paralelizacion con git worktrees | Base secuencial, que se paraleliza, como lanzar | Capitulo 3 |
+| 11. Verificacion E2E iterativa (fase final) | Refactor de tests + bateria de comandos, bucle "no parar" | Capitulo 4 |
+
+> Las secciones 9, 10 y 11 nacieron de fases que el plan `serverless-drop-sam`
+> ejecuto "fuera de lo planificado" y resultaron criticas. Por eso ahora son
+> parte obligatoria del formato: ningun plan se considera completo sin ellas.
+
+## Regla maestra: todo plan vive en una carpeta
+
+Todo plan se materializa como una **carpeta** `docs/specs/<nombre-kebab>/`,
+no como un archivo suelto:
+
+```text
+docs/specs/<nombre-kebab>/
+├── README.md                 # indice + estado + decisiones + matriz de verificacion
+├── 01-contexto-y-decision.md # secciones 1-3 del plan (contexto, solucion, AC)
+├── 02-<fase>.md              # una fase de implementacion por archivo
+├── ...
+├── NN-commits.md             # SECCION 9 (ver capitulo 2)
+├── NN-paralelizacion-worktrees.md  # SECCION 10 (ver capitulo 3)
+└── NN-verificacion-e2e.md    # SECCION 11 (ver capitulo 4)
+```
+
+Reglas de la carpeta:
+
+- El `README.md` es el indice navegable: tabla "Cuando leer", tabla de estado
+  por fase, decisiones tomadas (no reabrir), reglas criticas, matriz de
+  verificacion incremental.
+- Cada `.md` < 300 lineas (regla de `markdown-docs.md`). Si una fase es mas
+  larga, se parte.
+- Para planes **Micro** (1-2 archivos): la carpeta puede tener solo
+  `README.md` con todo adentro — pero las secciones 9, 10 y 11 siguen
+  presentes, en forma minima (1 commit, `worktrees: N/A`, verificacion corta).
+- Para planes **Small/Medium/Large**: un `.md` por fase + los tres archivos
+  de ejecucion (commits, worktrees, verificacion).
+
+---
+
+# Capitulo 1 — Seccion 8: Descomposicion para Paralelizacion
+
+Obligatoria en Small/Medium/Large. En Micro: `N/A — cambio atomico`.
 
 ## Reglas de paralelizabilidad
 
@@ -38,50 +86,348 @@ Cada tarea incluye 6 campos obligatorios:
 
 ### Tareas (orden topologico)
 
-#### T1: Crear modelo y migration
-- **Archivos**: `server/apps/products/models/product.py`, migrations
+#### T1: Crear modelo y schema
+- **Archivos**: `src/content/config.ts`, `src/content/projects/*.md`
 - **AC referenciados**: AC-1, AC-2
 - **Depende de**: ninguna (raiz)
 - **Paralelizable con**: T2 (no se solapan archivos)
-- **Verify**: `manage.py makemigrations` + `migrate` exitosos
-- **Done**: modelo creado, migration aplicada, test de creacion basica pasa
+- **Verify**: `pnpm run build` valida entries contra schema
+- **Done**: schema creado, build exitoso, entry de ejemplo renderiza
 
-#### T2: Crear enums y exceptions
-- **Archivos**: `server/apps/products/enums/status.py`, `server/apps/products/exceptions.py`
+#### T2: Crear utilities de formato
+- **Archivos**: `src/lib/format-date.ts`, `tests/unit/lib/format-date.test.ts`
 - **AC referenciados**: AC-3
 - **Depende de**: ninguna (raiz)
 - **Paralelizable con**: T1
-- **Verify**: import `from apps.products.enums import ProductStatus` funciona
-- **Done**: enums y exceptions disponibles para imports
+- **Verify**: `pnpm exec vitest run tests/unit/lib/format-date.test.ts`
+- **Done**: utility creada, tests verdes, coverage >= 80%
 
-#### T3: Service layer
-- **Archivos**: `server/apps/products/services/creation.py`
+#### T3: Componente que consume schema + utilities
+- **Archivos**: `src/components/ProjectCard.astro`
 - **AC referenciados**: AC-1, AC-2, AC-3
 - **Depende de**: T1, T2
 - **Paralelizable con**: ninguna (depende de raices)
-- **Verify**: unit tests del service pasan
-- **Done**: service creado, tests pasando, coverage >= 80%
+- **Verify**: `pnpm exec astro check` + `pnpm run build`
+- **Done**: componente renderiza, typecheck limpio
 ```
 
 ## Reglas de granularidad y limites
 
 - Granularidad por tamano de plan: Small=3-5 tareas, Medium=5-10, Large=10-20
 - Si supera 20 tareas, descomponer en multiples planes (Huge)
-- Limite practico de paralelizacion: **5-7 agentes concurrentes** (overhead de
-  review crece despues)
+- Limite practico de paralelizacion: **5-7 agentes concurrentes** (el overhead
+  de review crece despues)
 - Tareas raiz (sin dependencias) primero — habilitan paralelismo inmediato
 - NUNCA mas de un agente escribiendo en el mismo archivo simultaneamente
 
-## Anti-patrones de paralelizacion
+## Anti-patrones de descomposicion
 
 - Tareas con archivos solapados marcadas como "Paralelizable con" → race conditions
 - Tareas que cambian interfaces publicas concurrentemente con consumidores → builds rotos
 - "Paralelizable con: todas" sin verificacion real → falso positivo
-- Mas de 7 agentes concurrentes → coordinacion humana se vuelve cuello de botella
 - Tareas hoja (que dependen de muchas otras) marcadas como urgentes → bloquean el grafo
 
-## Referencias
+---
 
-- Workflow Anthropic Explore → Plan → Implement → Commit
-- `.claude/rules/plan-format.md` (regla principal, secciones 1-7 y 9)
-- `.claude/rules/harness-protocol.md` (subagentes con output en disco)
+# Capitulo 2 — Seccion 9: Listado de Commits
+
+Obligatoria en TODO plan. Archivo dedicado: `NN-commits.md` (o subseccion del
+README en planes Micro).
+
+## Que es
+
+Una secuencia explicita de commits incrementales que implementan el plan. Cada
+commit:
+
+- Tiene su mensaje en Conventional Commits espanol (subject + body), ya
+  redactado en el plan.
+- Deja el repo en **estado verde** (lint + typecheck + tests del scope tocado).
+- Es lo mas atomico y revisable posible (un commit = un cambio coherente).
+- Indica que AC de la seccion 3 cubre.
+
+## Regla por commit
+
+Antes de cada commit se ejecuta, ademas de la suite del scope:
+
+1. La verificacion del tipo de archivo (`.claude/rules/verify-before-done.md`).
+2. La **verificacion incremental** de la fase correspondiente — los comandos
+   reales que ya son posibles en ese punto del plan. NO se difiere la
+   verificacion al final.
+
+Ningun commit deja el repo roto. Si una migracion grande mantiene el sistema
+viejo y el nuevo en paralelo, eso se declara explicitamente (ej.
+`serverless-drop-sam`: hasta el commit 9, el CLI viejo seguia funcionando).
+
+## Plantilla de seccion 9
+
+```markdown
+## 9. Commits
+
+Rama base: `feature/<nombre>` desde `dev`.
+
+### Commit 1 — `docs(specs): plan de <nombre>`
+- Agrega `docs/specs/<nombre>/` (esta carpeta de plan).
+- Sin cambios de codigo.
+
+### Commit 2 — `feat(<scope>): <subject>`
+- Crea `src/lib/<archivo>.ts` + su test mirror.
+- Verde: AC-1, AC-2.
+- Verificacion incremental: `pnpm exec vitest run tests/unit/lib/<archivo>.test.ts`
+
+### Commit 3 — `feat(<scope>): <subject>`
+- Modifica `src/components/<Componente>.astro`.
+- Verde: AC-3.
+- Verificacion incremental: `pnpm exec astro check` + `pnpm run build`
+
+### Resumen de la secuencia
+
+​```text
+1  docs plan                 (sin codigo)
+2  utility + test            cubre AC-1, AC-2
+3  componente                cubre AC-3
+4  refactor de tests + verificacion E2E   (seccion 11)
+​```
+
+## PR
+
+Un solo PR `feature/<nombre> -> dev`. Body siguiendo
+`.claude/rules/git-workflow.md` (Problema / Solucion / Como probar / TODO).
+La seccion "Como probar" incluye la bateria de comandos de la seccion 11. El
+PR NO se mergea hasta que esa bateria pasa completa.
+```
+
+## Reglas de la seccion 9
+
+- El primer commit suele ser la propia carpeta del plan (`docs(specs): ...`).
+- El ultimo commit es el de la seccion 11 (refactor de tests + verificacion).
+- Los commits operativos que NO son de codigo (ej. "destruir y reaprovisionar
+  infra") se listan igual, marcados como operativos.
+- NUNCA atribucion de IA en los mensajes (politica de empresa).
+- En Micro: la seccion puede ser un solo commit; igual se documenta.
+
+---
+
+# Capitulo 3 — Seccion 10: Paralelizacion con git worktrees
+
+Obligatoria en TODO plan. Archivo dedicado: `NN-paralelizacion-worktrees.md`
+(o subseccion del README en Micro, donde sera `N/A — cambio secuencial`).
+
+## Que define
+
+Desde que commit se puede empezar a paralelizar la implementacion con git
+worktrees / subagentes concurrentes, y que fases son worktree-safe.
+
+## Regla base: la base secuencial
+
+Antes de lanzar cualquier worktree hay que identificar la **base secuencial**:
+los commits que TODOS los worktrees necesitan o que tocan archivos
+transversales. Tipicamente:
+
+- El/los commit(s) que crean modulos compartidos de los que el resto importa.
+- Cualquier commit con un diff **mecanico pero transversal** (ej. un rename
+  que toca muchos archivos) — colisionaria con todo worktree, va secuencial.
+
+```text
+Commit 1 (plan) ............ sin codigo
+Commit 2 (base compartida) ...... BASE — secuencial
+Commit 3 (rename transversal) ... BASE — secuencial
+   |
+   +--- desde aqui se lanzan worktrees ---
+```
+
+## Que se puede paralelizar
+
+Una fase es worktree-safe si toca archivos **disjuntos** de las demas fases
+concurrentes. Se documenta en una tabla:
+
+| Tarea | Archivos nuevos | Archivos modificados | Colision |
+|-------|-----------------|----------------------|----------|
+| Fase A (commit 4) | `a.ts`, tests | `shared.ts` | — |
+| Fase B (commit 5) | `b.ts`, tests | `config.ts` | — |
+| Fase C (commit 6) | `c.ts`, tests | — | — |
+
+Si dos fases tocan el mismo archivo, NO se paralelizan: una espera a la otra.
+
+## Que NO se paraleliza
+
+- Las fases que tocan archivos transversales (grilla de comandos CLI, config
+  central, barrel exports) — secuenciales por definicion.
+- La seccion 11 (verificacion E2E) — depende de TODO integrado, va al final.
+- Las fases de limpieza/borrado — solo tienen sentido con lo nuevo funcionando.
+
+## Plantilla de seccion 10
+
+```markdown
+## 10. Paralelizacion con git worktrees
+
+### Base secuencial (rama feature/<nombre>)
+- commit 1  plan
+- commit 2  base compartida          <- BASE
+- commit 3  rename transversal       <- BASE
+
+### Fase paralela (worktrees, lanzables tras commits 2 y 3)
+- worktree A: Fase A  -> commit 4   (toca a.ts, shared.ts — disjunto)
+- worktree B: Fase B  -> commit 5   (toca b.ts, config.ts — disjunto)
+- worktree C: Fase C  -> commit 6   (toca c.ts — disjunto)
+
+### Fase secuencial final
+- merge de worktrees A, B, C en orden
+- commit 7  reconexion (toca archivos transversales) <- requiere A+B+C
+- commit 8  verificacion E2E (seccion 11)
+
+Maximo paralelismo util: 3-4 worktrees.
+```
+
+## Como lanzar un worktree
+
+```bash
+# desde la raiz, con la base secuencial ya commiteada
+git worktree add ../portfolio-wt-<fase> feature/<nombre>
+cd ../portfolio-wt-<fase>
+git checkout -b feature/<nombre>-<fase>
+# ... implementar la fase ...
+# al terminar: merge a feature/<nombre> como el commit que corresponda
+```
+
+O con un subagente: `Agent` con `isolation: "worktree"`, prompt = el contenido
+del `.md` de la fase correspondiente.
+
+## Reglas al integrar worktrees
+
+- Integrar en el orden del listado de commits (seccion 9).
+- Tras cada merge: correr la suite completa del scope — los modulos nuevos
+  coexisten, no deben colisionar.
+- Los toques minimos a archivos transversales (un import nuevo) se aplican
+  AL INTEGRAR el worktree, no dentro de el, para no chocar con la fase de
+  reconexion.
+
+## Anti-patrones de worktrees
+
+- Lanzar worktrees antes de que la base secuencial este commiteada → conflictos
+- Dos worktrees tocando el mismo archivo → merge hell
+- Worktree que toca la grilla de comandos / config central → debe ser secuencial
+- Mas de 7 worktrees concurrentes → la coordinacion humana es el cuello de botella
+
+---
+
+# Capitulo 4 — Seccion 11: Verificacion E2E iterativa (fase final)
+
+Obligatoria en TODO plan. Archivo dedicado: `NN-verificacion-e2e.md` (o
+subseccion del README en Micro). Es SIEMPRE la ultima fase y el ultimo commit.
+
+## Que es
+
+La fase de cierre del plan. Dos partes obligatorias:
+
+1. **Refactor de TODOS los tests** afectados: que ningun test viejo quede
+   referenciando codigo eliminado, que los tests nuevos esten en la ruta y
+   convencion correctas, que la suite completa siga verde tras integrar todo.
+2. **Verificar que todo funciona** ejecutando los comandos / flujos reales —
+   NO se detiene hasta que cada uno pasa (bucle "no parar hasta que funcione").
+
+## Por que existe (no es redundante con la verificacion incremental)
+
+Cada fase ya ejecuta su verificacion incremental (regla de la seccion 9). Pero
+esa verificacion es **por fase y parcial**. Esta seccion NO la sustituye — la
+**consolida** y cubre lo que ninguna fase individual puede:
+
+- **Refactor global de tests**: solo posible con TODO el codigo integrado.
+- **Bateria E2E en una sola corrida**: la secuencia completa de punta a punta
+  con el codigo final, no porciones aisladas.
+- **Regla de cierre del PR**: iterar corrigiendo hasta que toda la bateria
+  pase. Es el gate que decide si el PR esta listo.
+
+## Plantilla de seccion 11
+
+```markdown
+## 11. Verificacion E2E iterativa
+
+### Parte A — refactor de tests
+
+| Archivo | Accion |
+|---------|--------|
+| `tests/unit/<viejo>.test.ts` | ELIMINAR — el modulo bajo test ya no existe |
+| `tests/unit/<modificado>.test.ts` | MODIFICAR — cubrir la nueva firma |
+| `tests/unit/<nuevo>.test.ts` | CREAR — tests de la feature |
+
+Barrido global (cero resultados esperados):
+
+​```bash
+rg -l "<simbolo-eliminado>" src/ tests/
+​```
+
+### Parte B — bateria de comandos reales
+
+​```bash
+# Verificacion del scope
+pnpm exec biome check .
+pnpm exec tsc --noEmit
+pnpm exec astro check
+pnpm exec vitest run --coverage      # >= 80% per-file
+pnpm run build                       # build estatico exitoso
+
+# E2E si el plan toca flujos de usuario
+python devtools/run.py docker up --env=local
+python devtools/run.py test_runner --module=feature --type=feature --env=local
+​```
+
+### Parte C — bucle de correccion ("no parar hasta que funcione")
+
+​```text
+ejecutar comando
+   |
+   v
+{paso?}--si--> siguiente comando
+   |
+   no
+   |
+   v
+diagnosticar (leer stderr, el output)
+   |
+   v
+corregir codigo o test
+   |
+   v
+re-ejecutar la suite + el comando que fallo
+   |
+   +-----------> volver a "ejecutar comando"
+​```
+
+### Regla de cierre
+
+Esta fase NO se marca completa mientras quede un comando fallando, un test
+rojo, o el coverage por debajo de 80%. Iterar — corregir, re-ejecutar,
+repetir — hasta que toda la bateria pase. Solo entonces el PR esta listo.
+```
+
+## Reglas de la seccion 11
+
+- Es SIEMPRE la ultima fase y el ultimo commit del listado de la seccion 9.
+- La Parte B se divide en comandos que NO requieren recursos externos (corren
+  siempre) y los que SI (AWS, Docker, deploy). Los primeros son obligatorios;
+  los segundos se ejecutan si hay acceso, o se documentan como pendientes en
+  el PR y se corren antes del merge.
+- El "Como probar" del body del PR reutiliza la bateria de comandos de aqui.
+- En Micro: la fase es minima — un barrido + la verificacion del scope + la
+  regla de cierre. Sigue siendo obligatoria.
+
+## Anti-patrones de la verificacion final
+
+- Declarar el plan "listo" sin ejecutar la bateria completa
+- Diferir TODA la verificacion al final (cada fase verifica lo suyo; esta solo
+  consolida)
+- Dejar tests referenciando codigo eliminado
+- Mergear el PR con comandos de la bateria fallando
+- Saltar el bucle de correccion ("se ve bien, lo dejo asi")
+
+---
+
+# Referencias
+
+- `.claude/rules/plan-format.md` — regla principal (estructura, secciones 1-7)
+- `.claude/rules/git-workflow.md` — Conventional Commits, flujo de PR
+- `.claude/rules/verify-before-done.md` — verificacion por tipo de archivo
+- `.claude/rules/harness-protocol.md` — subagentes con output en disco
+- `.claude/rules/markdown-docs.md` — formato de la carpeta del plan
+- Plan de referencia: `docs/specs/serverless-drop-sam/` (README + 12 docs)
+- Workflow Anthropic: Explore → Plan → Implement → Commit

--- a/.claude/rules/plan-format.md
+++ b/.claude/rules/plan-format.md
@@ -26,20 +26,47 @@ Anthropic recomienda 4 fases para cambios no triviales:
 
 Para features grandes o requisitos ambiguos, considerar fase de **Interview** previa con `AskUserQuestion` cubriendo edge cases, tradeoffs y constraints.
 
+## Todo plan vive en una carpeta
+
+Todo plan se materializa como una carpeta `docs/specs/<nombre-kebab>/`, NUNCA
+un archivo suelto:
+
+```text
+docs/specs/<nombre-kebab>/
+├── README.md                 # indice navegable + estado por fase + decisiones
+├── 01-contexto-y-decision.md # secciones 1-3 (contexto, solucion, AC)
+├── 02-<fase>.md              # una fase de implementacion por archivo
+├── ...
+├── NN-commits.md             # SECCION 9 — listado de commits
+├── NN-paralelizacion-worktrees.md  # SECCION 10 — git worktrees
+└── NN-verificacion-e2e.md    # SECCION 11 — verificacion E2E iterativa
+```
+
+El `README.md` es el indice (tabla "Cuando leer", estado por fase, decisiones
+no-reabribles, reglas criticas, matriz de verificacion). Cada `.md` < 300
+lineas (ver `.claude/rules/markdown-docs.md`). En **Micro** la carpeta puede
+ser solo `README.md` con todo adentro. El detalle del formato de la carpeta y
+de las secciones 8-11 esta en `.claude/docs/plan-format-large/README.md`.
+
 ## Escala del plan (scope-based ceremony)
 
 | Tamano | Archivos | Formato |
 |--------|----------|---------|
-| **Micro** | 1-2 archivos, hotfix | Plan corto: 3 lineas (objetivo + archivo + done). Saltar template. |
-| **Small** | 3-5 archivos | Template completo, secciones condicionales colapsadas |
-| **Medium** | 6-10 archivos | Template completo, todas las secciones aplicables |
-| **Large** | 11+ archivos | Template completo + Seccion 8 (ver `.claude/docs/plan-format-large/README.md`) |
+| **Micro** | 1-2 archivos, hotfix | Carpeta con solo `README.md`. Secciones 1-3 condensadas; 9, 10 y 11 en forma minima (1 commit, worktrees N/A, verificacion corta). |
+| **Small** | 3-5 archivos | Carpeta + un `.md` por fase. Template completo, condicionales colapsadas. |
+| **Medium** | 6-10 archivos | Carpeta + un `.md` por fase. Template completo, todas las secciones aplicables. |
+| **Large** | 11+ archivos | Carpeta + un `.md` por fase. Template completo, descomposicion detallada (seccion 8). |
 
-Si puedes describir el diff en una oracion, NO uses el template. Anti-pattern: forzar 8 secciones para un cambio de 5 lineas.
+NO existe el "plan de 3 lineas". Incluso un hotfix Micro tiene carpeta con las
+secciones de ejecucion (9, 10, 11) — minimas, pero presentes. Anti-pattern:
+forzar diagramas o 10 tareas para un cambio de 5 lineas; las secciones se
+escriben pero condensadas.
 
 ## Secciones obligatorias (en orden)
 
-Para Small/Medium/Large, incluir en este orden. Secciones 4, 5, 6 y 8 son condicionales.
+Incluir en este orden. Secciones 4, 5 y 6 son condicionales por contenido.
+Las secciones **8, 9, 10 y 11 son obligatorias en TODO plan** (en Micro, en
+forma minima). La seccion 8 se condensa a `N/A — cambio atomico` en Micro.
 
 ---
 
@@ -182,17 +209,78 @@ Reglas:
 
 ---
 
-### 8. Descomposicion para Paralelizacion — CONDICIONAL: solo Large
+### 8. Descomposicion para Paralelizacion — OBLIGATORIA (`N/A` en Micro)
 
-Aplicar solo si el plan es Large (11+ archivos) o se planea implementacion con multiples agentes en git worktrees.
+Descomposicion del plan en tareas atomicas. En Micro: `N/A — cambio atomico`.
 
-**Documento detallado**: `.claude/docs/plan-format-large/README.md` (plantilla, reglas de paralelizabilidad, granularidad, anti-patrones).
+**Documento detallado**: `.claude/docs/plan-format-large/README.md` capitulo 1
+(plantilla, reglas de paralelizabilidad, granularidad, anti-patrones).
 
-Resumen: cada tarea debe pasar 3 checks (File Exclusivity, Interface Stability, Bounded Scope) y tener 6 campos (**Archivos**, **AC referenciados**, **Depende de**, **Paralelizable con**, **Verify**, **Done**). Limite practico: 5-7 agentes concurrentes.
+Resumen: cada tarea pasa 3 checks (File Exclusivity, Interface Stability,
+Bounded Scope) y tiene 6 campos (**Archivos**, **AC referenciados**, **Depende
+de**, **Paralelizable con**, **Verify**, **Done**). Limite: 5-7 agentes
+concurrentes. Granularidad: Small 3-5, Medium 5-10, Large 10-20 tareas.
 
 ---
 
-### 9. Validacion y Definition of Done
+### 9. Commits — OBLIGATORIA
+
+Listado de commits incrementales que implementan el plan. Archivo dedicado
+`NN-commits.md` (subseccion del README en Micro). Cada commit:
+
+- Mensaje en Conventional Commits espanol, ya redactado en el plan.
+- Deja el repo verde (lint + typecheck + tests del scope).
+- Es atomico y revisable (un commit = un cambio coherente).
+- Indica que AC cubre + su verificacion incremental.
+
+El primer commit suele ser la carpeta del plan (`docs(specs): ...`); el ultimo
+es el de la seccion 11. Cada commit ejecuta su verificacion incremental ANTES
+de commitear — no se difiere al final. Un solo PR `feature/<nombre> -> dev`.
+
+**Documento detallado**: `.claude/docs/plan-format-large/README.md` capitulo 2
+(plantilla, regla por commit, resumen de secuencia, PR).
+
+---
+
+### 10. Paralelizacion con git worktrees — OBLIGATORIA (`N/A` en Micro)
+
+Desde que commit se puede paralelizar la implementacion con git worktrees /
+subagentes concurrentes, y que fases son worktree-safe. Archivo dedicado
+`NN-paralelizacion-worktrees.md`. En Micro: `N/A — cambio secuencial`.
+
+Define: la **base secuencial** (commits que todos los worktrees necesitan o
+que tocan archivos transversales), la tabla de fases worktree-safe (archivos
+disjuntos), lo que NO se paraleliza (config central, grilla de comandos,
+limpieza, la seccion 11), y como lanzar cada worktree.
+
+**Documento detallado**: `.claude/docs/plan-format-large/README.md` capitulo 3
+(regla base, tabla de colisiones, plantilla, anti-patrones).
+
+---
+
+### 11. Verificacion E2E iterativa (fase final) — OBLIGATORIA
+
+Fase de cierre del plan. Archivo dedicado `NN-verificacion-e2e.md`. SIEMPRE es
+la ultima fase y el ultimo commit. Dos partes:
+
+- **Parte A — refactor de tests**: ningun test viejo referencia codigo
+  eliminado; tests nuevos en ruta y convencion correctas; barrido global con
+  `rg -l` (cero resultados esperados).
+- **Parte B — bateria de comandos reales**: ejecutar la verificacion completa
+  de punta a punta con el codigo final. Bucle "no parar hasta que funcione":
+  ejecutar -> si falla, diagnosticar -> corregir -> re-ejecutar la suite ->
+  repetir. NO se marca completa con un comando fallando, un test rojo o
+  coverage < 80%.
+
+Esta fase consolida — no sustituye — la verificacion incremental de cada fase.
+El "Como probar" del PR reutiliza esta bateria. Es el gate del PR.
+
+**Documento detallado**: `.claude/docs/plan-format-large/README.md` capitulo 4
+(plantilla, bucle de correccion, regla de cierre).
+
+---
+
+### 12. Validacion y Definition of Done
 
 Dos checklists:
 
@@ -220,22 +308,31 @@ Dos checklists:
 
 ## Reglas generales
 
+- Todo plan es una carpeta `docs/specs/<nombre-kebab>/`, nunca un archivo suelto
 - Idioma espanol; ingles para terminos tecnicos
 - Sin emojis
 - Conciso: cada seccion lo mas corta posible sin perder informacion
 - Seccion condicional que no aplica → escribir `N/A — [razon]`
+- Secciones 8, 9, 10 y 11 son obligatorias en TODO plan; en Micro se condensan
+  (8 y 10 → `N/A`, 9 → 1 commit, 11 → verificacion corta) pero NUNCA se omiten
 - NO Mermaid en el plan, solo ASCII inline (portabilidad)
 - Si un diagrama justifica `.mmd` permanente, anotarlo en seccion 7
 - AC numerados son la fuente de verdad: tests y tareas los referencian
-- Para Large/Huge: considerar implementacion con subagentes paralelos en git worktrees
+- El ultimo commit del plan es SIEMPRE la seccion 11 (verificacion E2E)
 
 ## Anti-patrones
 
-- Forzar template completo en cambios Micro
+- Plan como archivo suelto en vez de carpeta `docs/specs/<nombre>/`
+- Omitir las secciones 9, 10 u 11 "porque el cambio es chico" (en Micro van
+  minimas, no ausentes)
 - Presentar multiples alternativas en seccion 2 (converger antes)
 - AC vagos sin formato BDD/EARS
 - Tests sin referencia a AC (rompe trazabilidad)
 - Lista de archivos sin verificacion explicita (no es ejecutable)
+- Commits que dejan el repo en rojo (cada commit debe ser verde)
+- Diferir TODA la verificacion al final (cada commit verifica lo suyo)
+- Lanzar worktrees antes de commitear la base secuencial (conflictos)
 - Mermaid inline en plan (usar ASCII + `.mmd` separado)
 - Definition of Done implicita en lugar de criterios observables
 - Descomposicion para paralelizacion sin verificar file exclusivity (race conditions)
+- Declarar el plan "listo" sin que la bateria de la seccion 11 pase completa

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ Antes de trabajar, identifica que contexto necesitas:
 | Git hooks | [.claude/rules/git-hooks.md](.claude/rules/git-hooks.md) | Quality gates pre-commit / pre-push |
 | Security | [.claude/rules/security.md](.claude/rules/security.md) | Secrets, CSP, headers, supply chain |
 | Archivos .env | [.claude/rules/env-files.md](.claude/rules/env-files.md) | NUNCA leer/importar `.env` (incl. `docker/env/**`): extraer solo la key con bash e inyectarla inline al comando |
-| Plan format | [.claude/rules/plan-format.md](.claude/rules/plan-format.md) | En plan mode o al planificar features |
+| Plan format | [.claude/rules/plan-format.md](.claude/rules/plan-format.md) + [.claude/docs/plan-format-large/README.md](.claude/docs/plan-format-large/README.md) | En plan mode o al planificar features. Todo plan vive en `docs/specs/<nombre>/` y trae 4 secciones de ejecucion obligatorias: descomposicion, commits, paralelizacion con worktrees y verificacion E2E iterativa |
 | Harness protocol | [.claude/rules/harness-protocol.md](.claude/rules/harness-protocol.md) | Subagentes, feature_list, current/history |
 | Markdown docs | [.claude/rules/markdown-docs.md](.claude/rules/markdown-docs.md) | Editar archivos de `docs/` |
 | Skills (frontmatter) | [.claude/rules/skills.md](.claude/rules/skills.md) | Crear / modificar skills |


### PR DESCRIPTION
## Problema

El formato de plan del proyecto (`.claude/rules/plan-format.md`) no exigia tres fases que resultaron criticas al ejecutar el plan `serverless-drop-sam`: el listado de commits incrementales, la paralelizacion con git worktrees y la fase final de refactor de tests + verificacion E2E iterativa. Esas fases se ejecutaron "fuera de lo planificado". Como no eran parte del formato, un plan podia declararse completo sin ellas.

## Solucion

Se convierten las tres fases en secciones obligatorias de TODO plan y se reescribe el documento extendido como estandar maestro:

- `.claude/docs/plan-format-large/README.md` reescrito con 4 capitulos: descomposicion (sec. 8), commits (sec. 9), paralelizacion con worktrees (sec. 10), verificacion E2E iterativa (sec. 11). Cada uno con plantilla, reglas y anti-patrones.
- Las secciones 9, 10 y 11 pasan de inexistentes/condicionales a obligatorias en todo plan. En Micro van en forma minima (1 commit, worktrees `N/A`, verificacion corta) pero nunca se omiten.
- Nueva regla: todo plan vive en una carpeta `docs/specs/<nombre>/` con README indice + un `.md` por fase. Se elimina el "plan de 3 lineas".
- `plan-format.md` renumerado a 12 secciones: la Definition of Done pasa de 9 a 12.
- Se documenta el bucle "no parar hasta que funcione" como regla de cierre del PR.
- `CLAUDE.md`: entrada del arbol de conocimiento ampliada.
- `docs/specs/serverless-drop-sam/` queda como plan de referencia del estandar.

## Como probar

1. Leer `.claude/rules/plan-format.md`: verificar 12 secciones numeradas, secciones 8-11 marcadas obligatorias.
2. Leer `.claude/docs/plan-format-large/README.md`: verificar los 4 capitulos con plantillas.
3. Validacion ejecutada con `claude -p` (bypassPermissions, sin web, sin MCP), 2 prompts en espanol: ambos describen correctamente las 12 secciones, las 4 obligatorias de ejecucion, el comportamiento Micro y el bucle de verificacion.

## TODO

- Quedan 3 angulos de validacion `claude -p` sin ejecutar (sintoma/error, negativo, terminologia legacy) — `.claude/rules/claude-config-testing.md` recomienda 5; se cubrieron 2.