### PR TITLE
fix(devtools): put-method idempotente ante deploy parcial

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -1011,6 +1011,10 @@ def _wire_http_trigger(
     resources['api_resource_id'] = resource_id
     resources['api_method'] = f'{trigger.method} {trigger.path}'
 
+    # Idempotente: si el method ya existe (caso CREATE tras deploy
+    # parcial previo o re-corrida del provisioner), put-method falla con
+    # ConflictException. Lo tratamos como noop — la config del method
+    # (authorization-type NONE) es invariante entre deploys.
     aws(
         [
             'apigateway',
@@ -1026,6 +1030,7 @@ def _wire_http_trigger(
         ],
         profile=profile,
         region=region,
+        check=False,
     )
     # Qualifier: si SnapStart=true, apunta al alias `:live` (necesario
     # para que SnapStart aplique). Sino, $LATEST (sin qualifier).


### PR DESCRIPTION
## Problema

El deploy de contact_form dev tras merge del PR #153 fallo con:

\`\`\`
Comando aws fallo (exit 254): apigateway put-method --rest-api-id gvz6y2xcsa --resource-id yhcjah --http-method POST --authorization-type NONE
\`\`\`

Causa raiz: ConflictException 'Method already exists for this resource'. El state.diff decidio Action.CREATE (state quedo parcial del deploy anterior), pero el method ya existia en API GW.

Es el mismo patron que el PR #147 resolvio para apigateway create-resource. Aplica al put-method del POST trigger.

## Solucion

Agregar check=False al put-method del trigger HTTP (linea 1014-1031 de provisioner.py). La config del method (authorization-type NONE) es invariante entre deploys, asi que tratarlo como noop es seguro.

El put-method OPTIONS (linea 853) ya tenia check=False — extiende el patron al POST.

## Como probar

1. Tests unitarios pasan: \`devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/provisioner.py -x\` -> 17 passed.
2. Tras merge: re-lanzar deploy-backend dev (workflow ya disparado por PR #153) y verificar que contact_form se deploye verde.

## TODO

- Plan contact-form-latency-optim espera este fix para que el deploy a dev pase. Tras merge + deploy verde -> tabla metrics + promocion stage + main.