### PR TITLE
feat(ci-cd): GitHub Environments + secrets_sync con fallback a os.environ

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -131,6 +131,11 @@ jobs:
     name: Deploy ${{ matrix.niche }}
     needs: [resolve-env, build-apps]
     runs-on: ubuntu-24.04
+    # GitHub Environment: aplica la deployment branch policy de prod
+    # (solo branch main) y registra el deploy en el audit log del env.
+    # Los secrets CLOUDFLARE_* siguen siendo Repository Secrets (mismos
+    # valores en los 3 envs).
+    environment: ${{ needs.resolve-env.outputs.stage }}
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -64,7 +64,33 @@ jobs:
     name: Apply DB migrations (${{ needs.resolve-env.outputs.stage }})
     needs: resolve-env
     runs-on: ubuntu-24.04
+    # GitHub Environment: hace visible los Environment Secrets de
+    # este stage. Aplica la deployment branch policy (prod -> main).
+    environment: ${{ needs.resolve-env.outputs.stage }}
     timeout-minutes: 10
+    # Inyecta las 20 keys del docker/env/server/.example como env vars
+    # del job. devtools/serverless/secrets_sync.py las resuelve desde
+    # os.environ cuando no existe el .env local (modo CI).
+    env:
+      TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+      TURNSTILE_BYPASS_SECRET: ${{ secrets.TURNSTILE_BYPASS_SECRET }}
+      DB_URL: ${{ secrets.DB_URL }}
+      OWNER_EMAIL: ${{ secrets.OWNER_EMAIL }}
+      EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+      EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+      EMAIL_BACKEND: ${{ secrets.EMAIL_BACKEND }}
+      AWS_SES_REGION: ${{ secrets.AWS_SES_REGION }}
+      AWS_S3_REGION_NAME: ${{ secrets.AWS_S3_REGION_NAME }}
+      AWS_STORAGE_BUCKET_NAME: ${{ secrets.AWS_STORAGE_BUCKET_NAME }}
+      SSM_PATH_PREFIX: ${{ secrets.SSM_PATH_PREFIX }}
+      KMS_KEY_ALIAS: ${{ secrets.KMS_KEY_ALIAS }}
+      DB_DB: ${{ secrets.DB_DB }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_SSLMODE: ${{ secrets.DB_SSLMODE }}
+      DB_CHANNEL_BINDING: ${{ secrets.DB_CHANNEL_BINDING }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 
@@ -159,11 +185,35 @@ jobs:
     needs: [resolve-env, detect-changes]
     if: needs.detect-changes.outputs.has-affected == 'true'
     runs-on: ubuntu-24.04
+    # GitHub Environment para Environment Secrets + branch policy.
+    environment: ${{ needs.resolve-env.outputs.stage }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         lambda: ${{ fromJSON(needs.detect-changes.outputs.affected) }}
+    # Mismas 20 keys que migrate-db (el deploy de cada lambda invoca
+    # internamente secrets_sync para publicar sus secretos a SSM).
+    env:
+      TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+      TURNSTILE_BYPASS_SECRET: ${{ secrets.TURNSTILE_BYPASS_SECRET }}
+      DB_URL: ${{ secrets.DB_URL }}
+      OWNER_EMAIL: ${{ secrets.OWNER_EMAIL }}
+      EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+      EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+      EMAIL_BACKEND: ${{ secrets.EMAIL_BACKEND }}
+      AWS_SES_REGION: ${{ secrets.AWS_SES_REGION }}
+      AWS_S3_REGION_NAME: ${{ secrets.AWS_S3_REGION_NAME }}
+      AWS_STORAGE_BUCKET_NAME: ${{ secrets.AWS_STORAGE_BUCKET_NAME }}
+      SSM_PATH_PREFIX: ${{ secrets.SSM_PATH_PREFIX }}
+      KMS_KEY_ALIAS: ${{ secrets.KMS_KEY_ALIAS }}
+      DB_DB: ${{ secrets.DB_DB }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_SSLMODE: ${{ secrets.DB_SSLMODE }}
+      DB_CHANNEL_BINDING: ${{ secrets.DB_CHANNEL_BINDING }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 

--- a/devtools/serverless/lambda_controller.py
+++ b/devtools/serverless/lambda_controller.py
@@ -24,6 +24,12 @@ import shutil
 import subprocess
 from typing import Any
 
+from shared.console import CYAN
+from shared.console import GREEN
+from shared.console import YELLOW
+from shared.console import _c
+from shared.console import _err
+
 from serverless import local_runtime
 from serverless import provisioner
 from serverless import state as state_mod
@@ -37,11 +43,6 @@ from serverless.resolve import ResolvedLambda
 from serverless.resolve import available_lambdas
 from serverless.resolve import resolve_lambda
 from serverless.vendoring import VendoringError
-from shared.console import CYAN
-from shared.console import GREEN
-from shared.console import YELLOW
-from shared.console import _c
-from shared.console import _err
 
 
 # Raiz del backend serverless del portfolio. La suite CENTRALIZADA de la
@@ -281,26 +282,29 @@ def _sync_secrets_before_deploy(
     if not used_secrets:
         return 0
 
-    env_file = (
-        _PORTFOLIO_SERVERLESS_ROOT.parent
-        / 'docker'
-        / 'env'
-        / 'server'
-        / f'.{stage}'
+    server_env_dir = (
+        _PORTFOLIO_SERVERLESS_ROOT.parent / 'docker' / 'env' / 'server'
     )
-    if not env_file.exists():
+    env_file = server_env_dir / f'.{stage}'
+    example_file = server_env_dir / '.example'
+    if not env_file.exists() and not example_file.exists():
         _err(
-            f'docker/env/server/.{stage} no existe. Crear desde '
-            f'docker/env/server/.example y completar los valores.',
+            f'docker/env/server/.{stage} no existe y tampoco hay '
+            'docker/env/server/.example para resolver via os.environ.',
         )
         return 1
 
     try:
         catalog = Catalog.load()
+        # `example_file` habilita el fallback: si `env_file` no existe
+        # (modo CI), las keys se resuelven desde `os.environ` usando el
+        # `.example` como schema canonico. GitHub Actions inyecta cada
+        # key como Environment Secret.
         results = sync_secrets_to_ssm(
             stage=stage,
             env_file=env_file,
             catalog=catalog,
+            example_file=example_file,
             profile=profile,
             region=region,
             only=tuple(used_secrets),

--- a/devtools/serverless/secrets.py
+++ b/devtools/serverless/secrets.py
@@ -238,16 +238,21 @@ def cmd_sync_secrets(flags: dict[str, Any]) -> int:
         return 2
 
     env_file = _SERVER_ENV_DIR / f'.{stage}'
+    example_file = _SERVER_ENV_DIR / '.example'
     only_raw = flags.get('only')
     only: tuple[str, ...] | None = None
     if only_raw:
         only = tuple(s.strip() for s in str(only_raw).split(',') if s.strip())
 
     try:
+        # `example_file` habilita el fallback a `os.environ` cuando el
+        # `.env` local no existe (modo CI). En local con `.env` presente
+        # se usa el archivo y `os.environ` se ignora.
         results = sync_secrets_to_ssm(
             stage=str(stage),
             env_file=env_file,
             catalog=Catalog.load(),
+            example_file=example_file,
             profile=flags.get('aws_profile'),
             only=only,
             dry_run=bool(flags.get('dry_run')),
@@ -317,7 +322,7 @@ def cmd_secrets_status(flags: dict[str, Any]) -> int:
     from serverless.secrets_catalog import Catalog
     from serverless.secrets_catalog import CatalogError
     from serverless.secrets_sync import SyncError
-    from serverless.secrets_sync import load_env_file
+    from serverless.secrets_sync import load_env_with_fallback
 
     stage = flags.get('stage')
     if not stage:
@@ -331,10 +336,11 @@ def cmd_secrets_status(flags: dict[str, Any]) -> int:
         return 1
 
     env_file = _SERVER_ENV_DIR / f'.{stage}'
+    example_file = _SERVER_ENV_DIR / '.example'
     env_values: dict[str, str] = {}
-    if env_file.exists():
+    if env_file.exists() or example_file.exists():
         try:
-            env_values = load_env_file(env_file)
+            env_values = load_env_with_fallback(env_file, example_file)
         except SyncError:
             env_values = {}
 

--- a/devtools/serverless/secrets_sync.py
+++ b/devtools/serverless/secrets_sync.py
@@ -7,6 +7,9 @@ Reglas:
 
 - El `.env` se carga con `dotenv_values` (PyPI `python-dotenv`) o, como
   fallback minimo, un parser custom (sin imprimir).
+- En CI (sin `.env` local) el valor de cada key se resuelve desde
+  `os.environ`, usando `docker/env/server/.example` como schema canonico
+  de keys validas. GitHub Actions inyecta cada key como Environment Secret.
 - `aws ssm put-parameter` recibe el valor por tempfile (`--value file://`).
   Tempfile con perms `0600`, borrado en `finally`. NUNCA por argumento
   (visible en `ps`) ni stdin (inflexible bajo `subprocess`).
@@ -97,6 +100,65 @@ def load_env_file(env_file: Path) -> dict[str, str]:
             if key:
                 result[key] = value
         return result
+
+
+def load_example_keys(example_file: Path) -> tuple[str, ...]:
+    """Devuelve las KEY declaradas en `.example`, en orden de aparicion.
+
+    El `.example` es el SCHEMA canonico: enumera todas las keys que el
+    backend serverless reconoce, con o sin valor por defecto. Esta
+    funcion solo extrae los NOMBRES (no los valores). El parsing acepta
+    keys con digitos (ej. `AWS_S3_REGION_NAME`).
+    """
+    if not example_file.exists():
+        raise SyncError(f'.example no existe: {example_file}')
+
+    keys: list[str] = []
+    seen: set[str] = set()
+    for line in example_file.read_text(encoding='utf-8').splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        if '=' not in stripped:
+            continue
+        key, _, _value = stripped.partition('=')
+        key = key.strip()
+        # Validar identificador: empieza con letra/underscore, resto
+        # alfanumerico o underscore (acepta digitos: AWS_S3_REGION_NAME).
+        if not key or not (key[0].isalpha() or key[0] == '_'):
+            continue
+        if not all(c.isalnum() or c == '_' for c in key):
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        keys.append(key)
+    return tuple(keys)
+
+
+def load_env_with_fallback(
+    env_file: Path,
+    example_file: Path,
+) -> dict[str, str]:
+    """Carga env vars con prioridad `.env` archivo -> `os.environ` schema.
+
+    - Si `env_file` existe: devuelve `load_env_file(env_file)`.
+    - Si NO existe: devuelve `{key: os.environ[key]}` para cada `key` del
+      `.example`. Las keys ausentes en `os.environ` se omiten (no se
+      defaultean a ''); el caller (`sync_secrets_to_ssm`) decide si la
+      ausencia es fatal segun `spec.required`.
+
+    Esto soporta dos modos:
+    - Local del dev: lee `docker/env/server/.{stage}` (con valores reales).
+    - CI: GitHub Actions inyecta cada key como Environment Secret a
+      `os.environ` y este modulo las resuelve usando `.example` como
+      schema canonico.
+    """
+    if env_file.exists():
+        return load_env_file(env_file)
+
+    keys = load_example_keys(example_file)
+    return {key: os.environ[key] for key in keys if key in os.environ}
 
 
 def _aws_cmd(profile: str | None, *extra: str) -> list[str]:
@@ -218,6 +280,7 @@ def _eval_one(
     profile: str | None,
     region: str,
     dry_run: bool,
+    env_source: str,
 ) -> SyncResult:
     """Evalua y sincroniza un secreto."""
     path = spec.path_for(stage)
@@ -225,8 +288,8 @@ def _eval_one(
     if not local_value:
         if spec.required:
             raise SyncError(
-                f'{spec.source_env_var} ausente o vacio en docker/env/server/'
-                f'.{stage} (requerido por secreto {spec.name!r})',
+                f'{spec.source_env_var} ausente o vacio en {env_source} '
+                f'(requerido por secreto {spec.name!r})',
             )
         return SyncResult(
             name=spec.name,
@@ -269,6 +332,7 @@ def sync_secrets_to_ssm(
     stage: str,
     env_file: Path,
     catalog: Catalog,
+    example_file: Path | None = None,
     profile: str | None = None,
     region: str = 'us-east-1',
     only: tuple[str, ...] | None = None,
@@ -279,6 +343,12 @@ def sync_secrets_to_ssm(
     Devuelve la lista de resultados (un SyncResult por secreto considerado).
     Levanta SyncError si un required falta en el .env.
 
+    Resolucion de valores:
+    - Si `env_file` existe, se carga ese archivo (modo dev local).
+    - Si NO existe y se paso `example_file`, las keys del `.example` se
+      resuelven desde `os.environ` (modo CI con Environment Secrets).
+    - Si NO existe y NO se paso `example_file`, se levanta SyncError.
+
     Hermetico: ningun valor real aparece en stdout/stderr/logs/exception
     messages.
     """
@@ -288,7 +358,16 @@ def sync_secrets_to_ssm(
             'Las env vars del .local se inyectan al runtime del lambda directo.',
         )
 
-    env_values = load_env_file(env_file)
+    if example_file is not None:
+        env_values = load_env_with_fallback(env_file, example_file)
+        env_source = (
+            f'docker/env/server/.{stage}'
+            if env_file.exists()
+            else 'os.environ (CI: GitHub Environment Secrets)'
+        )
+    else:
+        env_values = load_env_file(env_file)
+        env_source = f'docker/env/server/.{stage}'
     specs = catalog.for_stage(stage)
     if only:
         only_set = set(only)
@@ -303,6 +382,7 @@ def sync_secrets_to_ssm(
             profile=profile,
             region=region,
             dry_run=dry_run,
+            env_source=env_source,
         )
         results.append(result)
     return results

--- a/devtools/tests/unit/src/serverless/secrets_sync.py
+++ b/devtools/tests/unit/src/serverless/secrets_sync.py
@@ -144,6 +144,131 @@ class TestLoadEnvFile:
         assert result == {'KEY': 'value'}
 
 
+class TestLoadExampleKeys:
+    def test_when_file_does_not_exist_raises(self, tmp_path):
+        from serverless.secrets_sync import SyncError
+        from serverless.secrets_sync import load_example_keys
+
+        with pytest.raises(SyncError, match='no existe'):
+            load_example_keys(tmp_path / '.example')
+
+    def test_extracts_keys_in_order_skipping_comments(self, tmp_path):
+        from serverless.secrets_sync import load_example_keys
+
+        example = tmp_path / '.example'
+        example.write_text(
+            '# header comment\nFOO=\n\nBAR=value\n# inline comment\nBAZ=x\n',
+            encoding='utf-8',
+        )
+
+        keys = load_example_keys(example)
+
+        assert keys == ('FOO', 'BAR', 'BAZ')
+
+    def test_accepts_keys_with_digits(self, tmp_path):
+        from serverless.secrets_sync import load_example_keys
+
+        example = tmp_path / '.example'
+        example.write_text(
+            'AWS_S3_REGION_NAME=us-east-1\nDB_PORT=5432\n',
+            encoding='utf-8',
+        )
+
+        keys = load_example_keys(example)
+
+        assert keys == ('AWS_S3_REGION_NAME', 'DB_PORT')
+
+    def test_deduplicates_repeated_keys(self, tmp_path):
+        from serverless.secrets_sync import load_example_keys
+
+        example = tmp_path / '.example'
+        example.write_text('FOO=a\nBAR=b\nFOO=c\n', encoding='utf-8')
+
+        keys = load_example_keys(example)
+
+        assert keys == ('FOO', 'BAR')
+
+    def test_skips_invalid_identifiers(self, tmp_path):
+        from serverless.secrets_sync import load_example_keys
+
+        example = tmp_path / '.example'
+        example.write_text(
+            '1BAD_LEADING_DIGIT=x\nGOOD=y\nBAD-DASH=z\n',
+            encoding='utf-8',
+        )
+
+        keys = load_example_keys(example)
+
+        assert keys == ('GOOD',)
+
+
+class TestLoadEnvWithFallback:
+    def test_when_env_file_exists_uses_file(self, tmp_path, monkeypatch):
+        from serverless.secrets_sync import load_env_with_fallback
+
+        example = tmp_path / '.example'
+        example.write_text('FOO=\nBAR=\n', encoding='utf-8')
+        env_file = _write_env(tmp_path, 'FOO=from_file\nBAR=from_file\n')
+        # os.environ tiene un valor distinto para verificar que NO se usa.
+        monkeypatch.setenv('FOO', 'from_env')
+        monkeypatch.setenv('BAR', 'from_env')
+
+        result = load_env_with_fallback(env_file, example)
+
+        assert result == {'FOO': 'from_file', 'BAR': 'from_file'}
+
+    def test_when_env_file_absent_uses_os_environ(self, tmp_path, monkeypatch):
+        from serverless.secrets_sync import load_env_with_fallback
+
+        example = tmp_path / '.example'
+        example.write_text('FOO=\nBAR=\nBAZ=\n', encoding='utf-8')
+        # Solo FOO y BAR en os.environ; BAZ ausente.
+        monkeypatch.setenv('FOO', 'from_env_foo')
+        monkeypatch.setenv('BAR', 'from_env_bar')
+        monkeypatch.delenv('BAZ', raising=False)
+
+        result = load_env_with_fallback(tmp_path / '.dev', example)
+
+        assert result == {'FOO': 'from_env_foo', 'BAR': 'from_env_bar'}
+
+    def test_when_env_file_absent_and_example_absent_raises(self, tmp_path):
+        from serverless.secrets_sync import SyncError
+        from serverless.secrets_sync import load_env_with_fallback
+
+        with pytest.raises(SyncError, match='no existe'):
+            load_env_with_fallback(tmp_path / '.dev', tmp_path / '.example')
+
+
+class TestSyncFlowWithFallback:
+    """Comportamiento de sync_secrets_to_ssm con example_file."""
+
+    def test_fail_fast_message_in_ci_mentions_os_environ(
+        self, tmp_path, monkeypatch
+    ):
+        """Sin .env y con TURNSTILE_SECRET_KEY ausente en os.environ, el
+        mensaje de error debe citar 'os.environ' (no el path del .env)
+        para que el dev de CI entienda donde setear la env var."""
+        from serverless.secrets_catalog import Catalog
+        from serverless.secrets_sync import SyncError
+        from serverless.secrets_sync import sync_secrets_to_ssm
+
+        catalog_dir = _write_catalog_dir(tmp_path)
+        example = tmp_path / '.example'
+        example.write_text('TURNSTILE_SECRET_KEY=\nOWNER_EMAIL=\n', 'utf-8')
+        monkeypatch.delenv('TURNSTILE_SECRET_KEY', raising=False)
+        monkeypatch.delenv('OWNER_EMAIL', raising=False)
+
+        catalog = Catalog.load(catalog_dir)
+
+        with pytest.raises(SyncError, match='os.environ'):
+            sync_secrets_to_ssm(
+                stage='dev',
+                env_file=tmp_path / '.dev',  # NO existe
+                catalog=catalog,
+                example_file=example,
+            )
+
+
 class TestSyncFlow:
     def test_when_value_matches_ssm_returns_skip(self, tmp_path, monkeypatch):
         from serverless.secrets_catalog import Catalog


### PR DESCRIPTION
## Problema

Tras los fixes en #102, el `Re-deploy Lambda db` siguió fallando con un 3er bug arquitectural:

\`\`\`
[ERROR] docker/env/server/.dev no existe.
Crear desde docker/env/server/.example y completar los valores.
\`\`\`

\`devtools/serverless/lambda_controller.py\` (en \`deploy\`) y \`devtools/serverless/secrets_sync.py\` (en el sync a SSM) requerían **estrictamente** que existiera el \`.env\` local del stage. Eso rompe en CI por diseño: GitHub Actions no tiene el archivo (es gitignored) y los valores tendrían que vivir en GitHub Secrets.

## Solución

### Fallback en devtools (commit \`ab758fd\`)

\`secrets_sync.py\` ahora resuelve los valores con esta prioridad:

1. Si existe \`docker/env/server/.{stage}\` -> lo carga (modo dev local, sin cambio).
2. Si **NO** existe -> lee la lista de keys declaradas en \`docker/env/server/.example\` (schema canonico) y resuelve cada una desde \`os.environ\` (modo CI).
3. Si tampoco hay \`.example\` -> \`SyncError\` con mensaje claro.

Funciones nuevas: \`load_example_keys(example_file)\` y \`load_env_with_fallback(env_file, example_file)\`. \`sync_secrets_to_ssm\` acepta \`example_file\` opcional; los callers \`lambda_controller.py\`, \`secrets.py:cmd_sync_secrets\` y \`secrets.py:cmd_secrets_status\` se actualizaron para pasarlo.

Mensaje de error contextual: en CI cita \`os.environ (CI: GitHub Environment Secrets)\` en vez del path local.

9 tests nuevos cubriendo:
- Schema parsing con keys con dígitos (\`AWS_S3_REGION_NAME\`), comentarios, deduplicación.
- Prioridad archivo > \`os.environ\`.
- Fail-fast en CI con mensaje contextual.

### GitHub Environments + Environment Secrets (commit \`bab8a02\`)

- Creé los 3 environments en el repo: \`dev\`, \`stage\`, \`prod\`.
- \`prod\` con deployment branch policy \`main\` only (defense in depth).
- Subí las 20 keys del \`.example\` como Environment Secrets en cada env (60 secrets totales). Operación hermética: los valores pasan por pipe directo (\`grep -m1\` -> \`cut\` -> \`gh secret set\`), nunca tocan el contexto.
- \`deploy-backend.yml\`: jobs \`migrate-db\` y \`deploy-lambdas\` ahora declaran \`environment: <stage>\` + bloque \`env:\` mapeando las 20 keys a \`secrets.*\`.
- \`deploy-apps.yml\`: job \`deploy-pages\` declara \`environment: <stage>\` (para audit log + branch policy). Los \`CLOUDFLARE_*\` siguen como Repository Secrets.

## Como probar

\`\`\`bash
# 1. Tests unit (24 tests del modulo, 9 nuevos)
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/secrets_sync.py -q

# 2. Inventario de environments + secrets
gh api repos/bypabloc/cv/environments | jq '.environments | map(.name)'
# Esperado: ["dev", "stage", "prod"]
for env in dev stage prod; do echo "=== $env"; gh secret list --env $env --repo bypabloc/cv | wc -l; done
# Esperado: 20 en cada uno

# 3. Smoke local del fallback (simula CI)
cd /tmp && mkdir -p fake-env && touch fake-env/.example && echo "TURNSTILE_SECRET_KEY=" > fake-env/.example
# (con .env ausente y key en os.environ se resuelve desde os.environ)

# 4. Workflows YAML siguen validos
devtools/.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-backend.yml')); yaml.safe_load(open('.github/workflows/deploy-apps.yml'))"
\`\`\`

Verificación post-merge: el deploy a \`dev\` que dispara este PR debe pasar las 3 fases de \`Deploy Backend\`:
1. \`migrate-db\`: \`Re-deploy Lambda db\` ya no falla con "docker/env/server/.dev no existe" — resuelve via \`os.environ\` y publica los secrets a SSM \`/portfolio/dev/*\`.
2. \`detect-changes\`: detecta los Lambdas afectados (puede ser 0, no afecta).
3. \`deploy-lambdas\`: deploy de los Lambdas con sus secrets ya en SSM.

## TODO

- Los 63 tests pre-existentes en \`devtools/tests/unit/src/test_runner/flags.py\` siguen fallando (pre-existentes en \`dev\`, no relacionados con este PR).
- \`prod\` ya tiene branch policy \`main\` only. Si querés required reviewers, agregarlo desde la UI: Settings -> Environments -> prod -> Required reviewers.