### PR TITLE
release: fixes consolidados + group-tables-by-domain a production

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -106,6 +106,16 @@ jobs:
       - name: Setup uv (devtools bootstrap)
         run: pip install uv
 
+      # Provision de la infra compartida (API Gateway, tablas DynamoDB,
+      # roles IAM). Idempotente: si los recursos ya existen, no los
+      # recrea (estado guardado en devtools/serverless/.state/ o S3).
+      # Primera ejecucion en un stage nuevo crea desde cero y publica
+      # ARNs/IDs en SSM (/portfolio/<stage>/...).
+      - name: Provision shared infrastructure
+        run: |
+          python devtools/run.py serverless provision-infra \
+            --stage=${{ needs.resolve-env.outputs.stage }}
+
       # Re-deploy del Lambda db ANTES de invocar migrate: puede haber
       # cambios en migrations / models que requieren el codigo actualizado.
       - name: Re-deploy Lambda db

--- a/serverless/lambda/resources/api_gateway/portfolio-api.yaml
+++ b/serverless/lambda/resources/api_gateway/portfolio-api.yaml
@@ -27,19 +27,19 @@ custom_domain_by_stage:
   # api.portfolio -> 'prod'.
   dev:
     domain_name: api.portfolio.dev.the-full-stack.com
-    endpoint_type: EDGE
+    endpoint_type: REGIONAL
     certificate_arn: arn:aws:acm:us-east-1:637423614564:certificate/50c750aa-abbf-4b88-885b-17e4d243b439
     base_path_mappings:
       - { base_path: '', stage: dev }
   stage:
     domain_name: api.portfolio.stage.the-full-stack.com
-    endpoint_type: EDGE
+    endpoint_type: REGIONAL
     certificate_arn: arn:aws:acm:us-east-1:637423614564:certificate/50c750aa-abbf-4b88-885b-17e4d243b439
     base_path_mappings:
       - { base_path: '', stage: stage }
   prod:
     domain_name: api.portfolio.the-full-stack.com
-    endpoint_type: EDGE
+    endpoint_type: REGIONAL
     certificate_arn: arn:aws:acm:us-east-1:637423614564:certificate/50c750aa-abbf-4b88-885b-17e4d243b439
     base_path_mappings:
       - { base_path: '', stage: prod }


### PR DESCRIPTION
Promueve a production todos los fixes acumulados durante la promocion stage:

- ci(deploy-backend): provision-infra automatico (#128)
- fix(resources): custom_domains EDGE -> REGIONAL (#130)

Mas los fixes ya en stage:
- ci(deploy-backend): wait function-updated (#122)
- ci(deploy-backend): auto-seed (#124)
- fix(devtools): cli-read-timeout 600s (#125)

Y el plan original:
- feat(db): group tables by domain (#119)

GitHub Environment Variables prod ya pobladas (BASE_DOMAIN, BASE_SCHEME, PUBLIC_API_ENDPOINT, PUBLIC_TURNSTILE_SITEKEY, APEX_DOMAIN).

Branch Neon production RESETEADA antes (DROP + CREATE SCHEMA). El deploy automatico provisionara API Gateway + DynamoDB tables + aplicara init + correra seed.