### PR TITLE
fix(db): host(ip) en ensure_session_and_visit (visits redundantes)

### DIFF
--- a/serverless/lambda/shared/db/repository.py
+++ b/serverless/lambda/shared/db/repository.py
@@ -212,9 +212,13 @@ def ensure_session_and_visit(
     session.execute(sessions_upsert)
 
     # --- Paso 2: SELECT ultimo visit del session, FOR UPDATE --------
+    # host(ip) en vez de ip::text: INET cast a text agrega sufijo de
+    # mascara (/32 para IPv4, /128 para IPv6) y la comparacion contra
+    # el payload (str plano sin mascara) fallaba SIEMPRE. host() devuelve
+    # solo la direccion sin mascara, alineado con el formato del payload.
     last_visit_query = (
         text(
-            'SELECT visit_id, ip::text, utm_source, utm_medium, '
+            'SELECT visit_id, host(ip) AS ip, utm_source, utm_medium, '
             'utm_campaign, utm_content, utm_term '
             'FROM session_visits '
             'WHERE session_id = :sid '


### PR DESCRIPTION
## Problema

Hotfix del bug encontrado en la verificacion E2E post-merge del PR #117 (sessions-normalize):

`ensure_session_and_visit` creaba un NUEVO `session_visits` por cada evento, incluso cuando los 6 campos del visit-trigger eran identicos. La comparacion de IPs fallaba siempre porque:

- DB INET cast: `ip::text` → `'38.25.33.147/32'` (con sufijo de mascara)
- Payload del Lambda: `'38.25.33.147'` (str plano)

Smoke test mostro 3 visits para 3 eventos con utm_source=`twitter`,`linkedin`,`linkedin` (esperado: 2 — el segundo `linkedin` debia reusar).

## Solucion

`SELECT host(ip) AS ip` en lugar de `ip::text`. `host()` retorna la direccion sin sufijo de mascara, alineado con el formato del payload.

## Como probar

1. Mergear → deploy-backend redeploya `contact_form` + `tracking_pixel` + `cv` (shared/db cambio).
2. Re-correr el smoke test de 3 eventos: `twitter`, `linkedin`, `linkedin`. Esperado: 2 visits en `session_visits` para el mismo session (el segundo `linkedin` reusa el primero, `event_count=2`).

## TODO

- Agregar test integration del helper contra PG real (testcontainers) para detectar bugs de este tipo en CI.