### PR TITLE
fix(devtools): cambios al motor del deploy disparan redeploy de todos los lambdas

### DIFF
--- a/devtools/serverless/change_detector.py
+++ b/devtools/serverless/change_detector.py
@@ -9,6 +9,12 @@ hay que disparar. Reglas:
 2. `serverless/lambda/shared/<Y>/**` cambia -> redeploy TODOS los
    lambdas cuyo cierre transitivo incluye `shared.<Y>` (resuelto via
    `shared_resolver`). Excluye `shared/<Y>/tests/`.
+3. `devtools/serverless/{provisioner,packaging,vendoring,
+   shared_resolver,state}.py` cambia -> redeploy TODOS los lambdas:
+   son el motor del deploy, un cambio en como se renderizan/empaquetan
+   se debe materializar en AWS. Sin este caso, fixes al provisioner
+   (ej. limpieza de permission legacy) quedan dormidos hasta que algun
+   otro cambio dispare un redeploy.
 
 El comando CLI `serverless detect-changes --base=<sha> --head=<sha>`
 imprime JSON `{"affected": ["cv", ...]}` para que GitHub Actions lo
@@ -33,6 +39,20 @@ _EXCLUDED_SERVICE_SUBPATHS: tuple[str, ...] = (
 
 # Paths dentro de shared/<Y>/ que NO disparan redeploy.
 _EXCLUDED_SHARED_SUBPATHS: tuple[str, ...] = ('tests/',)
+
+# Archivos en devtools/serverless/ que tocan el motor del deploy: un
+# cambio aqui se debe materializar en TODOS los lambdas (redeploy
+# completo). Lista cerrada — agregar archivos solo si su comportamiento
+# afecta el shape del artefacto, del wiring o del state.
+_DEVTOOLS_DEPLOY_ENGINE_FILES: frozenset[str] = frozenset(
+    {
+        'devtools/serverless/provisioner.py',
+        'devtools/serverless/packaging.py',
+        'devtools/serverless/vendoring.py',
+        'devtools/serverless/shared_resolver.py',
+        'devtools/serverless/state.py',
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -174,6 +194,9 @@ def detect_affected_lambdas(
 
     affected: set[str] = set()
     affected_shared: set[str] = set()
+    engine_changed = any(
+        path in _DEVTOOLS_DEPLOY_ENGINE_FILES for path in file_list
+    )
 
     for path in file_list:
         kind = classify_path(path)
@@ -182,7 +205,19 @@ def detect_affected_lambdas(
         elif kind.kind == 'shared' and kind.name is not None:
             affected_shared.add(kind.name)
 
-    lambda_names = available_lambdas() if affected_shared or affected else []
+    # Si cambio el motor del deploy (provisioner, packaging, vendoring,
+    # shared_resolver, state) hay que redeployar TODOS los lambdas: un
+    # cambio en como se renderizan/empaquetan se debe materializar en
+    # AWS y el detector por-archivo no lo capta solo. Tambien se carga
+    # la lista de lambdas si hay shared o service afectado (logica vieja).
+    lambda_names = (
+        available_lambdas()
+        if affected_shared or affected or engine_changed
+        else []
+    )
+
+    if engine_changed:
+        affected.update(lambda_names)
 
     if affected_shared:
         consumers = _consumers_of_shared(

--- a/devtools/tests/unit/src/serverless/change_detector.py
+++ b/devtools/tests/unit/src/serverless/change_detector.py
@@ -242,6 +242,41 @@ class TestDetectAffectedLambdas:
         assert 'contact_form' in result
         assert {'cv', 'db', 'tracking_pixel'}.issubset(result)
 
+    def test_cambio_en_provisioner_dispara_todos_los_lambdas(self):
+        """
+        Given un cambio SOLO en devtools/serverless/provisioner.py,
+        When invoco detect_affected_lambdas,
+        Then devuelve TODOS los lambdas del repo: el provisioner es el
+             motor del deploy, un fix ahi (ej. limpieza del legacy SAM
+             permission) tiene que materializarse en cada lambda.
+        """
+        from serverless.resolve import available_lambdas
+
+        all_lambdas = set(available_lambdas())
+        result = detect_affected_lambdas(
+            base_sha='_unused',
+            head_sha='_unused',
+            lambdas_root=_lambdas_root(),
+            files=['devtools/serverless/provisioner.py'],
+        )
+        assert result == all_lambdas
+
+    def test_cambio_en_otro_archivo_devtools_no_dispara(self):
+        """
+        Given un cambio en devtools/serverless/flags.py (NO esta en la
+            whitelist del motor de deploy),
+        When invoco detect_affected_lambdas,
+        Then devuelve set() (un cambio a flags del CLI no requiere
+             redeployar lambdas).
+        """
+        result = detect_affected_lambdas(
+            base_sha='_unused',
+            head_sha='_unused',
+            lambdas_root=_lambdas_root(),
+            files=['devtools/serverless/flags.py'],
+        )
+        assert result == set()
+
     def test_archivos_irrelevantes_returns_empty(self):
         """
         Given files con solo cambios en docs/ y apps/,


### PR DESCRIPTION
## Problema

Los PRs #161 (\`_rewire_trigger_on_update\` + limpieza legacy SAM
permission) y #162 (\`trigger\`/\`snap_start\` en \`rendered_config\`)
arreglaban el provisioner pero **quedaron dormidos en AWS**:

- El \`change_detector\` solo mira paths en
  \`serverless/lambda/{services,shared}/\`.
- Un fix en \`devtools/serverless/provisioner.py\` no es ni \`services\`
  ni \`shared\` -> \`detect-changes\` reporta \`affected: []\` ->
  deploy-backend hace NOOP.
- Resultado: el statement legacy SAM en \`portfolio-contact-form-stage\`
  y \`-prod\` sigue ahi; el statement-id \`apigw-dev\` en dev sigue sin
  el sufijo \`-live\`. Verificable hoy mismo con \`aws lambda get-policy\`.

## Solucion

1. **\`_DEVTOOLS_DEPLOY_ENGINE_FILES\`** (whitelist cerrada): los 5
   archivos que conforman el motor del deploy:
   - \`devtools/serverless/provisioner.py\` (render + provision)
   - \`devtools/serverless/packaging.py\` (uv install + zip)
   - \`devtools/serverless/vendoring.py\` (copia selectiva de shared/)
   - \`devtools/serverless/shared_resolver.py\` (cierre AST)
   - \`devtools/serverless/state.py\` (diff hashes + state S3/local)

2. **\`detect_affected_lambdas\`** ahora detecta \`engine_changed\` y
   agrega TODOS los lambdas del repo. Idempotente con la logica vieja
   (un PR que toca shared + provisioner suma ambos sets).

3. **Tests** nuevos:
   - \`test_cambio_en_provisioner_dispara_todos_los_lambdas\`: confirma
     que un cambio SOLO en provisioner.py devuelve el set completo de
     lambdas (resuelto via \`available_lambdas()\` real del repo).
   - \`test_cambio_en_otro_archivo_devtools_no_dispara\`: confirma que
     un cambio en \`flags.py\` (NO en la whitelist) devuelve \`set()\`.

## Por que whitelist cerrada y no glob de \`devtools/serverless/\`

- \`flags.py\`, \`change_detector.py\` mismo, \`secrets_*.py\` NO afectan el
  artefacto AWS. Un cambio cosmetico ahi NO debe redeployar 5 lambdas.
- Lista cerrada hace explicito que archivos cuentan como \"motor del
  deploy\". Agregar uno nuevo requiere editar la constante (defensa
  contra falsos positivos por cambios menores en otros archivos).

## Como probar

Tests unit:

\`\`\`bash
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/change_detector.py
\`\`\`

Resultado: 21/21 passed (19 originales + 2 nuevos).

Tras el merge a \`dev\`, el \`deploy-backend\` workflow debe reportar
\`affected: ['contact_form', 'contact_worker', 'cv', 'tracking_pixel',
'tracking_worker']\` (el lambda \`db\` se excluye del matrix porque ya
fue redeployado en \`migrate-db\`).

Despues del deploy:

\`\`\`bash
# dev: statement-id deberia pasar de apigw-dev a apigw-dev-live
aws lambda get-policy --function-name portfolio-contact-form-dev \\
  --profile tfs-dev --query 'Policy' --output text | python3 -m json.tool
\`\`\`

Smoke /contact en cada env debe seguir respondiendo HTTP 202.

## TODO

Nada en scope.