### PR TITLE
release(prod): fix vis_session_visits raw SQL -> ORM (PR #136)

### DIFF
--- a/serverless/lambda/shared/db/repository.py
+++ b/serverless/lambda/shared/db/repository.py
@@ -18,13 +18,28 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import text
+from sqlalchemy import BigInteger, Column, MetaData, String, Table
+from sqlalchemy import func as sa_func
+from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session as OrmSession
 
 from .models import Contact, SessionVisit, TrackingEvent
 from .models import Session as SessionRow
 from .session import get_engine
+
+# `pg_stat_user_tables` es una system view del catalogo de Postgres
+# (no tiene modelo ORM porque NO es una tabla del schema del portfolio).
+# La declaramos como `Table` independiente para construir el SELECT con
+# Core en vez de raw SQL. MetaData propia para que el reflejo no toque
+# el `Base.metadata` del schema del portfolio.
+_pg_stat_user_tables = Table(
+    'pg_stat_user_tables',
+    MetaData(),
+    Column('schemaname', String),
+    Column('relname', String),
+    Column('n_live_tup', BigInteger),
+)
 
 
 class RepositoryError(Exception):
@@ -47,16 +62,6 @@ class RepositoryError(Exception):
         self.error_code = error_code
 
 
-# La query de listado de tablas: estimado de filas via las estadisticas
-# del planner (`pg_stat_user_tables`), sin contar fila por fila.
-_TABLES_QUERY = (
-    "SELECT schemaname || '.' || relname AS table_name, "
-    'n_live_tup AS estimated_rows '
-    'FROM pg_stat_user_tables '
-    'ORDER BY n_live_tup DESC'
-)
-
-
 def list_tables() -> dict[str, Any]:
     """Lista las tablas de la DB con un estimado de filas por tabla.
 
@@ -77,10 +82,21 @@ def list_tables() -> dict[str, Any]:
         Si la query falla (DB inaccesible, schema sin migrar, etc.) con
         `code=5000` y `error_code='DB_QUERY_FAILED'`.
     """
+    schemaname = _pg_stat_user_tables.c.schemaname
+    relname = _pg_stat_user_tables.c.relname
+    n_live_tup = _pg_stat_user_tables.c.n_live_tup
+    stmt = (
+        select(
+            (schemaname + '.' + relname).label('table_name'),
+            n_live_tup.label('estimated_rows'),
+        )
+        .select_from(_pg_stat_user_tables)
+        .order_by(n_live_tup.desc())
+    )
     try:
         engine = get_engine()
         with engine.connect() as conn:
-            rows = conn.execute(text(_TABLES_QUERY)).all()
+            rows = conn.execute(stmt).all()
     except Exception as exc:
         raise RepositoryError(
             f'No se pudo listar las tablas: {exc}',
@@ -207,7 +223,7 @@ def ensure_session_and_visit(
     )
     sessions_upsert = sessions_insert.on_conflict_do_update(
         index_elements=['session_id'],
-        set_={'last_seen_at': text('now()')},
+        set_={'last_seen_at': sa_func.now()},
     )
     session.execute(sessions_upsert)
 
@@ -217,19 +233,21 @@ def ensure_session_and_visit(
     # el payload (str plano sin mascara) fallaba SIEMPRE. host() devuelve
     # solo la direccion sin mascara, alineado con el formato del payload.
     last_visit_query = (
-        text(
-            'SELECT visit_id, host(ip) AS ip, utm_source, utm_medium, '
-            'utm_campaign, utm_content, utm_term '
-            'FROM vis_session_visits '
-            'WHERE session_id = :sid '
-            'ORDER BY started_at DESC '
-            'LIMIT 1 '
-            'FOR UPDATE'
+        select(
+            SessionVisit.visit_id,
+            sa_func.host(SessionVisit.ip).label('ip'),
+            SessionVisit.utm_source,
+            SessionVisit.utm_medium,
+            SessionVisit.utm_campaign,
+            SessionVisit.utm_content,
+            SessionVisit.utm_term,
         )
+        .where(SessionVisit.session_id == session_id)
+        .order_by(SessionVisit.started_at.desc())
+        .limit(1)
+        .with_for_update()
     )
-    last_visit = session.execute(
-        last_visit_query, {'sid': session_id}
-    ).first()
+    last_visit = session.execute(last_visit_query).first()
 
     incoming: dict[str, str | None] = {
         'ip': ip,
@@ -267,13 +285,12 @@ def ensure_session_and_visit(
     # --- Paso 3b: UPDATE visit existente (ended_at + event_count) --
     visit_id = str(last_visit.visit_id)
     session.execute(
-        text(
-            'UPDATE session_visits '
-            'SET ended_at = now(), '
-            '    event_count = event_count + :delta '
-            'WHERE visit_id = :vid'
-        ),
-        {'delta': bump_delta, 'vid': visit_id},
+        update(SessionVisit)
+        .where(SessionVisit.visit_id == visit_id)
+        .values(
+            ended_at=sa_func.now(),
+            event_count=SessionVisit.event_count + bump_delta,
+        )
     )
     return session_id, visit_id
 

--- a/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_inserts_new_visit_when_keys_differ.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_inserts_new_visit_when_keys_differ.py
@@ -1,0 +1,86 @@
+"""shared.db.repository.ensure_session_and_visit — INSERT branch.
+
+Given una Session sin visit previo (`first()` devuelve None),
+When se invoca ensure_session_and_visit,
+Then agrega un nuevo `SessionVisit` con todos los campos del payload,
+     hace flush para obtener el `visit_id`, y NO ejecuta UPDATE.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from shared.db.models import SessionVisit
+from shared.db.repository import ensure_session_and_visit
+
+pytestmark = pytest.mark.unit
+
+
+def test_ensure_session_and_visit_inserts_new_visit_when_keys_differ() -> None:
+    # Arrange — session sin visit previo
+    session = MagicMock()
+    session.execute.return_value.first.return_value = None
+
+    # Patch session.add para capturar el SessionVisit y poblar visit_id
+    # cuando flush() lo simulando el server-side default.
+    added_objects: list[SessionVisit] = []
+
+    def fake_add(obj: SessionVisit) -> None:
+        added_objects.append(obj)
+
+    def fake_flush() -> None:
+        # uuidv7 simulado para que str(new_visit.visit_id) no falle.
+        added_objects[0].visit_id = UUID(
+            '019e5fce-385d-7530-8f6e-8e17df16f08a'
+        )
+
+    session.add.side_effect = fake_add
+    session.flush.side_effect = fake_flush
+
+    # Act
+    session_id_ret, visit_id = ensure_session_and_visit(
+        session,
+        session_id='sess-abc',
+        ip='1.2.3.4',
+        country='CL',
+        user_agent='ua',
+        browser='Chrome',
+        browser_version='120',
+        os_name='Linux',
+        device_type='desktop',
+        utm_source='google',
+        utm_medium='cpc',
+        utm_campaign='launch',
+        utm_content=None,
+        utm_term=None,
+        referrer='https://example.com',
+        landing_page_path='/',
+        niche='fintech',
+        bump_event_count=True,
+    )
+
+    # Assert
+    assert session_id_ret == 'sess-abc'
+    assert visit_id == '019e5fce-385d-7530-8f6e-8e17df16f08a'
+    # session.execute se llamo dos veces: UPSERT sessions + SELECT visit
+    assert session.execute.call_count == 2
+    # Solo 1 add: el SessionVisit nuevo
+    assert len(added_objects) == 1
+    new_visit = added_objects[0]
+    assert isinstance(new_visit, SessionVisit)
+    assert new_visit.session_id == 'sess-abc'
+    assert new_visit.ip == '1.2.3.4'
+    assert new_visit.country == 'CL'
+    assert new_visit.utm_source == 'google'
+    assert new_visit.utm_medium == 'cpc'
+    assert new_visit.utm_campaign == 'launch'
+    assert new_visit.utm_content is None
+    assert new_visit.utm_term is None
+    assert new_visit.referrer == 'https://example.com'
+    assert new_visit.landing_page_path == '/'
+    assert new_visit.niche == 'fintech'
+    assert new_visit.event_count == 1
+    # flush emitido para obtener visit_id server-side
+    assert session.flush.call_count == 1

--- a/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_select_targets_vis_session_visits.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_select_targets_vis_session_visits.py
@@ -1,0 +1,74 @@
+"""shared.db.repository.ensure_session_and_visit — SELECT guardia.
+
+Given una Session,
+When ensure_session_and_visit ejecuta el SELECT FOR UPDATE del ultimo
+     visit del session,
+Then el statement compila a un SELECT FROM `vis_session_visits` con
+     `host(ip)`, ORDER BY started_at DESC LIMIT 1 FOR UPDATE.
+
+Guardia anti-regresion: el SELECT estaba en raw SQL previamente; al
+renombrarse la tabla podia quedar apuntando al nombre viejo. Ahora va
+por ORM (`select(SessionVisit.visit_id, ...)`) — el `__tablename__`
+del modelo es la unica fuente de verdad.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from shared.db.repository import ensure_session_and_visit
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import Select
+
+pytestmark = pytest.mark.unit
+
+
+def test_ensure_session_and_visit_select_targets_vis_session_visits() -> None:
+    # Arrange — visit previo None, foco esta en la query del SELECT
+    session = MagicMock()
+    session.execute.return_value.first.return_value = None
+    session.flush.side_effect = lambda: setattr(
+        session.add.call_args[0][0], 'visit_id', 'fake-uuid'
+    )
+
+    # Act
+    ensure_session_and_visit(
+        session,
+        session_id='sess-abc',
+        ip='1.2.3.4',
+        country=None,
+        user_agent=None,
+        browser=None,
+        browser_version=None,
+        os_name=None,
+        device_type=None,
+        utm_source=None,
+        utm_medium=None,
+        utm_campaign=None,
+        utm_content=None,
+        utm_term=None,
+        referrer=None,
+        landing_page_path=None,
+        niche=None,
+        bump_event_count=True,
+    )
+
+    # Assert — el segundo execute es el SELECT FOR UPDATE
+    select_stmt = session.execute.call_args_list[1][0][0]
+    assert isinstance(select_stmt, Select), (
+        f'esperaba Select, recibi {type(select_stmt)}'
+    )
+    compiled = str(
+        select_stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={'literal_binds': True},
+        )
+    )
+    assert 'FROM vis_session_visits' in compiled, compiled
+    assert 'host(vis_session_visits.ip)' in compiled
+    assert 'ORDER BY vis_session_visits.started_at DESC' in compiled
+    assert 'LIMIT 1' in compiled
+    assert 'FOR UPDATE' in compiled
+    # session_id literal viene como string en literal_binds
+    assert "'sess-abc'" in compiled

--- a/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_updates_existing_visit_when_keys_match.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_updates_existing_visit_when_keys_match.py
@@ -1,0 +1,141 @@
+"""shared.db.repository.ensure_session_and_visit — UPDATE branch.
+
+Given una Session con un visit previo cuyas 6 claves coinciden con el
+     payload entrante,
+When se invoca ensure_session_and_visit con bump_event_count=True,
+Then NO inserta un visit nuevo y emite un `UPDATE vis_session_visits`
+     que incrementa event_count en 1 y refresca ended_at via now().
+
+Este test guardia el bug que rompio /track en prod (commit del fix
+vis_session_visits): el raw SQL usaba el nombre viejo de la tabla
+(`session_visits`) y la consulta fallaba con UndefinedTable. Con ORM,
+el `__tablename__` del modelo es la fuente de verdad — no hay forma
+de que el nombre quede desincronizado.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+from shared.db.models import SessionVisit
+from shared.db.repository import ensure_session_and_visit
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import Update
+
+pytestmark = pytest.mark.unit
+
+
+def test_ensure_session_and_visit_updates_existing_visit_when_keys_match() -> None:
+    # Arrange — visit previo con las mismas 6 claves
+    visit_uuid = UUID('019e5fce-385d-7530-8f6e-8e17df16f08a')
+    existing_visit = SimpleNamespace(
+        visit_id=visit_uuid,
+        ip='1.2.3.4',
+        utm_source='google',
+        utm_medium='cpc',
+        utm_campaign='launch',
+        utm_content=None,
+        utm_term=None,
+    )
+    session = MagicMock()
+    session.execute.return_value.first.return_value = existing_visit
+
+    # Act
+    session_id_ret, visit_id = ensure_session_and_visit(
+        session,
+        session_id='sess-abc',
+        ip='1.2.3.4',
+        country='CL',
+        user_agent='ua',
+        browser='Chrome',
+        browser_version='120',
+        os_name='Linux',
+        device_type='desktop',
+        utm_source='google',
+        utm_medium='cpc',
+        utm_campaign='launch',
+        utm_content=None,
+        utm_term=None,
+        referrer='https://example.com',
+        landing_page_path='/',
+        niche='fintech',
+        bump_event_count=True,
+    )
+
+    # Assert — no nuevo insert
+    assert session.add.call_count == 0
+    assert session.flush.call_count == 0
+    assert visit_id == str(visit_uuid)
+    assert session_id_ret == 'sess-abc'
+
+    # 3 execute: UPSERT sessions + SELECT visit + UPDATE visit
+    assert session.execute.call_count == 3
+    update_stmt = session.execute.call_args_list[2][0][0]
+    assert isinstance(update_stmt, Update), (
+        f'esperaba Update, recibi {type(update_stmt)}'
+    )
+    compiled = str(
+        update_stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={'literal_binds': True},
+        )
+    )
+    # Guardia anti-regresion: el UPDATE DEBE apuntar a la tabla con
+    # prefijo `vis_` (renombrada en el squash de migraciones).
+    assert 'UPDATE vis_session_visits' in compiled, compiled
+    assert 'session_visits' in SessionVisit.__tablename__
+    assert SessionVisit.__tablename__ == 'vis_session_visits'
+    assert 'now()' in compiled
+    assert 'event_count + 1' in compiled
+    assert str(visit_uuid).replace('-', '') in compiled
+
+
+def test_ensure_session_and_visit_skips_bump_when_flag_false() -> None:
+    # Arrange — mismo visit previo, mismas keys
+    visit_uuid = UUID('019e5fce-385d-7530-8f6e-8e17df16f08a')
+    existing_visit = SimpleNamespace(
+        visit_id=visit_uuid,
+        ip='1.2.3.4',
+        utm_source=None,
+        utm_medium=None,
+        utm_campaign=None,
+        utm_content=None,
+        utm_term=None,
+    )
+    session = MagicMock()
+    session.execute.return_value.first.return_value = existing_visit
+
+    # Act
+    ensure_session_and_visit(
+        session,
+        session_id='sess-abc',
+        ip='1.2.3.4',
+        country=None,
+        user_agent=None,
+        browser=None,
+        browser_version=None,
+        os_name=None,
+        device_type=None,
+        utm_source=None,
+        utm_medium=None,
+        utm_campaign=None,
+        utm_content=None,
+        utm_term=None,
+        referrer=None,
+        landing_page_path=None,
+        niche=None,
+        bump_event_count=False,
+    )
+
+    # Assert — el UPDATE suma 0, no 1
+    update_stmt = session.execute.call_args_list[2][0][0]
+    compiled = str(
+        update_stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={'literal_binds': True},
+        )
+    )
+    assert 'event_count + 0' in compiled

--- a/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_upsert_uses_sa_func_now.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/test_ensure_session_and_visit_upsert_uses_sa_func_now.py
@@ -1,0 +1,71 @@
+"""shared.db.repository.ensure_session_and_visit — UPSERT guardia.
+
+Given una Session,
+When ensure_session_and_visit ejecuta el UPSERT inicial sobre
+     `vis_sessions`,
+Then el statement compila a un INSERT ... ON CONFLICT (session_id)
+     DO UPDATE SET last_seen_at = now() usando `sa_func.now()` (no
+     `text('now()')`).
+
+Guardia anti-regresion del cleanup de raw SQL: antes la clausula `SET`
+del ON CONFLICT venia como `text('now()')`. Migrarla a `sa_func.now()`
+deja el statement 100% Core y elimina otra fuente de strings sueltos.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from shared.db.models import Session as SessionRow
+from shared.db.repository import ensure_session_and_visit
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import Insert as PgInsert
+
+pytestmark = pytest.mark.unit
+
+
+def test_ensure_session_and_visit_upsert_targets_vis_sessions_with_now() -> None:
+    # Arrange — visit previo None, foco esta en el primer execute (UPSERT)
+    session = MagicMock()
+    session.execute.return_value.first.return_value = None
+    session.flush.side_effect = lambda: setattr(
+        session.add.call_args[0][0], 'visit_id', 'fake-uuid'
+    )
+
+    # Act
+    ensure_session_and_visit(
+        session,
+        session_id='sess-xyz',
+        ip='1.2.3.4',
+        country=None,
+        user_agent='ua',
+        browser='Chrome',
+        browser_version='120',
+        os_name='Linux',
+        device_type='desktop',
+        utm_source=None,
+        utm_medium=None,
+        utm_campaign=None,
+        utm_content=None,
+        utm_term=None,
+        referrer=None,
+        landing_page_path=None,
+        niche=None,
+    )
+
+    # Assert — el primer execute es el INSERT ON CONFLICT
+    upsert_stmt = session.execute.call_args_list[0][0][0]
+    assert isinstance(upsert_stmt, PgInsert), (
+        f'esperaba postgresql.Insert, recibi {type(upsert_stmt)}'
+    )
+    compiled = str(
+        upsert_stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={'literal_binds': True},
+        )
+    )
+    assert SessionRow.__tablename__ == 'vis_sessions'
+    assert 'INSERT INTO vis_sessions' in compiled, compiled
+    assert 'ON CONFLICT (session_id) DO UPDATE' in compiled
+    assert 'last_seen_at = now()' in compiled

--- a/serverless/lambda/shared/tests/unit/shared/db/test_list_tables_uses_core_pg_stat_user_tables.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/test_list_tables_uses_core_pg_stat_user_tables.py
@@ -1,0 +1,67 @@
+"""shared.db.repository.list_tables — guardia SQL Core.
+
+Given una DB de prueba,
+When list_tables construye el statement,
+Then compila a un SELECT contra `pg_stat_user_tables` ordenado DESC
+     por n_live_tup, sin raw SQL.
+
+Guardia del cleanup de raw SQL: antes la query era un str inmutable
+(`_TABLES_QUERY`). Ahora es un `select()` de SQLAlchemy Core sobre
+una Table del catalogo de Postgres.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from shared.db import repository
+from shared.db.repository import list_tables
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import Select
+
+pytestmark = pytest.mark.unit
+
+
+def test_list_tables_executes_core_select_against_pg_stat_user_tables() -> None:
+    # Arrange
+    rows = [
+        SimpleNamespace(table_name='public.cv_persons', estimated_rows=100),
+        SimpleNamespace(
+            table_name='public.vis_session_visits', estimated_rows=42
+        ),
+    ]
+    conn = MagicMock()
+    conn.execute.return_value.all.return_value = rows
+    engine = MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+
+    # Act
+    with patch('shared.db.repository.get_engine', return_value=engine):
+        result = list_tables()
+
+    # Assert — resultado correcto
+    assert result == {
+        'tables': [
+            {'name': 'public.cv_persons', 'rows': 100},
+            {'name': 'public.vis_session_visits', 'rows': 42},
+        ],
+    }
+
+    # Assert — el argumento de conn.execute es un Core Select (no text)
+    assert conn.execute.call_count == 1
+    stmt = conn.execute.call_args[0][0]
+    assert isinstance(stmt, Select), f'esperaba Select, recibi {type(stmt)}'
+    compiled = str(
+        stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={'literal_binds': True},
+        )
+    )
+    assert 'FROM pg_stat_user_tables' in compiled
+    assert 'ORDER BY pg_stat_user_tables.n_live_tup DESC' in compiled
+    # Guardia: el modulo expone la Table como _pg_stat_user_tables
+    assert repository._pg_stat_user_tables.name == 'pg_stat_user_tables'
+    cols = {c.name for c in repository._pg_stat_user_tables.c}
+    assert cols == {'schemaname', 'relname', 'n_live_tup'}


### PR DESCRIPTION
## Summary

Promueve a main el fix del bug `relation \"session_visits\" does not exist` en `/track` (#136 + #137). Migra raw SQL del helper `ensure_session_and_visit` a ORM para que el `__tablename__` del modelo sea la unica fuente de verdad de cada tabla.

## Validado en stage

- Smoke test rama INSERT (session nuevo): HTTP 204
- Smoke test rama UPDATE (mismo session, antes rota): HTTP 204
- 0 ERRORs en CloudWatch tras los smokes

## Cambios

- `UPDATE session_visits ...` -> `update(SessionVisit)...` (ahora apunta automaticamente a `vis_session_visits`)
- `SELECT FOR UPDATE` raw -> `select(SessionVisit...).with_for_update()`
- `text('now()')` -> `sa_func.now()`
- `list_tables()` raw -> SQLAlchemy Core con Table system view de `pg_stat_user_tables`
- 5 tests unit nuevos como guardia anti-regresion

## Test plan

- [ ] CI verde
- [ ] Tras merge: deploy-backend prod redeploya tracking_pixel + contact_form + cv
- [ ] Smoke test /track en prod (rama INSERT + UPDATE): HTTP 204 ambos