### PR TITLE
fix(ui): corrige NicheDropdown siempre visible en desktop

### DIFF
--- a/packages/ui/src/components/NicheDropdown.astro
+++ b/packages/ui/src/components/NicheDropdown.astro
@@ -66,7 +66,7 @@ const { label, items, currentViewLabel = 'Vista actual' } = Astro.props
       />
     </svg>
   </button>
-  <ul class="niche-dropdown__menu" role="menu" hidden data-niche-dropdown-menu>
+  <ul class="niche-dropdown__menu" role="menu" data-niche-dropdown-menu>
     {
       items.map((item) => (
         <li role="none">
@@ -131,11 +131,9 @@ const { label, items, currentViewLabel = 'Vista actual' } = Astro.props
 
       const close = (): void => {
         trigger.setAttribute('aria-expanded', 'false')
-        menu.hidden = true
       }
       const open = (): void => {
         trigger.setAttribute('aria-expanded', 'true')
-        menu.hidden = false
       }
 
       trigger.addEventListener(
@@ -225,6 +223,33 @@ const { label, items, currentViewLabel = 'Vista actual' } = Astro.props
     z-index: 60;
     display: grid;
     gap: 2px;
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(-4px);
+    pointer-events: none;
+    transition:
+      opacity var(--motion-fast) var(--easing-out),
+      transform var(--motion-fast) var(--easing-out),
+      visibility 0s linear var(--motion-fast);
+  }
+  .niche-dropdown:has(
+      > [data-niche-dropdown-trigger][aria-expanded='true']
+    )
+    .niche-dropdown__menu {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+    transition:
+      opacity var(--motion-fast) var(--easing-out),
+      transform var(--motion-fast) var(--easing-out),
+      visibility 0s;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .niche-dropdown__menu {
+      transition: none;
+      transform: none;
+    }
   }
   .niche-dropdown__item {
     display: flex;


### PR DESCRIPTION
## Problema

El dropdown "Otras vistas" del navbar aparecia siempre visible en desktop, sin que el usuario hubiera hecho click en el trigger. El atributo `hidden` del `<ul>` no surtia efecto porque la regla CSS `.niche-dropdown__menu { display: grid }` pisaba el `[hidden] { display: none }` del user-agent stylesheet (la specificity gana). El menu mobile (`<details>` nativo en `MobileNavDrawer.astro`) funcionaba correctamente.

## Solucion

- Removido atributo `hidden` del `<ul>` del dropdown. `aria-expanded` del `<button>` pasa a ser la unica fuente de verdad del estado.
- JS: eliminadas las dos lineas `menu.hidden = true/false`. El close/open ahora solo togglea `aria-expanded`.
- CSS: el estado cerrado se aplica con `visibility: hidden; opacity: 0; transform: translateY(-4px); pointer-events: none` (cuenta como hidden para Playwright `toBeHidden()`). El estado abierto se dispara via selector `.niche-dropdown:has(> [data-niche-dropdown-trigger][aria-expanded='true']) .niche-dropdown__menu`.
- Animacion fade + slide corto con `transition` sobre `opacity` + `transform` usando `--motion-fast` + `--easing-out`. Guard `@media (prefers-reduced-motion: reduce)` desactiva la animacion.
- `MobileNavDrawer.astro` sin cambios: el `<details>` nativo ya estaba cerrado por default.

## Como probar

1. Levantar el stack local:
   - `python3 devtools/run.py docker up --env=local`
2. Abrir cualquier subdominio en desktop (>=768px):
   - http://hub.localhost:9970/
   - http://fintech.localhost:9970/
3. Verificar:
   - El menu "Otras vistas" NO aparece visible al cargar la pagina.
   - Click en "Otras vistas" -> menu hace fade-in con slide.
   - Click fuera del menu -> hace fade-out (con animacion).
   - Tecla Escape -> cierra el menu y devuelve focus al trigger.
   - DevTools rendering -> `prefers-reduced-motion: reduce`: el toggle es instantaneo (sin slide/transform).
4. En mobile (DevTools 375x667 o similar):
   - El hamburger abre el drawer.
   - El acordeon `<details>` "Otras vistas" sigue cerrado por default y se expande con click.
5. (opcional) E2E del navbar:
   - `python3 devtools/run.py test_runner --module=feature --type=feature --env=local`

## TODO

- [ ] Sin items pendientes.