### PR TITLE
release: fix lambda update wait + group-tables-by-domain a stage

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -113,6 +113,15 @@ jobs:
           python devtools/run.py serverless deploy \
             --lambda=db --stage=${{ needs.resolve-env.outputs.stage }}
 
+      # update-function-code es async: retorna mientras la Lambda sigue
+      # en estado Pending. La proxima invocacion falla con
+      # ResourceConflictException. `aws lambda wait function-updated`
+      # bloquea hasta que LastUpdateStatus = Successful.
+      - name: Wait for Lambda db update to complete
+        run: |
+          aws lambda wait function-updated \
+            --function-name portfolio-db-${{ needs.resolve-env.outputs.stage }}
+
       # Aplicar migraciones (Alembic upgrade head). Idempotente: si no hay
       # nada pending, exit 0. El path de --event es relativo al directorio
       # del lambda (devtools lo resuelve como <lambda_dir>/<event_path>).


### PR DESCRIPTION
Promueve a stage:
- Fix race condition: 'aws lambda wait function-updated' antes de migrate (PR #122)
- Plan group-tables-by-domain (PR #119 ya mergeado a dev)

El intento anterior (PR #120 mergeado en 46a6bb0) fallo en deploy-backend stage por la race condition. Este PR trae el fix + re-dispara el deploy.