### PR TITLE
fix(shared/lambda_kit): snap_start_warmup sin requerir IAM extra (timeout 12s)

### DIFF
--- a/serverless/lambda/shared/lambda_kit/snap_start_warmup.py
+++ b/serverless/lambda/shared/lambda_kit/snap_start_warmup.py
@@ -115,7 +115,7 @@ def register_warmup(clients: list[str]) -> None:
                 client_name,
                 elapsed_ms,
             )
-        except Exception as exc:  # noqa: BLE001 — fail-safe deliberado
+        except Exception as exc:
             _logger.warning(
                 '[snap_start_warmup] %s: failed (%s: %s)',
                 client_name,

--- a/serverless/lambda/shared/lambda_kit/snap_start_warmup.py
+++ b/serverless/lambda/shared/lambda_kit/snap_start_warmup.py
@@ -1,19 +1,28 @@
 """SnapStart warmup hook generico para lambdas Python con snap_start=true.
 
-Pre-calienta handshakes TLS de los clientes boto3 indicados ANTES de que
-SnapStart tome el snapshot (durante PublishVersion). El snapshot Firecracker
-captura el cliente boto3 con su conexion HTTPS abierta + cert chain
-verificado. Post-restore, la primera invocacion reutiliza esa conexion:
-handshake ya hecho, gana 200-500ms por servicio AWS.
+Pre-instancia clientes boto3 ANTES de que SnapStart tome el snapshot
+(durante PublishVersion). El snapshot Firecracker captura el cliente
+boto3 con su endpoint resolver, sigv4 setup y configuracion HTTP pool
+ya cargados. Post-restore, la primera invocacion paga SOLO el handshake
+TLS (no el setup completo del cliente).
+
+Por que NO hace calls AWS: los roles IAM del lambda suelen estar
+scoped a recursos especificos (table arn, queue arn, parameter arn).
+Hacer `sqs.list_queues()` o `ssm.describe_parameters()` requiere
+permisos account-wide que NO tienen los roles least-privilege. El
+warmup se limita a instanciar el cliente — el ahorro real viene de
+evitar reparsear el endpoint, crear el connection pool y configurar
+sigv4 en cada cold start.
 
 Uso (module-scope del handler, NO dentro del handler):
 
     from shared.lambda_kit.snap_start_warmup import register_warmup
     register_warmup(clients=['sqs', 'dynamodb', 'ssm'])
 
-Soporta: sqs, dynamodb, ssm, ses, kms. Cada warmup call corre con
-try/except: si falla (AWS 5xx transitorio, permisos IAM faltantes), loguea
-WARNING y continua. NUNCA aborta el INIT.
+Soporta: sqs, dynamodb, ssm, ses, kms, s3, lambda (cualquier servicio
+boto3). Cada instanciacion corre con try/except: si falla (region
+invalida, service typo), loguea WARNING y continua. NUNCA aborta el
+INIT.
 """
 
 from __future__ import annotations
@@ -21,7 +30,6 @@ from __future__ import annotations
 import logging
 import os
 import time
-from collections.abc import Callable
 from typing import Any
 
 import boto3
@@ -33,20 +41,23 @@ from botocore.config import Config
 _logger = logging.getLogger('snap_start_warmup')
 
 
-# Calls de warmup soportados. Cada uno hace handshake TLS + sigv4 sin
-# tocar recursos del proyecto.
-_WARMUP_CALLS: dict[str, Callable[[Any], Any]] = {
-    'sqs': lambda c: c.list_queues(MaxResults=1),
-    'dynamodb': lambda c: c.describe_endpoints(),
-    'ssm': lambda c: c.describe_parameters(MaxResults=1),
-    'ses': lambda c: c.list_email_identities(PageSize=1),
-    'kms': lambda c: c.list_keys(Limit=1),
+# Mapping de service short_name -> boto3 service name. La mayoria son
+# identicos; 'ses' es 'sesv2' (preferimos v2).
+_SERVICE_NAME_MAP: dict[str, str] = {
+    'ses': 'sesv2',
 }
+
+# Whitelist de servicios soportados. Lista cerrada para defensa
+# fail-fast contra typos en el manifest. Si necesitas otro, agregarlo
+# aca + actualizar tests.
+_SUPPORTED_CLIENTS: frozenset[str] = frozenset(
+    {'sqs', 'dynamodb', 'ssm', 'ses', 'kms', 's3', 'lambda'}
+)
 
 
 def _build_client(service: str, region: str) -> Any:
     """boto3.client con timeouts conservadores (NO debe colgar el INIT)."""
-    boto_service = 'sesv2' if service == 'ses' else service
+    boto_service = _SERVICE_NAME_MAP.get(service, service)
     return boto3.client(
         boto_service,
         region_name=region,
@@ -59,48 +70,52 @@ def _build_client(service: str, region: str) -> Any:
 
 
 def register_warmup(clients: list[str]) -> None:
-    """Pre-calienta handshakes TLS de los clientes boto3 indicados.
+    """Pre-instancia clientes boto3 antes del snapshot SnapStart.
 
     Args:
-        clients: lista de servicios soportados (sqs, dynamodb, ssm, ses, kms).
+        clients: lista de servicios soportados (sqs, dynamodb, ssm, ses,
+            kms, s3, lambda).
 
     Raises:
         ValueError: si algun client no esta soportado (defensa fail-fast
             contra typo en el manifest del lambda). Se levanta ANTES de
-            hacer cualquier call AWS.
+            instanciar cualquier cliente.
 
     Notes:
         - Llama SOLO desde module-scope del handler del lambda.
-        - Cada warmup call tiene try/except: si falla, loguea WARNING y
-          continua con los demas.
+        - Cada instanciacion tiene try/except: si falla, loguea WARNING
+          y continua con los demas.
         - Si la lista esta vacia, no-op silencioso.
+        - Solo INSTANCIA el cliente — NO llama AWS. El ahorro viene de
+          tener el endpoint resolver + sigv4 setup + connection pool ya
+          cargados en el snapshot. La primera llamada post-restore paga
+          el TLS handshake (~100-200ms) pero NO el setup completo
+          (~200-400ms del cold start tradicional).
     """
     if not clients:
         return
 
     # Defensa fail-fast: typo en manifest aborta INIT con error claro.
-    unsupported = [c for c in clients if c not in _WARMUP_CALLS]
+    unsupported = [c for c in clients if c not in _SUPPORTED_CLIENTS]
     if unsupported:
         raise ValueError(
             f'snap_start_warmup: clientes no soportados: {unsupported}. '
-            f'Soportados: {sorted(_WARMUP_CALLS)}'
+            f'Soportados: {sorted(_SUPPORTED_CLIENTS)}'
         )
 
     region = os.environ.get('AWS_REGION', 'us-east-1')
 
     for client_name in clients:
-        warmup_call = _WARMUP_CALLS[client_name]
         try:
             start = time.perf_counter()
-            client = _build_client(client_name, region)
-            warmup_call(client)
+            _build_client(client_name, region)
             elapsed_ms = int((time.perf_counter() - start) * 1000)
             _logger.info(
                 '[snap_start_warmup] %s: ok (%dms)',
                 client_name,
                 elapsed_ms,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — fail-safe deliberado
             _logger.warning(
                 '[snap_start_warmup] %s: failed (%s: %s)',
                 client_name,

--- a/serverless/lambda/shared/tests/unit/shared/lambda_kit/test_snap_start_warmup_continues_when_one_client_fails.py
+++ b/serverless/lambda/shared/tests/unit/shared/lambda_kit/test_snap_start_warmup_continues_when_one_client_fails.py
@@ -1,5 +1,5 @@
 """
-Given dynamodb falla con BotoCoreError pero sqs y ssm exito,
+Given _build_client falla con BotoCoreError para dynamodb pero ok para sqs y ssm,
 When register_warmup(['sqs', 'dynamodb', 'ssm']) corre,
 Then loguea WARNING para dynamodb, completa sin raise.
 """
@@ -18,16 +18,12 @@ pytestmark = pytest.mark.unit
 def test_register_warmup_continues_when_one_client_fails(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Un client fallando NO aborta el resto ni propaga la excepcion."""
-    # Arrange: build_client devuelve un mock distinto por servicio.
+    """Un build falla NO aborta el resto ni propaga la excepcion."""
+    # Arrange: build_client devuelve un mock para sqs/ssm, raise para dynamodb
     def build_client_factory(service: str, _region: str) -> MagicMock:
-        c = MagicMock()
         if service == 'dynamodb':
-            c.describe_endpoints.side_effect = BotoCoreError()
-        else:
-            c.list_queues.return_value = {'QueueUrls': []}
-            c.describe_parameters.return_value = {'Parameters': []}
-        return c
+            raise BotoCoreError
+        return MagicMock()
 
     # Act
     with patch(

--- a/serverless/lambda/shared/tests/unit/shared/lambda_kit/test_snap_start_warmup_logs_ok_when_all_clients_succeed.py
+++ b/serverless/lambda/shared/tests/unit/shared/lambda_kit/test_snap_start_warmup_logs_ok_when_all_clients_succeed.py
@@ -1,5 +1,5 @@
 """
-Given los 3 clientes (sqs, dynamodb, ssm) responden exito,
+Given los 3 clientes (sqs, dynamodb, ssm) se instancian sin error,
 When register_warmup(['sqs', 'dynamodb', 'ssm']) corre,
 Then loguea 3 lineas INFO con prefijo [snap_start_warmup] X: ok (Yms).
 """
@@ -17,12 +17,9 @@ pytestmark = pytest.mark.unit
 def test_register_warmup_logs_ok_when_all_clients_succeed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Los 3 clientes exitosos producen 3 lineas INFO 'ok'."""
-    # Arrange
+    """Las 3 instanciaciones exitosas producen 3 lineas INFO 'ok'."""
+    # Arrange: build_client retorna un mock cualquiera (no se llama nada)
     mock_client = MagicMock()
-    mock_client.list_queues.return_value = {'QueueUrls': []}
-    mock_client.describe_endpoints.return_value = {'Endpoints': []}
-    mock_client.describe_parameters.return_value = {'Parameters': []}
 
     # Act
     with patch(

--- a/serverless/lambda/shared/tests/unit/shared/lambda_kit/test_snap_start_warmup_raises_on_unsupported_client.py
+++ b/serverless/lambda/shared/tests/unit/shared/lambda_kit/test_snap_start_warmup_raises_on_unsupported_client.py
@@ -1,7 +1,7 @@
 """
 Given un client no soportado en la lista,
-When register_warmup(['sqs', 's3']) corre (s3 no esta en _WARMUP_CALLS),
-Then raise ValueError ANTES de cualquier call AWS (fail-fast).
+When register_warmup(['sqs', 'nonexistent-service']) corre,
+Then raise ValueError ANTES de instanciar cualquier cliente (fail-fast).
 """
 
 from __future__ import annotations
@@ -12,9 +12,9 @@ pytestmark = pytest.mark.unit
 
 
 def test_register_warmup_raises_on_unsupported_client() -> None:
-    """Typo en manifest aborta el INIT con error claro y sin llamar a AWS."""
+    """Typo en manifest aborta el INIT con error claro y sin instanciar boto3."""
     # Act + Assert
     from shared.lambda_kit.snap_start_warmup import register_warmup
 
-    with pytest.raises(ValueError, match=r'no soportados.*s3'):
-        register_warmup(['sqs', 's3'])
+    with pytest.raises(ValueError, match=r'no soportados.*nonexistent-service'):
+        register_warmup(['sqs', 'nonexistent-service'])


### PR DESCRIPTION
## Problema

Tras merge PR #153 (plan latency-optim), el deploy contact_form dev paso pero el lambda falla en runtime con HTTP 500. CloudWatch reporta INIT_REPORT 12066ms (timeout init = 10s).

Causa raiz: el modulo \`shared/lambda_kit/snap_start_warmup.py\` hacia 3 calls AWS (\`sqs.list_queues\`, \`dynamodb.describe_endpoints\`, \`ssm.describe_parameters\`) que requieren permisos account-wide (\`sqs:ListQueues\`, \`ssm:DescribeParameters\`). El rol IAM del contact_form es least-privilege y NO los tiene. Cada call:

1. Hace HTTP a AWS
2. Recibe AccessDenied
3. boto3 hace 1 retry (configurado max_attempts=1 pero hay overhead)
4. try/except captura el error correctamente

Pero los 3 calls juntos suman >2s y empujan el INIT (~3.5s base) hasta >10s -> timeout.

## Solucion

Quitar los calls AWS. El warmup ahora solo INSTANCIA el cliente boto3 — eso ya carga endpoint resolver + sigv4 setup + connection pool en el snapshot. La primera llamada post-restore paga solo el TLS handshake (~100-200ms), no el setup completo (~200-400ms).

Cambios:
- snap_start_warmup.py: quita \`_WARMUP_CALLS\` dict y los \`warmup_call(client)\` calls
- Whitelist soportada: sqs, dynamodb, ssm, ses, kms, s3, lambda (lista cerrada para fail-fast contra typos)
- Test 'unsupported_client' usa 'nonexistent-service' en vez de 's3' (s3 ahora SI esta soportado)
- 4 tests warmup siguen GREEN

## Verificacion local

\`\`\`bash
cd serverless/lambda && /home/bypabloc/projects/bypabloc/portfolio/serverless/.venv/bin/python -m pytest shared/tests/unit/shared/lambda_kit/test_snap_start_warmup_*.py -v
# 4 passed
\`\`\`

## Como probar post-deploy

1. Tras merge: redeploy contact_form (local o CI).
2. Smoke con bypass: HTTP 202 + Duration < 2s (cold).
3. Logs CloudWatch deben mostrar:
   \`\`\`
   [snap_start_warmup] sqs: ok (Xms)
   [snap_start_warmup] dynamodb: ok (Xms)
   [snap_start_warmup] ssm: ok (Xms)
   \`\`\`
   donde X < 50ms (instanciacion pura, sin call AWS).

## TODO

Plan latency-optim queda desbloqueado tras este merge para capturar tabla post-deploy.