### PR TITLE
fix(ci-cd): boto3 dep + permisos contents:write en commit-comment

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -21,7 +21,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write  # commit-comment (Fase G)
 
 env:
   NODE_VERSION: "24"
@@ -168,6 +167,11 @@ jobs:
     needs: [resolve-env, deploy-pages]
     if: always()
     runs-on: ubuntu-24.04
+    permissions:
+      # commit-comment posts a comment on the merge commit:
+      # POST /repos/:owner/:repo/commits/:sha/comments requires contents:write
+      # (NOT pull-requests:write — that's for PR threads).
+      contents: write
     steps:
       - name: Build report body
         id: build-report

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -17,7 +17,6 @@ concurrency:
 permissions:
   id-token: write  # OIDC (aws-actions/configure-aws-credentials)
   contents: read
-  pull-requests: write  # commit-comment (Fase G)
 
 env:
   AWS_REGION: us-east-1
@@ -201,6 +200,11 @@ jobs:
     needs: [resolve-env, migrate-db, detect-changes, deploy-lambdas]
     if: always()
     runs-on: ubuntu-24.04
+    permissions:
+      # commit-comment posts a comment on the merge commit:
+      # POST /repos/:owner/:repo/commits/:sha/comments requires contents:write
+      # (NOT pull-requests:write — that's for PR threads).
+      contents: write
     steps:
       - name: Build report body
         id: build-report

--- a/devtools/pyproject.toml
+++ b/devtools/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pyyaml>=6",
+    # AWS SDK (used by serverless/state.py S3StateBackend when
+    # DEVTOOLS_STATE_BACKEND=s3 — the CI path)
+    "boto3>=1.35.0",
 ]
 
 [tool.uv]

--- a/devtools/uv.lock
+++ b/devtools/uv.lock
@@ -15,6 +15,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4b/616367e871ce3f1cb3e8545a97736b6331b9fb081497f2d44c5b2aa6959d/boto3-1.43.14.tar.gz", hash = "sha256:5c0a994b3182061ee101812e721100717a4d664f9f4ceaf4a86b6d032ce9fc2d", size = 113142, upload-time = "2026-05-22T19:28:47.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/00/59cb9329c18e2d3aa23062ceaa87d065f2e81e7d2931df24d64e9a7815aa/boto3-1.43.14-py3-none-any.whl", hash = "sha256:574335744656cfed0b362a0a0467aaf2eb2bf15526edcd02d31d3c661f4b09e4", size = 140536, upload-time = "2026-05-22T19:28:46.49Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz", hash = "sha256:b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516", size = 15382604, upload-time = "2026-05-22T19:28:36.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/7e/6e64821077cd2efc4aa51b7d638fb6d48e1c7c450201c529fbaf1de8bfd3/botocore-1.43.14-py3-none-any.whl", hash = "sha256:1f4a2a95ea78c10398e78431e98c1fe47adb54a7b10a32975144c1f541186658", size = 15061424, upload-time = "2026-05-22T19:28:32.682Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -112,6 +140,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -134,6 +171,7 @@ name = "portfolio-devtools"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "gitpython" },
     { name = "httpx" },
     { name = "pytest" },
@@ -144,6 +182,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "gitpython", specifier = ">=3.1.49" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -187,6 +226,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -241,10 +292,40 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
## Problema

El primer run real del pipeline CI/CD recien introducido en #101 expuso 2 bugs en `dev` (run [26335796057](https://github.com/bypabloc/cv/actions/runs/26335796057)):

1. **`ModuleNotFoundError: No module named 'boto3'`** en `devtools/serverless/state.py:209`. Con `DEVTOOLS_STATE_BACKEND=s3` (activado en CI), `_select_backend()` se ejecuta a module-load y crea un `S3StateBackend` que importa `boto3`. El import era lazy dentro de `__init__`, pero la instancia se crea inmediatamente -> el lazy no ayudo. `boto3` nunca fue declarado como dep de devtools.
2. **HTTP 403 Resource not accessible by integration** al postear el commit comment con `peter-evans/commit-comment@v3`. El workflow tenia `permissions: pull-requests: write` pero el endpoint que usa la action (`POST /repos/:owner/:repo/commits/:sha/comments`) requiere `contents: write` — `pull-requests:write` es para PR threads, no para commit comments. Mismo bug en `deploy-backend.yml` y `deploy-apps.yml`.

## Solucion

1. Agrega `boto3>=1.35.0` a `[project.dependencies]` en `devtools/pyproject.toml`. Regenera `devtools/uv.lock` (+7 paquetes: boto3, botocore, jmespath, python-dateutil, s3transfer, six, urllib3). En local `DEVTOOLS_STATE_BACKEND=local` por defecto, asi que boto3 se instala pero no se importa hasta que se opta a S3.
2. Mueve los permisos del commit-comment del nivel workflow al job `report` (least privilege) y cambia `pull-requests: write` por `contents: write` en `deploy-backend.yml` y `deploy-apps.yml`. El resto de jobs queda con `contents: read`.

## Como probar

\`\`\`bash
# 1. Smoke local del Fix 1 (S3StateBackend ya no rompe al cargar):
cd devtools && uv sync --frozen
cd ..
DEVTOOLS_STATE_BACKEND=s3 DEVTOOLS_STATE_BUCKET=test \
  devtools/.venv/bin/python -c "from serverless import state; print(type(state._backend).__name__)"
# Esperado: S3StateBackend

# 2. Workflows YAML siguen validos:
devtools/.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-backend.yml'))"
devtools/.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-apps.yml'))"

# 3. Tests de state.py siguen verdes:
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/state.py -q
# Esperado: 25 passed
\`\`\`

Verificacion post-merge: al mergear este PR a `dev`, el workflow `deploy-backend.yml` debe completar ambos jobs:
- `Re-deploy Lambda db` ya no falla con ModuleNotFoundError.
- `Report backend deploy summary` postea el commit comment sin HTTP 403.

## TODO

- 63 tests de `devtools/tests/unit/src/test_runner/flags.py` estan fallando desde antes (pre-existentes en `dev`, no relacionados con este PR). Vale crear un fix separado.