### PR TITLE
release: auto-seed + cli-timeout fix a stage

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -139,6 +139,18 @@ jobs:
             --stage=${{ needs.resolve-env.outputs.stage }} \
             --event=events/current.json
 
+      # Seed del CV: idempotente (ON CONFLICT DO NOTHING en cada upsert).
+      # Re-correr el seed en cada deploy garantiza que la data del CV
+      # este sincronizada con los YAMLs del repo en TODOS los stages.
+      # Datos del visitante (contacts, sessions, tracking_events) NO se
+      # tocan — el seed solo escribe en cv_*, tax_*, i18n_*.
+      - name: Run CV seed (idempotent)
+        run: |
+          python devtools/run.py serverless run \
+            --lambda=db \
+            --stage=${{ needs.resolve-env.outputs.stage }} \
+            --event=events/seed.json
+
   # ---------------------------------------------------------------------------
   # 2. Detect lambdas afectados (path-based + cierre shared) entre el sha
   # del push anterior y el actual. Excluye `db` (ya redeployado).

--- a/devtools/serverless/lambda_controller.py
+++ b/devtools/serverless/lambda_controller.py
@@ -468,10 +468,18 @@ def _invoke_remote(flags: dict[str, Any]) -> int:
     function_name = rendered.function_name
     region = str(resolved.manifest.get('region', 'us-east-1'))
 
+    # Timeouts del aws CLI mas generosos: el default (60s read) corta
+    # invocaciones legitimas de Lambdas que tardan mas en cold start
+    # (ej. seed del CV, ~90s). Usamos 600s para cubrir el max timeout
+    # de Lambda (15 min) y cualquier cold start.
     args = [
         'aws',
         'lambda',
         'invoke',
+        '--cli-read-timeout',
+        '600',
+        '--cli-connect-timeout',
+        '60',
         '--function-name',
         function_name,
         '--region',


### PR DESCRIPTION
Promueve a stage los fixes:
- ci(deploy-backend): seed automatico del CV en cada deploy (PR #124)
- fix(devtools/serverless): cli-read-timeout 600s en aws lambda invoke (PR #125)

Esperado en deploy stage: migrate + seed completos, stage queda con
CV poblado completo (1 profile, 9 experiences, 10 endorsements,
99 skills, 348 translations).