### PR TITLE
fix(contact-form): aceptar HTTP 202 ademas de 201 en respuesta exitosa

### DIFF
--- a/packages/ui/src/components/ContactFormReact.tsx
+++ b/packages/ui/src/components/ContactFormReact.tsx
@@ -376,7 +376,9 @@ export default function ContactFormReact({
   }, [funnelEventTypes.contactFormStart])
 
   function handleSuccess(contactId: string): void {
-    // Embudo: la respuesta fue 201. Emite `contact_form_success` [AC-6].
+    // Embudo: la respuesta fue 201 (sync legacy) o 202 (async — encoder
+    // publico a SQS y el worker procesara despues). Emite
+    // `contact_form_success` [AC-6].
     trackEvent(funnelEventTypes.contactFormSuccess)
     const record = saveContactRecord(contactId)
     setSentRecord(record)
@@ -463,7 +465,12 @@ export default function ContactFormReact({
         body: JSON.stringify(payload),
       })
       const body = await parseJsonSafe(response)
-      if (response.status === 201 && body?.contact_id) {
+      // 201 (sync legacy) o 202 (async — encoder publico a SQS y el
+      // worker procesara despues). Ambos llevan `contact_id` en el body.
+      if (
+        (response.status === 201 || response.status === 202) &&
+        body?.contact_id
+      ) {
         handleSuccess(body.contact_id)
         return
       }

--- a/tests/feature/contact/contact-form.spec.ts
+++ b/tests/feature/contact/contact-form.spec.ts
@@ -169,7 +169,7 @@ test.describe('Feature: Contact form (React 18 + Zod)', () => {
       )
     })
 
-    test('Given form valido When submit con bypass Then 201 + card de confirmacion', async ({
+    test('Given form valido When submit con bypass Then 202 + card de confirmacion', async ({
       page,
     }) => {
       await gotoContactReady(page)
@@ -178,14 +178,16 @@ test.describe('Feature: Contact form (React 18 + Zod)', () => {
       await page.locator('input[name="email"]').fill('pacg1991@gmail.com')
       await page.locator('textarea[name="message"]').fill(uniqueMsg)
 
-      // Capturar la response al backend para verificar status 201
+      // Capturar la response al backend para verificar status 202 (modo
+      // async actual; el encoder publica a SQS y el worker procesa
+      // despues).
       const responsePromise = page.waitForResponse(
         (res) =>
           res.url().includes('/contact') && res.request().method() === 'POST',
       )
       await page.getByTestId('contact-submit').click()
       const response = await responsePromise
-      expect(response.status()).toBe(201)
+      expect(response.status()).toBe(202)
       const body = (await response.json()) as { contact_id: string }
       expect(body.contact_id).toMatch(/^[0-9a-f-]{36}$/i)
 

--- a/tests/feature/contact/contact-funnel.spec.ts
+++ b/tests/feature/contact/contact-funnel.spec.ts
@@ -212,22 +212,25 @@ test.describe('Feature: embudo de contacto (SPEC-200)', () => {
       expect(errorEvent?.event_props).toEqual({ code: '429' })
     })
 
-    test('Given un envio 201 When submit Then emite submit seguido de success [AC-6]', async ({
+    test('Given un envio 202 When submit Then emite submit seguido de success [AC-6]', async ({
       page,
     }) => {
-      // Arrange: el POST /contact se mockea con 201 para no depender del
-      // backend AWS (el embudo se mide en el cliente, no en el Lambda).
+      // Arrange: el POST /contact se mockea con 202 (modo async actual:
+      // el encoder publica a SQS y el worker procesa despues) para no
+      // depender del backend AWS — el embudo se mide en el cliente, no
+      // en el Lambda.
       await disableSendBeacon(page)
       const captured = await captureTrackRequests(page)
       await page.route(
         /https:\/\/[a-z0-9]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com\/[a-z]+\/contact$/,
         async (route) => {
           await route.fulfill({
-            status: 201,
+            status: 202,
             contentType: 'application/json',
             body: JSON.stringify({
               contact_id: '019e28fc-b97d-7d79-91a5-44c9b19465b4',
               created_at: new Date().toISOString(),
+              accepted: true,
             }),
           })
         },

--- a/tests/feature/contact/contact-session-link.spec.ts
+++ b/tests/feature/contact/contact-session-link.spec.ts
@@ -49,8 +49,9 @@ async function disableSendBeacon(page: Page): Promise<void> {
 }
 
 /**
- * Intercepta el `POST /contact` (al API Gateway), responde 201 y captura el
- * body en el array devuelto.
+ * Intercepta el `POST /contact` (al API Gateway), responde 202 (modo async
+ * actual: el encoder publica a SQS y el worker procesa despues) y captura
+ * el body en el array devuelto.
  */
 async function captureContactPosts(page: Page): Promise<ContactPayload[]> {
   const captured: ContactPayload[] = []
@@ -65,11 +66,12 @@ async function captureContactPosts(page: Page): Promise<ContactPayload[]> {
       }
     }
     await route.fulfill({
-      status: 201,
+      status: 202,
       contentType: 'application/json',
       body: JSON.stringify({
         contact_id: '019e28fc-b97d-7d79-91a5-44c9b19465b4',
         created_at: new Date().toISOString(),
+        accepted: true,
       }),
     })
   })


### PR DESCRIPTION
## Problema

El usuario reporta que al enviar el form de contacto en cualquier env:

- La API responde `Status Code 202 Accepted` con `{contact_id, created_at, accepted: true}`.
- El frontend muestra `"Error del servidor. Intentá nuevamente en unos minutos."`

Causa raiz: el plan `lambdas-async-sqs` cambio el contrato del Lambda `contact_form`. En modo async (activo en los 3 envs) responde **202 Accepted** porque el encoder publica a SQS y el worker procesa despues. El frontend tenia el guard `if (response.status === 201 && body?.contact_id)` (linea 466) — `202` cae al `else` y dispara `handleApiError(202, body)` → `errorMessageFor(202)` cae al fallback `errorServer`.

## Solucion

- `ContactFormReact.tsx`: acepta tanto `201` (sync legacy) como `202` (async actual). Ambos llevan `contact_id` en el body.
- `contact-form.spec.ts`: el spec E2E real (con bypass) ahora espera `202`.
- `contact-funnel.spec.ts` y `contact-session-link.spec.ts`: los mocks de `POST /contact` responden `202` + `accepted: true` para reflejar el contrato real.

## Como probar

1. Test local:
   ```bash
   pnpm exec biome check packages/ui/src/components/ContactFormReact.tsx tests/feature/contact/
   pnpm --filter @portfolio/ui run typecheck
   pnpm --filter @portfolio/ui run test
   ```
   147 tests verde.

2. Tras merge a dev y deploy de apps a dev:
   - Abrir `https://portfolio.dev.the-full-stack.com/contact`.
   - Completar y enviar el form.
   - **Esperado**: card de confirmacion verde con el `contact_id`, NO el mensaje rojo `Error del servidor`.

3. Repetir en stage y prod tras promocion.

## TODO

- Cuando se elimine el feature flag `ASYNC_MODE` y todo el flujo sea async, el guard del 201 se puede simplificar a solo 202.