### PR TITLE
fix(ci-cd): naming CF Pages sin prefijo + tests de test_runner/flags alineados

### DIFF
--- a/.claude/docs/ci-cd-pipeline/troubleshooting.md
+++ b/.claude/docs/ci-cd-pipeline/troubleshooting.md
@@ -112,7 +112,7 @@ gh api -H "Accept: application/json" \
   "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects" \
   | jq -r '.result[].name' | sort
 
-# Crear el faltante (ej. portfolio-vibe-dev)
+# Crear el faltante (ej. vibe-dev)
 # Ver skill 'cloudflare-deploy' para el comando exacto.
 ```
 

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -123,9 +123,9 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Deploy de las 6 apps en paralelo. Mapeo:
-  #   dev   -> portfolio-{niche}-dev
-  #   stage -> portfolio-{niche}-stage
-  #   main  -> portfolio-{niche}    (sin sufijo)
+  #   dev   -> {niche}-dev
+  #   stage -> {niche}-stage
+  #   main  -> {niche}    (sin sufijo)
   # ---------------------------------------------------------------------------
   deploy-pages:
     name: Deploy ${{ matrix.niche }}
@@ -161,7 +161,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: >-
             pages deploy apps/${{ matrix.niche }}/dist
-            --project-name=portfolio-${{ matrix.niche }}${{ needs.resolve-env.outputs.project-suffix }}
+            --project-name=${{ matrix.niche }}${{ needs.resolve-env.outputs.project-suffix }}
             --branch=${{ github.ref_name }}
 
   # ---------------------------------------------------------------------------
@@ -200,7 +200,7 @@ jobs:
             echo "| Niche | Project | URL |"
             echo "|-------|---------|-----|"
             for niche in generic hub fintech architect leader vibe; do
-              project="portfolio-${niche}${suffix}"
+              project="${niche}${suffix}"
               if [[ "$niche" == "generic" && "$stage" == "prod" ]]; then
                 url="https://the-full-stack.com"
               else

--- a/devtools/test_runner/flags.py
+++ b/devtools/test_runner/flags.py
@@ -1,14 +1,17 @@
 """Flag validation for test_runner script.
 
 Validates and normalizes flags for the unified test runner that
-orchestrates tests across all project modules (server, dashboard, landing,
-devtools).
+orchestrates tests across all project modules (apps Astro, packages,
+devtools, feature E2E global).
 
 Mayo 2026: el módulo `e2e` y el tipo `--type=e2e` fueron eliminados.
-Ahora cada módulo expone su propio `--type=feature` (BDD-style):
-  - server: pytest -m feature contra tests/feature/ (DRF APIClient + DB seed)
-  - dashboard: Playwright contra dashboard/tests/feature/
-  - landing:   Playwright contra landing/tests/feature/
+Ahora los E2E del portfolio viven en `feature` (Playwright global contra
+los 6 sitios del stack local), separado de los unit tests por app:
+  - feature: Playwright contra tests/feature/ (los 6 niches via nginx)
+  - hub / generic / fintech / architect / leader / vibe: unit + coverage
+  - pkg-*: unit + coverage para los packages del workspace
+  - devtools: unit (Python 3.14)
+  - server: unit (Python serverless backend)
 """
 
 import os
@@ -99,8 +102,8 @@ def _validate_module(flags_dict: dict[str, Any]) -> None:
     """Validate --module flag against known modules with tests.
 
     Mayo 2026: rechaza explicitamente ``--module=e2e`` y ``--module=tests``
-    con mensaje de migración (ya no son módulos válidos; cada feature
-    test vive bajo el módulo de su producto: dashboard, landing, server).
+    con mensaje de migración (ya no son módulos válidos; los E2E del
+    portfolio viven en el módulo global ``feature``).
     """
     module = flags_dict.get('module')
     if module is None:
@@ -110,10 +113,8 @@ def _validate_module(flags_dict: dict[str, Any]) -> None:
     if module in {'e2e', 'tests'}:
         raise ValueError(
             f'--module={module} fue eliminado en mayo 2026.\n'
-            'Usa el módulo del producto y --type=feature:\n'
-            '  python devtools/run.py test_runner --module=dashboard --type=feature\n'
-            '  python devtools/run.py test_runner --module=landing --type=feature\n'
-            '  python devtools/run.py test_runner --module=server --type=feature',
+            'Usa el módulo `feature` (global Playwright) y --type=feature:\n'
+            '  python devtools/run.py test_runner --module=feature --type=feature',
         )
 
     valid_modules = [m for m, types in MODULE_TEST_TYPES.items() if types]
@@ -132,8 +133,8 @@ def _validate_type(flags_dict: dict[str, Any]) -> None:
     If not, validates that at least one module supports the type.
 
     Mayo 2026: rechaza ``--type=e2e`` con mensaje de migración. Antes el
-    tipo `e2e` solo aplicaba al módulo `e2e`; ahora cada producto tiene
-    su `--type=feature` (BDD-style).
+    tipo `e2e` solo aplicaba al módulo `e2e`; ahora los E2E del portfolio
+    viven en el módulo global `feature` con `--type=feature`.
     """
     test_type = flags_dict.get('type', 'all')
     if test_type == 'all':
@@ -142,10 +143,8 @@ def _validate_type(flags_dict: dict[str, Any]) -> None:
     if test_type == 'e2e':
         raise ValueError(
             '--type=e2e fue eliminado en mayo 2026. '
-            'Usa --type=feature por módulo:\n'
-            '  python devtools/run.py test_runner --module=dashboard --type=feature\n'
-            '  python devtools/run.py test_runner --module=landing --type=feature\n'
-            '  python devtools/run.py test_runner --module=server --type=feature',
+            'Usa --module=feature --type=feature:\n'
+            '  python devtools/run.py test_runner --module=feature --type=feature',
         )
 
     module = flags_dict.get('module')
@@ -201,7 +200,7 @@ def _validate_env(flags_dict: dict[str, Any]) -> None:
 def _validate_feature_flags(flags_dict: dict[str, Any]) -> None:
     """Validate --screenshots and --ui-review require feature context.
 
-    Estos flags solo aplican a Playwright (feature tests de dashboard/landing).
+    Estos flags solo aplican a Playwright (feature tests E2E del portfolio).
     Si ``--module=server --type=feature`` los usa, error: pytest no genera
     screenshots ni alimenta el UI review.
     """
@@ -218,7 +217,7 @@ def _validate_feature_flags(flags_dict: dict[str, Any]) -> None:
     if not is_playwright_feature:
         flag_name = '--screenshots' if screenshots else '--ui-review'
         raise ValueError(
-            f'{flag_name} requiere --module=dashboard|landing y --type=feature '
+            f'{flag_name} requiere --module=feature y --type=feature '
             '(solo Playwright soporta screenshots).',
         )
 
@@ -248,7 +247,7 @@ def _validate_playwright_only_flag(
     server o con --type distinto de feature.
 
     Sharding y projects son features de Playwright, así que requieren
-    --module=dashboard|landing y --type=feature.
+    --module=feature y --type=feature.
     """
     if not present:
         return
@@ -258,7 +257,7 @@ def _validate_playwright_only_flag(
     if not is_playwright_feature:
         raise ValueError(
             f'--{key.replace("_", "-")} requiere '
-            '--module=dashboard|landing y --type=feature',
+            '--module=feature y --type=feature',
         )
 
 
@@ -266,7 +265,7 @@ def _validate_sharding_flags(flags_dict: dict[str, Any]) -> None:
     """Válida --project, --shard, --shard-total, --fail-on-flaky.
 
     Reglas:
-    - Las 4 flags requieren --module=dashboard|landing y --type=feature
+    - Las 4 flags requieren --module=feature y --type=feature
     - --shard y --shard-total deben usarse juntos
     - shard y shard_total son enteros >= 1
     - shard <= shard_total
@@ -351,8 +350,8 @@ def describe() -> ScriptDescribe:
         'name': 'test_runner',
         'kind': 'monocommand',
         'summary': (
-            'Orquestador de tests (server pytest, dashboard+landing Vitest, '
-            'feature: Playwright en frontend / DRF APIClient en server)'
+            'Orquestador de tests (apps Astro Vitest + packages Vitest + '
+            'devtools pytest + feature Playwright global)'
         ),
         'commands': [],
         'flags': {
@@ -404,7 +403,7 @@ def describe() -> ScriptDescribe:
                 'default': False,
                 'summary': (
                     'Generar screenshots durante --type=feature '
-                    '(solo dashboard/landing)'
+                    '(solo --module=feature)'
                 ),
             },
             'ui_review': {
@@ -412,7 +411,7 @@ def describe() -> ScriptDescribe:
                 'default': False,
                 'summary': (
                     'Revisar screenshots con Gemini CLI tras feature tests '
-                    '(solo dashboard/landing)'
+                    '(solo --module=feature)'
                 ),
             },
             'project': {
@@ -426,7 +425,7 @@ def describe() -> ScriptDescribe:
                 'type': 'int',
                 'summary': (
                     'Shard index 1-based (requiere shard_total). '
-                    'Solo aplica a --type=feature en dashboard/landing.'
+                    'Solo aplica a --module=feature --type=feature.'
                 ),
             },
             'shard_total': {

--- a/devtools/tests/unit/src/test_runner/flags.py
+++ b/devtools/tests/unit/src/test_runner/flags.py
@@ -3,7 +3,7 @@
 Path mirroring: devtools/test_runner/flags.py -> this file.
 
 Cubre las flags de Playwright (--project, --shard, --shard-total,
---fail-on-flaky) que requieren --module=dashboard|landing y --type=feature
+--fail-on-flaky) que requieren --module=feature y --type=feature
 (mayo 2026: el módulo top-level `e2e` fue eliminado y cada producto
 tiene su `--type=feature`). La validación existente de module/type/env
 ya esta probada implicitamente al usarse en cada invocacion.
@@ -28,7 +28,7 @@ class TestProjectFlag:
 
         result = flag(
             {
-                'module': 'dashboard',
+                'module': 'feature',
                 'type': 'feature',
                 'project': 'desktop-chromium',
             },
@@ -39,7 +39,7 @@ class TestProjectFlag:
     def test_project_defaults_to_empty(self):
         from test_runner.flags import flag
 
-        result = flag({'module': 'dashboard', 'type': 'feature'})
+        result = flag({'module': 'feature', 'type': 'feature'})
 
         assert result.get('project', '') == ''
 
@@ -48,7 +48,7 @@ class TestProjectFlag:
 
         with pytest.raises(
             ValueError,
-            match=r'--project requiere --module=dashboard\|landing y --type=feature',
+            match=r'--project requiere --module=feature y --type=feature',
         ):
             flag(
                 {
@@ -72,7 +72,7 @@ class TestShardFlags:
 
         result = flag(
             {
-                'module': 'landing',
+                'module': 'feature',
                 'type': 'feature',
                 'shard': '1',
                 'shard_total': '4',
@@ -87,13 +87,13 @@ class TestShardFlags:
         from test_runner.flags import flag
 
         with pytest.raises(ValueError, match='--shard requiere --shard-total'):
-            flag({'module': 'dashboard', 'type': 'feature', 'shard': '1'})
+            flag({'module': 'feature', 'type': 'feature', 'shard': '1'})
 
     def test_shard_total_requires_shard(self):
         from test_runner.flags import flag
 
         with pytest.raises(ValueError, match='--shard-total requiere --shard'):
-            flag({'module': 'dashboard', 'type': 'feature', 'shard_total': '4'})
+            flag({'module': 'feature', 'type': 'feature', 'shard_total': '4'})
 
     def test_shard_must_be_positive(self):
         from test_runner.flags import flag
@@ -101,7 +101,7 @@ class TestShardFlags:
         with pytest.raises(ValueError, match='--shard debe ser >= 1'):
             flag(
                 {
-                    'module': 'dashboard',
+                    'module': 'feature',
                     'type': 'feature',
                     'shard': '0',
                     'shard_total': '4',
@@ -117,7 +117,7 @@ class TestShardFlags:
         ):
             flag(
                 {
-                    'module': 'dashboard',
+                    'module': 'feature',
                     'type': 'feature',
                     'shard': '5',
                     'shard_total': '4',
@@ -129,7 +129,7 @@ class TestShardFlags:
 
         with pytest.raises(
             ValueError,
-            match=r'--shard requiere --module=dashboard\|landing y --type=feature',
+            match=r'--shard requiere --module=feature y --type=feature',
         ):
             flag(
                 {
@@ -154,7 +154,7 @@ class TestFailOnFlakyFlag:
 
         result = flag(
             {
-                'module': 'dashboard',
+                'module': 'feature',
                 'type': 'feature',
                 'fail_on_flaky': True,
             },
@@ -165,7 +165,7 @@ class TestFailOnFlakyFlag:
     def test_defaults_to_false(self):
         from test_runner.flags import flag
 
-        result = flag({'module': 'dashboard', 'type': 'feature'})
+        result = flag({'module': 'feature', 'type': 'feature'})
 
         assert result.get('fail_on_flaky', False) is False
 
@@ -174,7 +174,7 @@ class TestFailOnFlakyFlag:
 
         with pytest.raises(
             ValueError,
-            match=r'--fail-on-flaky requiere --module=dashboard\|landing y --type=feature',
+            match=r'--fail-on-flaky requiere --module=feature y --type=feature',
         ):
             flag(
                 {
@@ -201,7 +201,7 @@ class TestDockerEnvDefault:
         import test_runner.flags as flags_mod
 
         importlib.reload(flags_mod)
-        result = flags_mod.flag({'module': 'dashboard', 'type': 'feature'})
+        result = flags_mod.flag({'module': 'feature', 'type': 'feature'})
 
         assert result['env'] == 'test'
 
@@ -218,7 +218,7 @@ class TestDockerEnvDefault:
         importlib.reload(flags_mod)
         result = flags_mod.flag(
             {
-                'module': 'dashboard',
+                'module': 'feature',
                 'type': 'feature',
                 'env': 'local',
             },
@@ -236,7 +236,7 @@ class TestDockerEnvDefault:
         import test_runner.flags as flags_mod
 
         importlib.reload(flags_mod)
-        result = flags_mod.flag({'module': 'dashboard', 'type': 'feature'})
+        result = flags_mod.flag({'module': 'feature', 'type': 'feature'})
 
         assert result['env'] == 'local'
 
@@ -254,7 +254,7 @@ class TestCIFlagCombination:
 
         result = flag(
             {
-                'module': 'dashboard',
+                'module': 'feature',
                 'type': 'feature',
                 'project': 'desktop-chromium',
                 'shard': '2',
@@ -263,7 +263,7 @@ class TestCIFlagCombination:
             },
         )
 
-        assert result['module'] == 'dashboard'
+        assert result['module'] == 'feature'
         assert result['type'] == 'feature'
         assert result['project'] == 'desktop-chromium'
         assert result['shard'] == 2
@@ -308,4 +308,4 @@ class TestE2EMigrationErrors:
             ValueError,
             match='--type=e2e fue eliminado',
         ):
-            flag({'module': 'dashboard', 'type': 'e2e'})
+            flag({'module': 'feature', 'type': 'e2e'})


### PR DESCRIPTION
## Problema

1. **Naming mismatch en Cloudflare Pages**: `deploy-apps.yml` buscaba proyectos con prefijo `portfolio-{niche}{suffix}` pero los 18 proyectos en Cloudflare están como `{niche}{suffix}` (sin prefijo). Resultado: cada deploy a Pages fallaba con HTTP 4xx (proyecto inexistente).

2. **14 tests fallando en `devtools/tests/unit/src/test_runner/flags.py`**: usaban módulo `dashboard` que ya no existe en este portfolio (vestigio de un proyecto anterior). El código de `test_runner/flags.py` validaba `module == 'feature'` pero los mensajes de error citaban `--module=dashboard|landing`, y los tests pasaban `'module': 'dashboard'`.

3. **Proyectos faltantes en CF**: la verificación inicial dijo que faltaban 8 proyectos. Falso positivo: el listado de la API estaba paginado con `per_page=10` default y hay 18 proyectos (2 páginas).

## Solución

### 1. `deploy-apps.yml` — naming sin prefijo (commit `90285b3`)
- `--project-name=portfolio-${{ matrix.niche }}${{ ... suffix }}` → `--project-name=${{ matrix.niche }}${{ ... suffix }}`
- Mismo fix en el step `Build report body` (commit comment).
- Mismo fix en `.claude/docs/ci-cd-pipeline/troubleshooting.md`.

### 2. `test_runner/flags.py` + tests (commit `83efa6a`)
- Reemplaza `dashboard`/`landing` (módulos de un proyecto anterior) por `feature` (el módulo Playwright global actual del portfolio).
- Mensajes de error de `--module`, `--type`, `--screenshots`, `--ui-review`, `--shard`, `--project`, `--fail-on-flaky` ahora citan `--module=feature` en lugar de `--module=dashboard|landing` (el código ya validaba `module == 'feature'` pero el mensaje no reflejaba la realidad).
- 14 tests actualizados: `'module': 'dashboard'` → `'module': 'feature'`. Regex matches alineados.
- Docstring del módulo + `describe()` actualizados al stack actual.

### 3. Proyectos CF — no requiere acción
- 18 proyectos verificados existir: `architect`, `architect-dev`, `architect-stage`, `fintech`, `fintech-dev`, `fintech-stage`, `generic`, `generic-dev`, `generic-stage`, `hub`, `hub-dev`, `hub-stage`, `leader`, `leader-dev`, `leader-stage`, `vibe`, `vibe-dev`, `vibe-stage`.

## Como probar

```bash
# 1. Tests de flags.py todos verdes
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/test_runner/flags.py -q
# Esperado: 19 passed (antes: 14 failed + 5 passed)

# 2. YAML workflows válidos
devtools/.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-apps.yml')); yaml.safe_load(open('.github/workflows/deploy-backend.yml'))"

# 3. Inventario CF (con paginación correcta)
CLOUDFLARE_ACCOUNT_ID="..." CLOUDFLARE_API_TOKEN="..." \
  bash -c 'for p in 1 2; do curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects?page=$p" | jq -r ".result[].name"; done' | sort
# Esperado: los 18 nombres listados arriba
```

Verificación post-merge: el deploy a `dev` debe completar los 6 jobs `Deploy <niche>` en `Deploy Apps` sin error HTTP 4xx.

## TODO

- Si en el futuro el proyecto se rebrandeo y los CF Pages deben tener prefijo (`portfolio-X`), reverter este PR o renombrar via API CF.