### PR TITLE
fix(devtools): _wire_http_trigger idempotente ante deploy parcial

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -969,22 +969,45 @@ def _wire_http_trigger(
     )
     path_part = (trigger.path or '').lstrip('/')
 
-    resource_result = aws(
+    # Idempotente: si el resource /path ya existe (caso CREATE tras
+    # deploy parcial previo o re-corrida del provisioner), reutilizar
+    # su id en vez de fallar con BadRequest.
+    existing_resources = aws(
         [
             'apigateway',
-            'create-resource',
+            'get-resources',
             '--rest-api-id',
             api_id,
-            '--parent-id',
-            root_id,
-            '--path-part',
-            path_part,
+            '--query',
+            f'items[?pathPart==`{path_part}`].id | [0]',
+            '--output',
+            'text',
         ],
         profile=profile,
         region=region,
-        parse_json=True,
+        check=False,
     )
-    resource_id = str(resource_result.json['id'])
+    existing_id = (existing_resources.stdout or '').strip()
+    if existing_id and existing_id != 'None':
+        resource_id = existing_id
+        print(f'  OK  resource /{path_part} ya existe ({resource_id})')
+    else:
+        resource_result = aws(
+            [
+                'apigateway',
+                'create-resource',
+                '--rest-api-id',
+                api_id,
+                '--parent-id',
+                root_id,
+                '--path-part',
+                path_part,
+            ],
+            profile=profile,
+            region=region,
+            parse_json=True,
+        )
+        resource_id = str(resource_result.json['id'])
     resources['api_resource_id'] = resource_id
     resources['api_method'] = f'{trigger.method} {trigger.path}'
 

--- a/devtools/tests/unit/src/serverless/provisioner.py
+++ b/devtools/tests/unit/src/serverless/provisioner.py
@@ -193,8 +193,9 @@ class TestRender:
         assert rendered.trigger.path == '/contact'
 
     def test_render_when_invalid_trigger_raises_manifest_error(self):
-        from serverless import provisioner
         from serverless.resolve import ManifestError
+
+        from serverless import provisioner
 
         manifest = _manifest_direct()
         manifest['trigger'] = {'type': 'cron'}
@@ -207,8 +208,9 @@ class TestProvisionCreate:
     """provision() con Action.CREATE corre la secuencia completa."""
 
     def test_provision_create_call_order(self, monkeypatch):
-        from serverless import provisioner
         from serverless.state import Action
+
+        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(
@@ -244,6 +246,9 @@ class TestProvisionCreate:
             'lambda.create-function',
             'ssm.get-parameter',
             'ssm.get-parameter',
+            # Idempotencia: get-resources verifica si /path ya existe
+            # antes de create-resource (evita BadRequest en re-corrida).
+            'apigateway.get-resources',
             'apigateway.create-resource',
             'apigateway.put-method',
             'apigateway.put-integration',
@@ -257,8 +262,9 @@ class TestProvisionCreate:
         assert state.resources['function_name'] == 'portfolio-contact-form-dev'
 
     def test_provision_create_records_resources(self, monkeypatch):
-        from serverless import provisioner
         from serverless.state import Action
+
+        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(
@@ -286,6 +292,54 @@ class TestProvisionCreate:
         )
         assert state.resources['api_resource_id'] == 'res9'
 
+    def test_provision_create_reuses_existing_api_resource(self, monkeypatch):
+        """Si /path ya existe en el API GW (re-corrida tras deploy parcial),
+        reutilizar su id y NO llamar create-resource."""
+        from serverless.aws_cli import AwsResult
+        from serverless.state import Action
+
+        from serverless import provisioner
+
+        calls = []
+        responses = _default_responses()
+        # get-resources devuelve el id existente via stdout (text output).
+        existing_resource_id = 'existing-res-id-42'
+
+        def fake(args, **_kwargs):
+            calls.append(args)
+            key = '.'.join(args[:2])
+            if key == 'apigateway.get-resources':
+                return AwsResult(
+                    returncode=0,
+                    stdout=existing_resource_id,
+                    stderr='',
+                    json=None,
+                )
+            return AwsResult(
+                returncode=0,
+                stdout='',
+                stderr='',
+                json=responses.get(key),
+            )
+
+        monkeypatch.setattr(provisioner, 'aws', fake)
+        monkeypatch.setattr(provisioner.time, 'sleep', lambda _s: None)
+
+        rendered = provisioner.render(_manifest_http(), stage='dev')
+        state = provisioner.provision(
+            rendered,
+            action=Action.CREATE,
+            zip_path=_ZIP_PATH,
+            previous=None,
+            profile=None,
+            region='us-east-1',
+        )
+
+        verbs = ['.'.join(c[:2]) for c in calls]
+        assert 'apigateway.get-resources' in verbs
+        assert 'apigateway.create-resource' not in verbs
+        assert state.resources['api_resource_id'] == existing_resource_id
+
 
 class TestProvisionUpdate:
     """provision() con Action.UPDATE_* corre solo lo que cambio."""
@@ -293,9 +347,10 @@ class TestProvisionUpdate:
     def test_provision_update_code_only_calls_update_function_code(
         self, monkeypatch
     ):
-        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
+
+        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(provisioner, 'aws', _fake_aws(calls))
@@ -327,9 +382,10 @@ class TestProvisionUpdate:
     def test_provision_update_config_calls_config_and_role_policy(
         self, monkeypatch
     ):
-        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
+
+        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(
@@ -378,9 +434,10 @@ class TestProvisionUpdate:
         assert role_arn == 'arn:aws:iam::111122223333:role/portfolio-x'
 
     def test_provision_update_both_runs_code_and_config(self, monkeypatch):
-        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
+
+        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(
@@ -420,9 +477,10 @@ class TestProvisionUpdate:
         ]
 
     def test_provision_noop_makes_no_aws_calls(self, monkeypatch):
-        from serverless import provisioner
         from serverless.state import Action
         from serverless.state import LambdaState
+
+        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(provisioner, 'aws', _fake_aws(calls))
@@ -454,10 +512,11 @@ class TestProvisionPartialFailure:
     def test_provision_partial_failure_records_created_resources(
         self, monkeypatch
     ):
-        from serverless import provisioner
         from serverless.aws_cli import AwsError
         from serverless.aws_cli import AwsResult
         from serverless.state import Action
+
+        from serverless import provisioner
 
         calls = []
         responses = _default_responses()
@@ -508,9 +567,10 @@ class TestDeprovision:
     """deprovision() borra los recursos en orden inverso al de creacion."""
 
     def test_deprovision_reverse_order(self, monkeypatch):
-        from serverless import provisioner
         from serverless.aws_cli import AwsResult
         from serverless.state import LambdaState
+
+        from serverless import provisioner
 
         calls = []
 
@@ -558,9 +618,10 @@ class TestDeprovision:
     def test_deprovision_stream_deletes_event_source_mappings(
         self, monkeypatch
     ):
-        from serverless import provisioner
         from serverless.aws_cli import AwsResult
         from serverless.state import LambdaState
+
+        from serverless import provisioner
 
         calls = []
         monkeypatch.setattr(


### PR DESCRIPTION
## Problema

Tras el merge de PR #146 a dev, el job `deploy-backend` en CI fallo con:

```
BadRequestException: Another resource with the same parent already has this name: contact
```

Causa raiz: en una corrida previa, `provision` con `Action.CREATE` para `contact-form` ya habia creado el resource `/contact` en API Gateway pero luego fallo (faltaba IAM `lambda:PublishVersion`). El state en S3 quedo parcial (`code_hash=''`), por lo que en el rerun `state.diff` volvio a decidir `CREATE` y `_wire_http_trigger` intento crear el resource otra vez.

## Solucion

`_wire_http_trigger` ahora es idempotente:

1. Antes de `apigateway create-resource`, hace `apigateway get-resources --query 'items[?pathPart==X].id | [0]'`.
2. Si el resource existe, reutiliza su id y omite el `create-resource`.
3. Si no existe, crea normalmente.

Esto desbloquea cualquier re-corrida del deploy backend cuando hubo un fallo intermedio que dejo el resource creado en AWS pero el state local/S3 incompleto.

## Como probar

1. Tests unitarios pasan:
   ```bash
   devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/provisioner.py -x
   ```
   17 tests verde (16 anteriores + 1 nuevo `test_provision_create_reuses_existing_api_resource`).

2. Verificacion en CI: tras merge, re-lanzar `deploy-backend` en dev. Debe ver en logs:
   ```
   OK  resource /contact ya existe (res-abc123)
   ```
   y NO debe ver `BadRequestException`.

## TODO

- Nada bloqueante. Plan tras este fix: smoke bypass Turnstile en dev y promover dev -> stage -> main.