### PR TITLE
fix(devtools/serverless): pin canonical role en update-function-configuration

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -1126,11 +1126,29 @@ def _provision_update_config(
     profile: str | None,
     region: str,
 ) -> None:
-    """Secuencia `Action.UPDATE_CONFIG`: config de funcion + IAM inline."""
-    import json
+    """Secuencia `Action.UPDATE_CONFIG`: config de funcion + IAM inline.
 
+    Garantiza que el rol canonico (`rendered.role_name`) existe y que el
+    Lambda esta amarrado a el via `--role`. Sin `--role`, un Lambda
+    creado originalmente por SAM/CFN nunca cambiaria de rol y quedaria
+    bloqueado en las permisos del legado (causa raiz del incidente del
+    25/05/2026 en prod /track y /contact: las nuevas Lambdas leen los
+    nombres de tablas DynamoDB desde SSM en cold start, pero el rol
+    legacy SAM no tenia `ssm:GetParameter`).
+    """
     account = _resolve_account(profile=profile, region=region)
     policy = _concrete_iam_policy(rendered, account)
+
+    resources: dict[str, str | None] = {}
+    _create_iam_role(
+        rendered,
+        policy,
+        account,
+        profile=profile,
+        region=region,
+        resources=resources,
+    )
+    role_arn = str(resources['role_arn'])
 
     _wait_function_active(
         rendered.function_name, profile=profile, region=region
@@ -1141,6 +1159,8 @@ def _provision_update_config(
             'update-function-configuration',
             '--function-name',
             rendered.function_name,
+            '--role',
+            role_arn,
             '--runtime',
             rendered.runtime,
             '--handler',
@@ -1151,20 +1171,6 @@ def _provision_update_config(
             str(rendered.timeout),
             '--environment',
             _environment_arg(rendered.env_vars),
-        ],
-        profile=profile,
-        region=region,
-    )
-    aws(
-        [
-            'iam',
-            'put-role-policy',
-            '--role-name',
-            rendered.role_name,
-            '--policy-name',
-            _INLINE_POLICY_NAME,
-            '--policy-document',
-            json.dumps(policy),
         ],
         profile=profile,
         region=region,

--- a/devtools/tests/unit/src/serverless/provisioner.py
+++ b/devtools/tests/unit/src/serverless/provisioner.py
@@ -193,9 +193,8 @@ class TestRender:
         assert rendered.trigger.path == '/contact'
 
     def test_render_when_invalid_trigger_raises_manifest_error(self):
-        from serverless.resolve import ManifestError
-
         from serverless import provisioner
+        from serverless.resolve import ManifestError
 
         manifest = _manifest_direct()
         manifest['trigger'] = {'type': 'cron'}
@@ -208,9 +207,8 @@ class TestProvisionCreate:
     """provision() con Action.CREATE corre la secuencia completa."""
 
     def test_provision_create_call_order(self, monkeypatch):
-        from serverless.state import Action
-
         from serverless import provisioner
+        from serverless.state import Action
 
         calls = []
         monkeypatch.setattr(
@@ -259,9 +257,8 @@ class TestProvisionCreate:
         assert state.resources['function_name'] == 'portfolio-contact-form-dev'
 
     def test_provision_create_records_resources(self, monkeypatch):
-        from serverless.state import Action
-
         from serverless import provisioner
+        from serverless.state import Action
 
         calls = []
         monkeypatch.setattr(
@@ -296,10 +293,9 @@ class TestProvisionUpdate:
     def test_provision_update_code_only_calls_update_function_code(
         self, monkeypatch
     ):
+        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
-
-        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(provisioner, 'aws', _fake_aws(calls))
@@ -331,10 +327,9 @@ class TestProvisionUpdate:
     def test_provision_update_config_calls_config_and_role_policy(
         self, monkeypatch
     ):
+        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
-
-        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(
@@ -364,17 +359,28 @@ class TestProvisionUpdate:
         verbs = ['.'.join(c[:2]) for c in calls]
         assert verbs == [
             'sts.get-caller-identity',
+            'iam.create-role',
+            'iam.put-role-policy',
+            'iam.attach-role-policy',
             'lambda.wait',
             'lambda.update-function-configuration',
-            'iam.put-role-policy',
         ]
         assert 'lambda.create-function' not in verbs
 
+        update_call = next(
+            c
+            for c in calls
+            if c[:2] == ['lambda', 'update-function-configuration']
+        )
+        assert '--role' in update_call
+        role_arn = update_call[update_call.index('--role') + 1]
+        # _default_responses devuelve este ARN fijo para iam.create-role.
+        assert role_arn == 'arn:aws:iam::111122223333:role/portfolio-x'
+
     def test_provision_update_both_runs_code_and_config(self, monkeypatch):
+        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
-
-        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(
@@ -406,16 +412,17 @@ class TestProvisionUpdate:
             'lambda.wait',
             'lambda.update-function-code',
             'sts.get-caller-identity',
+            'iam.create-role',
+            'iam.put-role-policy',
+            'iam.attach-role-policy',
             'lambda.wait',
             'lambda.update-function-configuration',
-            'iam.put-role-policy',
         ]
 
     def test_provision_noop_makes_no_aws_calls(self, monkeypatch):
+        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
-
-        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(provisioner, 'aws', _fake_aws(calls))
@@ -447,11 +454,10 @@ class TestProvisionPartialFailure:
     def test_provision_partial_failure_records_created_resources(
         self, monkeypatch
     ):
+        from serverless import provisioner
         from serverless.aws_cli import AwsError
         from serverless.aws_cli import AwsResult
         from serverless.state import Action
-
-        from serverless import provisioner
 
         calls = []
         responses = _default_responses()
@@ -502,10 +508,9 @@ class TestDeprovision:
     """deprovision() borra los recursos en orden inverso al de creacion."""
 
     def test_deprovision_reverse_order(self, monkeypatch):
+        from serverless import provisioner
         from serverless.aws_cli import AwsResult
         from serverless.state import LambdaState
-
-        from serverless import provisioner
 
         calls = []
 
@@ -553,10 +558,9 @@ class TestDeprovision:
     def test_deprovision_stream_deletes_event_source_mappings(
         self, monkeypatch
     ):
+        from serverless import provisioner
         from serverless.aws_cli import AwsResult
         from serverless.state import LambdaState
-
-        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(


### PR DESCRIPTION
## Problema

En el despliegue del 25/05/2026 a prod, los endpoints `/track` y `/contact` empezaron a responder HTTP 500 con `AccessDeniedException`:

```
User: arn:aws:sts::637423614564:assumed-role/portfolio-backend-prod-TrackingPixelFunctionRole-raHQWCniMtic/portfolio-tracking-pixel-prod
is not authorized to perform: ssm:GetParameter on resource:
arn:aws:ssm:us-east-1:637423614564:parameter/portfolio/prod/dynamodb/cache/name
```

Causa raiz: el provisioner creaba el rol canonico devtools (`portfolio-tracking-pixel-prod`) con la inline policy correcta y le aplicaba un `put-role-policy`, pero `aws lambda update-function-configuration` se ejecutaba **sin `--role`**, asi que el Lambda quedaba amarrado al rol SAM/CFN legacy (`portfolio-backend-prod-*FunctionRole-XXXXX`) sin permisos sobre los nuevos paths SSM. El codigo nuevo (post squash de migraciones) resuelve los nombres de tablas DynamoDB via `ssm:GetParameter` en cold start; el rol legacy SAM solo tenia DynamoDB.

Stage no rompio porque corre un SHA viejo que lee `CACHE_TABLE_NAME` directo del environment sin pasar por SSM.

## Solucion

`_provision_update_config` ahora:
1. Llama `_create_iam_role` (idempotente) para garantizar que el rol canonico existe con la inline policy renderizada actual.
2. Pasa `--role <arn-canonico>` a `aws lambda update-function-configuration` para que el Lambda se desamarre del rol legacy en el primer redeploy.

Quita el `put-role-policy` duplicado al final de la funcion (`_create_iam_role` ya lo hace).

## Como probar

```bash
cd devtools && .venv/bin/python -m pytest tests/unit/src/serverless/provisioner.py
# 16 passed
```

Verificacion en AWS (ya ejecutada manualmente sobre prod sin esperar este merge porque era incidente activo):

```bash
aws lambda update-function-configuration \
  --function-name portfolio-tracking-pixel-prod \
  --role arn:aws:iam::637423614564:role/portfolio-tracking-pixel-prod \
  --profile tfs-dev
aws lambda update-function-configuration \
  --function-name portfolio-contact-form-prod \
  --role arn:aws:iam::637423614564:role/portfolio-contact-form-prod \
  --profile tfs-dev
```

Post-swap: smoke test devuelve HTTP 400 (validacion Pydantic correcta), cero `AccessDenied` en CloudWatch en los siguientes 3 min.

Tras este merge, en el proximo redeploy de stage el provisioner desamarra automaticamente las Lambdas stage de sus roles SAM legacy. No requiere accion manual adicional.

## TODO

- Sin tareas pendientes en este PR.