### PR TITLE
fix(ci): event path relativo al lambda + revierte environment de deploy-pages

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -131,11 +131,12 @@ jobs:
     name: Deploy ${{ matrix.niche }}
     needs: [resolve-env, build-apps]
     runs-on: ubuntu-24.04
-    # GitHub Environment: aplica la deployment branch policy de prod
-    # (solo branch main) y registra el deploy en el audit log del env.
-    # Los secrets CLOUDFLARE_* siguen siendo Repository Secrets (mismos
-    # valores en los 3 envs).
-    environment: ${{ needs.resolve-env.outputs.stage }}
+    # SIN `environment:` a proposito: los secrets CLOUDFLARE_* son
+    # Repository Secrets (mismo valor en dev/stage/prod, no varian).
+    # Cuando un job declara `environment:`, GitHub OCULTA los Repository
+    # Secrets — solo los Environment Secrets del env activo son visibles.
+    # Si en el futuro los CF tokens varian por env, migrarlos a
+    # Environment Secrets y restaurar `environment: <stage>`.
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -114,20 +114,21 @@ jobs:
             --lambda=db --stage=${{ needs.resolve-env.outputs.stage }}
 
       # Aplicar migraciones (Alembic upgrade head). Idempotente: si no hay
-      # nada pending, exit 0.
+      # nada pending, exit 0. El path de --event es relativo al directorio
+      # del lambda (devtools lo resuelve como <lambda_dir>/<event_path>).
       - name: Apply migrations
         run: |
           python devtools/run.py serverless run \
             --lambda=db \
             --stage=${{ needs.resolve-env.outputs.stage }} \
-            --event=serverless/lambda/services/db/events/migrate.json
+            --event=events/migrate.json
 
       - name: Show current revision (audit)
         run: |
           python devtools/run.py serverless run \
             --lambda=db \
             --stage=${{ needs.resolve-env.outputs.stage }} \
-            --event=serverless/lambda/services/db/events/current.json
+            --event=events/current.json
 
   # ---------------------------------------------------------------------------
   # 2. Detect lambdas afectados (path-based + cierre shared) entre el sha


### PR DESCRIPTION
## Problema

Tras mergear #103, el deploy real a `dev` mostró 2 bugs nuevos:

1. **`Apply migrations` falla con path duplicado**:
   ```
   [ERROR] Event JSON no existe:
   /home/runner/work/cv/cv/serverless/lambda/services/db/serverless/lambda/services/db/events/migrate.json
   ```
   `devtools/serverless/local_runtime.py` resuelve `--event` como `<lambda_dir>/<event_path>`, así que pasarle un path desde repo root lo duplica.

2. **`Deploy Apps` falla con `CLOUDFLARE_API_TOKEN` ausente**:
   ```
   In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable
   ```
   Al agregar `environment: <stage>` al job `deploy-pages` en #103, GitHub deja de exponer los Repository Secrets — solo los Environment Secrets del env activo. `CLOUDFLARE_*` son Repository Secrets.

## Solución

1. **`deploy-backend.yml`**: cambia el path del `--event` de `serverless/lambda/services/db/events/migrate.json` a `events/migrate.json` (y `current.json`). devtools lo resuelve internamente respecto al `lambda_dir`.

2. **`deploy-apps.yml`**: revierte el `environment: <stage>` del job `deploy-pages`. `CLOUDFLARE_*` son Repository Secrets con el mismo valor en los 3 envs (no varían por stage). Trade-off: pierde audit log por env + branch policy `main`→prod en deploy-apps. `deploy-backend.yml` mantiene `environment:` porque sus secrets SÍ varían por env (DB_URL, DB_HOST, etc.).

## Como probar

```bash
# YAML valido
devtools/.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-backend.yml')); yaml.safe_load(open('.github/workflows/deploy-apps.yml'))"
```

Verificación post-merge: el deploy a `dev` debe:
- `deploy-backend.yml`: pasar `migrate-db` completo (3 steps: Re-deploy db, Apply migrations, Show current revision).
- `deploy-apps.yml`: completar los 6 deploys de Cloudflare Pages sin error de `CLOUDFLARE_API_TOKEN`.

## TODO

- Si en el futuro los `CLOUDFLARE_*` necesitan variar por env (tokens scoped por stage), migrarlos a Environment Secrets en cada env y restaurar `environment: <stage>` en `deploy-pages`.