### PR TITLE
chore(tests): fix devtools tests post direct-neon-writes + doc dead code dynamodb

### DIFF
--- a/devtools/tests/unit/src/serverless/change_detector.py
+++ b/devtools/tests/unit/src/serverless/change_detector.py
@@ -209,7 +209,8 @@ class TestDetectAffectedLambdas:
         When invoco detect_affected_lambdas con los lambdas reales del repo,
         Then devuelve los lambdas cuyo cierre transitivo incluye shared.db
              (segun el shared_resolver real). Para el portfolio esto incluye
-             db, cv y stream_processor.
+             contact_form, cv, db y tracking_pixel (todos escriben/leen
+             Neon tras spec direct-neon-writes).
         """
         result = detect_affected_lambdas(
             base_sha='_unused',
@@ -218,8 +219,7 @@ class TestDetectAffectedLambdas:
             files=['serverless/lambda/shared/db/__init__.py'],
         )
         # Cualquier lambda que importe shared.db debe estar en el resultado.
-        # db (Lambda db), cv (cv_repository) y stream_processor (writes).
-        assert {'db', 'cv', 'stream_processor'}.issubset(result)
+        assert {'contact_form', 'cv', 'db', 'tracking_pixel'}.issubset(result)
 
     def test_combinacion_de_service_y_shared(self):
         """
@@ -237,9 +237,9 @@ class TestDetectAffectedLambdas:
             ],
         )
         # contact_form esta porque su path cambio directo.
-        # Los consumers de shared.db (db, cv, stream_processor) tambien.
+        # Los demas consumers de shared.db (cv, db, tracking_pixel) tambien.
         assert 'contact_form' in result
-        assert {'db', 'cv', 'stream_processor'}.issubset(result)
+        assert {'cv', 'db', 'tracking_pixel'}.issubset(result)
 
     def test_archivos_irrelevantes_returns_empty(self):
         """

--- a/devtools/tests/unit/src/serverless/infra_provision.py
+++ b/devtools/tests/unit/src/serverless/infra_provision.py
@@ -229,17 +229,21 @@ class TestRenderResource:
 class TestDiscoverResources:
     """discover_resources lista los fragmentos reales de resources/."""
 
-    def test_discover_finds_seven_resources(self):
+    def test_discover_finds_four_resources(self):
         """
-        Given los 7 fragmentos de serverless/lambda/resources/,
+        Given los 4 fragmentos de serverless/lambda/resources/,
         When discover_resources,
-        Then devuelve exactamente 7 paths y ninguno empieza con '_'.
+        Then devuelve exactamente 4 paths y ninguno empieza con '_'.
+
+        Cantidad post spec direct-neon-writes: 3 tablas DDB (cache +
+        rate-limit-rules + rate-limit-buckets) + 1 API GW. Se eliminaron
+        las tablas `contacts`/`tracking` y la SQS DLQ del stream_processor.
         """
         from serverless import infra_provision
 
         paths = infra_provision.discover_resources()
 
-        assert len(paths) == 7
+        assert len(paths) == 4
         assert all(not p.stem.startswith('_') for p in paths)
 
 

--- a/devtools/tests/unit/src/serverless/provisioner.py
+++ b/devtools/tests/unit/src/serverless/provisioner.py
@@ -21,7 +21,12 @@ _ZIP_PATH = Path('build') / 'build.zip'
 
 
 def _manifest_http():
-    """Manifiesto de un Lambda con trigger http y uses (contact-form)."""
+    """Manifiesto de un Lambda con trigger http y uses (contact-form).
+
+    Tablas: solo infra (cache + rate-limit-buckets). Spec
+    direct-neon-writes elimino `contacts` y `tracking` del catalogo
+    `_TABLES` del provisioner — los Lambdas escriben directo a Neon.
+    """
     return {
         'name': 'contact-form',
         'runtime': 'python3.13',
@@ -32,7 +37,7 @@ def _manifest_http():
         'trigger': {'type': 'http', 'method': 'POST', 'path': '/contact'},
         'uses': {
             'tables': {
-                'contacts': 'read-write',
+                'rate-limit-buckets': 'read-write',
                 'cache': 'read-write',
             },
             'secrets': ['turnstile-secret', 'owner-email'],
@@ -42,28 +47,6 @@ def _manifest_http():
             'default': {'LOG_LEVEL': 'INFO'},
             'dev': {'LOG_LEVEL': 'INFO'},
         },
-    }
-
-
-def _manifest_stream():
-    """Manifiesto de un Lambda con trigger on-table-changes."""
-    return {
-        'name': 'stream-processor',
-        'runtime': 'python3.13',
-        'handler': 'core.handler.lambda_handler',
-        'memory': 512,
-        'timeout': 60,
-        'region': 'us-east-1',
-        'trigger': {
-            'type': 'on-table-changes',
-            'tables': ['contacts', 'tracking'],
-        },
-        'uses': {
-            'tables': [],
-            'secrets': ['neon-url'],
-            'sends-email': False,
-        },
-        'env': {'default': {'LOG_LEVEL': 'INFO'}},
     }
 
 
@@ -142,7 +125,7 @@ class TestRender:
         assert len(dynamo) == 2
         assert dynamo[0]['Resource'] == [
             'arn:aws:dynamodb:us-east-1:${account}:'
-            'table/portfolio-contacts-dev',
+            'table/portfolio-rate-limit-buckets-dev',
         ]
 
     def test_render_iam_policy_when_uses_secrets(self):
@@ -180,27 +163,6 @@ class TestRender:
             'arn:aws:ses:us-east-1:${account}:identity/the-full-stack.com'
             in ses[0]['Resource']
         )
-
-    def test_render_iam_policy_when_on_table_changes(self):
-        from serverless import provisioner
-
-        rendered = provisioner.render(_manifest_stream(), stage='dev')
-
-        statements = rendered.iam_policy['Statement']
-        stream = [s for s in statements if 'dynamodb:GetRecords' in s['Action']]
-        sqs = [s for s in statements if s['Action'] == ['sqs:SendMessage']]
-        assert len(stream) == 1
-        assert len(sqs) == 1
-        assert stream[0]['Resource'] == [
-            'arn:aws:dynamodb:us-east-1:${account}:'
-            'table/portfolio-contacts-dev/stream/*',
-            'arn:aws:dynamodb:us-east-1:${account}:'
-            'table/portfolio-tracking-dev/stream/*',
-        ]
-        assert sqs[0]['Resource'] == [
-            'arn:aws:sqs:us-east-1:${account}:'
-            'portfolio-stream-processor-dlq-dev',
-        ]
 
     def test_render_is_pure_same_input_same_output(self):
         from serverless import provisioner
@@ -269,6 +231,11 @@ class TestProvisionCreate:
         )
 
         verbs = ['.'.join(c[:2]) for c in calls]
+        # Orden post fix CORS preflight (PR #107): el _wire_http_trigger
+        # crea POST + OPTIONS con sus put-method-response/put-integration-
+        # response antes de la deployment. La 2a `apigateway.put-method`
+        # corresponde a OPTIONS y las 2 put-*-response son su respuesta
+        # mockeada para devolver headers CORS al preflight.
         assert verbs == [
             'sts.get-caller-identity',
             'iam.create-role',
@@ -282,6 +249,10 @@ class TestProvisionCreate:
             'apigateway.create-resource',
             'apigateway.put-method',
             'apigateway.put-integration',
+            'apigateway.put-method',
+            'apigateway.put-integration',
+            'apigateway.put-method-response',
+            'apigateway.put-integration-response',
             'apigateway.create-deployment',
             'lambda.add-permission',
         ]
@@ -317,39 +288,6 @@ class TestProvisionCreate:
             '/aws/lambda/portfolio-contact-form-dev'
         )
         assert state.resources['api_resource_id'] == 'res9'
-
-    def test_provision_create_stream_creates_event_source_mappings(
-        self, monkeypatch
-    ):
-        from serverless.state import Action
-
-        from serverless import provisioner
-
-        calls = []
-        monkeypatch.setattr(
-            provisioner,
-            'aws',
-            _fake_aws(calls, _default_responses()),
-        )
-        monkeypatch.setattr(provisioner.time, 'sleep', lambda _s: None)
-
-        rendered = provisioner.render(_manifest_stream(), stage='dev')
-        state = provisioner.provision(
-            rendered,
-            action=Action.CREATE,
-            zip_path=_ZIP_PATH,
-            previous=None,
-            profile=None,
-            region='us-east-1',
-        )
-
-        mappings = [
-            c
-            for c in calls
-            if '.'.join(c[:2]) == 'lambda.create-event-source-mapping'
-        ]
-        assert len(mappings) == 2
-        assert state.resources['event_source_uuids'] == 'uuid-1,uuid-1'
 
 
 class TestProvisionUpdate:

--- a/devtools/tests/unit/src/serverless/resolve.py
+++ b/devtools/tests/unit/src/serverless/resolve.py
@@ -111,10 +111,12 @@ class TestResolveByLambdaName:
 
         names = available_lambdas()
 
+        # 4 lambdas reales tras spec direct-neon-writes (stream_processor
+        # se elimino: contact_form/tracking_pixel escriben directo a Neon).
         assert names == [
             'contact_form',
+            'cv',
             'db',
-            'stream_processor',
             'tracking_pixel',
         ]
 
@@ -127,7 +129,7 @@ class TestResolveByLambdaName:
         for name in (
             'contact_form',
             'tracking_pixel',
-            'stream_processor',
+            'cv',
             'db',
         ):
             resolved = resolve_lambda({'lambda': name})

--- a/serverless/lambda/shared/dynamodb/__init__.py
+++ b/serverless/lambda/shared/dynamodb/__init__.py
@@ -6,17 +6,23 @@ acceso boto3, reusa el resource singleton de `shared.dynamodb_client`,
 convierte `Decimal` de forma transparente y expone DML (datos) + DDL
 acotado (verificacion de esquema + create solo para tests/local).
 
-Las tablas reales de dev/stage/prod las sigue creando CloudFormation
-(`serverless/infra/infra.yaml`): es el unico que puede conectar el
-DynamoDB Stream al `stream_processor` y exportar los `TableArn` para el
-IAM least-privilege. Ver `README.md` de este paquete.
+Las tablas reales de dev/stage/prod las sigue creando devtools con
+`aws dynamodb create-table`, leyendo el catalogo de
+`serverless/lambda/resources/dynamodb/*.yaml` (3 tablas: `cache`,
+`rate-limit-rules`, `rate-limit-buckets`). Ver `README.md` de este
+paquete.
 
-Uso ergonomico:
+Modelos en uso (produccion):
 
-    from shared.dynamodb import ContactItem
+    from shared.dynamodb import CacheItem, RateLimitBucketItem
 
-    ContactItem(id='...', created_at='...', name='Pablo').save()
-    item = ContactItem.get('the-id')
+Modelos legacy (TEST FIXTURES — spec direct-neon-writes):
+
+    ContactItem, TrackingEventItem ya no se importan en codigo de
+    produccion (`contact_form`/`tracking_pixel` escriben directo a Neon).
+    Se conservan como exemplars de `BaseModel` para los tests de
+    `shared.dynamodb`. Si se refactorizan esos tests, las clases pueden
+    eliminarse — ver docstring en `models/{contact,tracking}.py`.
 """
 
 from shared.dynamodb._schema import GSIMeta, SchemaDiff, TableMeta

--- a/serverless/lambda/shared/dynamodb/models/contact.py
+++ b/serverless/lambda/shared/dynamodb/models/contact.py
@@ -1,7 +1,15 @@
-"""Modelo de la tabla `portfolio-contacts-{stage}`.
+"""Modelo de la tabla `portfolio-contacts-{stage}` — TEST FIXTURE LEGACY.
 
 Tabla del form de contacto. PK simple `id` (UUIDv7); `created_at` es un
 atributo, NO sort key (paridad con `infra.yaml`).
+
+**NOTA (spec direct-neon-writes)**: ningun Lambda en produccion importa
+esta clase — `contact_form` escribe directo a Neon (`shared.db.Contact`)
+en vez de DynamoDB. La clase se conserva como fixture para los tests de
+`shared.dynamodb.BaseModel` (~10 archivos en `tests/.../shared/dynamodb/`
+la usan como exemplar concreto). Cuando esos tests se refactoricen a usar
+`CacheItem`/`RateLimitBucketItem` como fixtures unicos, esta clase y la
+tabla DDB se pueden eliminar.
 """
 
 from __future__ import annotations

--- a/serverless/lambda/shared/dynamodb/models/tracking.py
+++ b/serverless/lambda/shared/dynamodb/models/tracking.py
@@ -1,10 +1,19 @@
-"""Modelo de la tabla `portfolio-tracking-{stage}`.
+"""Modelo de la tabla `portfolio-tracking-{stage}` — TEST FIXTURE LEGACY.
 
 Tabla de eventos de tracking pixel. PK compuesta `session_id` (HASH) +
 `page_id` (RANGE). TTL 60d via `expires_at`.
 
 GSI `niche-created_at-index` (PK `niche`, SK `created_at`): habilita
 queries de dashboard por nicho ordenadas por fecha sin full scan.
+
+**NOTA (spec direct-neon-writes)**: ningun Lambda en produccion importa
+esta clase — `tracking_pixel` escribe directo a Neon
+(`shared.db.TrackingEvent`) en vez de DynamoDB. La clase se conserva
+como fixture para los tests de `shared.dynamodb.BaseModel` (~10 archivos
+en `tests/.../shared/dynamodb/` la usan como exemplar concreto).
+Cuando esos tests se refactoricen a usar `CacheItem`/
+`RateLimitBucketItem` como fixtures unicos, esta clase y la tabla DDB
+se pueden eliminar.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problema

Tras el merge de PR #110 (direct-neon-writes) quedaron 2 grupos de items pendientes que rompian la suite devtools:

1. **Tests de devtools desactualizados** referenciando `stream_processor`, la tabla DDB `contacts`/`tracking`, y el trigger `on-table-changes` — todo eliminado en PR #110.
2. **Dead code en `shared/dynamodb/models/{contact,tracking}.py`**: ningun lambda en produccion los importa, pero ~10 tests de `shared.dynamodb.BaseModel` los usan como exemplares concretos.

## Solucion

### Tests devtools (4 archivos, 281/281 verde)

- `change_detector.py`: el cierre transitivo de `shared/db/__init__.py` ahora incluye `{contact_form, cv, db, tracking_pixel}` (no `stream_processor`).
- `resolve.py`: `available_lambdas()` retorna `['contact_form', 'cv', 'db', 'tracking_pixel']` (4 lambdas).
- `provisioner.py`: tabla `'contacts'` -> `'rate-limit-buckets'` en el manifest fixture; eliminado `_manifest_stream` + sus 2 tests de `on-table-changes`; actualizada la lista de verbos del `call_order` test (18 en vez de 14, incluye OPTIONS preflight de PR #107).
- `infra_provision.py`: `test_discover_finds_seven_resources` -> `test_discover_finds_four_resources` (3 tablas DDB + 1 API GW).

### Dead code dynamodb (3 archivos, docstrings)

Decidi NO eliminar los modelos: ~10 tests de `BaseModel` los usan como exemplars. El refactor a usar `CacheItem`/`RateLimitBucketItem` como unicos fixtures es mucho diff con poco valor. En su lugar:

- `shared/dynamodb/__init__.py`: docstring actualizada — produccion usa solo Cache + RateLimit; Contact + TrackingEvent son legacy test fixtures.
- `shared/dynamodb/models/{contact,tracking}.py`: docstring marcado `TEST FIXTURE LEGACY` con instrucciones de eliminacion futura.

### Cleanup adicional

- `rm -rf serverless/lambda/services/stream_processor/` — el dir tenia artefactos no-tracked (.venv, build/, .pytest_cache, .invoke, build.zip) tras el git rm de PR #110.

## Como probar

```bash
# devtools serverless tests
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/  # 281 passed

# shared tests
python devtools/run.py serverless tests --type=unit --shared              # 327 passed

# lambdas refactorizados
python devtools/run.py serverless tests --type=unit --lambda=tracking_pixel  # 15
python devtools/run.py serverless tests --type=unit --lambda=contact_form    # 14
python devtools/run.py serverless tests --type=unit --lambda=db              # 47
```

## TODO

**No incluido en este PR** (pre-existing failures NO relacionadas a direct-neon-writes):

- `devtools/tests/unit/src/shared/{classification,coverage,deletion_mirror,purity}.py`: ~50 tests referencian modulos `dashboard` y `landing` que NO existen en este portfolio. Artefactos copiados de otro proyecto, requieren eliminacion o refactor — follow-up aparte.

- Refactor de los ~10 tests de `shared.dynamodb` para usar `CacheItem`/`RateLimitBucketItem` como exemplars y eliminar definitivamente `ContactItem`/`TrackingEventItem`. Decision diferida: alto diff, bajo valor.