### PR TITLE
fix(lambda): agrega CORS_ALLOWED_ORIGINS al manifest del contact_form

### DIFF
--- a/serverless/lambda/services/contact_form/manifest.yaml
+++ b/serverless/lambda/services/contact_form/manifest.yaml
@@ -48,13 +48,22 @@ uses:
   sends-email: true
 
 # --- Variables de entorno por stage ---
+# CORS_ALLOWED_ORIGINS define la whitelist de origins permitidos por
+# el handler HTTP (common/cors.py) Y el set de hostnames validos del
+# widget Turnstile (shared/http/turnstile._expected_hostnames). Por eso
+# debe coincidir con el dominio publico de cada stage; si falta, el
+# siteverify rechaza con CAPTCHA_HOSTNAME_MISMATCH (defensa contra
+# widget hijacking). Misma whitelist que tracking_pixel y cv.
 env:
   default:
     LOG_LEVEL: INFO
     AWS_SES_REGION: us-east-1
   dev:
     LOG_LEVEL: INFO
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com'
   stage:
     LOG_LEVEL: INFO
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com'
   prod:
     LOG_LEVEL: WARNING
+    CORS_ALLOWED_ORIGINS: 'https://the-full-stack.com,https://www.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com'


### PR DESCRIPTION
## Problema

`POST /contact` en dev devolvia **HTTP 403** con `code=CAPTCHA_HOSTNAME_MISMATCH` aunque el form generaba un token Turnstile valido (sitekey publicado correcto, widget en Cloudflare con los hostnames de dev OK).

Causa raiz: el `manifest.yaml` del Lambda `contact_form` **no declaraba** la env var `CORS_ALLOWED_ORIGINS` en ninguno de los stages. Sin ella, `shared/http/turnstile._expected_hostnames()` retornaba solo `{'localhost', '127.0.0.1'}` y rechazaba cualquier hostname publico devuelto por el siteverify de Cloudflare.

Sintoma en CloudWatch (`portfolio-contact-form-dev`):
```
"reason": "Hostname mismatch: 'portfolio.dev.the-full-stack.com'"
"reason": "Hostname mismatch: 'vibe.portfolio.dev.the-full-stack.com'"
"code":   "CAPTCHA_HOSTNAME_MISMATCH"
```

`tracking_pixel/manifest.yaml` y `cv/manifest.yaml` SI tenian la env var (por eso `/track` funcionaba); solo `contact_form` la habia perdido.

## Solucion

- Agregado `CORS_ALLOWED_ORIGINS` en `env.{dev,stage,prod}` del manifest, replicando el set exacto de `tracking_pixel` + `cv` (6 origins por stage; prod incluye apex + `www`).
- Comentario en el manifest explicando la doble funcion del env var (CORS handler + Turnstile hostname guard) para evitar regresiones.
- Sin cambios en codigo del Lambda. El fix vive solo en la config.

## Como probar

1. Mergear el PR. `deploy-backend.yml` corre `migrate-db` (no-op aqui) + `detect-changes` -> `deploy-lambdas` matrix con `contact_form` afectado por el cambio en su manifest.
2. Esperar el redeploy (~1-2 min).
3. En el browser, abrir `https://hub.portfolio.dev.the-full-stack.com/contact` (o cualquiera de los 6 niches dev) y enviar el form de contacto con datos validos. Esperado: **HTTP 200**, email enviado al owner.
4. Verificacion CloudWatch:
   ```bash
   aws --profile tfs-dev logs filter-log-events --region us-east-1 \
     --log-group-name '/aws/lambda/portfolio-contact-form-dev' \
     --start-time $(( ($(date +%s) - 300) * 1000 )) \
     --filter-pattern '"CAPTCHA_HOSTNAME_MISMATCH"' \
     --query 'events[*].timestamp' --output text
   ```
   Esperado: vacio (0 rejections post-deploy).
5. Verificacion env var live:
   ```bash
   aws --profile tfs-dev lambda get-function-configuration --region us-east-1 \
     --function-name portfolio-contact-form-dev \
     --query 'Environment.Variables.CORS_ALLOWED_ORIGINS' --output text
   ```
   Esperado: `https://portfolio.dev.the-full-stack.com,https://hub.portfolio...,...,https://vibe.portfolio.dev.the-full-stack.com`.

## TODO

- [ ] (opcional, fuera de scope) Centralizar `CORS_ALLOWED_ORIGINS` en un anchor YAML compartido entre `contact_form`, `tracking_pixel` y `cv` para que un cambio futuro de subdominios se haga en un solo lugar.