### PR TITLE
fix(api-gw): agregar OPTIONS CORS preflight a /track, /contact, /cv

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -815,6 +815,134 @@ def _ssm_value(path: str, *, profile: str | None, region: str) -> str:
     return str(result.json['Parameter']['Value'])
 
 
+def _wire_cors_options(
+    *,
+    api_id: str,
+    resource_id: str,
+    method: str,
+    profile: str | None,
+    region: str,
+) -> None:
+    """Crea el method OPTIONS para CORS preflight en un resource de API GW.
+
+    Patron estandar de CORS:
+    - PUT method OPTIONS authType=NONE.
+    - MOCK integration con request template para application/json y
+      passthroughBehavior=WHEN_NO_TEMPLATES (sin este flag, browsers que
+      hacen preflight sin Content-Type reciben 500).
+    - method-response + integration-response con los 4 headers
+      Access-Control-* (Origin=*, Methods, Headers, Max-Age=600).
+
+    Headers permitidos: Content-Type + los headers Turnstile del form de
+    contacto. Si en el futuro el frontend manda headers custom, ampliar
+    aqui (anyway el preflight los lista en Access-Control-Request-Headers
+    y el navegador valida contra Access-Control-Allow-Headers).
+
+    Idempotente: cada `aws apigateway put-*` acepta re-aplicacion sobre
+    una entidad existente (sobrescribe). Para flexibilidad ante re-deploys,
+    los errores "ConflictException: Method already exists" se ignoran.
+    """
+    allowed_headers = 'Content-Type,X-Turnstile-Token,X-Turnstile-Bypass-Secret'
+    allowed_methods = f'{method},OPTIONS'
+
+    # 1. put-method OPTIONS — puede fallar con ConflictException si ya
+    # existe. Lo tratamos como noop.
+    aws(
+        [
+            'apigateway',
+            'put-method',
+            '--rest-api-id',
+            api_id,
+            '--resource-id',
+            resource_id,
+            '--http-method',
+            'OPTIONS',
+            '--authorization-type',
+            'NONE',
+        ],
+        profile=profile,
+        region=region,
+        check=False,
+    )
+
+    # 2. put-integration MOCK
+    aws(
+        [
+            'apigateway',
+            'put-integration',
+            '--rest-api-id',
+            api_id,
+            '--resource-id',
+            resource_id,
+            '--http-method',
+            'OPTIONS',
+            '--type',
+            'MOCK',
+            '--request-templates',
+            '{"application/json":"{\\"statusCode\\":200}"}',
+            '--passthrough-behavior',
+            'WHEN_NO_TEMPLATES',
+        ],
+        profile=profile,
+        region=region,
+        check=False,
+    )
+
+    # 3. put-method-response 200 declarando los 4 headers CORS
+    aws(
+        [
+            'apigateway',
+            'put-method-response',
+            '--rest-api-id',
+            api_id,
+            '--resource-id',
+            resource_id,
+            '--http-method',
+            'OPTIONS',
+            '--status-code',
+            '200',
+            '--response-parameters',
+            (
+                'method.response.header.Access-Control-Allow-Origin=true,'
+                'method.response.header.Access-Control-Allow-Methods=true,'
+                'method.response.header.Access-Control-Allow-Headers=true,'
+                'method.response.header.Access-Control-Max-Age=true'
+            ),
+        ],
+        profile=profile,
+        region=region,
+        check=False,
+    )
+
+    # 4. put-integration-response 200 con los VALORES de los headers
+    aws(
+        [
+            'apigateway',
+            'put-integration-response',
+            '--rest-api-id',
+            api_id,
+            '--resource-id',
+            resource_id,
+            '--http-method',
+            'OPTIONS',
+            '--status-code',
+            '200',
+            '--response-parameters',
+            (
+                '{'
+                '"method.response.header.Access-Control-Allow-Origin":"\'*\'",'
+                f'"method.response.header.Access-Control-Allow-Methods":"\'{allowed_methods}\'",'
+                f'"method.response.header.Access-Control-Allow-Headers":"\'{allowed_headers}\'",'
+                '"method.response.header.Access-Control-Max-Age":"\'600\'"'
+                '}'
+            ),
+        ],
+        profile=profile,
+        region=region,
+        check=False,
+    )
+
+
 def _wire_http_trigger(
     rendered: RenderedLambda,
     stage: str,
@@ -895,6 +1023,19 @@ def _wire_http_trigger(
             '--uri',
             invoke_arn,
         ],
+        profile=profile,
+        region=region,
+    )
+    # CORS preflight: agrega OPTIONS al resource para que los browsers que
+    # disparan preflight (Content-Type application/json o headers custom)
+    # reciban un 200 con los headers Access-Control-* correctos. Sin esto,
+    # API Gateway responde MissingAuthenticationTokenException (HTTP 403) y
+    # el browser bloquea la request real. Idempotente — los `put-*` aceptan
+    # re-aplicacion sobre un metodo existente.
+    _wire_cors_options(
+        api_id=api_id,
+        resource_id=resource_id,
+        method=str(trigger.method),
         profile=profile,
         region=region,
     )


### PR DESCRIPTION
## Problema

Verificacion post-merge revelo que el OPTIONS preflight de los 3 endpoints retornaba HTTP 403 `MissingAuthenticationToken`:

```bash
curl -X OPTIONS https://gvz6y2xcsa.execute-api.us-east-1.amazonaws.com/dev/track \
  -H "Origin: https://generic.portfolio.dev.the-full-stack.com" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: content-type"
# HTTP/2 403
# {"message":"Missing Authentication Token"}
```

Causa: el `_wire_http_trigger` del provisioner solo creaba el metodo principal (POST/GET) en API Gateway, sin agregar el metodo `OPTIONS` necesario para CORS preflight. Resultado: cualquier browser que disparara preflight (Content-Type `application/json`, o headers custom como `X-Turnstile-Token`) recibia 403 antes de poder hacer la request real.

Por que "funcionaba" antes:
- `TrackingPixel` envia `Content-Type: text/plain` (CORS-safelisted) → no dispara preflight.
- Pero el form de contacto envia `application/json` + `X-Turnstile-Token` → SI dispara preflight → 403.
- Si alguna vez TrackingPixel cambia a JSON normal, tambien rompe.

## Solucion

Nueva funcion `_wire_cors_options(api_id, resource_id, method, ...)` en `provisioner.py` que crea via AWS CLI:

1. `put-method OPTIONS` con `authType=NONE`.
2. `put-integration` tipo `MOCK` con `passthroughBehavior=WHEN_NO_TEMPLATES` (sin este flag, preflights sin Content-Type generan HTTP 500 en la MOCK).
3. `put-method-response 200` declarando los 4 headers `Access-Control-*`.
4. `put-integration-response 200` con los VALORES (`Allow-Origin: *`, `Allow-Methods: POST,OPTIONS`, `Allow-Headers: Content-Type,X-Turnstile-Token,X-Turnstile-Bypass-Secret`, `Max-Age: 600`).

Inyectada en `_wire_http_trigger` despues del `put-integration` del metodo principal. Idempotente — cada `aws apigateway put-*` acepta re-aplicacion (`check=False` para tolerar `ConflictException`).

## Estado actual

Fix aplicado manualmente en dev mediante AWS CLI ANTES de este commit. Verificacion post-fix:

```bash
# OPTIONS preflight
curl -X OPTIONS https://.../dev/track -H "Origin: ..." -H "Access-Control-Request-Method: POST"
# HTTP/2 200
# access-control-allow-origin: *
# access-control-allow-headers: Content-Type
# access-control-allow-methods: POST,OPTIONS
# access-control-max-age: 600

# POST real con application/json + Origin
curl -X POST https://.../dev/track -H "Origin: ..." -H "Content-Type: application/json" -d '{...}'
# HTTP/2 204
```

Este PR garantiza que el patron se aplique automaticamente en futuros deploys (incluido stage y prod).

## Como probar

Tras merge a `dev`:

1. El workflow `deploy-backend.yml` re-deploy los 3 lambdas afectados.
2. El `provisioner._wire_http_trigger` ejecuta el nuevo `_wire_cors_options` para cada trigger.
3. Verificar:

```bash
for env in dev stage prod; do
  for path in track contact cv; do
    echo -n "$env /$path OPTIONS: "
    curl -sS -o /dev/null -w "%{http_code}\n" -X OPTIONS \
      "https://<api>.execute-api.us-east-1.amazonaws.com/$env/$path" \
      -H "Origin: https://example.test" \
      -H "Access-Control-Request-Method: POST"
  done
done
# Debe imprimir 200 para los 9 casos.
```

## TODO

- En stage y prod: el wiring CORS solo se aplicara cuando esos lambdas se re-desplieguen. El proximo deploy automatico (cuando algun PR a stage/main toque uno de los 3 lambdas) lo aplicara. Si quieres aplicarlo YA en stage/prod, correr `serverless deploy --lambda=tracking_pixel --stage=stage` (y lo mismo para contact_form, cv) tras mergear este PR.