### PR TITLE
fix(devtools): strip trailing whitespace en alarm description

### DIFF
--- a/devtools/serverless/infra_provision.py
+++ b/devtools/serverless/infra_provision.py
@@ -27,14 +27,15 @@ from dataclasses import field
 from pathlib import Path
 from typing import Any
 
-from serverless import aws_cli
-from serverless import state
-from serverless.aws_cli import AwsError
 from shared.console import CYAN
 from shared.console import GREEN
 from shared.console import YELLOW
 from shared.console import _c
 from shared.console import _err
+
+from serverless import aws_cli
+from serverless import state
+from serverless.aws_cli import AwsError
 
 
 # Raiz del backend serverless del portfolio.
@@ -1320,8 +1321,11 @@ def _provision_cloudwatch_alarm(
         '--treat-missing-data',
         spec.get('treat_missing_data', 'notBreaching'),
     ]
-    if spec.get('description'):
-        args.extend(['--alarm-description', spec['description']])
+    description = spec.get('description')
+    if description:
+        # YAML `description: >` (folded) puede dejar trailing newline
+        # que AWS CLI no maneja bien.
+        args.extend(['--alarm-description', description.strip()])
 
     dims = metric.get('dimensions') or {}
     if dims:


### PR DESCRIPTION
## Problema

deploy-backend.yml en CI (push a dev tras merge del PR #142) fallo en
\`provision-infra\` con exit 254 en \`cloudwatch put-metric-alarm\`:

\`\`\`
--alarm-description Hay mensajes ... la DLQ.
 --dimensions ...   <- newline antes de --dimensions confunde al CLI
\`\`\`

YAML \`description: >\` deja trailing newline. En mi shell local
funciono pero el shell del runner CI rompio.

## Solucion

\`description.strip()\` en \`_provision_cloudwatch_alarm\` antes de
pasarlo a AWS CLI. Robusto frente a cualquier formato YAML.

## Como probar

\`\`\`bash
python devtools/run.py serverless provision-infra --stage=dev --aws-profile=tfs-dev
\`\`\`
Debe completar sin errores.

## TODO

- (nada)