### PR TITLE
docs(devtools): docstring del provisioner + dispara redeploy de todos los lambdas

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -10,6 +10,15 @@ cosas:
      Sin tocar AWS. Es lo testeable.
   2. `provision(rendered, action, ...)` — ejecuta las llamadas AWS CLI
      segun la `Action` que decidio `state.diff` (CREATE / UPDATE_* ).
+     En UPDATE_CONFIG y UPDATE_BOTH, ademas, llama a
+     `_rewire_trigger_on_update` para que cambios en `trigger.*` y
+     `snap_start` se materializen en API GW / EventSourceMapping
+     (URI con qualifier `:live`, statement-id del add-permission).
+     El wiring corre `_cleanup_legacy_permissions` antes del
+     add-permission canonico, borrando statements obsoletos del
+     resource-policy del Lambda (legacy SAM o devtools previo con
+     qualifier distinto), scoped por `source_arn` para NO tocar
+     permisos legitimos de otros origenes.
   3. `deprovision(state, ...)` — borra los recursos en orden inverso.
 
 La traduccion `uses` -> IAM resuelve los ARNs a strings concretos


### PR DESCRIPTION
## Problema

Los PRs #161, #162 y #163 dejaron el codigo correcto en \`dev\` pero el
cambio nunca llego a AWS:
- #161 + #162 arreglaron el provisioner.
- #163 arreglo el detector.
- Ningun PR posterior toco un archivo del whitelist
  \`_DEVTOOLS_DEPLOY_ENGINE_FILES\`, asi que el detector reporto
  \`affected: []\` en cada deploy y no se materializo nada.

## Solucion

Pequeno cambio cosmetico al docstring del provisioner que documenta las
funciones nuevas (\`_rewire_trigger_on_update\`,
\`_cleanup_legacy_permissions\`). Sin impacto funcional.

Efecto buscado: \`provisioner.py\` ESTA en la whitelist, asi que el
detector marca \`engine_changed=True\` -> redeploya los 5 lambdas con
la version vigente del provisioner. El UPDATE_CONFIG resultante
ejecuta el wiring nuevo:
- En dev: statement-id pasa de \`apigw-dev\` a \`apigw-dev-live\`.
- En stage/prod: borra el statement legacy SAM
  (\`portfolio-backend-{stage,prod}-...PermissionStage-XYZ\`) y deja
  solo el statement canonico.

## Como probar

Tras el merge a dev:

\`\`\`bash
gh run watch \$(gh run list --workflow=deploy-backend.yml --branch=dev --limit=1 --json databaseId --jq '.[0].databaseId') --exit-status
\`\`\`

Espera \`affected: ['contact_form', 'contact_worker', 'cv',
'tracking_pixel', 'tracking_worker']\` en el job \"Detect affected
lambdas\".

Verificacion del policy post-deploy:

\`\`\`bash
aws lambda get-policy --function-name portfolio-contact-form-dev \\
  --profile tfs-dev --query 'Policy' --output text | python3 -m json.tool
\`\`\`

Espera: \`Sid: apigw-dev-live\` (antes era \`apigw-dev\`).

Smoke /contact debe seguir respondiendo HTTP 202.

## TODO

Nada en scope.