### PR TITLE
fix(devtools): incluye trigger + snap_start en rendered_config

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -20,6 +20,7 @@ identificadores de infra (Stream ARN, ApiId) se leen de SSM con
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
 import json
@@ -1778,6 +1779,7 @@ def rendered_config(rendered: RenderedLambda) -> dict[str, Any]:
     dict[str, Any]
         Campos de config que, al cambiar, fuerzan un re-deploy de config.
     """
+
     return {
         'runtime': rendered.runtime,
         'architecture': rendered.architecture,
@@ -1786,6 +1788,13 @@ def rendered_config(rendered: RenderedLambda) -> dict[str, Any]:
         'timeout': rendered.timeout,
         'env_vars': rendered.env_vars,
         'iam_policy': rendered.iam_policy,
+        # Wiring del trigger: si cambia type/method/path/queue/snap_start
+        # el diff debe materializar el cambio en API GW / EventSourceMapping
+        # (URI con qualifier `:live`, statement-id del add-permission).
+        # Sin esto, el provisioner se queda en NOOP y el cambio queda
+        # registrado solo en el manifest, no en AWS.
+        'trigger': asdict(rendered.trigger),
+        'snap_start': rendered.snap_start,
     }
 
 


### PR DESCRIPTION
## Problema

El PR #161 agrego \`_rewire_trigger_on_update\` para que cambios en el
wiring (URI con qualifier \`:live\`, statement-id, etc.) se materializen
en API GW al hacer un UPDATE_CONFIG. Pero faltaba la otra mitad: el
\`config_hash\` que calcula \`rendered_config\` NO incluye \`trigger\` ni
\`snap_start\`, asi que un cambio en \`trigger.method/path/type\` o en
\`snap_start\` queda como NOOP en el diff y el wiring nuevo nunca se
dispara.

Verificacion del problema: tras mergear el PR #161 a \`dev\`, el deploy
automatico detecto \`affected: []\` y NO redeployo contact_form. El
statement-id en el policy del Lambda dev sigue siendo \`apigw-dev\`
(sin \`-live\`), aunque el manifest tiene \`snap_start: true\`. Es el
hash el que esta congelado, no el codigo del provisioner.

## Solucion

Agregar 2 campos al dict que retorna \`rendered_config\`:

\`\`\`python
'trigger': asdict(rendered.trigger),
'snap_start': rendered.snap_start,
\`\`\`

Consecuencias:

1. Cambios futuros en \`trigger.*\` o \`snap_start\` en cualquier manifest
   YA disparan UPDATE_CONFIG -> \`_rewire_trigger_on_update\` corre.
2. **El proximo deploy** (de TODOS los lambdas que tengan trigger) vera
   el config_hash distinto al previo (porque incluye campos nuevos),
   entrara a UPDATE_CONFIG y mi \`_rewire_trigger_on_update\` limpiara
   el statement-id legacy de SAM en los lambdas que aun lo tengan
   (\`portfolio-contact-form-stage\` y \`-prod\`).

## Como probar

Tests unit:

\`\`\`bash
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/provisioner.py
\`\`\`

Resultado: 18/18 passed (los tests usan \`_fake_aws\` y no comparan
hashes, asi que el cambio es transparente para ellos).

Tras el merge, validar en runtime: los 4 Lambdas seran redeployados
con accion UPDATE_CONFIG (porque el hash cambia). Verificar despues:

\`\`\`bash
aws lambda get-policy --function-name portfolio-contact-form-dev --profile tfs-dev \\
  --query 'Policy' --output text | python3 -m json.tool
\`\`\`

Esperado en dev: 1 statement con Sid \`apigw-dev-live\` (antes era
\`apigw-dev\` sin sufijo).

\`\`\`bash
aws lambda get-policy --function-name portfolio-contact-form-stage --profile tfs-dev \\
  --query 'Policy' --output text | python3 -m json.tool
\`\`\`

Esperado en stage post-merge a stage: el statement legacy
\`portfolio-backend-stage-ContactFormFunctionPostContactPermissionStage-XXX\`
borrado, queda solo \`apigw-stage-live\`.

Smoke /contact en cada env post-redeploy debe responder HTTP 202.

## TODO

Nada en scope de este PR.