### PR TITLE
fix(change_detector): filtrar lambdas eliminados del repo

### DIFF
--- a/devtools/serverless/change_detector.py
+++ b/devtools/serverless/change_detector.py
@@ -182,14 +182,20 @@ def detect_affected_lambdas(
         elif kind.kind == 'shared' and kind.name is not None:
             affected_shared.add(kind.name)
 
+    lambda_names = available_lambdas() if affected_shared or affected else []
+
     if affected_shared:
-        lambda_names = available_lambdas()
         consumers = _consumers_of_shared(
             affected_shared, lambdas_root, lambda_names
         )
         affected.update(consumers)
 
-    return affected
+    # Filtrar lambdas que ya no existen en el repo (ej. un lambda
+    # eliminado: el diff lo lista como service pero `services/<name>/`
+    # ya no existe). Sin este filtro, el CI matrix intentaria deployar
+    # un lambda inexistente y fallaria con "No existe el lambda".
+    valid = set(lambda_names)
+    return {name for name in affected if name in valid}
 
 
 # ---------------------------------------------------------------------------

--- a/devtools/tests/unit/src/serverless/change_detector.py
+++ b/devtools/tests/unit/src/serverless/change_detector.py
@@ -308,3 +308,35 @@ class TestCmdDetectChanges:
         captured = capsys.readouterr()
         payload = json.loads(captured.out)
         assert payload == {'affected': ['cv', 'db']}
+
+
+class TestFilterDeletedLambdas:
+    """Lambdas eliminados del repo (`services/<name>/` no existe) no deben aparecer en `affected`.
+
+    Bug del 2026-05-24: un cambio que toca shared/db y a la vez elimina
+    el lambda `stream_processor` hacia que `change_detector` lo incluyera
+    en `affected` (porque el diff lo lista como `service`), y el CI matrix
+    intentaba deployarlo fallando con "No existe el lambda".
+    """
+
+    def test_lambda_eliminado_del_repo_no_aparece_en_affected(self):
+        """
+        Given un diff que toca services/stream_processor/X.py (lambda
+             eliminado del repo) + shared/db/__init__.py,
+        When invoco detect_affected_lambdas con los lambdas reales,
+        Then `stream_processor` NO esta en el resultado (solo los lambdas
+             que existen en services/).
+        """
+        result = detect_affected_lambdas(
+            base_sha='_unused',
+            head_sha='_unused',
+            lambdas_root=_lambdas_root(),
+            files=[
+                'serverless/lambda/services/stream_processor/core/handler.py',
+                'serverless/lambda/shared/db/__init__.py',
+            ],
+        )
+        # stream_processor fue eliminado — no debe aparecer.
+        assert 'stream_processor' not in result
+        # Los lambdas que SI existen y consumen shared.db sí aparecen.
+        assert {'contact_form', 'cv', 'db', 'tracking_pixel'}.issubset(result)


### PR DESCRIPTION
## Problema

Tras el merge de PR #110 (direct-neon-writes) el workflow deploy-backend.yml fallaba en el matrix step \`Deploy stream_processor\` con:

\`\`\`
[ERROR] Error ejecutando deploy: No existe el lambda 'stream_processor' en /serverless/lambda/services. Lambdas validos: contact_form, cv, db, tracking_pixel.
\`\`\`

Causa: \`change_detector.detect_affected_lambdas\` listaba a \`stream_processor\` como afectado porque el diff lo incluye (como service path con archivos eliminados), aunque la carpeta \`services/stream_processor/\` ya no exista.

## Solucion

Filtrar el set \`affected\` al final de la funcion contra \`available_lambdas()\`. Cualquier lambda en el diff que ya no exista en \`services/\` queda fuera.

Test nuevo (\`TestFilterDeletedLambdas\`) reproduce exactamente el bug.

## Como probar

\`\`\`bash
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/change_detector.py
# 19 passed

devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/
# 282 passed (era 281)
\`\`\`

Tras merge, el siguiente run de deploy-backend.yml debe pasar sin \`Deploy stream_processor\` en el matrix.

## TODO

(ninguno)