### PR TITLE
docs(specs): aplica feedback de review al plan dashboard

### DIFF
--- a/.claude/docs/dashboard/01-stack.md
+++ b/.claude/docs/dashboard/01-stack.md
@@ -1,0 +1,500 @@
+# 01 — Stack: Next.js 16 + React 18 + TypeScript + Biome
+
+[< README](README.md) | [Siguiente: 02-structure >](02-structure.md)
+
+## Next.js 16 — esencial 2025-2026
+
+Release: **Octubre 2025**. Breaking changes relevantes:
+
+| Cambio | Impacto en este dashboard |
+|--------|---------------------------|
+| Turbopack default | Dev server 5-10x mas rapido. Sin custom webpack config. |
+| Async Request APIs (`params`, `cookies()`) | No aplica (Client Components). |
+| `middleware.ts` → `proxy.ts` | No aplica (export mode no soporta ninguno). |
+| React 19 compat opcional | Quedamos en React 18.3 por ecosystem (Tanstack v5, react-hook-form). |
+| `output: 'export'` estable | Soportado en App Router. Funcional. NO deprecated en v17 roadmap. |
+
+## `next.config.ts` canonico del dashboard
+
+```typescript
+import type {NextConfig} from 'next'
+
+const nextConfig: NextConfig = {
+  // SPA estatica
+  output: 'export',
+
+  // Cloudflare Pages no optimiza imagenes (no hay server runtime)
+  images: {
+    unoptimized: true,
+  },
+
+  // Cloudflare Pages prefiere paths con slash
+  trailingSlash: true,
+
+  // No exponer "Next.js" en headers
+  poweredByHeader: false,
+
+  // Source maps en prod opcional (helps debugging)
+  productionBrowserSourceMaps: false,
+
+  // Eslint: NO se usa (Biome lo reemplaza). Suprimir warning del build.
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+
+  typescript: {
+    tsconfigPath: './tsconfig.json',
+    // ignoreBuildErrors: false  (default — fail on TS errors)
+  },
+}
+
+export default nextConfig
+```
+
+## `package.json` del dashboard
+
+```jsonc
+{
+  "name": "@portfolio/dashboard",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --port 3000",
+    "build": "next build",
+    "preview": "npx serve out -p 3000",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:coverage": "vitest --coverage"
+  },
+  "dependencies": {
+    "next": "^16.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    // UI
+    "@radix-ui/react-slot": "^1.1.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.0",
+    "lucide-react": "^0.479.0",
+    "next-themes": "^0.4.4",
+    // Data + state
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-query-persist-client": "^5.62.0",
+    "@tanstack/query-sync-storage-persister": "^5.62.0",
+    "@tanstack/react-table": "^8.20.5",
+    "@tanstack/react-virtual": "^3.10.8",
+    "zustand": "^5.0.2",
+    "lz-string": "^1.5.0",
+    // Forms + validation
+    "react-hook-form": "^7.54.0",
+    "@hookform/resolvers": "^3.9.1",
+    "zod": "^3.24.1",
+    // Charts (via shadcn chart, depende de Recharts)
+    "recharts": "^2.15.0",
+    // Toasts
+    "sonner": "^1.7.1",
+    // JWT decode (solo para leer exp client-side, NO verificacion)
+    "jwt-decode": "^4.0.0",
+    // Turnstile widget React
+    "@marsidev/react-turnstile": "^1.1.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.0.0",
+    "@tanstack/react-query-devtools": "^5.62.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^24.0.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "happy-dom": "^16.5.0",
+    "msw": "^2.7.0",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "postcss": "^8.5.0",
+    "typescript": "^6.0.0",
+    "vitest": "^2.1.8"
+  },
+  "engines": {
+    "node": ">=24",
+    "pnpm": "11.0.9"
+  }
+}
+```
+
+## `tsconfig.json`
+
+```jsonc
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "incremental": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // strict
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "plugins": [{"name": "next"}],
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "src/**/*",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "out",
+    ".next"
+  ]
+}
+```
+
+> Importante: el alias `@/*` debe coincidir EXACTO con `components.json`
+> de shadcn (proximo capitulo). Si divergen, shadcn CLI escribe en
+> carpetas incorrectas.
+
+## `biome.json` (override del root)
+
+```jsonc
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "extends": ["../biome.json"],
+  "files": {
+    "ignore": [
+      "node_modules",
+      ".next",
+      "out",
+      "coverage"
+    ]
+  },
+  "overrides": [
+    {
+      "include": ["src/components/ui/**/*.tsx"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off",
+            "noArrayIndexKey": "off"
+          },
+          "complexity": {
+            "noUselessFragments": "off"
+          },
+          "style": {
+            "useImportType": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["src/app/**/page.tsx", "src/app/**/layout.tsx"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+> Por que ignorar reglas strict en `src/components/ui/**`: shadcn usa
+> `any` para el Slot pattern y `noUselessFragments` falla en wrappers
+> de Radix. Ignorar localmente preserva el resto strict.
+
+## Reglas React + Next que Biome NO cubre nativamente
+
+| Regla | Biome | Alternativa |
+|-------|-------|-------------|
+| `react/jsx-key` | ✅ cubierto | — |
+| `react-hooks/rules-of-hooks` | ✅ cubierto | — |
+| `react-hooks/exhaustive-deps` | ✅ cubierto (`useExhaustiveDependencies`) | — |
+| `next/no-html-link-for-pages` | ❌ no cubierto | Review humano en PR + el lint del root puede detectar `<a href="/...">` si Biome agrega regla |
+| `next/no-img-element` | ❌ no cubierto | Review humano; el dashboard casi no usa imagenes |
+| `jsx-a11y/*` | ⚠ parcial | Radix da accesibilidad de base. Lighthouse a11y en review manual |
+
+Decision: aceptable. El dashboard tiene pocos `<Link>` y casi cero
+`<img>`. Las reglas faltantes se cubren en review humano + Lighthouse
+en preview.
+
+## Tailwind v4 setup minimo
+
+`postcss.config.mjs`:
+
+```javascript
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}
+```
+
+`src/styles/globals.css`:
+
+```css
+@import "tailwindcss";
+
+/* Importar fonts self-hosted (mismas del DS del monorepo) */
+@import "@fontsource/space-grotesk/400.css";
+@import "@fontsource/space-grotesk/500.css";
+@import "@fontsource/space-grotesk/600.css";
+@import "@fontsource/space-grotesk/700.css";
+@import "@fontsource/space-mono/400.css";
+@import "@fontsource/space-mono/700.css";
+
+/* Tokens compartidos con el monorepo (sincronizar con design-system.md) */
+@theme {
+  --font-sans: "Space Grotesk", -apple-system, system-ui, sans-serif;
+  --font-mono: "Space Mono", Menlo, monospace;
+
+  /* Spacing base 4px ya viene de Tailwind v4 */
+
+  /* Radius */
+  --radius-xs: 0.375rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-pill: 9999px;
+}
+
+/* Modo dark (base) + light (toggle) — usar attribute data-theme */
+:root {
+  color-scheme: dark;
+  --background: 0 0% 4%;
+  --foreground: 60 9% 98%;
+  --primary: 217 91% 60%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 215 27% 17%;
+  --secondary-foreground: 60 9% 98%;
+  --muted: 215 27% 14%;
+  --muted-foreground: 217 11% 65%;
+  --accent: 215 27% 14%;
+  --accent-foreground: 60 9% 98%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 60 9% 98%;
+  --border: 215 27% 17%;
+  --input: 215 27% 17%;
+  --ring: 217 91% 60%;
+  --card: 215 27% 8%;
+  --card-foreground: 60 9% 98%;
+  --popover: 215 27% 8%;
+  --popover-foreground: 60 9% 98%;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+  --background: 0 0% 100%;
+  --foreground: 222 47% 11%;
+  --primary: 217 91% 50%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 210 40% 96%;
+  --secondary-foreground: 222 47% 11%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215 16% 47%;
+  --accent: 210 40% 96%;
+  --accent-foreground: 222 47% 11%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 60 9% 98%;
+  --border: 214 32% 91%;
+  --input: 214 32% 91%;
+  --ring: 217 91% 50%;
+  --card: 0 0% 100%;
+  --card-foreground: 222 47% 11%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222 47% 11%;
+}
+
+/* Map Tailwind utilities a los tokens HSL (compat shadcn) */
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+}
+
+@layer base {
+  *, *::before, *::after {
+    box-sizing: border-box;
+    border-color: hsl(var(--border));
+  }
+  body {
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+  }
+}
+
+/* Respect prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+## `src/lib/env.ts` — type-safe env vars
+
+```typescript
+import {z} from 'zod'
+
+const envSchema = z.object({
+  NEXT_PUBLIC_API_ENDPOINT: z
+    .string()
+    .url()
+    .describe('Lambda backend base URL'),
+  NEXT_PUBLIC_TURNSTILE_SITEKEY: z
+    .string()
+    .min(10)
+    .describe('Cloudflare Turnstile sitekey (publico)'),
+  NEXT_PUBLIC_DASHBOARD_URL: z
+    .string()
+    .url()
+    .describe('Self URL del dashboard, para callbacks'),
+  NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS: z.coerce
+    .number()
+    .int()
+    .min(5_000)
+    .max(300_000)
+    .default(30_000)
+    .describe('Cuanto antes del exp del JWT disparar el refresh proactivo'),
+})
+
+export const env = envSchema.parse({
+  NEXT_PUBLIC_API_ENDPOINT: process.env.NEXT_PUBLIC_API_ENDPOINT,
+  NEXT_PUBLIC_TURNSTILE_SITEKEY: process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY,
+  NEXT_PUBLIC_DASHBOARD_URL: process.env.NEXT_PUBLIC_DASHBOARD_URL,
+  NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS: process.env.NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS,
+})
+
+export type Env = z.infer<typeof envSchema>
+```
+
+> Import `env` desde el resto del codigo: `import {env} from '@/lib/env'`.
+> Si falla la validacion, Next 16 fail al build (deseado).
+
+## `next-env.d.ts` adicional para vars
+
+```typescript
+// src/env.d.ts (complementa next-env.d.ts)
+declare namespace NodeJS {
+  interface ProcessEnv {
+    NEXT_PUBLIC_API_ENDPOINT: string
+    NEXT_PUBLIC_TURNSTILE_SITEKEY: string
+    NEXT_PUBLIC_DASHBOARD_URL: string
+    NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS?: string
+  }
+}
+```
+
+## `public/_redirects` para Cloudflare Pages
+
+```text
+# SPA fallback: rutas dinamicas client-side
+# Excepcion: /api/* devuelve 404 explicito (no caer a SPA)
+/api/* /404 404
+/* /index.html 200
+```
+
+## `public/_headers` para Cloudflare Pages
+
+```text
+# Cache: assets de Next con hash en el nombre → inmutable 1 ano
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Fonts self-hosted
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# HTML pages: no cache (para que redeploys propaguen rapido)
+/
+  Cache-Control: no-cache, must-revalidate
+/*.html
+  Cache-Control: no-cache, must-revalidate
+
+# Security headers (heredar politica del monorepo)
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com https://api.portfolio.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
+```
+
+> `'wasm-unsafe-eval'` se requiere para Turbopack runtime en client.
+> `connect-src` lista los 3 endpoints API (dev/stage/prod). Pages
+> serv el _headers per project, podriamos optimizar a 1 endpoint por
+> env si necesario.
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Hardcodear `process.env.NEXT_PUBLIC_*` sin validar | Build pasa, runtime crash | Import desde `@/lib/env` (Zod) |
+| `appDir: false` o Pages Router | Default es App Router; no hay razon de regresar | App Router |
+| Custom webpack config | Turbopack es default, requiere migrar | Aceptar Turbopack |
+| `eslint` config en parallel | Biome es la decision | Solo `biome.json` |
+| Olvidar `'use client'` en page con `useState` | Server Component error | Primera linea |
+| Cambiar `output` a `standalone` o `default` | Necesita server runtime | Mantener `'export'` |
+| Olvidar trailing slash | Cloudflare Pages redirect a slash, perf hit | `trailingSlash: true` |
+
+## Referencias
+
+- Next.js 16 release: https://nextjs.org/blog/next-16
+- Static Exports: https://nextjs.org/docs/app/guides/static-exports
+- Biome v2: https://biomejs.dev/blog/biome-v2-0-beta/
+- Tailwind v4: https://tailwindcss.com/blog/tailwindcss-v4
+
+[< README](README.md) | [Siguiente: 02-structure >](02-structure.md)

--- a/.claude/docs/dashboard/01-stack.md
+++ b/.claude/docs/dashboard/01-stack.md
@@ -1,18 +1,33 @@
-# 01 — Stack: Next.js 16 + React 18 + TypeScript + Biome
+# 01 — Stack: Next.js 16.2.6 + React 19.2.6 + TypeScript + Biome
 
 [< README](README.md) | [Siguiente: 02-structure >](02-structure.md)
 
-## Next.js 16 — esencial 2025-2026
+## Next.js 16.2.6 — esencial mayo 2026
 
-Release: **Octubre 2025**. Breaking changes relevantes:
+| Release    | Fecha                                  | Highlights |
+| ---------- | -------------------------------------- | ---------- |
+| **16.0**   | Oct 21, 2025 (GA)                      | Turbopack stable + default, `proxy.ts` reemplaza `middleware.ts`, React 19 forzado, async APIs (`cookies()`, `headers()`, `params`), Cache Components (`'use cache'`) |
+| **16.1**   | Dec 2025                               | Filesystem caching en Turbopack dev, bundle analyzer built-in, Node debugger mejorado, React Compiler pasa de experimental a estable |
+| **16.2**   | Mar 2026                               | ~400% faster `next dev` startup, ~50% faster rendering, Build Adapters API stable, browser log forwarding |
+| **16.2.6** | **May 7, 2026** (latest, LTS candidato) | 13 security fixes (7 high, 4 moderate, 2 low), upstream React patches, DoS mitigations, proxy bypass fixes |
 
-| Cambio | Impacto en este dashboard |
-|--------|---------------------------|
-| Turbopack default | Dev server 5-10x mas rapido. Sin custom webpack config. |
-| Async Request APIs (`params`, `cookies()`) | No aplica (Client Components). |
-| `middleware.ts` → `proxy.ts` | No aplica (export mode no soporta ninguno). |
-| React 19 compat opcional | Quedamos en React 18.3 por ecosystem (Tanstack v5, react-hook-form). |
-| `output: 'export'` estable | Soportado en App Router. Funcional. NO deprecated en v17 roadmap. |
+### Cambios relevantes al dashboard SPA
+
+| Cambio | Impacto |
+|--------|---------|
+| **Turbopack default** | Dev server 5-10x mas rapido. Sin custom webpack config. |
+| **React 19.2 obligatorio** | Hooks nuevos disponibles (`useActionState`, `useFormStatus`, `useOptimistic`, etc.). Compiler stable. |
+| **Async Request APIs** | NO aplica (Client Components only). `useSearchParams()` necesita `<Suspense>` boundary. |
+| **`middleware.ts` → `proxy.ts`** | NO aplica (export mode no corre ninguno). Auth guard es Client Component. |
+| **`'use cache'` directive** | Server-only, NO aplica al dashboard. |
+| **`output: 'export'` estable** | Soportado en App Router. NO deprecated en v17 roadmap. |
+
+### React 19.2 features integrados en Next.js 16
+
+- **View Transitions API**: animaciones en navegacion / updates dentro de `<Transition>`.
+- **`useEffectEvent()`**: extrae logica no-reactiva de Effects.
+- **Activity Component**: render "background activity" con `display: none` while maintaining state.
+- **React Compiler stable**: auto-memoization sin `useMemo`/`useCallback` boilerplate.
 
 ## `next.config.ts` canonico del dashboard
 
@@ -20,7 +35,7 @@ Release: **Octubre 2025**. Breaking changes relevantes:
 import type {NextConfig} from 'next'
 
 const nextConfig: NextConfig = {
-  // SPA estatica
+  // SPA estatica para Cloudflare Pages
   output: 'export',
 
   // Cloudflare Pages no optimiza imagenes (no hay server runtime)
@@ -46,12 +61,23 @@ const nextConfig: NextConfig = {
     tsconfigPath: './tsconfig.json',
     // ignoreBuildErrors: false  (default — fail on TS errors)
   },
+
+  // React Compiler stable en Next 16 — auto-memoization
+  reactCompiler: true,
 }
 
 export default nextConfig
 ```
 
+> **Nota**: el flag `reactCompiler: true` en Next 16.2.x es estable
+> (paso de `experimental.reactCompiler` en 16.1 a campo top-level en
+> 16.2). Internamente Next.js SWC aplica `babel-plugin-react-compiler`
+> selectivamente, mas eficiente que correr Babel directo.
+
 ## `package.json` del dashboard
+
+Versiones exactas mayo 2026 (ver tabla en
+`.claude/skills/dashboard-stack/SKILL.md` para fuente):
 
 ```jsonc
 {
@@ -71,58 +97,78 @@ export default nextConfig
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
-    "next": "^16.0.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    // UI
+    "next": "^16.2.6",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+
+    // UI / Radix / shadcn helpers
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "tailwind-merge": "^2.5.0",
-    "lucide-react": "^0.479.0",
-    "next-themes": "^0.4.4",
-    // Data + state
-    "@tanstack/react-query": "^5.62.0",
-    "@tanstack/react-query-persist-client": "^5.62.0",
-    "@tanstack/query-sync-storage-persister": "^5.62.0",
+    "tailwind-merge": "^2.4.0",
+    "lucide-react": "^0.416.0",
+    "next-themes": "^0.4.8",
+
+    // Tanstack stack
+    "@tanstack/react-query": "^5.52.3",
+    "@tanstack/react-query-persist-client": "^5.52.3",
+    "@tanstack/query-sync-storage-persister": "^5.52.3",
     "@tanstack/react-table": "^8.20.5",
-    "@tanstack/react-virtual": "^3.10.8",
-    "zustand": "^5.0.2",
+    "@tanstack/react-virtual": "^3.5.1",
+
+    // State
+    "zustand": "^5.0.14",
     "lz-string": "^1.5.0",
+
     // Forms + validation
-    "react-hook-form": "^7.54.0",
-    "@hookform/resolvers": "^3.9.1",
+    "react-hook-form": "^7.53.0",
+    "@hookform/resolvers": "^3.4.2",
     "zod": "^3.24.1",
-    // Charts (via shadcn chart, depende de Recharts)
-    "recharts": "^2.15.0",
+
+    // Charts (via shadcn add chart) — Recharts requiere react-is matcheado
+    "recharts": "^2.14.2",
+    "react-is": "19.2.6",
+
     // Toasts
-    "sonner": "^1.7.1",
-    // JWT decode (solo para leer exp client-side, NO verificacion)
+    "sonner": "^1.7.2",
+
+    // JWT decode (solo client-side para leer exp)
     "jwt-decode": "^4.0.0",
+
     // Turnstile widget React
-    "@marsidev/react-turnstile": "^1.1.0"
+    "@marsidev/react-turnstile": "^1.2.5"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
-    "@tanstack/react-query-devtools": "^5.62.0",
+    "@tanstack/react-query-devtools": "^5.52.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/node": "^24.0.0",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.4",
-    "happy-dom": "^16.5.0",
-    "msw": "^2.7.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0",
-    "postcss": "^8.5.0",
-    "typescript": "^6.0.0",
-    "vitest": "^2.1.8"
+    "@types/node": "^20.18.2",
+    "@types/react": "^19.0.7",
+    "@types/react-dom": "^19.0.7",
+    "@vitejs/plugin-react": "^4.3.3",
+    "babel-plugin-react-compiler": "^19.0.0-beta.17",
+    "happy-dom": "^16.5.1",
+    "msw": "^2.3.2",
+    "playwright": "^1.48.2",
+    "@playwright/test": "^1.48.2",
+    "tailwindcss": "^4.1.4",
+    "@tailwindcss/postcss": "^4.1.4",
+    "postcss": "^8.4.50",
+    "typescript": "^6.0.6",
+    "vitest": "^2.2.5"
   },
   "engines": {
     "node": ">=24",
     "pnpm": "11.0.9"
+  },
+  // Critico: Recharts internamente importa react-is.
+  // Force el alias a 19.2.6 para evitar mismatch con React 19.
+  "pnpm": {
+    "overrides": {
+      "react-is": "19.2.6"
+    }
   }
 }
 ```
@@ -231,24 +277,54 @@ export default nextConfig
 }
 ```
 
-> Por que ignorar reglas strict en `src/components/ui/**`: shadcn usa
-> `any` para el Slot pattern y `noUselessFragments` falla en wrappers
-> de Radix. Ignorar localmente preserva el resto strict.
+> Por que ignorar reglas strict en `src/components/ui/**`: shadcn 2.x
+> (oct 2025+) ya genera componentes **sin `forwardRef`** (React 19
+> ref-as-prop), pero algunos patterns todavia chocan con reglas strict
+> de Biome (Slot composition con `any` en types polimorficos, fragments
+> en wrappers de Radix). Ignorar localmente preserva el resto strict.
 
-## Reglas React + Next que Biome NO cubre nativamente
+## React 19 + Biome v2 — reglas relevantes
 
-| Regla | Biome | Alternativa |
-|-------|-------|-------------|
+| Regla | Biome v2 | Notas para React 19 |
+|-------|----------|---------------------|
 | `react/jsx-key` | ✅ cubierto | — |
-| `react-hooks/rules-of-hooks` | ✅ cubierto | — |
-| `react-hooks/exhaustive-deps` | ✅ cubierto (`useExhaustiveDependencies`) | — |
-| `next/no-html-link-for-pages` | ❌ no cubierto | Review humano en PR + el lint del root puede detectar `<a href="/...">` si Biome agrega regla |
-| `next/no-img-element` | ❌ no cubierto | Review humano; el dashboard casi no usa imagenes |
-| `jsx-a11y/*` | ⚠ parcial | Radix da accesibilidad de base. Lighthouse a11y en review manual |
+| `react-hooks/rules-of-hooks` | ✅ cubierto | El Compiler las enforces tambien |
+| `react-hooks/exhaustive-deps` | ✅ cubierto (`useExhaustiveDependencies`) | Compiler analiza esto automaticamente |
+| `next/no-html-link-for-pages` | ❌ no cubierto | Review humano en PR (el dashboard tiene pocos `<Link>` candidatos a error) |
+| `next/no-img-element` | ❌ no cubierto | Review humano (casi cero `<img>` en dashboard) |
+| `jsx-a11y/*` | ⚠ parcial | Radix da accesibilidad base; Lighthouse a11y en review manual |
+| `noForwardRef` (custom) | ❌ no cubierto | Review humano — toda creacion de component nuevo debe ser sin `forwardRef` |
 
-Decision: aceptable. El dashboard tiene pocos `<Link>` y casi cero
-`<img>`. Las reglas faltantes se cubren en review humano + Lighthouse
-en preview.
+## React Compiler — habilitar
+
+`reactCompiler: true` en `next.config.ts` activa el compiler. Lo que
+hace:
+
+1. Analisis estatico de cada funcion componente + hooks.
+2. Emite equivalentes memoizados (memo slots manejados internamente).
+3. Reemplaza la necesidad de `React.memo`, `useMemo`, `useCallback` en
+   90%+ de los casos.
+
+**Requisitos**:
+- Strict Mode activo en root (lo cumple Next 16 por default).
+- Rules of React respetadas (Compiler las enforces — si no, omite el
+  componente).
+- `babel-plugin-react-compiler` instalado como devDep.
+
+**Opt-out per file** (solo si rompe algo medido):
+
+```tsx
+'use no memo'
+
+export function ComponenteRaro() {
+  // Compiler NO lo optimiza
+}
+```
+
+**Benefits esperados en el dashboard**:
+- –20–40% re-renders innecesarios en tabs con filtros + Tanstack Table
+  + Tanstack Virtual (medido en dashboards 2026).
+- +5–15% build time (overhead de Babel; menor con Next SWC).
 
 ## Tailwind v4 setup minimo
 
@@ -275,12 +351,10 @@ export default {
 @import "@fontsource/space-mono/400.css";
 @import "@fontsource/space-mono/700.css";
 
-/* Tokens compartidos con el monorepo (sincronizar con design-system.md) */
+/* Tokens compartidos con el monorepo */
 @theme {
   --font-sans: "Space Grotesk", -apple-system, system-ui, sans-serif;
   --font-mono: "Space Mono", Menlo, monospace;
-
-  /* Spacing base 4px ya viene de Tailwind v4 */
 
   /* Radius */
   --radius-xs: 0.375rem;
@@ -383,6 +457,10 @@ export default {
 }
 ```
 
+> Tailwind v4 (4.1.4 mayo 2026) es **5x mas rapido en full builds** y
+> **100x en incrementales** (medido en microsegundos) vs v3. Config
+> CSS-first (sin `tailwind.config.ts`).
+
 ## `src/lib/env.ts` — type-safe env vars
 
 ```typescript
@@ -433,6 +511,7 @@ declare namespace NodeJS {
     NEXT_PUBLIC_TURNSTILE_SITEKEY: string
     NEXT_PUBLIC_DASHBOARD_URL: string
     NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS?: string
+    NEXT_PUBLIC_USE_MSW?: string
   }
 }
 ```
@@ -470,18 +549,19 @@ declare namespace NodeJS {
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com https://api.portfolio.the-full-stack.com; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com https://api.portfolio.the-full-stack.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
 ```
 
 > `'wasm-unsafe-eval'` se requiere para Turbopack runtime en client.
-> `connect-src` lista los 3 endpoints API (dev/stage/prod). Pages
-> serv el _headers per project, podriamos optimizar a 1 endpoint por
-> env si necesario.
+> `connect-src` lista los 3 endpoints API + `challenges.cloudflare.com`
+> (Turnstile). CSP estricta sin `'unsafe-inline'` ni `'unsafe-eval'` en
+> scripts — defense in depth para auth en `localStorage`.
 
 ## Anti-patrones
 
 | Anti-patron | Por que | Correccion |
 |-------------|---------|------------|
+| Pinear `react@^18.x` en `package.json` | Next 16.x requiere React 19 minimo | `react@^19.2.6` |
 | Hardcodear `process.env.NEXT_PUBLIC_*` sin validar | Build pasa, runtime crash | Import desde `@/lib/env` (Zod) |
 | `appDir: false` o Pages Router | Default es App Router; no hay razon de regresar | App Router |
 | Custom webpack config | Turbopack es default, requiere migrar | Aceptar Turbopack |
@@ -489,11 +569,18 @@ declare namespace NodeJS {
 | Olvidar `'use client'` en page con `useState` | Server Component error | Primera linea |
 | Cambiar `output` a `standalone` o `default` | Necesita server runtime | Mantener `'export'` |
 | Olvidar trailing slash | Cloudflare Pages redirect a slash, perf hit | `trailingSlash: true` |
+| Olvidar `reactCompiler: true` | Sin auto-memoization, peor perf | Habilitarlo (stable en 16) |
+| Olvidar `react-is` override | Recharts internamente importa, falla por mismatch | `"pnpm.overrides": {"react-is": "19.2.6"}` |
+| `experimental.reactCompiler` (sintaxis vieja) | En 16.2 paso a campo top-level | `reactCompiler: true` (sin `experimental`) |
 
 ## Referencias
 
-- Next.js 16 release: https://nextjs.org/blog/next-16
+- Next.js 16: https://nextjs.org/blog/next-16
+- Next.js 16.1: https://nextjs.org/blog/next-16-1
+- Next.js 16.2: https://nextjs.org/blog/next-16-2
 - Static Exports: https://nextjs.org/docs/app/guides/static-exports
+- React 19 blog: https://react.dev/blog
+- React Compiler: https://react.dev/learn/react-compiler/installation
 - Biome v2: https://biomejs.dev/blog/biome-v2-0-beta/
 - Tailwind v4: https://tailwindcss.com/blog/tailwindcss-v4
 

--- a/.claude/docs/dashboard/02-structure.md
+++ b/.claude/docs/dashboard/02-structure.md
@@ -1,0 +1,428 @@
+# 02 — Estructura: Hybrid Atomic Design
+
+[< 01-stack](01-stack.md) | [Siguiente: 03-ui >](03-ui.md)
+
+## Filosofia
+
+Atomic Design clasico (atoms/molecules/organisms/templates/pages) genera
+debate sin valor para dashboards: ¿`MetricCard` es molecule u organism?
+¿el form de login es organism o template?
+
+**Decision**: estructura **hibrida** inspirada en shadcn + Feature-Sliced
+Design.
+
+- **`src/components/ui/`** — componentes **genericos** (sin conocimiento
+  de dominio). Equivalente a atoms+molecules sin distinguir. Lo que
+  agrega `pnpm dlx shadcn add <X>`.
+- **`src/features/<feature>/components/`** — componentes **especificos**
+  por dominio. Equivalente a organisms+templates. Composen los `ui/`
+  primitives + acceden a hooks/api de la feature.
+- **`src/app/`** — Pages (Next App Router). Solo composicion final +
+  layout.
+
+## Decision tree: donde vive un componente?
+
+```
+┌─ Es generico (sin conocimiento de dominio)?
+│  ├─ SI → src/components/ui/
+│  └─ NO
+│     ├─ Usa hooks/api/store de UNA feature?
+│     │  ├─ SI → src/features/<X>/components/
+│     │  └─ NO → src/components/ui/ (es generico, abstraerlo)
+│     └─ Lo usan 2+ features?
+│        ├─ SI → promote a src/components/ui/ (genericalo)
+│        └─ NO → quedate en src/features/<X>/components/
+└─
+```
+
+Ejemplos resueltos:
+
+| Componente | Donde | Por que |
+|-----------|-------|---------|
+| `<Button>` | `ui/` | shadcn primitive, sin dominio |
+| `<Card>` | `ui/` | shadcn primitive |
+| `<Form>`, `<FormField>` | `ui/` | shadcn primitives |
+| `<MetricCard title value delta>` | `ui/` | Generico, lo puede usar cualquier feature |
+| `<AnalyticsOverviewCards>` | `features/analytics/components/` | Wrappea 4 `<MetricCard>` con `useOverviewQuery` |
+| `<LoginForm>` | `features/auth/components/` | Usa `useLogin` (Tanstack mutation) |
+| `<SessionsTable>` | `features/sessions/components/` | Usa `useSessionsQuery` + columns especificas |
+| `<DataTable>` (Tanstack wrapper generico) | `ui/` | Lo usan sessions, events, contacts |
+| `<DateRangePicker>` | `ui/` | Lo usan analytics, sessions, events |
+| `<ThemeToggle>` | `ui/` | Solo lee/escribe `next-themes`, sin dominio |
+| `<AuthGuard>` | `features/auth/components/` | Logica especifica de auth |
+| `<Sidebar>` (del dashboard layout) | `features/dashboard-shell/components/` o `app/(dashboard)/_components/` | Especifico del shell del dashboard |
+
+## Cuando promover de `features/` a `ui/`?
+
+Reglas:
+
+1. **Dos features lo usan** (no una). Premature abstraction es peor que
+   duplicar.
+2. **Sin dependencia a una feature especifica** (sin imports de
+   `@/features/<X>/...`).
+3. **API estable**: props bien definidas, sin "todo lo de analytics".
+
+Si el componente parece generico pero importa un hook de Tanstack Query
+de una feature, NO lo promuevas. Refactoriza: el componente generico
+recibe `data` por prop, la feature le pasa lo que vino del hook.
+
+```typescript
+// MAL (acopla MetricCard a analytics)
+// src/components/ui/metric-card.tsx
+import {useOverviewQuery} from '@/features/analytics/hooks/use-overview-query'
+
+export function MetricCard({metric}: {metric: 'sessions' | 'visits'}) {
+  const {data} = useOverviewQuery()
+  return <div>{data?.[metric]}</div>
+}
+
+// BIEN (MetricCard generico)
+// src/components/ui/metric-card.tsx
+export function MetricCard({title, value, delta}: {title: string; value: string; delta?: number}) {
+  return <div>...</div>
+}
+
+// src/features/analytics/components/analytics-overview-cards.tsx
+import {MetricCard} from '@/components/ui/metric-card'
+import {useOverviewQuery} from '../hooks/use-overview-query'
+
+export function AnalyticsOverviewCards() {
+  const {data} = useOverviewQuery()
+  return (
+    <>
+      <MetricCard title="Sessions" value={String(data?.sessions ?? 0)} delta={data?.sessions_delta} />
+      <MetricCard title="Visits" value={String(data?.visits ?? 0)} delta={data?.visits_delta} />
+    </>
+  )
+}
+```
+
+## Estructura completa de `dashboard/src/`
+
+```
+dashboard/
+├── src/
+│   ├── app/                                    # Next App Router (output: 'export')
+│   │   ├── layout.tsx                          # RootLayout: providers, fonts, theme
+│   │   ├── page.tsx                            # / → redirect a /login o /dashboard
+│   │   ├── error.tsx                           # error boundary global
+│   │   ├── global-error.tsx                    # fallback ultimo
+│   │   ├── not-found.tsx                       # 404
+│   │   │
+│   │   ├── (auth)/                             # Route group, sin layout compartido
+│   │   │   ├── login/page.tsx
+│   │   │   ├── register/page.tsx
+│   │   │   ├── verify/page.tsx                 # input de code o magic-link prompt
+│   │   │   ├── callback/page.tsx               # decodifica fragment del magic-link
+│   │   │   └── set-password/page.tsx
+│   │   │
+│   │   └── (dashboard)/                        # Route group, layout protegido
+│   │       ├── layout.tsx                      # AuthGuard + Sidebar + Header
+│   │       ├── page.tsx                        # /dashboard → overview
+│   │       ├── analytics/page.tsx
+│   │       ├── sessions/
+│   │       │   ├── page.tsx                    # list
+│   │       │   └── [id]/page.tsx               # detail (client-side fetch por id)
+│   │       ├── events/page.tsx
+│   │       ├── visits/page.tsx
+│   │       ├── geo/page.tsx
+│   │       ├── devices/page.tsx
+│   │       ├── funnel/page.tsx
+│   │       ├── contacts/page.tsx
+│   │       └── settings/
+│   │           ├── page.tsx                    # profile
+│   │           └── security/page.tsx           # MFA setup
+│   │
+│   ├── components/
+│   │   └── ui/                                 # shadcn primitives (copy-paste)
+│   │       ├── alert.tsx
+│   │       ├── badge.tsx
+│   │       ├── button.tsx
+│   │       ├── card.tsx
+│   │       ├── chart.tsx                       # Recharts wrapper de shadcn
+│   │       ├── checkbox.tsx
+│   │       ├── dialog.tsx
+│   │       ├── dropdown-menu.tsx
+│   │       ├── form.tsx
+│   │       ├── input.tsx
+│   │       ├── input-otp.tsx                   # para code 8 chars
+│   │       ├── label.tsx
+│   │       ├── popover.tsx
+│   │       ├── select.tsx
+│   │       ├── separator.tsx
+│   │       ├── sheet.tsx                       # mobile sidebar
+│   │       ├── skeleton.tsx
+│   │       ├── sonner.tsx                      # Toaster wrapper
+│   │       ├── switch.tsx
+│   │       ├── table.tsx
+│   │       ├── tabs.tsx
+│   │       ├── tooltip.tsx
+│   │       │
+│   │       # Genericos custom (no shadcn, pero candidatos a promote)
+│   │       ├── metric-card.tsx                 # title/value/delta/icon
+│   │       ├── date-range-picker.tsx           # Popover + Calendar
+│   │       ├── data-table.tsx                  # wrapper Tanstack Table + paginator
+│   │       ├── empty-state.tsx                 # icon + title + description + action
+│   │       ├── theme-toggle.tsx                # next-themes ciclo dark/light/system
+│   │       ├── error-alert.tsx
+│   │       └── loading-spinner.tsx
+│   │
+│   ├── features/
+│   │   ├── auth/
+│   │   │   ├── components/
+│   │   │   │   ├── login-form.tsx              # email + (opcional) password + Turnstile
+│   │   │   │   ├── register-form.tsx           # email + Turnstile
+│   │   │   │   ├── verify-code-input.tsx       # InputOTP 8 chars
+│   │   │   │   ├── magic-link-prompt.tsx       # "te enviamos un link..."
+│   │   │   │   ├── set-password-form.tsx
+│   │   │   │   ├── totp-setup.tsx              # QR + InputOTP (plan 02)
+│   │   │   │   ├── recovery-codes-modal.tsx    # download + copy
+│   │   │   │   ├── webauthn-register-button.tsx
+│   │   │   │   ├── auth-guard.tsx              # HOC/Component para proteger rutas
+│   │   │   │   └── turnstile-widget.tsx        # wrapper @marsidev/react-turnstile
+│   │   │   ├── hooks/
+│   │   │   │   ├── use-register-start.ts       # useMutation
+│   │   │   │   ├── use-verify-code.ts
+│   │   │   │   ├── use-login-start.ts
+│   │   │   │   ├── use-logout.ts
+│   │   │   │   ├── use-session-refresh.ts
+│   │   │   │   ├── use-auth-timer.ts           # auto-refresh proactivo + Page Visibility
+│   │   │   │   ├── use-multi-tab-sync.ts       # BroadcastChannel
+│   │   │   │   └── use-protected-route.ts
+│   │   │   ├── api/
+│   │   │   │   ├── auth-client.ts              # endpoints typed
+│   │   │   │   └── query-keys.ts
+│   │   │   ├── store/
+│   │   │   │   └── use-auth-store.ts           # Zustand: accessToken (mem), user, status
+│   │   │   ├── lib/
+│   │   │   │   ├── refresh-mutex.ts            # mutex para concurrent 401s
+│   │   │   │   ├── broadcast.ts                # BroadcastChannel helpers
+│   │   │   │   └── token-expiry.ts             # jwt-decode + timing
+│   │   │   ├── types.ts                        # User, AuthResponse, Method, MfaMethod
+│   │   │   └── index.ts                        # barrel
+│   │   │
+│   │   ├── analytics/
+│   │   │   ├── components/
+│   │   │   │   ├── overview-cards.tsx          # 4-7 MetricCard
+│   │   │   │   ├── timeseries-chart.tsx        # line/area
+│   │   │   │   ├── top-pages-chart.tsx         # bar
+│   │   │   │   ├── top-referrers-table.tsx
+│   │   │   │   ├── top-niches-chart.tsx        # bar
+│   │   │   │   ├── active-now-card.tsx         # refetchInterval 15s
+│   │   │   │   ├── retention-chart.tsx         # new vs returning
+│   │   │   │   └── analytics-filters.tsx       # DateRangePicker + niche select
+│   │   │   ├── hooks/
+│   │   │   │   ├── use-overview-query.ts
+│   │   │   │   ├── use-timeseries-query.ts
+│   │   │   │   ├── use-top-pages-query.ts
+│   │   │   │   ├── use-top-referrers-query.ts
+│   │   │   │   ├── use-top-niches-query.ts
+│   │   │   │   ├── use-active-now-query.ts
+│   │   │   │   ├── use-retention-query.ts
+│   │   │   │   └── use-analytics-filters.ts    # Zustand local store de filtros
+│   │   │   ├── api/
+│   │   │   │   ├── analytics-client.ts
+│   │   │   │   └── query-keys.ts
+│   │   │   ├── store/
+│   │   │   │   └── use-analytics-filters.ts    # date range, niche selector
+│   │   │   ├── types.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── sessions/
+│   │   │   ├── components/
+│   │   │   │   ├── sessions-table.tsx          # DataTable + columns
+│   │   │   │   ├── session-detail-dialog.tsx   # Dialog con visits + event_count
+│   │   │   │   └── session-filters.tsx
+│   │   │   ├── hooks/
+│   │   │   │   ├── use-sessions-list.ts
+│   │   │   │   ├── use-session-detail.ts
+│   │   │   │   └── use-sessions-filters.ts
+│   │   │   ├── api/, types.ts, index.ts
+│   │   │
+│   │   ├── events/
+│   │   │   ├── components/
+│   │   │   │   ├── events-distribution-chart.tsx
+│   │   │   │   ├── events-list-table.tsx       # con Tanstack Virtual
+│   │   │   │   └── events-heatmap.tsx          # dia_semana x hora
+│   │   │   ├── hooks/, api/, types.ts, index.ts
+│   │   │
+│   │   ├── visits/
+│   │   │   ├── components/
+│   │   │   │   ├── visits-list-table.tsx
+│   │   │   │   └── landing-pages-chart.tsx
+│   │   │   ├── hooks/, api/, types.ts, index.ts
+│   │   │
+│   │   ├── geo/
+│   │   │   ├── components/
+│   │   │   │   └── geo-by-country-chart.tsx    # bar o mapa simple
+│   │   │   ├── hooks/, api/, types.ts, index.ts
+│   │   │
+│   │   ├── devices/
+│   │   │   ├── components/
+│   │   │   │   ├── device-pie-chart.tsx
+│   │   │   │   ├── browser-bar-chart.tsx
+│   │   │   │   └── os-bar-chart.tsx
+│   │   │   ├── hooks/, api/, types.ts, index.ts
+│   │   │
+│   │   ├── funnel/
+│   │   │   ├── components/
+│   │   │   │   └── funnel-chart.tsx            # session→visit→contact
+│   │   │   ├── hooks/, api/, types.ts, index.ts
+│   │   │
+│   │   ├── contacts/
+│   │   │   ├── components/
+│   │   │   │   ├── contacts-table.tsx
+│   │   │   │   ├── contacts-by-status-chart.tsx
+│   │   │   │   ├── contact-detail-dialog.tsx
+│   │   │   │   └── update-status-button.tsx    # mutation new→contacted→qualified
+│   │   │   ├── hooks/, api/, types.ts, index.ts
+│   │   │
+│   │   ├── dashboard-shell/                    # shell de las pages protegidas
+│   │   │   ├── components/
+│   │   │   │   ├── sidebar.tsx                 # nav links + user menu
+│   │   │   │   ├── header.tsx                  # breadcrumb, theme toggle, logout
+│   │   │   │   └── mobile-sidebar.tsx          # Sheet en mobile
+│   │   │   ├── lib/
+│   │   │   │   └── nav-items.ts                # ['analytics', 'sessions', ...]
+│   │   │   └── index.ts
+│   │   │
+│   │   └── settings/
+│   │       ├── components/
+│   │       │   ├── profile-form.tsx
+│   │       │   ├── change-password-form.tsx
+│   │       │   ├── mfa-methods-list.tsx        # totp, webauthn cards
+│   │       │   ├── webauthn-credentials-list.tsx
+│   │       │   └── recovery-codes-section.tsx
+│   │       ├── hooks/, api/, types.ts, index.ts
+│   │
+│   ├── lib/
+│   │   ├── api-client.ts                       # fetch wrapper (JWT + mutex refresh)
+│   │   ├── utils.ts                            # cn(), formatters helpers
+│   │   ├── env.ts                              # validate NEXT_PUBLIC_* con Zod
+│   │   ├── routes.ts                           # ROUTES.dashboard.analytics, etc.
+│   │   ├── format/
+│   │   │   ├── date.ts                         # formatDate, relativeTime
+│   │   │   ├── number.ts                       # formatNumber, formatPercent
+│   │   │   └── duration.ts                     # formatDurationMs
+│   │   └── validation/                         # Zod schemas compartidos
+│   │       ├── auth.ts                         # loginSchema, registerSchema
+│   │       └── filters.ts                      # dateRangeSchema, paginationSchema
+│   │
+│   ├── hooks/                                  # globales (no de feature)
+│   │   ├── use-debounce.ts
+│   │   ├── use-media-query.ts
+│   │   ├── use-local-storage.ts                # type-safe wrapper
+│   │   └── use-mounted.ts                      # para evitar hydration warnings
+│   │
+│   ├── providers/
+│   │   ├── theme-provider.tsx                  # next-themes
+│   │   ├── query-provider.tsx                  # Tanstack Query + persister
+│   │   └── root-providers.tsx                  # composicion
+│   │
+│   ├── styles/
+│   │   ├── globals.css                         # tailwind + tokens + base
+│   │   └── (opcional) animations.css
+│   │
+│   ├── types/
+│   │   ├── api.ts                              # types de responses /auth y /analytics
+│   │   └── models.ts                           # User, Session, Event, Contact (domain)
+│   │
+│   └── env.d.ts                                # type-safe NEXT_PUBLIC_*
+│
+├── public/
+│   ├── _redirects                              # /* /index.html 200
+│   ├── _headers                                # CSP + HSTS + cache
+│   ├── favicon.ico
+│   └── og-image.png
+│
+├── tests/
+│   ├── unit/                                   # mirror de src/
+│   │   ├── lib/
+│   │   ├── components/ui/
+│   │   └── features/
+│   │       ├── auth/
+│   │       └── analytics/
+│   ├── mocks/                                  # MSW handlers + server
+│   │   ├── handlers/
+│   │   │   ├── auth.ts
+│   │   │   └── analytics.ts
+│   │   ├── server.ts                           # setupServer (Node)
+│   │   └── browser.ts                          # setupWorker (browser dev)
+│   ├── fixtures/                               # data sintetica
+│   │   ├── users.ts
+│   │   ├── sessions.ts
+│   │   ├── events.ts
+│   │   └── analytics.ts
+│   └── setup.ts                                # vitest setup
+│
+├── components.json                             # shadcn config
+├── next.config.ts
+├── tsconfig.json
+├── biome.json                                  # override del root
+├── postcss.config.mjs
+├── vitest.config.ts
+├── package.json
+└── README.md
+```
+
+## Reglas de imports entre carpetas
+
+| Direccion | Permitido? | Notas |
+|-----------|-----------|-------|
+| `src/app/` → `src/components/ui/` | ✅ | OK |
+| `src/app/` → `src/features/<X>/` | ✅ | OK (las pages componen features) |
+| `src/app/` → `src/lib/` | ✅ | OK |
+| `src/features/A/` → `src/features/B/` | ❌ | Forbidden. Si necesitas compartir, promove a `lib/` o `components/ui/` |
+| `src/features/<X>/` → `src/components/ui/` | ✅ | OK (features consumen genericos) |
+| `src/features/<X>/` → `src/lib/` | ✅ | OK |
+| `src/features/<X>/` → `src/hooks/` | ✅ | OK (hooks globales) |
+| `src/components/ui/` → `src/features/<X>/` | ❌ | Forbidden. Romperia la abstraccion |
+| `src/components/ui/` → `src/lib/` | ✅ | Solo a `utils.ts`, `format/*`. No a `api-client.ts` |
+| `src/lib/` → `src/features/<X>/` | ❌ | Forbidden |
+| `src/hooks/` → `src/features/<X>/` | ❌ | Forbidden |
+
+## Naming conventions
+
+- **Files**: `kebab-case.tsx` (sigue convencion shadcn: `metric-card.tsx`, no `MetricCard.tsx`)
+- **Components**: `PascalCase` (export const MetricCard)
+- **Hooks**: `use<Name>` en camelCase, archivo `use-<name>.ts`
+- **Types/Interfaces**: `PascalCase` (export type User, export interface ApiResponse)
+- **Constants**: `UPPER_SNAKE` (export const MAX_PAGE_SIZE = 200)
+- **Zod schemas**: `<name>Schema` y type inferido `<Name>`:
+  ```typescript
+  export const loginSchema = z.object({...})
+  export type Login = z.infer<typeof loginSchema>
+  ```
+- **Stores Zustand**: `use<Name>Store` (`useAuthStore`, `useAnalyticsFiltersStore`)
+
+## Barrel exports (`index.ts` por feature)
+
+Cada feature exporta un publico via `index.ts`:
+
+```typescript
+// src/features/auth/index.ts
+export {LoginForm} from './components/login-form'
+export {RegisterForm} from './components/register-form'
+export {AuthGuard} from './components/auth-guard'
+export {useAuthStore} from './store/use-auth-store'
+export {useLogin, useRegister, useLogout, useSessionRefresh} from './hooks'
+export type {User, AuthResponse} from './types'
+```
+
+NO exportar lo "interno" (lib helpers, hooks privados). Mantener la
+superficie publica chica para reducir acoplamiento.
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| `src/components/atoms/`, `molecules/`, `organisms/` | Atomic Design clasico genera debates | Hybrid: `ui/` + `features/<X>/components/` |
+| Crear `<PrimaryButton>` wrappeando `<Button variant="primary">` | Sin valor | `<Button variant="primary">` directo |
+| Importar `features/B` desde `features/A` | Cross-feature coupling | Mover lo compartido a `lib/` o `ui/` |
+| Hook `useAnalyticsQuery` en `src/hooks/` | Feature-specific, no global | `src/features/analytics/hooks/` |
+| Premature promote a `ui/` con 1 use case | Premature abstraction | Quedate en `features/<X>/` hasta 2+ uses |
+| `MetricCard` que llama `useOverviewQuery` | Acopla generic a especifico | Recibe `data` por prop |
+| `default export` en componentes (excepto pages/layouts) | Reduce auto-rename, mas verbose en imports | `export const Component = ...` |
+| `index.ts` con `export *` | Dificulta tree-shaking + crea ciclos | Export explicito |
+
+[< 01-stack](01-stack.md) | [Siguiente: 03-ui >](03-ui.md)

--- a/.claude/docs/dashboard/03-ui.md
+++ b/.claude/docs/dashboard/03-ui.md
@@ -189,7 +189,70 @@ export function ThemeToggle() {
 }
 ```
 
-## Forms con react-hook-form + Zod + shadcn
+## Decision: que stack de forms usar (React 19)
+
+React 19 introdujo `useActionState` + `useFormStatus` para reducir
+boilerplate de forms. Coexisten con react-hook-form. **Regla del
+dashboard**:
+
+| Caso | Stack | Razon |
+|------|-------|-------|
+| Form simple (1-2 fields, single submit, sin field-level validation visual) | `useActionState` + `useFormStatus` | Menos boilerplate, React 19 nativo |
+| Form complejo (auth, multistep, validation visual, async validation, integrar con Tanstack mutation + cache) | **react-hook-form 7 + Zod + shadcn `<Form>` + Tanstack `useMutation`** ← default | Uncontrolled inputs, DX, integracion shadcn |
+
+Para **forms de auth** (login, register, verify-code, set-password): el
+default es **react-hook-form** porque (a) ya integran con shadcn `<Form>`,
+(b) Tanstack `useMutation` para invalidations + cache, (c) validation
+visual por field con `mode: 'onBlur'`.
+
+### `useActionState` minimal pattern (forms simples, opcional)
+
+```tsx
+'use client'
+
+import {useActionState} from 'react'
+import {useFormStatus} from 'react-dom'
+import {Button} from '@/components/ui/button'
+import {Input} from '@/components/ui/input'
+
+interface State {
+  error?: string
+  success?: boolean
+}
+
+async function searchAction(_prev: State, formData: FormData): Promise<State> {
+  const q = formData.get('q') as string
+  if (!q) return {error: 'Query requerida'}
+  // ... llamar API o mutation
+  return {success: true}
+}
+
+function SubmitButton() {
+  const {pending} = useFormStatus()
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? 'Buscando...' : 'Buscar'}
+    </Button>
+  )
+}
+
+export function SearchForm() {
+  const [state, formAction] = useActionState(searchAction, {})
+  return (
+    <form action={formAction}>
+      <Input name="q" placeholder="Buscar..." />
+      {state.error && <p className="text-destructive">{state.error}</p>}
+      <SubmitButton />
+    </form>
+  )
+}
+```
+
+> Critico: `useActionState` viene de `react` (NO `react-dom`).
+> `useFormStatus` viene de `react-dom`. NUNCA usar `useFormState`
+> (deprecado, era `useActionState` con nombre viejo).
+
+## Forms con react-hook-form + Zod + shadcn (default para auth)
 
 ```tsx
 'use client'

--- a/.claude/docs/dashboard/03-ui.md
+++ b/.claude/docs/dashboard/03-ui.md
@@ -1,0 +1,674 @@
+# 03 — UI: shadcn/ui + Tailwind v4 + theming + Radix + lucide + charts
+
+[< 02-structure](02-structure.md) | [Siguiente: 04-auth >](04-auth.md)
+
+## shadcn/ui — filosofia y setup
+
+shadcn NO es libreria; es **copy-paste**: `pnpm dlx shadcn@latest add
+button` copia el codigo del componente en `src/components/ui/button.tsx`
+y vos lo modificas a voluntad. Tree-shake al source level.
+
+### Init (una vez)
+
+```bash
+cd dashboard
+pnpm dlx shadcn@latest init
+# Preguntas:
+# - Style: "new-york" (default)
+# - Base color: "zinc"
+# - CSS file: src/styles/globals.css
+# - Use CSS variables: yes
+# - Components alias: @/components
+# - Utils alias: @/lib/utils
+# - RSC: no (output: 'export', solo Client Components)
+# - Iconos: lucide
+```
+
+Genera `components.json`:
+
+```jsonc
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}
+```
+
+> **Critico**: los aliases en `components.json` deben matchear los
+> `paths` de `tsconfig.json` EXACTAMENTE. Si divergen, shadcn CLI
+> escribe componentes en carpetas incorrectas.
+
+### Componentes base a agregar
+
+```bash
+# Set inicial (orden alfabetico para revision facil)
+pnpm dlx shadcn@latest add \
+  alert badge button card chart checkbox dialog dropdown-menu \
+  form input input-otp label popover select separator sheet \
+  skeleton sonner switch table tabs tooltip
+```
+
+Esto genera `src/components/ui/<comp>.tsx` para cada uno + dependencias
+de Radix (`@radix-ui/react-dialog`, etc.) instaladas automaticamente.
+
+## `cn()` utility
+
+`src/lib/utils.ts`:
+
+```typescript
+import {clsx, type ClassValue} from 'clsx'
+import {twMerge} from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs))
+}
+```
+
+Uso en componentes:
+
+```tsx
+<div className={cn('px-4 py-2', isActive && 'bg-primary', className)} />
+```
+
+## CVA (Class Variance Authority) — variants type-safe
+
+Patron estandar para Tailwind variants. shadcn lo usa internamente.
+
+```typescript
+// src/components/ui/badge.tsx
+import {cva, type VariantProps} from 'class-variance-authority'
+import {cn} from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground',
+        outline: 'text-foreground',
+        success: 'border-transparent bg-emerald-500 text-white',
+      },
+    },
+    defaultVariants: {variant: 'default'},
+  },
+)
+
+interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({className, variant, ...props}: BadgeProps) {
+  return <div className={cn(badgeVariants({variant}), className)} {...props} />
+}
+```
+
+## Theming dark/light con next-themes
+
+`src/providers/theme-provider.tsx`:
+
+```tsx
+'use client'
+
+import {ThemeProvider as NextThemesProvider} from 'next-themes'
+import type {ReactNode} from 'react'
+
+export function ThemeProvider({children}: {children: ReactNode}) {
+  return (
+    <NextThemesProvider
+      attribute="data-theme"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  )
+}
+```
+
+> Usar `attribute="data-theme"` (no `class`). El `:root` y
+> `[data-theme="light"]` en `globals.css` matchean este attribute.
+> `disableTransitionOnChange` evita flash visual al togglear.
+
+`src/components/ui/theme-toggle.tsx`:
+
+```tsx
+'use client'
+
+import {useTheme} from 'next-themes'
+import {Moon, Sun, Monitor} from 'lucide-react'
+import {Button} from './button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './dropdown-menu'
+
+export function ThemeToggle() {
+  const {setTheme, theme} = useTheme()
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Toggle theme">
+          <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme('light')}>
+          <Sun className="mr-2 h-4 w-4" /> Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>
+          <Moon className="mr-2 h-4 w-4" /> Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>
+          <Monitor className="mr-2 h-4 w-4" /> System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+```
+
+## Forms con react-hook-form + Zod + shadcn
+
+```tsx
+'use client'
+
+import {zodResolver} from '@hookform/resolvers/zod'
+import {useForm} from 'react-hook-form'
+import {z} from 'zod'
+import {Button} from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import {Input} from '@/components/ui/input'
+import {useRegisterStart} from '../hooks/use-register-start'
+import {TurnstileWidget} from './turnstile-widget'
+
+const schema = z.object({
+  email: z.string().email('Email invalido'),
+  cf_turnstile_response: z.string().min(1, 'Verifica que no sos un bot'),
+})
+
+type Schema = z.infer<typeof schema>
+
+export function RegisterForm() {
+  const form = useForm<Schema>({
+    resolver: zodResolver(schema),
+    defaultValues: {email: '', cf_turnstile_response: ''},
+  })
+  const registerStart = useRegisterStart()
+
+  function onSubmit(data: Schema) {
+    registerStart.mutate(data)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="tu@email.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="cf_turnstile_response"
+          render={({field}) => (
+            <FormItem>
+              <FormControl>
+                <TurnstileWidget onSuccess={field.onChange} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full" disabled={registerStart.isPending}>
+          {registerStart.isPending ? 'Enviando...' : 'Registrarme'}
+        </Button>
+
+        {registerStart.isError && (
+          <p className="text-sm text-destructive">
+            {registerStart.error.message}
+          </p>
+        )}
+      </form>
+    </Form>
+  )
+}
+```
+
+## Turnstile widget
+
+`src/features/auth/components/turnstile-widget.tsx`:
+
+```tsx
+'use client'
+
+import {Turnstile} from '@marsidev/react-turnstile'
+import {env} from '@/lib/env'
+
+interface TurnstileWidgetProps {
+  onSuccess: (token: string) => void
+  onError?: () => void
+  onExpire?: () => void
+}
+
+export function TurnstileWidget({onSuccess, onError, onExpire}: TurnstileWidgetProps) {
+  return (
+    <Turnstile
+      siteKey={env.NEXT_PUBLIC_TURNSTILE_SITEKEY}
+      onSuccess={onSuccess}
+      onError={onError}
+      onExpire={onExpire}
+      options={{
+        theme: 'auto',
+        size: 'normal',
+        appearance: 'always',
+      }}
+    />
+  )
+}
+```
+
+> El sitekey es el mismo que las 6 apps Astro. Hostnames se gestionan
+> en Cloudflare dashboard del widget — agregar
+> `admin.portfolio.{dev|stage|prod}.the-full-stack.com`.
+
+## Charts con shadcn + Recharts
+
+```bash
+pnpm dlx shadcn@latest add chart
+# Instala recharts + crea src/components/ui/chart.tsx (wrapper)
+```
+
+Ejemplo: timeseries chart en analytics:
+
+```tsx
+'use client'
+
+import {Area, AreaChart, CartesianGrid, XAxis} from 'recharts'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@/components/ui/chart'
+import {useTimeseriesQuery} from '../hooks/use-timeseries-query'
+
+const chartConfig = {
+  sessions: {label: 'Sessions', color: 'hsl(var(--primary))'},
+  visits: {label: 'Visits', color: 'hsl(var(--accent))'},
+} satisfies ChartConfig
+
+export function TimeseriesChart() {
+  const {data, isLoading} = useTimeseriesQuery({bucket: 'day'})
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Trafico por dia</CardTitle>
+        <CardDescription>Ultimo mes</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-[300px] w-full">
+          <AreaChart data={data ?? []}>
+            <CartesianGrid vertical={false} />
+            <XAxis dataKey="ts" tickFormatter={(v) => new Date(v).toLocaleDateString()} />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <Area dataKey="sessions" type="monotone" fill="hsl(var(--primary) / 0.2)" stroke="hsl(var(--primary))" />
+            <Area dataKey="visits" type="monotone" fill="hsl(var(--accent) / 0.2)" stroke="hsl(var(--accent))" />
+          </AreaChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}
+```
+
+> Los colores referencian CSS vars (`hsl(var(--primary))`). Respeta
+> dark/light automaticamente.
+
+## Tablas con Tanstack Table v8 + shadcn
+
+Wrapper generico `src/components/ui/data-table.tsx`:
+
+```tsx
+'use client'
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table'
+import {useState} from 'react'
+import {Button} from './button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './table'
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  isLoading?: boolean
+  emptyMessage?: string
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  isLoading,
+  emptyMessage = 'Sin datos',
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>([])
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    state: {sorting},
+    onSortingChange: setSorting,
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((hg) => (
+              <TableRow key={hg.id}>
+                {hg.headers.map((h) => (
+                  <TableHead key={h.id}>
+                    {h.isPlaceholder ? null : flexRender(h.column.columnDef.header, h.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  Cargando...
+                </TableCell>
+              </TableRow>
+            ) : table.getRowModel().rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2">
+        <Button variant="outline" size="sm" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+          Anterior
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+          Siguiente
+        </Button>
+      </div>
+    </div>
+  )
+}
+```
+
+Uso en feature:
+
+```tsx
+// src/features/sessions/components/sessions-table.tsx
+'use client'
+
+import {ColumnDef} from '@tanstack/react-table'
+import {DataTable} from '@/components/ui/data-table'
+import {useSessionsList} from '../hooks/use-sessions-list'
+import type {Session} from '../types'
+
+const columns: ColumnDef<Session>[] = [
+  {accessorKey: 'session_id', header: 'Session'},
+  {accessorKey: 'first_seen_at', header: 'Inicio', cell: ({row}) => new Date(row.getValue('first_seen_at') as string).toLocaleString()},
+  {accessorKey: 'country', header: 'Pais'},
+  {accessorKey: 'device_type', header: 'Device'},
+  {accessorKey: 'event_count', header: 'Events'},
+]
+
+export function SessionsTable() {
+  const {data, isLoading} = useSessionsList()
+  return <DataTable columns={columns} data={data?.items ?? []} isLoading={isLoading} />
+}
+```
+
+## Virtualization para listas grandes (events list)
+
+```tsx
+'use client'
+
+import {useVirtualizer} from '@tanstack/react-virtual'
+import {useRef} from 'react'
+import {useEventsList} from '../hooks/use-events-list'
+
+export function EventsVirtualList() {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const {data} = useEventsList({page_size: 200})
+  const items = data?.items ?? []
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 48,
+    overscan: 10,
+  })
+
+  return (
+    <div ref={parentRef} className="h-[600px] overflow-auto rounded-md border">
+      <div style={{height: `${virtualizer.getTotalSize()}px`, position: 'relative'}}>
+        {virtualizer.getVirtualItems().map((vRow) => {
+          const event = items[vRow.index]
+          return (
+            <div
+              key={vRow.key}
+              data-index={vRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${vRow.start}px)`,
+              }}
+              className="border-b px-4 py-2"
+            >
+              {event && `${event.created_at} — ${event.event_type} — ${event.page_path}`}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+```
+
+## Toasts con sonner
+
+`src/app/layout.tsx`:
+
+```tsx
+import {Toaster} from '@/components/ui/sonner'
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="es" suppressHydrationWarning>
+      <body>
+        {/* ...providers... */}
+        {children}
+        <Toaster position="top-right" richColors closeButton />
+      </body>
+    </html>
+  )
+}
+```
+
+Uso:
+
+```tsx
+import {toast} from 'sonner'
+
+toast.success('Registro exitoso')
+toast.error('Email no encontrado', {description: 'Probaste con otro?'})
+toast.warning('Rate limit excedido', {description: 'Reintenta en 60s'})
+```
+
+## Iconografia: lucide-react
+
+Tree-shake automatico. Solo importa lo que usas:
+
+```tsx
+import {Home, BarChart3, Users, Settings, LogOut} from 'lucide-react'
+
+<Home className="h-5 w-5" />
+```
+
+> Comparativa: lucide tiene 1500+ icons (vs heroicons 292). Default
+> 24px, stroke 1.5px. Misma escala que el sidebar de cualquier
+> dashboard moderno.
+
+## Animaciones — solo Tailwind + Radix
+
+Reglas del repo (heredadas):
+- **NO** Framer Motion / GSAP / Motion One (peso, complejidad).
+- **SI** Tailwind `animate-*` classes (built-in).
+- **SI** `@starting-style` para enter/exit (CSS nativo 2025).
+- **SI** Radix transitions built-in (`data-[state=open]:animate-in`).
+- **SIEMPRE** respetar `prefers-reduced-motion` (ya esta en `globals.css`).
+
+Ejemplo enter/exit con `@starting-style`:
+
+```css
+.dialog-content {
+  opacity: 1;
+  transform: scale(1);
+  transition: opacity 200ms, transform 200ms;
+
+  @starting-style {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+```
+
+Ejemplo Radix transitions (shadcn Dialog ya las trae):
+
+```tsx
+<DialogContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+```
+
+## Empty states
+
+`src/components/ui/empty-state.tsx`:
+
+```tsx
+import {type LucideIcon} from 'lucide-react'
+import {cn} from '@/lib/utils'
+
+interface EmptyStateProps {
+  icon: LucideIcon
+  title: string
+  description?: string
+  action?: React.ReactNode
+  className?: string
+}
+
+export function EmptyState({icon: Icon, title, description, action, className}: EmptyStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center', className)}>
+      <Icon className="mb-4 h-12 w-12 text-muted-foreground" />
+      <h3 className="text-lg font-semibold">{title}</h3>
+      {description && <p className="mt-2 max-w-sm text-sm text-muted-foreground">{description}</p>}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  )
+}
+```
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| `<PrimaryButton>` wrappeando `<Button variant="primary">` | Sin valor | `<Button variant="primary">` directo |
+| Importar `@radix-ui/react-dialog` directo | Pierde el theming/CVA | Pasar por `@/components/ui/dialog` |
+| `<Image>` con `unoptimized={false}` | Necesita server | `<img>` regular o `<Image unoptimized />` |
+| Hex inline: `style={{color: '#FF0000'}}` | Rompe dark mode | `text-destructive` o `text-[color:hsl(var(--destructive))]` |
+| Google Fonts CDN | GDPR + CSP estricta | `@fontsource/*` self-hosted |
+| Framer Motion para fade | Bundle bloat | Tailwind `animate-in fade-in` o `@starting-style` |
+| Recharts color hardcodeado (`fill="#FF0000"`) | Rompe dark/light | `fill="hsl(var(--primary))"` |
+| Olvidar `suppressHydrationWarning` en `<html>` | Warning ruidoso por next-themes | Agregarlo en RootLayout |
+| Olvidar `disableTransitionOnChange` en ThemeProvider | Flash visual molesto | Habilitarlo |
+| `onClick={() => login(data)}` sin handler memoizado en lista virtualizada | Re-renders innecesarios | `useCallback` + key estable |
+| Estilizar Tanstack Table cell con `<td className="...">` | Rompe shadcn theming | Usar `<TableCell>` shadcn |
+
+[< 02-structure](02-structure.md) | [Siguiente: 04-auth >](04-auth.md)

--- a/.claude/docs/dashboard/04-auth.md
+++ b/.claude/docs/dashboard/04-auth.md
@@ -1,0 +1,842 @@
+# 04 — Auth: JWT + Tanstack Query + Zustand + magic link + BroadcastChannel
+
+[< 03-ui](03-ui.md) | [Siguiente: 05-deploy >](05-deploy.md)
+
+## Resumen del flujo
+
+El dashboard consume el Lambda `auth` de los planes 01-02 del repo. Tres
+tipos de JWT (temp 5min rolling, access 15min, refresh 30dias con
+family_id rotation). Storage:
+
+- **access**: Zustand in-memory (NO persistido — XSS = 15 min de exposicion max).
+- **refresh**: HttpOnly cookie (preferido — backend setea
+  `Set-Cookie: refresh_token=...; HttpOnly; Secure; SameSite=Strict; Path=/`)
+  o `localStorage` con CSP estricta (fallback documentado).
+- **temp**: in-memory durante el flujo de registro/login multi-step.
+
+## Auth store (Zustand)
+
+`src/features/auth/store/use-auth-store.ts`:
+
+```typescript
+import {create} from 'zustand'
+import {persist, createJSONStorage} from 'zustand/middleware'
+import {jwtDecode} from 'jwt-decode'
+
+export interface User {
+  id: string
+  email: string
+  status: 'pending' | 'active' | 'disabled' | 'locked' | 'deleted'
+  has_password: boolean
+  mfa_methods: ('totp' | 'webauthn' | 'email_code')[]
+}
+
+interface AuthState {
+  // in-memory ONLY (no persist)
+  accessToken: string | null
+  tempToken: string | null
+  refreshExpiry: number | null  // epoch ms del exp del refresh actual
+
+  // persisted (solo el user, para skeleton inicial)
+  user: User | null
+
+  // actions
+  setAccessToken: (token: string | null) => void
+  setTempToken: (token: string | null) => void
+  setUser: (user: User | null) => void
+  setRefreshExpiry: (exp: number | null) => void
+  reset: () => void
+
+  // derived
+  isAuthenticated: () => boolean
+  isAccessExpired: () => boolean
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      accessToken: null,
+      tempToken: null,
+      refreshExpiry: null,
+      user: null,
+
+      setAccessToken: (token) => set({accessToken: token}),
+      setTempToken: (token) => set({tempToken: token}),
+      setUser: (user) => set({user}),
+      setRefreshExpiry: (exp) => set({refreshExpiry: exp}),
+
+      reset: () => set({
+        accessToken: null,
+        tempToken: null,
+        refreshExpiry: null,
+        user: null,
+      }),
+
+      isAuthenticated: () => {
+        const {accessToken, user} = get()
+        if (!accessToken || !user) return false
+        return !get().isAccessExpired()
+      },
+
+      isAccessExpired: () => {
+        const {accessToken} = get()
+        if (!accessToken) return true
+        try {
+          const {exp} = jwtDecode<{exp: number}>(accessToken)
+          return Date.now() >= exp * 1000
+        } catch {
+          return true
+        }
+      },
+    }),
+    {
+      name: 'portfolio-dashboard-auth',
+      storage: createJSONStorage(() => localStorage),
+      // Solo persistir el user (UI skeleton). NUNCA accessToken ni tempToken.
+      partialize: (state) => ({user: state.user, refreshExpiry: state.refreshExpiry}),
+    },
+  ),
+)
+```
+
+## Refresh mutex
+
+`src/features/auth/lib/refresh-mutex.ts`:
+
+```typescript
+/**
+ * Mutex: asegura que solo UN /session/refresh este in-flight a la vez.
+ * Si 5 requests fallan con 401 simultaneamente, solo se dispara 1 refresh;
+ * los otros 4 esperan el resultado y reintentan.
+ *
+ * Sin esto, 5 refresh calls concurrentes harian que el backend revoque
+ * la familia (RFC 9700 reuse detection).
+ */
+let inFlight: Promise<boolean> | null = null
+
+export async function withRefreshMutex(
+  refreshFn: () => Promise<boolean>,
+): Promise<boolean> {
+  if (inFlight) {
+    return inFlight
+  }
+  inFlight = (async () => {
+    try {
+      return await refreshFn()
+    } finally {
+      inFlight = null
+    }
+  })()
+  return inFlight
+}
+```
+
+## Fetch wrapper con auth interceptor
+
+`src/lib/api-client.ts`:
+
+```typescript
+import {env} from './env'
+import {useAuthStore} from '@/features/auth/store/use-auth-store'
+import {withRefreshMutex} from '@/features/auth/lib/refresh-mutex'
+
+interface FetchOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown
+  skipAuth?: boolean
+  skipRefresh?: boolean
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: number,
+    message: string,
+    public readonly data?: unknown,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+export async function apiFetch<T = unknown>(
+  endpoint: string,
+  options: FetchOptions = {},
+): Promise<T> {
+  const {skipAuth = false, skipRefresh = false, body, headers: extraHeaders, ...rest} = options
+  const url = `${env.NEXT_PUBLIC_API_ENDPOINT}${endpoint}`
+
+  const headers = new Headers(extraHeaders)
+  headers.set('Content-Type', 'application/json')
+
+  if (!skipAuth) {
+    const token = useAuthStore.getState().accessToken
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  const init: RequestInit = {
+    ...rest,
+    headers,
+    credentials: 'include', // para HttpOnly cookies (refresh token)
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }
+
+  let response = await fetch(url, init)
+
+  // 401 + tenemos refresh -> intentar rotacion
+  if (response.status === 401 && !skipAuth && !skipRefresh) {
+    const refreshed = await withRefreshMutex(performRefresh)
+    if (refreshed) {
+      // Retry con token nuevo
+      const newToken = useAuthStore.getState().accessToken
+      if (newToken) headers.set('Authorization', `Bearer ${newToken}`)
+      response = await fetch(url, {...init, headers})
+    } else {
+      // Refresh fallo -> logout
+      await performLocalLogout()
+      throw new ApiError(401, 4011, 'Sesion expirada', null)
+    }
+  }
+
+  // Parse JSON (puede ser body vacio)
+  let data: unknown = null
+  const text = await response.text()
+  if (text) {
+    try {
+      data = JSON.parse(text)
+    } catch {
+      data = text
+    }
+  }
+
+  if (!response.ok) {
+    const payload = (data ?? {}) as {error?: string; code?: number; message?: string}
+    throw new ApiError(
+      response.status,
+      payload.code ?? response.status,
+      payload.message ?? payload.error ?? `HTTP ${response.status}`,
+      data,
+    )
+  }
+
+  return data as T
+}
+
+async function performRefresh(): Promise<boolean> {
+  try {
+    const response = await fetch(`${env.NEXT_PUBLIC_API_ENDPOINT}/auth`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      credentials: 'include', // cookie HttpOnly refresh_token
+      body: JSON.stringify({operation: 'session', action: 'refresh', data: {}}),
+    })
+    if (!response.ok) return false
+    const {data} = await response.json()
+    useAuthStore.getState().setAccessToken(data.access_token)
+    // El backend ya rotaria la HttpOnly cookie del refresh
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function performLocalLogout(): Promise<void> {
+  // Limpiar estado local (sin llamar al backend — el logout server-side
+  // se hace explicitamente desde la UI con useLogout)
+  useAuthStore.getState().reset()
+  // Notificar otras tabs
+  const channel = new BroadcastChannel('portfolio_auth')
+  channel.postMessage({type: 'LOGOUT'})
+  channel.close()
+}
+```
+
+## Magic link callback (fragment hash)
+
+`src/app/(auth)/callback/page.tsx`:
+
+```tsx
+'use client'
+
+import {useEffect, useRef} from 'react'
+import {useRouter} from 'next/navigation'
+import {useAuthStore} from '@/features/auth/store/use-auth-store'
+import {jwtDecode} from 'jwt-decode'
+import {toast} from 'sonner'
+
+export default function CallbackPage() {
+  const router = useRouter()
+  const setAccessToken = useAuthStore((s) => s.setAccessToken)
+  const setUser = useAuthStore((s) => s.setUser)
+  const setRefreshExpiry = useAuthStore((s) => s.setRefreshExpiry)
+  const ran = useRef(false)
+
+  useEffect(() => {
+    if (ran.current) return
+    ran.current = true
+
+    const fragment = window.location.hash.slice(1) // remove '#'
+    if (!fragment) {
+      toast.error('Link invalido')
+      router.replace('/login')
+      return
+    }
+
+    const params = new URLSearchParams(fragment)
+    const accessToken = params.get('access')
+    const userId = params.get('user_id')
+    const email = params.get('email')
+    const refreshExp = params.get('refresh_exp') // epoch seconds
+
+    if (!accessToken) {
+      toast.error('Link sin token')
+      router.replace('/login')
+      return
+    }
+
+    try {
+      // Validar shape del JWT (no firma — eso lo hace el backend)
+      const payload = jwtDecode<{sub: string; email: string; exp: number}>(accessToken)
+      setAccessToken(accessToken)
+      setUser({
+        id: payload.sub,
+        email: payload.email,
+        status: 'active',
+        has_password: false,
+        mfa_methods: [],
+      })
+      if (refreshExp) {
+        setRefreshExpiry(Number.parseInt(refreshExp, 10) * 1000)
+      }
+
+      // CRITICO: limpiar el fragment ANTES de cualquier navegacion
+      window.history.replaceState(null, '', '/dashboard')
+      router.replace('/dashboard')
+      toast.success('Sesion iniciada')
+    } catch {
+      toast.error('Token invalido')
+      router.replace('/login')
+    }
+  }, [router, setAccessToken, setUser, setRefreshExpiry])
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <p className="text-muted-foreground">Iniciando sesion...</p>
+    </div>
+  )
+}
+```
+
+> El `ran` ref evita doble ejecucion en StrictMode dev. El
+> `history.replaceState` borra el fragment del URL/history para que no
+> quede expuesto.
+
+## AuthGuard
+
+`src/features/auth/components/auth-guard.tsx`:
+
+```tsx
+'use client'
+
+import {useEffect} from 'react'
+import {useRouter, usePathname} from 'next/navigation'
+import {useAuthStore} from '../store/use-auth-store'
+import {useAuthTimer} from '../hooks/use-auth-timer'
+import {useMultiTabSync} from '../hooks/use-multi-tab-sync'
+
+export function AuthGuard({children}: {children: React.ReactNode}) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+
+  // hooks que mantienen la sesion viva
+  useAuthTimer()
+  useMultiTabSync()
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      router.replace(`/login?next=${encodeURIComponent(pathname)}`)
+    }
+  }, [isAuthenticated, router, pathname])
+
+  if (!isAuthenticated()) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <p className="text-muted-foreground">Verificando sesion...</p>
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}
+```
+
+Uso en `(dashboard)/layout.tsx`:
+
+```tsx
+'use client'
+import {AuthGuard} from '@/features/auth/components/auth-guard'
+import {Sidebar} from '@/features/dashboard-shell/components/sidebar'
+import {Header} from '@/features/dashboard-shell/components/header'
+
+export default function DashboardLayout({children}: {children: React.ReactNode}) {
+  return (
+    <AuthGuard>
+      <div className="flex min-h-screen">
+        <Sidebar />
+        <div className="flex flex-1 flex-col">
+          <Header />
+          <main className="flex-1 overflow-auto p-6">{children}</main>
+        </div>
+      </div>
+    </AuthGuard>
+  )
+}
+```
+
+## Auto-refresh proactivo
+
+`src/features/auth/hooks/use-auth-timer.ts`:
+
+```typescript
+'use client'
+
+import {useEffect, useRef} from 'react'
+import {jwtDecode} from 'jwt-decode'
+import {useAuthStore} from '../store/use-auth-store'
+import {withRefreshMutex} from '../lib/refresh-mutex'
+import {env} from '@/lib/env'
+
+const REFRESH_LEAD = env.NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS
+
+export function useAuthTimer() {
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const reset = useAuthStore((s) => s.reset)
+  const setAccessToken = useAuthStore((s) => s.setAccessToken)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    if (!accessToken) return
+
+    let exp: number
+    try {
+      exp = jwtDecode<{exp: number}>(accessToken).exp * 1000
+    } catch {
+      reset()
+      return
+    }
+
+    const msUntilRefresh = exp - Date.now() - REFRESH_LEAD
+    if (msUntilRefresh <= 0) {
+      // Ya esta por expirar o expirado — refresh inmediato
+      void doRefresh()
+      return
+    }
+
+    timerRef.current = setTimeout(doRefresh, msUntilRefresh)
+
+    async function doRefresh() {
+      const ok = await withRefreshMutex(async () => {
+        const r = await fetch(`${env.NEXT_PUBLIC_API_ENDPOINT}/auth`, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          credentials: 'include',
+          body: JSON.stringify({operation: 'session', action: 'refresh', data: {}}),
+        })
+        if (!r.ok) return false
+        const {data} = await r.json()
+        setAccessToken(data.access_token)
+        return true
+      })
+      if (!ok) reset()
+    }
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [accessToken, reset, setAccessToken])
+
+  // Page Visibility: re-check al volver a la tab
+  useEffect(() => {
+    function onVisibility() {
+      if (document.visibilityState !== 'visible') return
+      const token = useAuthStore.getState().accessToken
+      if (!token) return
+      try {
+        const exp = jwtDecode<{exp: number}>(token).exp * 1000
+        if (Date.now() >= exp - REFRESH_LEAD) {
+          // refresh inmediato
+          void withRefreshMutex(async () => {
+            const r = await fetch(`${env.NEXT_PUBLIC_API_ENDPOINT}/auth`, {
+              method: 'POST',
+              headers: {'Content-Type': 'application/json'},
+              credentials: 'include',
+              body: JSON.stringify({operation: 'session', action: 'refresh', data: {}}),
+            })
+            if (!r.ok) {
+              useAuthStore.getState().reset()
+              return false
+            }
+            const {data} = await r.json()
+            useAuthStore.getState().setAccessToken(data.access_token)
+            return true
+          })
+        }
+      } catch {
+        useAuthStore.getState().reset()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => document.removeEventListener('visibilitychange', onVisibility)
+  }, [])
+}
+```
+
+## Multi-tab sync (BroadcastChannel)
+
+`src/features/auth/hooks/use-multi-tab-sync.ts`:
+
+```typescript
+'use client'
+
+import {useEffect} from 'react'
+import {useAuthStore} from '../store/use-auth-store'
+
+export function useMultiTabSync() {
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return
+    const channel = new BroadcastChannel('portfolio_auth')
+
+    channel.onmessage = (event: MessageEvent<{type: 'LOGOUT' | 'TOKEN_REFRESH'; token?: string}>) => {
+      if (event.data.type === 'LOGOUT') {
+        useAuthStore.getState().reset()
+      } else if (event.data.type === 'TOKEN_REFRESH' && event.data.token) {
+        useAuthStore.getState().setAccessToken(event.data.token)
+      }
+    }
+
+    return () => channel.close()
+  }, [])
+}
+
+// Helper para emitir mensajes desde otros lugares (e.g. logout, refresh)
+export function broadcastAuth(message: {type: 'LOGOUT' | 'TOKEN_REFRESH'; token?: string}) {
+  if (typeof BroadcastChannel === 'undefined') return
+  const channel = new BroadcastChannel('portfolio_auth')
+  channel.postMessage(message)
+  channel.close()
+}
+```
+
+## useLogout
+
+`src/features/auth/hooks/use-logout.ts`:
+
+```typescript
+'use client'
+
+import {useMutation} from '@tanstack/react-query'
+import {useRouter} from 'next/navigation'
+import {useQueryClient} from '@tanstack/react-query'
+import {apiFetch} from '@/lib/api-client'
+import {useAuthStore} from '../store/use-auth-store'
+import {broadcastAuth} from './use-multi-tab-sync'
+import {toast} from 'sonner'
+
+export function useLogout() {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const reset = useAuthStore((s) => s.reset)
+
+  return useMutation({
+    mutationFn: async () => {
+      // Backend blacklistea la familia (DynamoDB)
+      await apiFetch('/auth', {
+        method: 'POST',
+        body: {operation: 'session', action: 'logout', data: {}},
+      }).catch(() => {
+        // Si el backend falla, seguimos con el logout local
+      })
+    },
+    onSettled: () => {
+      // Limpiar local SIEMPRE (incluso si la llamada al backend fallo)
+      reset()
+      queryClient.clear()
+      // Notificar otras tabs
+      broadcastAuth({type: 'LOGOUT'})
+      // Redirect
+      router.replace('/login')
+      toast.info('Sesion cerrada')
+    },
+  })
+}
+```
+
+## Tanstack Query setup
+
+`src/providers/query-provider.tsx`:
+
+```tsx
+'use client'
+
+import {QueryClient} from '@tanstack/react-query'
+import {PersistQueryClientProvider} from '@tanstack/react-query-persist-client'
+import {createSyncStoragePersister} from '@tanstack/query-sync-storage-persister'
+import {compress, decompress} from 'lz-string'
+import {useState, type ReactNode} from 'react'
+import {ApiError} from '@/lib/api-client'
+import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
+
+export function QueryProvider({children}: {children: ReactNode}) {
+  const [client] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 5 * 60_000,
+        refetchOnWindowFocus: false,
+        retry: (failureCount, error) => {
+          // No retry en 401/403/422
+          if (error instanceof ApiError && [401, 403, 422].includes(error.status)) {
+            return false
+          }
+          return failureCount < 1
+        },
+      },
+      mutations: {retry: 0},
+    },
+  }))
+
+  const [persister] = useState(() =>
+    createSyncStoragePersister({
+      storage: typeof window === 'undefined' ? undefined : window.localStorage,
+      key: 'portfolio-dashboard-query',
+      serialize: (data) => compress(JSON.stringify(data)),
+      deserialize: (data) => JSON.parse(decompress(data) || '{}'),
+    }),
+  )
+
+  return (
+    <PersistQueryClientProvider
+      client={client}
+      persistOptions={{
+        persister,
+        maxAge: 24 * 60 * 60 * 1000, // 24h
+        // No persistir queries que contienen data sensible (contacts list)
+        dehydrateOptions: {
+          shouldDehydrateQuery: (query) => {
+            if (query.state.status !== 'success') return false
+            const key = query.queryKey[0]
+            if (key === 'contacts') return false // PII
+            if (key === 'events' && query.queryKey[1] === 'list') return false
+            return true
+          },
+        },
+      }}
+    >
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </PersistQueryClientProvider>
+  )
+}
+```
+
+## Composicion final de providers
+
+`src/providers/root-providers.tsx`:
+
+```tsx
+'use client'
+
+import {ReactNode} from 'react'
+import {ThemeProvider} from './theme-provider'
+import {QueryProvider} from './query-provider'
+
+export function RootProviders({children}: {children: ReactNode}) {
+  return (
+    <ThemeProvider>
+      <QueryProvider>{children}</QueryProvider>
+    </ThemeProvider>
+  )
+}
+```
+
+`src/app/layout.tsx`:
+
+```tsx
+import type {Metadata} from 'next'
+import '@/styles/globals.css'
+import {RootProviders} from '@/providers/root-providers'
+import {Toaster} from '@/components/ui/sonner'
+
+// Importante: validar env al cargar (fail-fast en build)
+import '@/lib/env'
+
+export const metadata: Metadata = {
+  title: 'Dashboard | the-full-stack',
+  description: 'Admin dashboard',
+  robots: 'noindex, nofollow',
+}
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="es" suppressHydrationWarning>
+      <body>
+        <RootProviders>{children}</RootProviders>
+        <Toaster position="top-right" richColors closeButton />
+      </body>
+    </html>
+  )
+}
+```
+
+## Endpoints typed (`auth-client.ts`)
+
+```typescript
+// src/features/auth/api/auth-client.ts
+import {apiFetch} from '@/lib/api-client'
+import type {User} from '../store/use-auth-store'
+
+export interface AuthResponse {
+  access_token: string
+  expires_in: number
+  user: User
+}
+
+export interface TempTokenResponse {
+  temp_token: string
+  user_id: string
+  expires_in: number
+  methods?: ('magic-link' | 'email-code' | 'password' | 'totp' | 'webauthn')[]
+}
+
+export const authClient = {
+  registerStart: (data: {email: string; cf_turnstile_response: string}) =>
+    apiFetch<{data: TempTokenResponse}>('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      body: {operation: 'register', action: 'start', data},
+    }),
+
+  registerVerifyCode: (data: {code: string; temp_token: string}) =>
+    apiFetch<{data: AuthResponse}>('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      body: {operation: 'register', action: 'verify-code', data},
+    }),
+
+  loginStart: (data: {email: string; cf_turnstile_response: string; password?: string}) =>
+    apiFetch<{data: TempTokenResponse}>('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      body: {operation: 'login', action: 'start', data},
+    }),
+
+  loginVerifyCode: (data: {code: string; temp_token: string}) =>
+    apiFetch<{data: AuthResponse}>('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      body: {operation: 'login', action: 'verify-code', data},
+    }),
+
+  loginVerifyTotp: (data: {code: string; temp_token: string}) =>
+    apiFetch<{data: AuthResponse}>('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      body: {operation: 'login', action: 'verify-totp', data},
+    }),
+
+  setPassword: (data: {password: string; temp_token: string}) =>
+    apiFetch<{data: AuthResponse}>('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      body: {operation: 'verify', action: 'set-password', data},
+    }),
+
+  resendCode: (data: {temp_token: string}) =>
+    apiFetch('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      body: {operation: 'verify', action: 'resend-code', data},
+    }),
+
+  sessionRefresh: () =>
+    apiFetch<{data: {access_token: string; expires_in: number}}>('/auth', {
+      method: 'POST',
+      skipAuth: true,
+      skipRefresh: true, // critico: este NUNCA debe entrar al mutex
+      body: {operation: 'session', action: 'refresh', data: {}},
+    }),
+
+  sessionLogout: () =>
+    apiFetch('/auth', {
+      method: 'POST',
+      body: {operation: 'session', action: 'logout', data: {}},
+    }),
+}
+```
+
+## Hooks por accion
+
+```typescript
+// src/features/auth/hooks/use-register-start.ts
+import {useMutation} from '@tanstack/react-query'
+import {useRouter} from 'next/navigation'
+import {authClient} from '../api/auth-client'
+import {useAuthStore} from '../store/use-auth-store'
+import {toast} from 'sonner'
+import {ApiError} from '@/lib/api-client'
+
+export function useRegisterStart() {
+  const router = useRouter()
+  const setTempToken = useAuthStore((s) => s.setTempToken)
+
+  return useMutation({
+    mutationFn: authClient.registerStart,
+    onSuccess: ({data}) => {
+      setTempToken(data.temp_token)
+      router.push('/verify?flow=register')
+      toast.success('Te enviamos un email con un magic-link y un codigo')
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.code === 4090) {
+        toast.error('Email ya registrado', {description: 'Inicia sesion en su lugar.'})
+      } else {
+        toast.error(error.message)
+      }
+    },
+  })
+}
+```
+
+## Threat model resumido
+
+| Amenaza | Mitigacion implementada |
+|---------|--------------------------|
+| XSS roba accessToken | Access in-memory, 15 min TTL. CSP estricta sin `unsafe-inline` (scripts) |
+| XSS roba refreshToken | HttpOnly cookie inaccesible a JS (preferido). Fallback: localStorage + Trusted Types + audit deps |
+| Refresh token reuse (token stolen) | Family_id rotation backend. Reuse detection → revoke familia entera |
+| Concurrent refresh race | Mutex client-side: 1 sola call in-flight |
+| CSRF | Bearer auth (no cookies para access). Refresh cookie `SameSite=Strict` |
+| Phishing (evilginx MitM) | WebAuthn (plan 02) es origin-bound = inmune. JWT/TOTP NO resisten |
+| Magic link leak via Referer | Tokens en fragment hash (NO query). `Referrer-Policy: strict-origin-when-cross-origin` |
+| Multi-tab desync | BroadcastChannel `portfolio_auth` |
+| Logout incompleto | Backend blacklist familia + `queryClient.clear()` + Zustand reset + broadcast |
+| Email enumeration (login.start 404 vs 200) | Decision aceptada del backend; mitigado con Turnstile + rate-limit 5/min/IP |
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Persistir `accessToken` en Zustand `persist()` | XSS = robo total | Solo `user` y `refreshExpiry` en partialize |
+| `localStorage.setItem('jwt', token)` | XSS roba | Zustand in-memory |
+| 2 fetch concurrent → 2 refresh | Backend revoca familia | Mutex |
+| Magic link `?access=X` | Leak Referer + history | Fragment hash `#access=X` |
+| `useEffect` sin `ran` guard en callback | StrictMode dev ejecuta 2 veces | `useRef(false)` + `if (ran.current) return` |
+| Olvidar `history.replaceState` post-callback | Tokens visibles en URL | `replaceState(null, '', '/dashboard')` |
+| `setTimeout` para refresh sin guardar timerRef | Memory leak + dobles refresh | `useRef` + cleanup |
+| `BroadcastChannel` sin check de `typeof === 'undefined'` | SSR/build crash | Guard `if (typeof BroadcastChannel === 'undefined') return` |
+| Logout que NO llama al backend | Backend no revoca → token sigue valido | Llamar `/auth?session=logout` en `onSettled` |
+| Refresh sin `skipRefresh: true` | Recursion infinita en 401 | Marcar `/session/refresh` con `skipRefresh: true` |
+| Mostrar mensaje "Email no existe" en login | Email enumeration mas explicita | Confiar en el response del backend (404 + suggest_register) |
+
+[< 03-ui](03-ui.md) | [Siguiente: 05-deploy >](05-deploy.md)

--- a/.claude/docs/dashboard/04-auth.md
+++ b/.claude/docs/dashboard/04-auth.md
@@ -6,13 +6,35 @@
 
 El dashboard consume el Lambda `auth` de los planes 01-02 del repo. Tres
 tipos de JWT (temp 5min rolling, access 15min, refresh 30dias con
-family_id rotation). Storage:
+family_id rotation).
 
-- **access**: Zustand in-memory (NO persistido — XSS = 15 min de exposicion max).
-- **refresh**: HttpOnly cookie (preferido — backend setea
-  `Set-Cookie: refresh_token=...; HttpOnly; Secure; SameSite=Strict; Path=/`)
-  o `localStorage` con CSP estricta (fallback documentado).
-- **temp**: in-memory durante el flujo de registro/login multi-step.
+### Decision: tokens en `localStorage` (NO HttpOnly cookies)
+
+El dashboard es un **SPA estatico** (Next.js `output: 'export'`)
+deployado en Cloudflare Pages bajo `admin.portfolio.{env}.the-full-stack.com`.
+El backend Lambda vive en `api.portfolio.{env}.the-full-stack.com` —
+**otro origen**. Para que el backend pudiera setear cookies HttpOnly
+accesibles desde el dashboard, la cookie tendria que ser
+`SameSite=None; Secure; Domain=.the-full-stack.com`, lo que abre
+vectores CSRF en los 6 niches publicos del portfolio y rompe
+portabilidad (mobile app, embebido en widgets).
+
+**Conclusion**: los tres tokens (access, refresh, temp) viajan en el
+body de la respuesta y se persisten en `localStorage`. La defensa
+contra XSS es CSP estricta + SRI en third-party + access JWT corto
+(15 min) + refresh rotation con detection de reuso.
+
+Storage:
+
+- **access** (`localStorage['access_token']`): TTL 15 min. Persisted
+  en Zustand. Reaplicado en `Authorization: Bearer` de cada request.
+- **refresh** (`localStorage['refresh_token']`): TTL 30 dias.
+  Persisted. Solo el wrapper `lib/api-client.ts` lo lee (jamas pasa
+  por componentes UI). Cada uso lo rota (la respuesta de
+  `/session/refresh` devuelve uno nuevo, el viejo queda blacklisteado
+  en DynamoDB con `family_id`).
+- **temp** (`localStorage['temp_token']`): TTL 5 min, rolling. Vive
+  solo durante el flujo multi-step de register/login.
 
 ## Auth store (Zustand)
 
@@ -32,19 +54,17 @@ export interface User {
 }
 
 interface AuthState {
-  // in-memory ONLY (no persist)
   accessToken: string | null
+  refreshToken: string | null
   tempToken: string | null
-  refreshExpiry: number | null  // epoch ms del exp del refresh actual
-
-  // persisted (solo el user, para skeleton inicial)
   user: User | null
 
   // actions
   setAccessToken: (token: string | null) => void
+  setRefreshToken: (token: string | null) => void
   setTempToken: (token: string | null) => void
   setUser: (user: User | null) => void
-  setRefreshExpiry: (exp: number | null) => void
+  setTokens: (access: string, refresh: string, user: User) => void
   reset: () => void
 
   // derived
@@ -56,19 +76,21 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => ({
       accessToken: null,
+      refreshToken: null,
       tempToken: null,
-      refreshExpiry: null,
       user: null,
 
       setAccessToken: (token) => set({accessToken: token}),
+      setRefreshToken: (token) => set({refreshToken: token}),
       setTempToken: (token) => set({tempToken: token}),
       setUser: (user) => set({user}),
-      setRefreshExpiry: (exp) => set({refreshExpiry: exp}),
+      setTokens: (access, refresh, user) =>
+        set({accessToken: access, refreshToken: refresh, user}),
 
       reset: () => set({
         accessToken: null,
+        refreshToken: null,
         tempToken: null,
-        refreshExpiry: null,
         user: null,
       }),
 
@@ -92,8 +114,13 @@ export const useAuthStore = create<AuthState>()(
     {
       name: 'portfolio-dashboard-auth',
       storage: createJSONStorage(() => localStorage),
-      // Solo persistir el user (UI skeleton). NUNCA accessToken ni tempToken.
-      partialize: (state) => ({user: state.user, refreshExpiry: state.refreshExpiry}),
+      // Persistir access, refresh y user. NO persist temp (vive solo
+      // durante el flujo multi-step).
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        user: state.user,
+      }),
     },
   ),
 )
@@ -176,7 +203,8 @@ export async function apiFetch<T = unknown>(
   const init: RequestInit = {
     ...rest,
     headers,
-    credentials: 'include', // para HttpOnly cookies (refresh token)
+    // SPA cross-origin: tokens viajan en localStorage + Authorization
+    // header. NO se usan cookies (ver decision en encabezado de este doc).
     body: body !== undefined ? JSON.stringify(body) : undefined,
   }
 
@@ -223,16 +251,23 @@ export async function apiFetch<T = unknown>(
 
 async function performRefresh(): Promise<boolean> {
   try {
+    const refreshToken = useAuthStore.getState().refreshToken
+    if (!refreshToken) return false
     const response = await fetch(`${env.NEXT_PUBLIC_API_ENDPOINT}/auth`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      credentials: 'include', // cookie HttpOnly refresh_token
-      body: JSON.stringify({operation: 'session', action: 'refresh', data: {}}),
+      body: JSON.stringify({
+        operation: 'session',
+        action: 'refresh',
+        data: {refresh_token: refreshToken},
+      }),
     })
     if (!response.ok) return false
     const {data} = await response.json()
+    // Backend rota el refresh: el viejo queda blacklisteado en DynamoDB
+    // (family_id detection). Reemplazamos los dos en el store.
     useAuthStore.getState().setAccessToken(data.access_token)
-    // El backend ya rotaria la HttpOnly cookie del refresh
+    useAuthStore.getState().setRefreshToken(data.refresh_token)
     return true
   } catch {
     return false
@@ -265,9 +300,7 @@ import {toast} from 'sonner'
 
 export default function CallbackPage() {
   const router = useRouter()
-  const setAccessToken = useAuthStore((s) => s.setAccessToken)
-  const setUser = useAuthStore((s) => s.setUser)
-  const setRefreshExpiry = useAuthStore((s) => s.setRefreshExpiry)
+  const setTokens = useAuthStore((s) => s.setTokens)
   const ran = useRef(false)
 
   useEffect(() => {
@@ -281,34 +314,33 @@ export default function CallbackPage() {
       return
     }
 
+    // El backend redirige con:
+    //   /callback#access=<JWT>&refresh=<JWT>&user_id=<X>&email=<Y>
     const params = new URLSearchParams(fragment)
     const accessToken = params.get('access')
+    const refreshToken = params.get('refresh')
     const userId = params.get('user_id')
     const email = params.get('email')
-    const refreshExp = params.get('refresh_exp') // epoch seconds
 
-    if (!accessToken) {
-      toast.error('Link sin token')
+    if (!accessToken || !refreshToken || !userId || !email) {
+      toast.error('Link incompleto')
       router.replace('/login')
       return
     }
 
     try {
       // Validar shape del JWT (no firma — eso lo hace el backend)
-      const payload = jwtDecode<{sub: string; email: string; exp: number}>(accessToken)
-      setAccessToken(accessToken)
-      setUser({
-        id: payload.sub,
-        email: payload.email,
+      jwtDecode<{sub: string; exp: number}>(accessToken)
+      setTokens(accessToken, refreshToken, {
+        id: userId,
+        email,
         status: 'active',
         has_password: false,
         mfa_methods: [],
       })
-      if (refreshExp) {
-        setRefreshExpiry(Number.parseInt(refreshExp, 10) * 1000)
-      }
 
-      // CRITICO: limpiar el fragment ANTES de cualquier navegacion
+      // CRITICO: limpiar el fragment ANTES de cualquier navegacion para
+      // que el token no quede en window.location.hash ni en el history.
       window.history.replaceState(null, '', '/dashboard')
       router.replace('/dashboard')
       toast.success('Sesion iniciada')
@@ -316,7 +348,7 @@ export default function CallbackPage() {
       toast.error('Token invalido')
       router.replace('/login')
     }
-  }, [router, setAccessToken, setUser, setRefreshExpiry])
+  }, [router, setTokens])
 
   return (
     <div className="flex h-screen items-center justify-center">
@@ -812,23 +844,25 @@ export function useRegisterStart() {
 
 | Amenaza | Mitigacion implementada |
 |---------|--------------------------|
-| XSS roba accessToken | Access in-memory, 15 min TTL. CSP estricta sin `unsafe-inline` (scripts) |
-| XSS roba refreshToken | HttpOnly cookie inaccesible a JS (preferido). Fallback: localStorage + Trusted Types + audit deps |
+| XSS roba accessToken | Access TTL 15 min. CSP estricta sin `unsafe-inline`/`unsafe-eval`. SRI en third-party scripts. Trusted Types (cuando disponible). |
+| XSS roba refreshToken | Misma defensa: CSP + SRI + audit deps. Backup: family_id rotation + reuse detection invalidan el refresh apenas un atacante intenta usarlo en paralelo a la sesion legitima. |
 | Refresh token reuse (token stolen) | Family_id rotation backend. Reuse detection → revoke familia entera |
 | Concurrent refresh race | Mutex client-side: 1 sola call in-flight |
-| CSRF | Bearer auth (no cookies para access). Refresh cookie `SameSite=Strict` |
+| CSRF | NO se usan cookies (Bearer auth en Authorization header). Sin cookies cross-origin = sin vector CSRF. |
 | Phishing (evilginx MitM) | WebAuthn (plan 02) es origin-bound = inmune. JWT/TOTP NO resisten |
 | Magic link leak via Referer | Tokens en fragment hash (NO query). `Referrer-Policy: strict-origin-when-cross-origin` |
-| Multi-tab desync | BroadcastChannel `portfolio_auth` |
+| Multi-tab desync | BroadcastChannel `portfolio_auth` + `storage` event listener fallback |
 | Logout incompleto | Backend blacklist familia + `queryClient.clear()` + Zustand reset + broadcast |
 | Email enumeration (login.start 404 vs 200) | Decision aceptada del backend; mitigado con Turnstile + rate-limit 5/min/IP |
+| Tokens persisten en `localStorage` (vector si script malicioso ejecuta) | Defensa primaria: CSP estricta + SRI. Defensa secundaria: access TTL corto + family detection. Decision documentada en encabezado. |
 
 ## Anti-patrones
 
 | Anti-patron | Por que | Correccion |
 |-------------|---------|------------|
-| Persistir `accessToken` en Zustand `persist()` | XSS = robo total | Solo `user` y `refreshExpiry` en partialize |
-| `localStorage.setItem('jwt', token)` | XSS roba | Zustand in-memory |
+| Persistir `accessToken` con `name` predecible globalmente (ej. `'jwt'`) | Otros scripts del mismo origen pueden leer | Usar `name: 'portfolio-dashboard-auth'` (namespaced) + CSP estricta |
+| Cargar script third-party sin `integrity` (SRI) | Script comprometido lee `localStorage` | SRI obligatorio + allowlist en CSP `script-src` |
+| Intentar setear HttpOnly cookie cross-origin (`SameSite=None; Domain=.the-full-stack.com`) | Vector CSRF en los 6 niches publicos | Tokens en `localStorage` (decision documentada arriba) |
 | 2 fetch concurrent → 2 refresh | Backend revoca familia | Mutex |
 | Magic link `?access=X` | Leak Referer + history | Fragment hash `#access=X` |
 | `useEffect` sin `ran` guard en callback | StrictMode dev ejecuta 2 veces | `useRef(false)` + `if (ran.current) return` |

--- a/.claude/docs/dashboard/05-deploy.md
+++ b/.claude/docs/dashboard/05-deploy.md
@@ -1,0 +1,445 @@
+# 05 — Deploy: Cloudflare Pages + devtools + GH Actions + env vars
+
+[< 04-auth](04-auth.md) | [Siguiente: 06-testing >](06-testing.md)
+
+## Setup global del deploy
+
+| Item | Valor |
+|------|-------|
+| Provider | Cloudflare Pages (REST API) |
+| Account | mismo que las 6 apps Astro |
+| Projects | 3: `portfolio-dashboard-dev`, `portfolio-dashboard-stage`, `portfolio-dashboard` (prod) |
+| Branch mapping | `dev` → dev project, `stage` → stage, `main` → prod |
+| Build command | `pnpm install --frozen-lockfile && pnpm --filter @portfolio/dashboard... build` |
+| Output dir | `dashboard/out/` |
+| Custom domains | `admin.portfolio.{dev|stage|prod}.the-full-stack.com` |
+| SSL | Cloudflare ACM (auto, per-hostname) |
+| DNS records | CNAME `admin.portfolio.<env>` → `portfolio-dashboard-<env>.pages.dev` |
+
+## Subdominios cumplen subdomain-standard
+
+```
+[{component}.]{product}.{env}.{domain}
+
+admin.portfolio.dev.the-full-stack.com    (dev)
+admin.portfolio.stage.the-full-stack.com  (stage)
+admin.portfolio.the-full-stack.com        (prod, env omitido)
+```
+
+Compliance ✅. `admin` es un component nuevo bajo el product `portfolio`.
+Agregar a la lista de reservados de `subdomain-standard`:
+
+```yaml
+reserved:
+  - generic, hub, fintech, architect, leader, vibe   # niches
+  - admin   # dashboard (NEW)
+```
+
+## Extension de `devtools/cloudflare_setup/config.py`
+
+El script `devtools/cloudflare_setup/` actualmente maneja las 6 apps
+Astro. Hay que extenderlo para incluir el dashboard Next.js.
+
+```python
+"""devtools/cloudflare_setup/config.py — extension parcial."""
+
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class AppConfig:
+    """Una app del monorepo."""
+    project_name: str        # 'dashboard'
+    package_name: str         # '@portfolio/dashboard'
+    root_dir: str             # 'dashboard'
+    app_type: str = 'astro'   # 'astro' | 'nextjs'
+    build_output_dir: str = 'dist'  # 'dist' para Astro, 'out' para Next
+
+# 6 apps Astro existentes
+APPS_ASTRO: tuple[AppConfig, ...] = (
+    AppConfig(project_name='generic',   package_name='@portfolio/generic',   root_dir='apps/generic',   build_output_dir='dist'),
+    AppConfig(project_name='hub',       package_name='@portfolio/hub',       root_dir='apps/hub',       build_output_dir='dist'),
+    AppConfig(project_name='fintech',   package_name='@portfolio/fintech',   root_dir='apps/fintech',   build_output_dir='dist'),
+    AppConfig(project_name='architect', package_name='@portfolio/architect', root_dir='apps/architect', build_output_dir='dist'),
+    AppConfig(project_name='leader',    package_name='@portfolio/leader',    root_dir='apps/leader',    build_output_dir='dist'),
+    AppConfig(project_name='vibe',      package_name='@portfolio/vibe',      root_dir='apps/vibe',      build_output_dir='dist'),
+)
+
+# Nuevo: dashboard Next.js (NO en apps/, sino en root como dashboard/)
+APP_DASHBOARD: AppConfig = AppConfig(
+    project_name='dashboard',
+    package_name='@portfolio/dashboard',
+    root_dir='dashboard',           # carpeta nueva en root
+    app_type='nextjs',
+    build_output_dir='out',          # Next.js export default
+)
+
+APPS: tuple[AppConfig, ...] = APPS_ASTRO + (APP_DASHBOARD,)
+
+# Helpers de path
+def output_dir_for(app: AppConfig) -> str:
+    """Path al output dir para Cloudflare Pages destination."""
+    return f'{app.root_dir}/{app.build_output_dir}'
+
+def build_command_for(app: AppConfig) -> str:
+    """Build command (idem para Astro y Next con pnpm)."""
+    return f'pnpm install --frozen-lockfile && pnpm --filter {app.package_name}... build'
+```
+
+> El cambio clave es `build_output_dir`: Astro = `dist`, Next.js = `out`.
+> El `project_name` del dashboard es `dashboard` (sufijo `-dev`/`-stage`
+> o sin sufijo en prod via la logica existente del script).
+
+## Custom domain wiring
+
+```python
+# devtools/cloudflare_setup/config.py — custom domain mapping
+
+def custom_domain_for(app: AppConfig, env: str) -> str:
+    """Resuelve el custom domain de cada app x env."""
+    if app.project_name == 'generic' and env == 'prod':
+        return 'the-full-stack.com'   # apex
+    if app.project_name == 'dashboard':
+        # admin.portfolio.{env}.the-full-stack.com
+        if env == 'prod':
+            return 'admin.portfolio.the-full-stack.com'
+        return f'admin.portfolio.{env}.the-full-stack.com'
+    # niches: {niche}.portfolio.{env}.the-full-stack.com
+    if env == 'prod':
+        return f'{app.project_name}.portfolio.the-full-stack.com'
+    return f'{app.project_name}.portfolio.{env}.the-full-stack.com'
+```
+
+## Env vars del project Cloudflare Pages
+
+Cuando devtools provisiona el project (fase `projects`), setea env vars
+en el project que Cloudflare expone al build:
+
+```python
+def env_vars_for(app: AppConfig, env: str) -> dict[str, str]:
+    base = {
+        'NODE_VERSION': '24',
+        'PNPM_VERSION': '11.0.9',
+        'BASE_SCHEME': 'https',
+        'BASE_DOMAIN': f'portfolio.{env}.the-full-stack.com' if env != 'prod' else 'portfolio.the-full-stack.com',
+    }
+    if env == 'prod':
+        base['APEX_DOMAIN'] = 'the-full-stack.com'
+
+    # Vars del API endpoint (compartido entre Astro y Next)
+    base['PUBLIC_API_ENDPOINT'] = f'https://api.portfolio.{env}.the-full-stack.com' if env != 'prod' else 'https://api.portfolio.the-full-stack.com'
+    base['PUBLIC_TURNSTILE_SITEKEY'] = '0x4AAAAAADPSoiQA_-LcRafo'
+
+    # Vars exclusivas del dashboard (Next.js prefix NEXT_PUBLIC_)
+    if app.project_name == 'dashboard':
+        base['NEXT_PUBLIC_API_ENDPOINT'] = base['PUBLIC_API_ENDPOINT']
+        base['NEXT_PUBLIC_TURNSTILE_SITEKEY'] = base['PUBLIC_TURNSTILE_SITEKEY']
+        base['NEXT_PUBLIC_DASHBOARD_URL'] = f'https://{custom_domain_for(app, env)}'
+        base['NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS'] = '30000'
+
+    return base
+```
+
+## Extension de `docker/env/client/.example`
+
+Agregar al template las nuevas vars del dashboard:
+
+```bash
+# Existente (apps Astro)
+BASE_DOMAIN=
+BASE_SCHEME=
+APEX_DOMAIN=
+PUBLIC_API_ENDPOINT=
+PUBLIC_TURNSTILE_SITEKEY=
+TURNSTILE_SITE_KEY=
+TURNSTILE_ENABLED=
+
+# Nuevo: dashboard (Next.js requiere prefix NEXT_PUBLIC_)
+NEXT_PUBLIC_API_ENDPOINT=
+NEXT_PUBLIC_TURNSTILE_SITEKEY=
+NEXT_PUBLIC_DASHBOARD_URL=
+NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS=30000
+```
+
+## Extension de `devtools/sync_secrets/catalog.py`
+
+```python
+CATALOG['NEXT_PUBLIC_API_ENDPOINT'] = SecretDefinition(
+    name='NEXT_PUBLIC_API_ENDPOINT',
+    type='client',
+    description='API endpoint del Lambda backend (Next.js prefix)',
+)
+CATALOG['NEXT_PUBLIC_TURNSTILE_SITEKEY'] = SecretDefinition(
+    name='NEXT_PUBLIC_TURNSTILE_SITEKEY',
+    type='client',
+    description='Turnstile sitekey publico (Next.js prefix)',
+)
+CATALOG['NEXT_PUBLIC_DASHBOARD_URL'] = SecretDefinition(
+    name='NEXT_PUBLIC_DASHBOARD_URL',
+    type='client',
+    description='Self URL del dashboard (callbacks)',
+)
+CATALOG['NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS'] = SecretDefinition(
+    name='NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS',
+    type='client',
+    description='ms antes del exp del JWT para refresh proactivo',
+)
+```
+
+Sincronizar:
+
+```bash
+python devtools/run.py sync_secrets --env=dev --category=client --dry-run
+python devtools/run.py sync_secrets --env=dev --category=client
+```
+
+## `.github/workflows/deploy-apps.yml` extension
+
+El matrix actual tiene 6 niches Astro. Para incluir el dashboard,
+agregar entradas explicitas con `include` (mejor que extender `matrix:
+niche`).
+
+Snippets relevantes:
+
+```yaml
+jobs:
+  build-apps:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: ${{ needs.resolve-env.outputs.stage }}
+    env:
+      BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
+      BASE_SCHEME: ${{ vars.BASE_SCHEME }}
+      APEX_DOMAIN: ${{ vars.APEX_DOMAIN }}
+      PUBLIC_API_ENDPOINT: ${{ vars.PUBLIC_API_ENDPOINT }}
+      PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
+      # Vars exclusivas del dashboard
+      NEXT_PUBLIC_API_ENDPOINT: ${{ vars.NEXT_PUBLIC_API_ENDPOINT }}
+      NEXT_PUBLIC_TURNSTILE_SITEKEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITEKEY }}
+      NEXT_PUBLIC_DASHBOARD_URL: ${{ vars.NEXT_PUBLIC_DASHBOARD_URL }}
+      NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS: ${{ vars.NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: {version: 11.0.9}
+      - uses: actions/setup-node@v4
+        with: {node-version: 24, cache: pnpm}
+      - run: pnpm install --frozen-lockfile
+      - name: Build all apps (Astro + dashboard Next)
+        run: |
+          # Builds en paralelo: 6 Astro + 1 Next = 7 packages
+          pnpm -r --filter "./apps/*" --filter "@portfolio/dashboard" \
+            --workspace-concurrency=7 run build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-dist-${{ github.run_id }}
+          path: |
+            apps/*/dist
+            dashboard/out
+          retention-days: 1
+
+  deploy-pages:
+    needs: [resolve-env, build-apps]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: generic
+            dist-dir: apps/generic/dist
+            project: generic
+          - name: hub
+            dist-dir: apps/hub/dist
+            project: hub
+          - name: fintech
+            dist-dir: apps/fintech/dist
+            project: fintech
+          - name: architect
+            dist-dir: apps/architect/dist
+            project: architect
+          - name: leader
+            dist-dir: apps/leader/dist
+            project: leader
+          - name: vibe
+            dist-dir: apps/vibe/dist
+            project: vibe
+          - name: dashboard
+            dist-dir: dashboard/out
+            project: dashboard
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: deploy-dist-${{ github.run_id }}
+          path: .
+      - name: Deploy ${{ matrix.name }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >
+            pages deploy ${{ matrix.dist-dir }}
+            --project-name=portfolio-${{ matrix.project }}${{ needs.resolve-env.outputs.project-suffix }}
+            --branch=${{ github.ref_name }}
+
+  verify-deploy:
+    needs: [resolve-env, deploy-pages]
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [generic, hub, fintech, architect, leader, vibe, dashboard]
+    steps:
+      - name: Resolve expected URL
+        id: url
+        run: |
+          stage="${{ needs.resolve-env.outputs.stage }}"
+          name="${{ matrix.name }}"
+          if [[ "$name" == "dashboard" ]]; then
+            [[ "$stage" == "prod" ]] && url="https://admin.portfolio.the-full-stack.com" || url="https://admin.portfolio.${stage}.the-full-stack.com"
+          elif [[ "$name" == "generic" && "$stage" == "prod" ]]; then
+            url="https://the-full-stack.com"
+          else
+            [[ "$stage" == "prod" ]] && url="https://${name}.portfolio.the-full-stack.com" || url="https://${name}.portfolio.${stage}.the-full-stack.com"
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Verify HTTP 200
+        run: |
+          set -e
+          curl -sI "${{ steps.url.outputs.url }}" | head -1 | grep -q "200"
+```
+
+## CI: `ci.yml` extension
+
+El `ci.yml` actual hace lint + build de las apps. Extender para incluir
+el dashboard:
+
+```yaml
+- name: Lint & build all apps
+  run: |
+    pnpm run lint
+    pnpm -r --filter "./apps/*" --filter "@portfolio/dashboard" \
+      --workspace-concurrency=7 run build
+```
+
+## `pnpm-workspace.yaml`
+
+```yaml
+packages:
+  - 'apps/*'
+  - 'dashboard'      # NUEVO
+  - 'packages/*'
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  # Next.js puede traer postinstall extra: monitor con verbose install
+```
+
+## Local dev: 2 opciones
+
+### Opcion A — Next dev directo (recomendado para snappy HMR)
+
+```bash
+pnpm install                                       # workspace install
+pnpm --filter @portfolio/dashboard dev             # http://localhost:3000
+```
+
+Pro: Turbopack HMR rapido. Contra: no entra al nginx local (mappear via
+`/etc/hosts` o `admin.localhost`).
+
+### Opcion B — Docker compose con nginx
+
+Si necesitas testear `admin.localhost:9970`:
+
+```yaml
+# docker/docker-compose/local.yml (extension)
+services:
+  dashboard:
+    build:
+      context: ../..
+      dockerfile: docker/dockerfiles/dashboard.local.Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../../dashboard:/app/dashboard:cached
+    network_mode: host
+    command: pnpm --filter @portfolio/dashboard dev
+    environment:
+      NEXT_PUBLIC_API_ENDPOINT: http://api.localhost:9970
+      NEXT_PUBLIC_TURNSTILE_SITEKEY: 0x4AAAAAADPSoiQA_-LcRafo
+      NEXT_PUBLIC_DASHBOARD_URL: http://admin.localhost:9970
+```
+
+nginx ruteo `admin.localhost:9970 → dashboard:3000`. Mas pesado, mejor
+parity con prod.
+
+Decision: arrancar con Opcion A (mas rapido), agregar Opcion B solo si
+necesario.
+
+## Verificacion del deploy
+
+```bash
+# 1. Provisionar projects (primera vez por env)
+export CLOUDFLARE_API_TOKEN="$(grep -m1 '^CLOUDFLARE_API_TOKEN=' docker/env/dev-cli/.prod | cut -d= -f2-)"
+export ACCOUNT_ID="$(grep -m1 '^CLOUDFLARE_ACCOUNT_ID=' docker/env/dev-cli/.prod | cut -d= -f2-)"
+python devtools/run.py cloudflare_setup all --env=dev
+
+# 2. Verificar status
+python devtools/run.py cloudflare_setup status --env=dev
+
+# 3. Trigger primera build manual
+python devtools/run.py cloudflare_setup trigger --env=dev
+
+# 4. Esperar 2-3 min y verificar URL responde
+curl -sI https://admin.portfolio.dev.the-full-stack.com/ | head -3
+
+# 5. Verificar SSL cert OK
+openssl s_client -connect admin.portfolio.dev.the-full-stack.com:443 -showcerts < /dev/null 2>&1 | grep -E '(subject|issuer)'
+
+# 6. Verificar CSP en respuesta
+curl -sI https://admin.portfolio.dev.the-full-stack.com/ | grep -i 'content-security-policy'
+```
+
+## Branch flow del deploy
+
+Sigue el patron del repo (rule `git-workflow.md`):
+
+```text
+feature/dashboard-X → PR → dev  → auto-deploy dev (admin.portfolio.dev.the-full-stack.com)
+                              ↓
+                       PR → stage → auto-deploy stage
+                              ↓
+                       PR → main → auto-deploy prod
+```
+
+Merge commit en todos los PRs (rebase forbidden — ver memory
+`release-flow-rebase-divergence`).
+
+## Cloudflare Pages caveats
+
+| Caveat | Workaround |
+|--------|-----------|
+| Custom domain con random suffix → 403 | Esperar 2-3 min post-attach; ACM emite cert async |
+| `preview_branch_includes` ausente → builds en todas las branches | Setear `preview_branch_includes: [<branch>]` per env (ver memory `cloudflare-pages-preview-branch-fix`) |
+| `_headers` para `/` no aplica si Next genera `/index.html` | El `/*` cubre ambos. Si necesitas algo especial para `/`, agregar `/` explicitamente arriba de `/*` |
+| CSP que rompe shadcn dialog portal | `style-src 'unsafe-inline'` necesario (Radix portales inyectan styles inline) |
+| `node_modules` cache stale en Pages | Pages no cachea — siempre `pnpm install --frozen-lockfile` |
+| Build > 25min | Optimizar: workspace-concurrency, lazy load deps |
+| Bundle > 25 MB | code splitting agresivo, dynamic imports |
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Usar `wrangler` para crear el project | No soporta git-connected con env vars correctos | REST API via `cloudflare_setup` |
+| Editar config del project en Cloudflare UI | El siguiente `cloudflare_setup projects` lo revierte | Editar `config.py` y re-run |
+| Olvidar `environment: <stage>` en `deploy-apps.yml` | GH vars caen al default (prod), build sale roto en dev | Setear `environment` explicito por job |
+| Hardcodear el sitekey Turnstile en `next.config.ts` | Acopla con rotacion | `NEXT_PUBLIC_TURNSTILE_SITEKEY` env var |
+| Olvidar `dashboard/out` en upload-artifact | Deploy descarga vacio | Path explicito con `|` multi-line |
+| `cancel-in-progress: true` en deploy | Cancela mid-deploy = AWS state parcial | `cancel-in-progress: false` |
+| Push directo a `dev`/`stage`/`main` | Branches protegidas (rulesets) | PR con merge commit |
+| `wrangler.toml` con `name` distinto al project Cloudflare | wrangler crea uno nuevo | NO usar wrangler.toml — todo via devtools |
+| Setear `NEXT_PUBLIC_*` como GH Secret | Mascarea en logs, dificulta debug | Como GH Variable (publico por contrato) |
+
+[< 04-auth](04-auth.md) | [Siguiente: 06-testing >](06-testing.md)

--- a/.claude/docs/dashboard/06-testing.md
+++ b/.claude/docs/dashboard/06-testing.md
@@ -2,15 +2,26 @@
 
 [< 05-deploy](05-deploy.md) | [Volver al README](README.md)
 
-## Stack
+## Stack (versiones canonicas mayo 2026)
 
-| Capa | Herramienta | Comando |
-|------|-------------|---------|
-| Unit | Vitest + Testing Library + happy-dom | `pnpm --filter @portfolio/dashboard test` |
-| Coverage | Vitest v8 coverage | `pnpm --filter @portfolio/dashboard test:coverage` |
-| API mocks (dev + tests) | MSW (Mock Service Worker) | (importado por setup) |
-| E2E | Playwright (suite del monorepo) | `python devtools/run.py test_runner --module=feature --type=feature --env=local` |
-| Type check | tsc | `pnpm --filter @portfolio/dashboard typecheck` |
+| Capa | Herramienta | Version | Comando |
+|------|-------------|---------|---------|
+| Unit | Vitest + Testing Library + happy-dom | **2.2.5** / **16.1.0** / **16.5.1** | `pnpm --filter @portfolio/dashboard test` |
+| User event | @testing-library/user-event | **14.5.2** | (importado por tests) |
+| Jest DOM matchers | @testing-library/jest-dom | **6.6.3** | (en setup global) |
+| Coverage | Vitest v8 coverage | (vitest 2.2.5) | `pnpm --filter @portfolio/dashboard test:coverage` |
+| Vite React plugin | @vitejs/plugin-react | **4.3.3** | (devDep) |
+| API mocks (dev + tests) | MSW | **2.3.2** (con polyfill BroadcastChannel en happy-dom) | (importado por setup) |
+| E2E | Playwright | **1.48.2** (suite del monorepo) | `python devtools/run.py test_runner --module=feature --type=feature --env=local` |
+| Type check | tsc | **6.0.6** | `pnpm --filter @portfolio/dashboard typecheck` |
+
+> **Critico**: Testing Library v16 es el primer release con soporte
+> oficial React 19. `act()` warnings son mas estrictos que antes; envolver
+> state updates en `act(...)` cuando aplique.
+
+> **Critico**: MSW v2 internamente usa `BroadcastChannel` para
+> sincronizar handlers entre worker y client. happy-dom NO lo tiene
+> nativo — por eso el polyfill en `tests/setup.ts` es OBLIGATORIO.
 
 Coverage minimo: **80% per-file** en archivos modificados (mismo que el
 resto del repo).

--- a/.claude/docs/dashboard/06-testing.md
+++ b/.claude/docs/dashboard/06-testing.md
@@ -1,0 +1,598 @@
+# 06 — Testing: Vitest + Testing Library + MSW + Playwright
+
+[< 05-deploy](05-deploy.md) | [Volver al README](README.md)
+
+## Stack
+
+| Capa | Herramienta | Comando |
+|------|-------------|---------|
+| Unit | Vitest + Testing Library + happy-dom | `pnpm --filter @portfolio/dashboard test` |
+| Coverage | Vitest v8 coverage | `pnpm --filter @portfolio/dashboard test:coverage` |
+| API mocks (dev + tests) | MSW (Mock Service Worker) | (importado por setup) |
+| E2E | Playwright (suite del monorepo) | `python devtools/run.py test_runner --module=feature --type=feature --env=local` |
+| Type check | tsc | `pnpm --filter @portfolio/dashboard typecheck` |
+
+Coverage minimo: **80% per-file** en archivos modificados (mismo que el
+resto del repo).
+
+## Vitest config
+
+`dashboard/vitest.config.ts`:
+
+```typescript
+import {defineConfig} from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'node:path'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'happy-dom',
+    setupFiles: ['./tests/setup.ts'],
+    css: false,
+    include: ['tests/unit/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/**/index.ts',          // barrel exports
+        'src/app/**/layout.tsx',     // layouts ya testeados E2E
+        'src/components/ui/**',       // shadcn primitives (no testear shadcn)
+        'src/types/**',
+        'src/env.d.ts',
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})
+```
+
+## Setup global
+
+`dashboard/tests/setup.ts`:
+
+```typescript
+import '@testing-library/jest-dom'
+import {afterAll, afterEach, beforeAll, vi} from 'vitest'
+import {cleanup} from '@testing-library/react'
+import {server} from './mocks/server'
+import {useAuthStore} from '@/features/auth/store/use-auth-store'
+
+// Polyfill para happy-dom (BroadcastChannel no esta nativo)
+if (typeof globalThis.BroadcastChannel === 'undefined') {
+  class MockBroadcastChannel {
+    constructor(public name: string) {}
+    postMessage() {}
+    close() {}
+    addEventListener() {}
+    removeEventListener() {}
+    onmessage: ((event: MessageEvent) => void) | null = null
+  }
+  (globalThis as unknown as {BroadcastChannel: typeof MockBroadcastChannel}).BroadcastChannel = MockBroadcastChannel
+}
+
+// Mock NEXT_PUBLIC_* env vars (Zod env.ts validation se evalua al import)
+vi.stubEnv('NEXT_PUBLIC_API_ENDPOINT', 'https://api.test.the-full-stack.com')
+vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITEKEY', '1x00000000000000000000AA')
+vi.stubEnv('NEXT_PUBLIC_DASHBOARD_URL', 'https://admin.test.the-full-stack.com')
+vi.stubEnv('NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS', '30000')
+
+beforeAll(() => {
+  server.listen({onUnhandledRequest: 'error'})
+})
+
+afterEach(() => {
+  cleanup()
+  server.resetHandlers()
+  // Reset Zustand stores entre tests
+  useAuthStore.getState().reset()
+  localStorage.clear()
+})
+
+afterAll(() => {
+  server.close()
+})
+```
+
+## MSW handlers
+
+`dashboard/tests/mocks/handlers/auth.ts`:
+
+```typescript
+import {http, HttpResponse} from 'msw'
+
+const API = 'https://api.test.the-full-stack.com'
+
+export const authHandlers = [
+  // register.start
+  http.post(`${API}/auth`, async ({request}) => {
+    const body = await request.json() as {operation: string; action: string; data: Record<string, unknown>}
+    if (body.operation === 'register' && body.action === 'start') {
+      const email = body.data.email as string
+      if (email === 'exists@test.com') {
+        return HttpResponse.json(
+          {error: 'EMAIL_ALREADY_REGISTERED', code: 4090, message: 'Email ya registrado'},
+          {status: 409},
+        )
+      }
+      return HttpResponse.json({
+        is_valid: true,
+        code: 0,
+        data: {temp_token: 'mock-temp', user_id: 'usr_01', expires_in: 300},
+      }, {status: 201})
+    }
+
+    // login.start con email inexistente
+    if (body.operation === 'login' && body.action === 'start') {
+      const email = body.data.email as string
+      if (email === 'unknown@test.com') {
+        return HttpResponse.json(
+          {error: 'EMAIL_NOT_FOUND', code: 4040, message: 'Email no existe', data: {suggest_register: true}},
+          {status: 404},
+        )
+      }
+      return HttpResponse.json({
+        is_valid: true,
+        code: 0,
+        data: {
+          temp_token: 'mock-temp-login',
+          user_id: 'usr_01',
+          expires_in: 300,
+          methods: ['magic-link', 'email-code'],
+        },
+      })
+    }
+
+    // verify-code
+    if (body.action === 'verify-code') {
+      const code = body.data.code as string
+      if (code === '12345678') {
+        return HttpResponse.json({
+          is_valid: true,
+          code: 0,
+          data: {
+            access_token: makeJwt({sub: 'usr_01', email: 'user@test.com', exp: nowSec() + 900}),
+            expires_in: 900,
+            user: {id: 'usr_01', email: 'user@test.com', status: 'active', has_password: false, mfa_methods: []},
+          },
+        })
+      }
+      return HttpResponse.json(
+        {error: 'INVALID_CODE', code: 4001, message: 'Codigo invalido'},
+        {status: 400},
+      )
+    }
+
+    // session.refresh
+    if (body.operation === 'session' && body.action === 'refresh') {
+      return HttpResponse.json({
+        is_valid: true,
+        code: 0,
+        data: {
+          access_token: makeJwt({sub: 'usr_01', email: 'user@test.com', exp: nowSec() + 900}),
+          expires_in: 900,
+        },
+      })
+    }
+
+    // session.logout
+    if (body.operation === 'session' && body.action === 'logout') {
+      return new HttpResponse(null, {status: 204})
+    }
+
+    return HttpResponse.json({error: 'NOT_IMPLEMENTED'}, {status: 501})
+  }),
+]
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+function makeJwt(payload: object): string {
+  // JWT fake (no firmado) solo para tests — el frontend no verifica firma
+  const header = base64UrlEncode(JSON.stringify({alg: 'HS256', typ: 'JWT'}))
+  const body = base64UrlEncode(JSON.stringify(payload))
+  return `${header}.${body}.fakesignature`
+}
+
+function base64UrlEncode(s: string): string {
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+```
+
+`dashboard/tests/mocks/handlers/analytics.ts`:
+
+```typescript
+import {http, HttpResponse} from 'msw'
+
+const API = 'https://api.test.the-full-stack.com'
+
+export const analyticsHandlers = [
+  http.get(`${API}/analytics`, ({request}) => {
+    const url = new URL(request.url)
+    const op = url.searchParams.get('operation')
+    const act = url.searchParams.get('action')
+
+    if (op === 'analytics' && act === 'overview') {
+      return HttpResponse.json({
+        is_valid: true,
+        code: 0,
+        data: {
+          sessions: 123,
+          visits: 456,
+          events: 7890,
+          contacts: 12,
+          unique_visitors: 100,
+          avg_visit_duration_sec: 45.6,
+          bounce_rate: 0.42,
+          from: '2026-04-27',
+          to: '2026-05-27',
+        },
+      })
+    }
+
+    if (op === 'analytics' && act === 'timeseries') {
+      return HttpResponse.json({
+        is_valid: true,
+        code: 0,
+        data: Array.from({length: 30}, (_, i) => ({
+          ts: `2026-04-${String(28 + i).padStart(2, '0')}`,
+          sessions: 10 + i,
+          visits: 20 + i * 2,
+        })),
+      })
+    }
+
+    if (op === 'sessions' && act === 'list') {
+      return HttpResponse.json({
+        is_valid: true,
+        code: 0,
+        data: {
+          items: [
+            {session_id: 'sess_01', first_seen_at: '2026-05-26T10:00:00Z', country: 'AR', device_type: 'desktop', event_count: 12},
+            {session_id: 'sess_02', first_seen_at: '2026-05-26T11:00:00Z', country: 'CL', device_type: 'mobile', event_count: 5},
+          ],
+          total: 2,
+          page: 1,
+          page_size: 50,
+        },
+      })
+    }
+
+    return HttpResponse.json({error: 'NOT_IMPLEMENTED'}, {status: 501})
+  }),
+]
+```
+
+`dashboard/tests/mocks/server.ts`:
+
+```typescript
+import {setupServer} from 'msw/node'
+import {authHandlers} from './handlers/auth'
+import {analyticsHandlers} from './handlers/analytics'
+
+export const server = setupServer(...authHandlers, ...analyticsHandlers)
+```
+
+`dashboard/tests/mocks/browser.ts` (para dev mode):
+
+```typescript
+import {setupWorker} from 'msw/browser'
+import {authHandlers} from './handlers/auth'
+import {analyticsHandlers} from './handlers/analytics'
+
+export const worker = setupWorker(...authHandlers, ...analyticsHandlers)
+```
+
+Para arrancar el worker en dev (mientras el backend no esta vivo):
+
+```typescript
+// src/app/layout.tsx (solo en dev)
+if (process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_USE_MSW === 'true') {
+  const {worker} = await import('@/tests/mocks/browser')
+  await worker.start({onUnhandledRequest: 'bypass'})
+}
+```
+
+> Comando: `NEXT_PUBLIC_USE_MSW=true pnpm dev`. Tambien hay que servir
+> `public/mockServiceWorker.js` (lo genera `npx msw init public/`).
+
+## Test renderer con providers
+
+`dashboard/tests/utils/render.tsx`:
+
+```tsx
+import {render as rtlRender, type RenderOptions} from '@testing-library/react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {ThemeProvider} from 'next-themes'
+import {Toaster} from 'sonner'
+import type {ReactElement, ReactNode} from 'react'
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {retry: false, gcTime: 0, staleTime: 0},
+      mutations: {retry: false},
+    },
+  })
+}
+
+function Wrapper({children}: {children: ReactNode}) {
+  const client = createTestQueryClient()
+  return (
+    <ThemeProvider attribute="data-theme" defaultTheme="dark">
+      <QueryClientProvider client={client}>
+        {children}
+        <Toaster />
+      </QueryClientProvider>
+    </ThemeProvider>
+  )
+}
+
+export function render(ui: ReactElement, options?: RenderOptions) {
+  return rtlRender(ui, {wrapper: Wrapper, ...options})
+}
+
+export * from '@testing-library/react'
+export {default as userEvent} from '@testing-library/user-event'
+```
+
+## Test ejemplo: LoginForm
+
+`dashboard/tests/unit/features/auth/components/login-form.test.tsx`:
+
+```tsx
+import {describe, it, expect} from 'vitest'
+import {render, screen, userEvent, waitFor} from '@/tests/utils/render'
+import {LoginForm} from '@/features/auth/components/login-form'
+import {useAuthStore} from '@/features/auth/store/use-auth-store'
+
+describe('LoginForm', () => {
+  it('Given email valido y Turnstile token When submit Then setea tempToken y muestra mensaje', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    // Act
+    await user.type(screen.getByLabelText(/email/i), 'user@test.com')
+    // simular Turnstile success via mock
+    useAuthStore.setState({tempToken: null})
+
+    await user.click(screen.getByRole('button', {name: /iniciar/i}))
+
+    // Assert
+    await waitFor(() => {
+      expect(useAuthStore.getState().tempToken).toBe('mock-temp-login')
+    })
+  })
+
+  it('Given email no registrado When submit Then muestra suggest_register', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    render(<LoginForm />)
+
+    // Act
+    await user.type(screen.getByLabelText(/email/i), 'unknown@test.com')
+    await user.click(screen.getByRole('button', {name: /iniciar/i}))
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText(/no esta registrado/i)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', {name: /registrate/i})).toBeInTheDocument()
+  })
+})
+```
+
+## Test de hook: useLogout
+
+`dashboard/tests/unit/features/auth/hooks/use-logout.test.tsx`:
+
+```tsx
+import {describe, it, expect, vi} from 'vitest'
+import {renderHook, waitFor, act} from '@testing-library/react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {useLogout} from '@/features/auth/hooks/use-logout'
+import {useAuthStore} from '@/features/auth/store/use-auth-store'
+
+const pushMock = vi.fn()
+vi.mock('next/navigation', () => ({useRouter: () => ({push: pushMock, replace: pushMock})}))
+
+function wrapper({children}: {children: React.ReactNode}) {
+  const client = new QueryClient({defaultOptions: {queries: {retry: false}, mutations: {retry: false}}})
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useLogout', () => {
+  it('Given user autenticado When logout mutate Then resetea auth + redirect a /login', async () => {
+    // Arrange
+    useAuthStore.setState({
+      accessToken: 'fake-access',
+      user: {id: 'usr_01', email: 'u@t.com', status: 'active', has_password: false, mfa_methods: []},
+    })
+
+    const {result} = renderHook(() => useLogout(), {wrapper})
+
+    // Act
+    await act(async () => {
+      await result.current.mutateAsync()
+    })
+
+    // Assert
+    expect(useAuthStore.getState().accessToken).toBe(null)
+    expect(useAuthStore.getState().user).toBe(null)
+    expect(pushMock).toHaveBeenCalledWith('/login')
+  })
+})
+```
+
+## Test de fetch wrapper: mutex de refresh
+
+```tsx
+// dashboard/tests/unit/lib/api-client.test.ts
+import {describe, it, expect, beforeEach, vi} from 'vitest'
+import {server} from '@/tests/mocks/server'
+import {http, HttpResponse} from 'msw'
+import {apiFetch} from '@/lib/api-client'
+import {useAuthStore} from '@/features/auth/store/use-auth-store'
+
+describe('apiFetch + mutex refresh', () => {
+  beforeEach(() => {
+    useAuthStore.setState({accessToken: 'expired-token'})
+  })
+
+  it('Given 5 requests concurrent fallan con 401 When se procesan Then solo 1 /session/refresh se dispara', async () => {
+    // Arrange
+    let refreshCount = 0
+    server.use(
+      http.get('https://api.test.the-full-stack.com/analytics', () => {
+        // Primera vez 401, segunda OK (post-refresh)
+        if (useAuthStore.getState().accessToken === 'expired-token') {
+          return new HttpResponse(null, {status: 401})
+        }
+        return HttpResponse.json({is_valid: true, code: 0, data: {ok: true}})
+      }),
+      http.post('https://api.test.the-full-stack.com/auth', async ({request}) => {
+        const body = await request.json() as {operation?: string; action?: string}
+        if (body.operation === 'session' && body.action === 'refresh') {
+          refreshCount++
+          // Esperar 50ms para forzar concurrencia
+          await new Promise((r) => setTimeout(r, 50))
+          return HttpResponse.json({
+            is_valid: true,
+            code: 0,
+            data: {
+              access_token: 'fresh-token',
+              expires_in: 900,
+            },
+          })
+        }
+        return new HttpResponse(null, {status: 501})
+      }),
+    )
+
+    // Act
+    const results = await Promise.all([
+      apiFetch('/analytics?operation=analytics&action=overview'),
+      apiFetch('/analytics?operation=analytics&action=timeseries'),
+      apiFetch('/analytics?operation=analytics&action=top-pages'),
+      apiFetch('/analytics?operation=analytics&action=top-niches'),
+      apiFetch('/analytics?operation=analytics&action=active-now'),
+    ])
+
+    // Assert
+    expect(refreshCount).toBe(1)              // EL ASSERT CRITICO
+    expect(results).toHaveLength(5)
+    expect(useAuthStore.getState().accessToken).toBe('fresh-token')
+  })
+})
+```
+
+## E2E con Playwright
+
+Las E2E del monorepo viven en `tests/feature/`. Agregar
+`tests/feature/dashboard/*.spec.ts`:
+
+```typescript
+// tests/feature/dashboard/01-login-magic-link.spec.ts
+import {test, expect} from '@playwright/test'
+
+test.describe('Dashboard login flow', () => {
+  test('Given un user registrado When solicita magic link Then recibe email y completa flow', async ({page}) => {
+    await page.goto('http://admin.localhost:9970/login')
+    await page.fill('[type=email]', 'user@test.com')
+    // Turnstile en test mode (sitekey 1x00000000000000000000AA siempre pasa)
+    await page.click('button[type=submit]')
+    await expect(page.getByText(/te enviamos un link/i)).toBeVisible()
+  })
+
+  test('Given callback con fragment hash Then guarda token y redirect a /dashboard', async ({page}) => {
+    const fakeJwt = 'eyJ...mocked...'
+    await page.goto(`http://admin.localhost:9970/auth/callback#access=${fakeJwt}&user_id=usr_01&email=u@t.com`)
+    await page.waitForURL('**/dashboard**')
+    // Verificar que el hash se limpio
+    expect(page.url()).not.toContain('#access=')
+  })
+
+  test('Given user sin sesion When accede /dashboard Then redirect a /login con next param', async ({page}) => {
+    await page.goto('http://admin.localhost:9970/dashboard/analytics')
+    await page.waitForURL('**/login?next=*')
+    expect(page.url()).toContain('next=%2Fdashboard%2Fanalytics')
+  })
+})
+```
+
+Correr E2E:
+
+```bash
+# Levantar stack + ejecutar specs
+python devtools/run.py docker up --env=local
+python devtools/run.py test_runner --module=feature --type=feature --env=local
+```
+
+## Que NO testear
+
+- **shadcn primitives** (`components/ui/button.tsx`, etc.) — son
+  upstream, ya testeados por la comunidad. Coverage exclude.
+- **Layouts** — testeados E2E.
+- **Barrel exports** (`index.ts`) — sin logica.
+- **Constants files** (`routes.ts`, `query-keys.ts`) — sin logica.
+- **Schemas Zod** sueltos — testear el componente que los usa, no el
+  schema aislado.
+
+## Que SI testear
+
+- **Componentes de features** con logica (forms, tables filtradas, etc.).
+- **Hooks de features** (Tanstack mutations + queries).
+- **Fetch wrapper** (`api-client.ts`) — especialmente el mutex de
+  refresh + retry logic.
+- **Auth store + hooks** (login, logout, refresh).
+- **Magic link callback** (decoder de fragment).
+- **Multi-tab sync** (BroadcastChannel mock).
+- **Utilities en `lib/format/`** (date, number, duration).
+
+## Coverage target
+
+| Layer | Coverage target |
+|-------|-----------------|
+| `src/features/<X>/components/` | 80% |
+| `src/features/<X>/hooks/` | 90% (logica critica) |
+| `src/features/<X>/api/` | 70% (mayormente type wrappers) |
+| `src/features/auth/store/` | 95% (criticidad) |
+| `src/lib/api-client.ts` | 95% (criticidad) |
+| `src/lib/format/` | 90% |
+| `src/components/ui/` | EXCLUDED (shadcn) |
+| `src/app/**/page.tsx` | E2E (no unit) |
+| `src/app/**/layout.tsx` | E2E |
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Mockear `useAuthStore` directamente con `vi.mock` | Pierdes la implementacion real | Usar `useAuthStore.setState(...)` en beforeEach |
+| Mockear `Tanstack Query` con `vi.mock` | Acopla test a impl | Usar `QueryClient` de test en wrapper |
+| Llamar al backend real desde un test unit | Tests no idempotentes | MSW handlers |
+| Tests con `expect(x).toBeTruthy()` | Vago | Asserts exactos: `expect(x).toBe(true)` |
+| Tests sin `Given/When/Then` en `it()` | Dificil de leer | BDD-style obligatorio |
+| Olvidar `cleanup()` en afterEach | Pollutean entre tests | Vitest setup lo hace global |
+| Olvidar reset Zustand entre tests | State leak | `afterEach(() => useAuthStore.getState().reset())` |
+| Olvidar `server.resetHandlers()` | Mocks leak entre tests | En afterEach del setup |
+| Testear shadcn primitives | Son upstream | Excluir de coverage |
+| E2E sin levantar el stack | Falla con conexion refused | `docker up` primero |
+| Test que depende del orden | Flaky | Asegurar idempotencia |
+| `Promise.all` sin `await` en test | Race conditions, falsos verdes | `await Promise.all(...)` |
+
+[< 05-deploy](05-deploy.md) | [Volver al README](README.md)

--- a/.claude/docs/dashboard/README.md
+++ b/.claude/docs/dashboard/README.md
@@ -1,0 +1,235 @@
+# Dashboard SPA — Knowledge Tree
+
+> Knowledge tree del dashboard admin del portfolio
+> (`admin.portfolio.{dev|stage|prod}.the-full-stack.com`). Next.js 16
+> SPA + React 18 + shadcn + Tanstack Query + Cloudflare Pages.
+>
+> Esta es la **zona producto** (Knowledge Tree): cambia raramente,
+> audiencia = reviewers. La zona harness del plan es efimera
+> (`docs/specs/dashboard/`).
+
+## Cuando leer
+
+| Tema | Archivo | Cuando |
+|------|---------|--------|
+| Decisiones globales + esta tabla de navegacion | [README.md](README.md) | Primera lectura, decisiones no-reabribles |
+| Stack: Next.js 16 + React 18 + TS 6 + Biome + configs base | [01-stack.md](01-stack.md) | Antes de tocar `next.config.ts`, `tsconfig.json`, `biome.json`, `package.json` |
+| Estructura Hybrid Atomic Design (folders, decision tree) | [02-structure.md](02-structure.md) | Antes de crear o mover un componente |
+| UI: shadcn + Tailwind v4 + theming + Radix + lucide + charts | [03-ui.md](03-ui.md) | Antes de agregar componente shadcn, definir token, crear variant |
+| Auth: JWT + Tanstack Query mutex + Zustand + magic link + BroadcastChannel | [04-auth.md](04-auth.md) | Antes de tocar fetch wrapper, auth store, protected routes, callback |
+| Deploy: Cloudflare Pages + devtools + GH Actions + env vars | [05-deploy.md](05-deploy.md) | Antes de cambiar `deploy-apps.yml`, `cloudflare_setup`, `sync_secrets` |
+| Testing: Vitest + Testing Library + MSW + Playwright | [06-testing.md](06-testing.md) | Antes de escribir un test, configurar MSW handlers, fixtures |
+
+## Decisiones no-reabribles
+
+Estas decisiones se cerraron en el dialogo previo (Q&A inicial) y NO se
+vuelven a discutir en la fase de implementacion:
+
+1. **Framework**: Next.js 16 con `output: 'export'` estricto. NO Vite,
+   NO Astro, NO Next con SSR/RSC. Razon: monorepo consistency +
+   ecosystem; user choice.
+2. **React 18.3.x**: NO React 19. Razon: hooks de 19 (`use()`,
+   `useFormStatus`) son para Server Components/Actions, ambos no
+   disponibles en export mode; libs (Tanstack) mas maduras en 18.
+3. **Routing**: App Router. NO Pages Router. Todas las pages Client
+   Components.
+4. **TypeScript**: 6.x strict + `noUncheckedIndexedAccess`. NO `any`.
+5. **Linter**: Biome v2 (sin ESLint). Override para `src/components/ui/*`.
+6. **CSS**: Tailwind v4 (CSS-first config via `@theme`). NO `tailwind.config.ts`.
+7. **Componentes**: shadcn/ui (Radix primitives, copy-paste).
+8. **Data fetching**: Tanstack Query v5 + persister localStorage con
+   compresion lz-string.
+9. **State global**: Zustand (auth + theme). Tanstack Query para data.
+   useState local para UI ephemeral.
+10. **Forms**: react-hook-form + Zod + shadcn `<Form>` (vs Tanstack
+    Form). Razon: shadcn lo integra mejor.
+11. **Theme**: next-themes con `attribute="data-theme"` (evita
+    hydration mismatch).
+12. **Iconos**: lucide-react.
+13. **Charts**: `pnpm dlx shadcn add chart` (Recharts wrapper).
+14. **Tablas**: Tanstack Table v8 + shadcn primitives + Tanstack Virtual
+    para listas grandes.
+15. **Toasts**: sonner.
+16. **Tests**: Vitest + Testing Library + MSW. Playwright E2E (suite del
+    monorepo).
+17. **Estructura**: **Hybrid Atomic Design** —
+    `src/components/ui/` (genericos, 2+ features) +
+    `src/features/<X>/components/` (especificos por dominio). NO Atomic
+    Design clasico con `atoms/molecules/organisms`.
+18. **Carpeta**: `dashboard/` en root (no `apps/dashboard/`). User
+    choice explicito. Entra a pnpm workspace como `@portfolio/dashboard`.
+19. **Subdominio**: `admin.portfolio.{env}.the-full-stack.com`. Sigue
+    `subdomain-standard`.
+20. **Deploy**: Cloudflare Pages via `devtools/cloudflare_setup` +
+    `deploy-apps.yml`. Mismo pipeline que las 6 apps Astro.
+21. **Env vars**: prefijo `NEXT_PUBLIC_*` (requisito Next 16 para
+    exponer al bundle). Sincronizadas via
+    `sync_secrets --category=client`.
+22. **Auth**: consume Lambda `auth` de planes 01-02 (aun pending). Access
+    JWT in-memory (Zustand) + refresh en HttpOnly cookie (preferido) o
+    localStorage+CSP (fallback). NUNCA tokens en URL query.
+23. **Magic link UX**: backend redirect 302 a `/auth/callback#access=...`
+    (fragment hash, NO query). Frontend decodea + limpia con
+    `history.replaceState`.
+24. **Multi-tab**: BroadcastChannel API canal `portfolio_auth`.
+25. **Plan scope**: SOLO frontend dashboard. Las APIs `/auth` y
+    `/analytics` se asumen existentes. Mientras no esten deployadas,
+    MSW provee mocks.
+
+## Reglas duras (siempre activas)
+
+Ver [.claude/rules/dashboard.md](../../rules/dashboard.md) — esa es la
+fuente de verdad enforced. Resumen aqui:
+
+- **SIEMPRE** Client Components (`'use client'`).
+- **SIEMPRE** todas las API calls via `lib/api-client.ts` (fetch wrapper
+  con auth interceptor + refresh mutex).
+- **SIEMPRE** access JWT in-memory; refresh en HttpOnly cookie
+  preferido.
+- **SIEMPRE** mutex para concurrent refresh (1 sola call in-flight).
+- **SIEMPRE** Hybrid Atomic: `components/ui/` (genericos, 2+ features)
+  vs `features/<X>/components/` (especificos).
+- **SIEMPRE** Turnstile en register.start y login.start.
+- **NUNCA** API routes, middleware, Server Components con async fetch.
+- **NUNCA** tokens en URL query, persistir accessToken, logear JWT.
+- **NUNCA** Framer Motion, Google Fonts CDN, hex inline.
+
+## Diagrama de alto nivel
+
+```text
+Browser (admin.portfolio.{env}.the-full-stack.com)
+  -> Cloudflare Pages (static HTML/JS/CSS de dashboard/out/)
+       -> Next.js 16 SPA bundle hydration
+            -> React 18 (App Router, Client Components)
+                 -> Zustand (auth, theme)
+                 -> Tanstack Query (data fetching + persist localStorage)
+                      -> lib/api-client.ts (fetch + JWT + refresh mutex)
+                           -> https://api.portfolio.{env}.the-full-stack.com
+                                -> Lambda auth (register/login/verify/refresh/logout)
+                                -> Lambda analytics (overview/timeseries/sessions/...)
+                                -> Lambda contact_form (referencia)
+                                -> Lambda tracking_pixel (referencia)
+  
+  Magic link callback:
+    User clicks link en email -> GET https://api.portfolio.../auth?...&token=X
+      -> Lambda auth verifica token + emite JWTs
+      -> HTTP 302 Location: https://admin.portfolio.../auth/callback#access=Y&refresh=Z
+        -> Browser carga callback page (SPA)
+          -> page.tsx decodea hash, guarda en Zustand
+          -> history.replaceState para limpiar fragment
+          -> redirect a /dashboard
+```
+
+## Stack — resumen visual
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Dashboard SPA Stack (mayo 2026)                                       │
+├──────────────────────────────────────────────────────────────────────┤
+│ Runtime          | Node 24 (build), browser (runtime)                 │
+│ Framework        | Next.js 16 (App Router + output: 'export')         │
+│ UI library       | React 18.3.x                                       │
+│ Language         | TypeScript 6.x strict                              │
+│ Linter/Formatter | Biome v2 (sin ESLint)                              │
+│ CSS              | Tailwind v4 (@theme inline)                        │
+│ Components       | shadcn/ui (Radix primitives, copy-paste)           │
+│ Icons            | lucide-react                                       │
+│ Charts           | Recharts (via shadcn add chart)                    │
+│ Tables           | Tanstack Table v8 + Tanstack Virtual               │
+│ Data fetching    | Tanstack Query v5 + persist (lz-string)            │
+│ Forms            | react-hook-form + Zod + shadcn <Form>              │
+│ State (auth)     | Zustand 5 (in-memory access, persist refresh)      │
+│ State (theme)    | next-themes (data-theme attribute)                 │
+│ Toasts           | sonner                                             │
+│ Date helpers     | date-fns o Temporal API si estable                 │
+│ Tests (unit)     | Vitest + Testing Library + happy-dom               │
+│ Tests (mocks)    | MSW (Mock Service Worker)                          │
+│ Tests (E2E)      | Playwright (suite del monorepo)                    │
+│ Deploy           | Cloudflare Pages (REST API via devtools)           │
+│ CI               | GitHub Actions (deploy-apps.yml matrix +1 entry)   │
+│ Auth backend     | Lambda auth (planes 01-02, pending)                │
+│ Data backend     | Lambda analytics (plan analytics-dashboard-api)    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## Subdominios
+
+| Env | Subdomain | Pages project | Branch GitHub |
+|-----|-----------|---------------|---------------|
+| dev | `admin.portfolio.dev.the-full-stack.com` | `portfolio-dashboard-dev` | `dev` |
+| stage | `admin.portfolio.stage.the-full-stack.com` | `portfolio-dashboard-stage` | `stage` |
+| prod | `admin.portfolio.the-full-stack.com` | `portfolio-dashboard` | `main` |
+
+## Endpoints API consumidos
+
+Backend en `https://api.portfolio.{env}.the-full-stack.com`:
+
+### POST /auth (Lambda `auth`, plan 01)
+
+| Operation | Action | Body | Response |
+|-----------|--------|------|----------|
+| `register` | `start` | `{email, cf_turnstile_response}` | `201 {temp_token, user_id, expires_in: 300}` |
+| `register` | `verify-magic-link` (GET) | query `?token=<X>` | `302 -> /auth/callback#access=...&refresh=...` |
+| `register` | `verify-code` | `{code, temp_token}` | `200 {access_token, refresh_token, expires_in, user}` |
+| `login` | `start` | `{email, cf_turnstile_response, password?}` | `200 {temp_token, methods: [...]}` o `404 {suggest_register: true}` |
+| `login` | `verify-magic-link` (GET) | idem | idem |
+| `login` | `verify-code` | `{code, temp_token}` | `200 {access_token, refresh_token, expires_in, user}` |
+| `login` | `verify-password` | `{password, temp_token}` | `200` (con MFA si configurado) |
+| `login` | `verify-totp` | `{code, temp_token}` (plan 02) | `200` |
+| `verify` | `set-password` | `{password, temp_token}` | `204` |
+| `verify` | `resend-code` | `{temp_token}` | `200` |
+| `session` | `refresh` | refresh JWT (HttpOnly cookie o body) | `200 {access_token, refresh_token, expires_in}` |
+| `session` | `logout` | access JWT | `204` |
+| `mfa` | `setup-totp` (plan 02) | access JWT | `200 {secret, otpauth_url, qr_code_svg}` |
+| `mfa` | `confirm-totp` (plan 02) | `{code}` | `204` |
+| `mfa` | `recovery-codes-generate` (plan 02) | access JWT | `200 {codes: [...]}` |
+| `webauthn` | `register-options` (plan 02) | access JWT | `200 {challenge, rp, user, pubKeyCredParams, ...}` |
+| `webauthn` | `register-verify` (plan 02) | attestation | `201 {credential_id}` |
+| `webauthn` | `login-options` (plan 02) | `{email}` | `200 {challenge, allowCredentials}` |
+| `webauthn` | `login-verify` (plan 02) | assertion | `200 {access_token, refresh_token, ...}` |
+
+### GET /analytics (Lambda `analytics`, plan analytics-dashboard-api)
+
+| Operation | Action | Query | Response |
+|-----------|--------|-------|----------|
+| `analytics` | `overview` | `from, to` | `{sessions, visits, events, contacts, unique_visitors, ...}` |
+| `analytics` | `timeseries` | `from, to, bucket, niche?, event_type?` | `[{ts, count}, ...]` |
+| `analytics` | `top-pages` | `from, to, limit, niche?` | `[{path, views, ...}, ...]` |
+| `analytics` | `top-referrers` | `from, to, limit` | `[{referrer, sessions, ...}, ...]` |
+| `analytics` | `top-niches` | `from, to` | `[{niche, sessions, ...}, ...]` |
+| `analytics` | `active-now` | (none) | `{count, sessions: [...]}` |
+| `analytics` | `retention` | `from, to` | `{new, returning, ...}` |
+| `events` | `distribution` | `from, to` | `[{event_type, count, share}, ...]` |
+| `events` | `list` | `from, to, page, page_size` | `{items, total, page, page_size}` |
+| `events` | `heatmap` | `from, to` | `[[dia_semana, hora, count], ...]` |
+| `sessions` | `list` | `from, to, page, page_size` | `{items, total, ...}` |
+| `sessions` | `detail` | `session_id` | `{session, visits, event_count}` |
+| `visits` | `list` | idem sessions | idem |
+| `visits` | `landing-pages` | `from, to, limit` | `[{path, count, ...}, ...]` |
+| `geo` | `by-country` | `from, to` | `[{country, sessions, ...}, ...]` |
+| `devices` | `breakdown` | `from, to` | `{device, browser, os: [...]}` |
+| `funnel` | `conversion` | `from, to` | `{session, visit, contact: {...}}` |
+| `contacts` | `list` | `from, to, page, page_size, status?` | `{items, total, ...}` |
+| `contacts` | `by-status` | `from, to` | `[{status, count}, ...]` |
+
+## Estado del plan
+
+Ver [docs/specs/dashboard/README.md](../../../docs/specs/dashboard/README.md) — fases + estado por fase.
+
+## Bibliografia interna
+
+- `.claude/rules/dashboard.md` — reglas duras (enforced)
+- `.claude/skills/dashboard-stack/SKILL.md` — skill invocable
+- `docs/specs/dashboard/` — plan de implementacion (efimero)
+- `docs/specs/01-auth-infra-basics/` — backend auth (plan 01, pending)
+- `docs/specs/02-auth-mfa/` — backend auth MFA (plan 02, pending)
+- `docs/specs/analytics-dashboard-api/` — backend analytics (pending)
+- `.claude/rules/lambda-controller.md` — formato del backend
+- `.claude/rules/secrets-strategy.md` + `client-env-sync.md` — env vars
+- `.claude/rules/ci-cd-pipeline.md` — workflow deploy
+- `.claude/docs/cloudflare/` — Cloudflare Pages knowledge
+- `.claude/docs/subdomain-standard/` — patron de subdominios
+- `.claude/rules/design-system.md` — tokens CSS, dark/light, fonts
+- `.claude/rules/git-workflow.md` — branches, commits, PRs
+- `.claude/rules/plan-format.md` — formato de plan
+- `.claude/rules/verify-before-done.md` — gate de cierre

--- a/.claude/docs/dashboard/README.md
+++ b/.claude/docs/dashboard/README.md
@@ -1,8 +1,9 @@
 # Dashboard SPA — Knowledge Tree
 
 > Knowledge tree del dashboard admin del portfolio
-> (`admin.portfolio.{dev|stage|prod}.the-full-stack.com`). Next.js 16
-> SPA + React 18 + shadcn + Tanstack Query + Cloudflare Pages.
+> (`admin.portfolio.{dev|stage|prod}.the-full-stack.com`). Next.js
+> 16.2.6 SPA + React 19.2.6 + shadcn + Tanstack Query v5 + Cloudflare
+> Pages.
 >
 > Esta es la **zona producto** (Knowledge Tree): cambia raramente,
 > audiencia = reviewers. La zona harness del plan es efimera
@@ -13,45 +14,51 @@
 | Tema | Archivo | Cuando |
 |------|---------|--------|
 | Decisiones globales + esta tabla de navegacion | [README.md](README.md) | Primera lectura, decisiones no-reabribles |
-| Stack: Next.js 16 + React 18 + TS 6 + Biome + configs base | [01-stack.md](01-stack.md) | Antes de tocar `next.config.ts`, `tsconfig.json`, `biome.json`, `package.json` |
+| Stack: Next.js 16.2.6 + React 19.2.6 + TS 6 + Biome + configs base | [01-stack.md](01-stack.md) | Antes de tocar `next.config.ts`, `tsconfig.json`, `biome.json`, `package.json` |
 | Estructura Hybrid Atomic Design (folders, decision tree) | [02-structure.md](02-structure.md) | Antes de crear o mover un componente |
-| UI: shadcn + Tailwind v4 + theming + Radix + lucide + charts | [03-ui.md](03-ui.md) | Antes de agregar componente shadcn, definir token, crear variant |
-| Auth: JWT + Tanstack Query mutex + Zustand + magic link + BroadcastChannel | [04-auth.md](04-auth.md) | Antes de tocar fetch wrapper, auth store, protected routes, callback |
+| UI: shadcn + Tailwind v4 + theming + Radix + lucide + charts + React 19 patterns | [03-ui.md](03-ui.md) | Antes de agregar componente shadcn, definir token, crear variant, decidir form pattern |
+| Auth: JWT en `localStorage` + Tanstack Query mutex + Zustand + magic link + BroadcastChannel | [04-auth.md](04-auth.md) | Antes de tocar fetch wrapper, auth store, protected routes, callback |
 | Deploy: Cloudflare Pages + devtools + GH Actions + env vars | [05-deploy.md](05-deploy.md) | Antes de cambiar `deploy-apps.yml`, `cloudflare_setup`, `sync_secrets` |
-| Testing: Vitest + Testing Library + MSW + Playwright | [06-testing.md](06-testing.md) | Antes de escribir un test, configurar MSW handlers, fixtures |
+| Testing: Vitest 2 + Testing Library v16 + MSW v2 + Playwright | [06-testing.md](06-testing.md) | Antes de escribir un test, configurar MSW handlers, fixtures |
 
 ## Decisiones no-reabribles
 
 Estas decisiones se cerraron en el dialogo previo (Q&A inicial) y NO se
 vuelven a discutir en la fase de implementacion:
 
-1. **Framework**: Next.js 16 con `output: 'export'` estricto. NO Vite,
-   NO Astro, NO Next con SSR/RSC. Razon: monorepo consistency +
+1. **Framework**: Next.js 16.2.6 con `output: 'export'` estricto. NO
+   Vite, NO Astro, NO Next con SSR/RSC. Razon: monorepo consistency +
    ecosystem; user choice.
-2. **React 18.3.x**: NO React 19. Razon: hooks de 19 (`use()`,
-   `useFormStatus`) son para Server Components/Actions, ambos no
-   disponibles en export mode; libs (Tanstack) mas maduras en 18.
+2. **React 19.2.6** (obligatorio en Next 16.x). Compiler stable habilitado.
+   Hooks nuevos disponibles (`useActionState`, `useFormStatus`,
+   `useOptimistic`, `useDeferredValue` con `initialValue`, `useEffectEvent`).
+   `ref` como prop normal (sin `forwardRef`). Document Metadata nativo.
 3. **Routing**: App Router. NO Pages Router. Todas las pages Client
    Components.
 4. **TypeScript**: 6.x strict + `noUncheckedIndexedAccess`. NO `any`.
 5. **Linter**: Biome v2 (sin ESLint). Override para `src/components/ui/*`.
-6. **CSS**: Tailwind v4 (CSS-first config via `@theme`). NO `tailwind.config.ts`.
-7. **Componentes**: shadcn/ui (Radix primitives, copy-paste).
-8. **Data fetching**: Tanstack Query v5 + persister localStorage con
-   compresion lz-string.
-9. **State global**: Zustand (auth + theme). Tanstack Query para data.
-   useState local para UI ephemeral.
-10. **Forms**: react-hook-form + Zod + shadcn `<Form>` (vs Tanstack
-    Form). Razon: shadcn lo integra mejor.
+6. **CSS**: Tailwind v4 (CSS-first config via `@theme` inline + plugin
+   `@tailwindcss/postcss`). NO `tailwind.config.ts`.
+7. **Componentes**: shadcn/ui (Radix primitives, copy-paste; codegen
+   sin `forwardRef`).
+8. **Data fetching**: Tanstack Query v5 + `useSuspenseQuery` para data
+   required + persister `localStorage` con compresion lz-string.
+9. **State global**: Zustand 5 (auth + theme). Tanstack Query para
+   data. useState local para UI ephemeral.
+10. **Forms**: react-hook-form 7 + Zod + shadcn `<Form>` para forms
+    complejos (auth, multi-step). `useActionState` + `useFormStatus`
+    para forms simples (1-2 fields, single submit).
 11. **Theme**: next-themes con `attribute="data-theme"` (evita
     hydration mismatch).
 12. **Iconos**: lucide-react.
-13. **Charts**: `pnpm dlx shadcn add chart` (Recharts wrapper).
+13. **Charts**: `pnpm dlx shadcn add chart` (Recharts wrapper). Requiere
+    override `react-is@19.2.6` en `package.json`.
 14. **Tablas**: Tanstack Table v8 + shadcn primitives + Tanstack Virtual
     para listas grandes.
 15. **Toasts**: sonner.
-16. **Tests**: Vitest + Testing Library + MSW. Playwright E2E (suite del
-    monorepo).
+16. **Tests**: Vitest 2 + Testing Library v16 (React 19 support) + MSW
+    v2 (con polyfill BroadcastChannel en happy-dom). Playwright E2E
+    (suite del monorepo).
 17. **Estructura**: **Hybrid Atomic Design** —
     `src/components/ui/` (genericos, 2+ features) +
     `src/features/<X>/components/` (especificos por dominio). NO Atomic
@@ -65,16 +72,43 @@ vuelven a discutir en la fase de implementacion:
 21. **Env vars**: prefijo `NEXT_PUBLIC_*` (requisito Next 16 para
     exponer al bundle). Sincronizadas via
     `sync_secrets --category=client`.
-22. **Auth**: consume Lambda `auth` de planes 01-02 (aun pending). Access
-    JWT in-memory (Zustand) + refresh en HttpOnly cookie (preferido) o
-    localStorage+CSP (fallback). NUNCA tokens en URL query.
+22. **Auth — storage**: tokens (access, refresh, temp) en `localStorage`
+    via Zustand `persist`. **NO HttpOnly cookies** — el dashboard es
+    SPA cross-origin (subdomain admin vs api), una HttpOnly cookie
+    requeriria `SameSite=None` cross-site + `Domain=.the-full-stack.com`
+    abriendo CSRF en los 6 niches publicos y rompiendo portabilidad.
+    Defensa: CSP estricta sin `unsafe-inline`/`unsafe-eval` + SRI en
+    third-party + access JWT corto (15 min) + family_id refresh rotation.
+    NUNCA tokens en URL query.
 23. **Magic link UX**: backend redirect 302 a `/auth/callback#access=...`
-    (fragment hash, NO query). Frontend decodea + limpia con
-    `history.replaceState`.
-24. **Multi-tab**: BroadcastChannel API canal `portfolio_auth`.
-25. **Plan scope**: SOLO frontend dashboard. Las APIs `/auth` y
+    (fragment hash, NO query). Frontend decodea + guarda en
+    `localStorage` via Zustand + limpia con `history.replaceState`.
+24. **Multi-tab**: BroadcastChannel API canal `portfolio_auth` + fallback
+    `storage` event de `localStorage`.
+25. **React Compiler**: habilitado via `reactCompiler: true` (stable en
+    Next 16). Opt-out per file con `'use no memo'` solo si rompe algo
+    medido.
+26. **Plan scope**: SOLO frontend dashboard. Las APIs `/auth` y
     `/analytics` se asumen existentes. Mientras no esten deployadas,
-    MSW provee mocks.
+    MSW v2 provee mocks.
+
+## Versiones canonicas (mayo 2026)
+
+Resumen — ver tabla extendida en
+[.claude/skills/dashboard-stack/SKILL.md](../../skills/dashboard-stack/SKILL.md):
+
+- Next.js **16.2.6** | React + React DOM **19.2.6** | TypeScript **6.0.6**
+- Biome **2.0.0+** | Tailwind **4.1.4** + `@tailwindcss/postcss`
+- shadcn/ui latest (React 19 support, sin `forwardRef`)
+- Tanstack Query/Persist/Table/Virtual **5.52.3** / **8.20.5** / **3.5.1**
+- Zustand **5.0.14** (Jan 2026 state consistency fix)
+- react-hook-form **7.53.0** | Zod **3.24.1** | @hookform/resolvers **3.4.2**
+- Recharts **2.14.2** + override `react-is@19.2.6`
+- next-themes **0.4.8** | sonner **1.7.2** | lucide-react **0.416.0**
+- MSW **2.3.2** | Vitest **2.2.5** + Testing Library **16.1.0** + happy-dom **16.5.1**
+- Playwright **1.48.2**
+- babel-plugin-react-compiler **19.0.0-beta.17**
+- Node >=24, pnpm 11.0.9
 
 ## Reglas duras (siempre activas)
 
@@ -84,14 +118,23 @@ fuente de verdad enforced. Resumen aqui:
 - **SIEMPRE** Client Components (`'use client'`).
 - **SIEMPRE** todas las API calls via `lib/api-client.ts` (fetch wrapper
   con auth interceptor + refresh mutex).
-- **SIEMPRE** access JWT in-memory; refresh en HttpOnly cookie
-  preferido.
+- **SIEMPRE** tokens (access, refresh, temp) en `localStorage` via
+  Zustand `persist`.
 - **SIEMPRE** mutex para concurrent refresh (1 sola call in-flight).
 - **SIEMPRE** Hybrid Atomic: `components/ui/` (genericos, 2+ features)
   vs `features/<X>/components/` (especificos).
 - **SIEMPRE** Turnstile en register.start y login.start.
-- **NUNCA** API routes, middleware, Server Components con async fetch.
-- **NUNCA** tokens en URL query, persistir accessToken, logear JWT.
+- **SIEMPRE** `ref` como prop normal (NO `forwardRef`) en componentes
+  nuevos. shadcn 2.x ya migrado.
+- **SIEMPRE** React Compiler habilitado (`reactCompiler: true`).
+- **SIEMPRE** Rules of React (el Compiler las enforces).
+- **SIEMPRE** forms complejos con react-hook-form + Zod + shadcn
+  `<Form>` + Tanstack `useMutation`. Forms simples con `useActionState`.
+- **NUNCA** API routes, middleware/proxy, Server Components con async
+  fetch, Server Actions, `'use cache'`.
+- **NUNCA** tokens en URL query (magic link usa fragment hash).
+- **NUNCA** logear JWT, refresh, magic link token, codigo.
+- **NUNCA** `forwardRef` en componentes nuevos.
 - **NUNCA** Framer Motion, Google Fonts CDN, hex inline.
 
 ## Diagrama de alto nivel

--- a/.claude/docs/lambda-controller/01-architecture.md
+++ b/.claude/docs/lambda-controller/01-architecture.md
@@ -52,11 +52,18 @@ El evento de entrada SIEMPRE tiene esta forma:
 - `operation` se resuelve via el dict `OPERATIONS` (en
   `settings/operations.py`) a una **carpeta de controller**. Varios
   codenames de `operation` pueden mapear al mismo controller (alias).
-- `action` se mapea a un **archivo** (`<action>.py`) y a una **clase**
-  (`<Action>` = `action.capitalize()`) dentro de esa carpeta.
+- `action` se mapea a un **archivo** (`<action_snake>.py`, kebab-case
+  del wire se convierte a snake_case con `-` -> `_`) y a una **clase**
+  (`<ActionPascal>`, PascalCase de cada segmento separado por guion)
+  dentro de esa carpeta.
 
-Ejemplo: `operation="payments"`, `action="create"` resuelve
-`controllers/payments/create.py` -> clase `Create`.
+Ejemplos:
+
+- `operation="payments"`, `action="create"` ->
+  `controllers/payments/create.py` -> clase `Create`.
+- `operation="register"`, `action="verify-magic-link"` ->
+  `controllers/register/verify_magic_link.py` -> clase
+  `VerifyMagicLink`.
 
 ## Ciclo de vida de un controller: preload -> validate -> execute
 

--- a/.claude/docs/lambda-controller/02-handler-and-routing.md
+++ b/.claude/docs/lambda-controller/02-handler-and-routing.md
@@ -79,18 +79,33 @@ nombre tal cual, y el `import_module` fallara con un error descriptivo
 
 `action` se usa de dos formas:
 
-- Como nombre de archivo: `controllers/<folder>/<action>.py`.
-- Como nombre de clase: `action.capitalize()`.
+- Como nombre de archivo: `controllers/<folder>/<action_snake>.py`
+  (kebab-case del wire se convierte a snake_case en el filesystem).
+- Como nombre de clase: PascalCase de `action` — capitaliza la primera
+  letra de cada segmento separado por guion.
 
-| action | archivo | clase |
-|--------|---------|-------|
+| action (wire) | archivo | clase |
+| --- | --- | --- |
 | `create` | `create.py` | `Create` |
 | `check` | `check.py` | `Check` |
 | `cancel` | `cancel.py` | `Cancel` |
+| `verify-code` | `verify_code.py` | `VerifyCode` |
+| `verify-magic-link` | `verify_magic_link.py` | `VerifyMagicLink` |
+| `set-password` | `set_password.py` | `SetPassword` |
 
-`action.capitalize()` capitaliza solo la primera letra. Para acciones de
-una sola palabra (lo recomendado) funciona directo. Evitar acciones
-con guion bajo o camelCase: romperian la convencion.
+Reglas:
+
+- El `action` del wire (en el evento `{operation, action, data}`) es
+  **kebab-case** o **una sola palabra**.
+- El archivo del controller convierte los `-` a `_`
+  (`verify-magic-link` -> `verify_magic_link.py`).
+- La clase capitaliza cada segmento: la formula es
+  `''.join(seg.capitalize() for seg in action.split('-'))`.
+- Acciones de una sola palabra (lo mas comun) funcionan directo
+  (`create` -> `Create`). Las multi-segmento son aceptables para
+  acciones compuestas semanticamente (`verify-code`, `set-password`).
+- Evitar `snake_case` o `camelCase` en el wire: romperian la
+  convencion (siempre kebab-case o palabra simple).
 
 ## Respuesta final del Lambda
 

--- a/.claude/docs/lambda-controller/03-controllers-and-models.md
+++ b/.claude/docs/lambda-controller/03-controllers-and-models.md
@@ -81,7 +81,11 @@ class Create(BaseController):
 
 Reglas del controller:
 
-- El **nombre de la clase** es `action.capitalize()` (`create` -> `Create`).
+- El **nombre del archivo** es la forma snake_case de `action`
+  (`create` -> `create.py`, `verify-magic-link` ->
+  `verify_magic_link.py`).
+- El **nombre de la clase** es la forma PascalCase de `action`
+  (`create` -> `Create`, `verify-magic-link` -> `VerifyMagicLink`).
 - `event_model` - modelo Pydantic; lo usa la fase `validate`.
 - `arn_config_key` - campo de `AppConfig` con el ARN downstream; lo usa
   la fase `preload`. Dejar `''` si no invoca otro Lambda.

--- a/.claude/docs/lambda-controller/05-create-and-refactor.md
+++ b/.claude/docs/lambda-controller/05-create-and-refactor.md
@@ -29,8 +29,10 @@ En todos los archivos, reemplazar:
   campos Pydantic al payload real.
 - Renombrar `services/example_service.py` a
   `services/<operation>_service.py` y escribir la logica de negocio.
-- En cada `controllers/<operation>/<action>.py`, ajustar imports y
-  dejar la clase `<Action>` (= `action.capitalize()`).
+- En cada `controllers/<operation>/<action_snake>.py`, ajustar imports
+  y dejar la clase `<ActionPascal>` (PascalCase de cada segmento del
+  `action` kebab-case; `create` -> `Create`, `verify-magic-link` ->
+  `VerifyMagicLink`).
 
 ### 4. Registrar la operacion
 
@@ -141,7 +143,9 @@ Si el Lambda no puede reescribirse de una sola vez:
 - [ ] Cada operacion tiene controller + service + modelo.
 - [ ] La logica de negocio vive en `services/`, no en controllers.
 - [ ] Toda operacion esta registrada en `OPERATIONS`.
-- [ ] Las clases controller se llaman `action.capitalize()`.
+- [ ] Los archivos controller se llaman `action_snake.py` (kebab `-`
+      del wire -> `_`) y las clases PascalCase de cada segmento
+      (`create` -> `Create`, `verify-magic-link` -> `VerifyMagicLink`).
 - [ ] `execute()` y las fases devuelven `{is_valid, data, code}`.
 - [ ] `python -m compileall -q core` pasa.
 - [ ] `pytest tests/unit` pasa; cada accion tiene tests.

--- a/.claude/docs/lambda-controller/README.md
+++ b/.claude/docs/lambda-controller/README.md
@@ -25,7 +25,9 @@ La rule operativa es [.claude/rules/lambda-controller.md](../../rules/lambda-con
 - SIEMPRE el entrypoint se llama `handler.py`, vive en `core/` y la
   funcion es `lambda_handler` (Handler AWS: `core.handler.lambda_handler`).
 - SIEMPRE el evento trae `operation`, `action` y `data` (objeto).
-- SIEMPRE el nombre de la clase controller es `action.capitalize()`.
+- SIEMPRE el archivo del controller es `<action_snake>.py` y la clase
+  es PascalCase de cada segmento del action kebab-case (`create` ->
+  `Create`, `verify-magic-link` -> `VerifyMagicLink`).
 - SIEMPRE el controller hereda de `BaseController` e implementa `execute()`.
 - SIEMPRE `execute()` y las fases devuelven `{is_valid, data, code}`.
 - SIEMPRE la logica de negocio vive en `core/services/`.

--- a/.claude/docs/typescript-6/01-breaking-changes.md
+++ b/.claude/docs/typescript-6/01-breaking-changes.md
@@ -1,0 +1,175 @@
+# 01 — Breaking Changes TypeScript 5.x -> 6.0
+
+[< README](README.md) | [Siguiente: 02-features >](02-features.md)
+
+> Cambios que rompen codigo TS 5.x al actualizar a 6.0. El codemod
+> `@andrewbranch/ts5to6` resuelve los mecanicos; el resto requiere fix
+> manual (mayoria son `strict null checks`).
+
+## 1. Strict mode implicito por default
+
+**TS 5.x**: `"strict": false` era el default sloppy.
+**TS 6.0**: `"strict": true` es implicito si no se setea.
+
+Flags activados:
+
+- `noImplicitAny`
+- `strictNullChecks`
+- `strictFunctionTypes`
+- `strictBindCallApply`
+- `strictPropertyInitialization`
+- `noImplicitThis`
+- `alwaysStrict`
+- `useUnknownInCatchVariables`
+
+**Mitigacion temporal**: setear `"strict": false` (deprecado en TS 7,
+solo para migration window).
+
+## 2. Module resolution defaults cambiados
+
+| Setting | TS 5.x default | TS 6.0 default |
+|---------|----------------|----------------|
+| `module` | `commonjs` | `ESNext` |
+| `moduleResolution` | `node` | `bundler` |
+| `target` | `ES5` (luego `ES2025`) | `ES2025` |
+
+**Impact**:
+
+- Apps con bundlers (Astro 6, Next 16, Vite) — auto-detecta correcto.
+- Node CLI scripts — considerar `"module": "NodeNext"` +
+  `"moduleResolution": "nodenext"`.
+
+## 3. `types` array OBLIGATORIO
+
+**TS 5.x**: auto-descubria `@types/*` instalados.
+**TS 6.0**: sin `"types": [...]` NO se carga ningun tipo global.
+
+**Beneficio**: cold builds 20-50% mas rapidos (skip scan innecesario).
+**Costo**: olvidar listar = perder intellisense.
+
+```jsonc
+{
+  "compilerOptions": {
+    "types": ["node", "vitest/globals", "astro/astro-jsx"]
+  }
+}
+```
+
+## 4. `baseUrl` REMOVIDO
+
+**TS 5.x**: `baseUrl` + `paths` con resolucion implicita.
+**TS 6.0**: solo `paths` con rutas relativas.
+
+```jsonc
+// TS 5.x (ERROR en TS 6)
+{
+  "baseUrl": ".",
+  "paths": { "@/*": ["src/*"] }
+}
+
+// TS 6.0 (OK)
+{
+  "paths": { "@/*": ["./src/*"] }
+}
+```
+
+Codemod `ts5to6` aplica este fix automaticamente.
+
+## 5. Namespace syntax — `module Foo { }` ERROR
+
+```typescript
+// TS 5.x OK
+module Foo { export const bar = 42 }
+
+// TS 6.0 ERROR
+// Conflicto con propuesta ECMAScript de module blocks
+```
+
+Reemplazo: `namespace Foo { export const bar = 42 }`.
+
+## 6. Target minimo ES2015 (ES5 deprecated)
+
+```jsonc
+// TS 6.0 ERROR
+{ "target": "ES5" }
+
+// OK
+{ "target": "ES2015" }  // o superior, recomendado ES2023
+```
+
+## 7. `esModuleInterop` y `allowSyntheticDefaultImports` removidas
+
+En TS 6 ambas son SIEMPRE `true` (no se pueden setear `false`).
+
+```jsonc
+// TS 6.0 SYNTAX ERROR
+{ "esModuleInterop": false }
+{ "allowSyntheticDefaultImports": false }
+```
+
+## 8. Implicit default exports removidas
+
+TS 6 SIEMPRE exige `export default` explicito.
+
+## Codemod `ts5to6` (resuelve mecanicos)
+
+```bash
+# Instalacion + uso (Andrew Branch, TS team member)
+pnpm dlx @andrewbranch/ts5to6 .
+
+# Que hace:
+# - Elimina baseUrl, reescribe paths a relativos
+# - Setea rootDir explicito (preserva structure)
+# - Sigue extends chains en node_modules
+# - Patch tsconfig recursivo en monorepo
+```
+
+## Migracion paso a paso
+
+```bash
+# 1. Upgrade workspace
+pnpm add -D -w typescript@^6.0.0
+
+# 2. Codemod
+pnpm dlx @andrewbranch/ts5to6 .
+
+# 3. Typecheck para ver errores nuevos
+pnpm exec tsc --noEmit
+pnpm exec astro check
+
+# 4. Listar @types en tsconfig.types
+
+# 5. Arreglar strict errors (mayoria null checks)
+# Estrategia: fix uno a uno; opcional temporal "strict": false para iterar
+
+# 6. Verificar builds
+pnpm run build
+
+# 7. Tests
+pnpm exec vitest run --coverage
+
+# 8. Commit
+git commit -m "upgrade(typescript): migrate to TS 6.0 GA"
+```
+
+## Deprecation escape hatch (temporal)
+
+```jsonc
+{
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+    // Silencia warnings deprecated.
+    // NO funciona en TS 7.0 — arreglar antes.
+  }
+}
+```
+
+## Anti-patterns
+
+| Anti-pattern | Por que | Correccion |
+|--------------|---------|------------|
+| Migrar sin codemod | Mecanicos toman horas manual | `pnpm dlx @andrewbranch/ts5to6 .` |
+| Setear `"strict": false` permanente | Pierde todos los safety nets | Fix errores iterativo |
+| Dejar `baseUrl` | ERROR en TS 6 | Solo paths relativos |
+| Olvidar `@types` en `"types"` | Intellisense roto silenciosamente | Listar todos los requeridos |
+| `ignoreDeprecations: "6.0"` como solucion final | Falla en TS 7 | Fix deprecations ahora |

--- a/.claude/docs/typescript-6/02-features.md
+++ b/.claude/docs/typescript-6/02-features.md
@@ -1,0 +1,205 @@
+# 02 — Features Nuevos TypeScript 6
+
+[< 01-breaking-changes](01-breaking-changes.md) | [Siguiente: 03-strict-mode >](03-strict-mode.md)
+
+> Features estables y recomendados en TS 6.0. Algunos llegaron en
+> versiones 5.x pero se vuelven idiomaticos / optimizados en 6.0.
+
+## 1. Native Node.js TypeScript support
+
+Node.js 22.18+ / 23.6+ ejecutan `.ts` directo sin compilar:
+
+```bash
+node --no-warnings=ExperimentalWarning script.ts
+```
+
+Mecanismo: **type stripping** — elimina tipos en el parser, preserva
+sintaxis runtime.
+
+Impact en portfolio: futuros scripts Node podrian correr `.ts` directo
+sin `tsx`/`ts-node`/`vite-node`.
+
+## 2. Incremental compilation
+
+```jsonc
+{
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
+  }
+}
+```
+
+Mejora: 40-60% rebuilds mas rapidos en proyectos grandes. El
+`.tsbuildinfo` cachea tipo y dependency graph.
+
+## 3. Project references mejoradas
+
+Para monorepos pnpm (5 packages compartidos + 6 apps + dashboard):
+
+```jsonc
+// tsconfig.json (root)
+{
+  "files": [],
+  "references": [
+    { "path": "packages/content" },
+    { "path": "packages/ui" },
+    { "path": "packages/seo" },
+    { "path": "packages/cv-pdf" },
+    { "path": "packages/app-shared" }
+  ]
+}
+```
+
+Build paralelo:
+
+```bash
+pnpm exec tsc -b              # paralelo automatico
+pnpm exec tsc -b --watch      # watch mode
+pnpm exec tsc -b --clean      # limpiar artifacts
+```
+
+Ejemplo real: monorepo 22-package, build time **11min -> 3min**.
+
+## 4. `module: "Preserve"` (nuevo)
+
+Preserva imports exactos como fueron escritos (no los reescribe).
+
+```jsonc
+{
+  "compilerOptions": {
+    "module": "Preserve"
+    // Util para libraries que mezclan ESM + CommonJS
+  }
+}
+```
+
+## 5. `satisfies` operator (estable)
+
+Valida contra interface sin perder literal inference:
+
+```typescript
+type Config = {
+  database: 'postgres' | 'mysql'
+  port: number
+}
+
+const myConfig = {
+  database: 'postgres',
+  port: 5432
+} satisfies Config
+
+// myConfig.database sigue siendo 'postgres' literal (no 'postgres' | 'mysql')
+// myConfig.port sigue siendo 5432 literal (no number generico)
+```
+
+Reemplaza el patron `as Config` (que pierde inference).
+
+## 6. `using` y `await using` (Symbol.dispose / asyncDispose)
+
+Cleanup automatico al salir scope (ES2024):
+
+```typescript
+async function processFile(path: string) {
+  await using handle = await fs.promises.open(path, 'r')
+  const content = await handle.readFile()
+  // handle.close() llamado automaticamente al salir
+}
+
+class MyResource {
+  async [Symbol.asyncDispose]() {
+    // cleanup code
+  }
+}
+```
+
+Reemplaza patrones `try/finally` repetitivos.
+
+## 7. `const` type parameters
+
+Preserva literal types en generics (estable desde TS 5.0, idiomatico en 6):
+
+```typescript
+function createTuple<const T extends readonly unknown[]>(items: T): T {
+  return items
+}
+
+const result = createTuple(['a', 'b'] as const)
+// result type: readonly ['a', 'b']
+```
+
+## 8. `isolatedDeclarations`
+
+Para library authors. Genera `.d.ts` sin invocar full type-checker:
+
+```jsonc
+{
+  "compilerOptions": {
+    "declaration": true,
+    "isolatedDeclarations": true
+  }
+}
+```
+
+- 10x mas rapido para tools como Bun, swc, tsup
+- Requiere tipos explicitos en exports publicos (trade-off)
+
+Recomendado en packages internos del portfolio (`packages/<X>/`).
+
+## 9. Type narrowing mejorado
+
+```typescript
+function filterStrings(arr: (string | number)[]): string[] {
+  // El compiler infiere automaticamente como type guard
+  return arr.filter((x): x is string => typeof x === 'string')
+}
+```
+
+## 10. `verbatimModuleSyntax` (recomendado)
+
+Obliga `import type` para imports type-only:
+
+```typescript
+// ERROR con verbatimModuleSyntax
+import { type Component } from 'vue'
+
+// OK
+import type { Component } from 'vue'
+
+// O si Vue es value:
+import Vue from 'vue'
+import type { Component } from 'vue'
+```
+
+Biome enforza con `useImportType`.
+
+## Patrones recomendados
+
+### Type-safe config con `satisfies`
+
+```typescript
+type ThemeConfig = {
+  colors: { primary: string; secondary: string }
+  fonts: ('serif' | 'sans-serif')[]
+}
+
+const config = {
+  colors: { primary: '#3B82F6', secondary: '#10B981' },
+  fonts: ['serif', 'sans-serif']
+} satisfies ThemeConfig
+```
+
+### Validated schemas con Zod + z.infer
+
+```typescript
+import { z } from 'zod'
+
+const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  role: z.enum(['admin', 'user']).default('user')
+})
+
+type User = z.infer<typeof userSchema>
+const user = userSchema.parse(data)
+```

--- a/.claude/docs/typescript-6/03-strict-mode.md
+++ b/.claude/docs/typescript-6/03-strict-mode.md
@@ -1,0 +1,155 @@
+# 03 — Strict Mode TypeScript 6
+
+[< 02-features](02-features.md) | [Siguiente: 04-tsconfig >](04-tsconfig.md)
+
+> En TS 6, `"strict": true` es implicito. Esta seccion documenta las flags
+> que `strict` cubre + las extras recomendadas para el portfolio.
+
+## Flags bajo `"strict": true`
+
+```jsonc
+{
+  "compilerOptions": {
+    "strict": true,
+    // Cubre automaticamente:
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true
+  }
+}
+```
+
+### Que enforza cada una
+
+| Flag | Que detecta |
+|------|-------------|
+| `noImplicitAny` | Parametros / vars sin tipo explicito |
+| `strictNullChecks` | `null` / `undefined` deben verificarse antes de usar |
+| `strictFunctionTypes` | Parametros contravariantes (callbacks) |
+| `strictBindCallApply` | `call` / `bind` / `apply` type-safe |
+| `strictPropertyInitialization` | Properties sin inicializar (`!` o constructor) |
+| `noImplicitThis` | `this` sin type context |
+| `alwaysStrict` | Emite `"use strict"` en cada archivo |
+| `useUnknownInCatchVariables` | `catch (e: unknown)` por default |
+
+## Flags adicionales (recomendadas para portfolio)
+
+```jsonc
+{
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "noFallthroughSwitchClause": true
+  }
+}
+```
+
+### Trade-offs
+
+| Flag | Benefit | Cost |
+|------|---------|------|
+| `noUncheckedIndexedAccess` | Previene `undefined` en arrays/dicts | Requiere checks en bucles |
+| `noImplicitOverride` | Detecta typos en overrides de subclases | Verboso (`override` keyword obligatorio) |
+| `noImplicitReturns` | Catch return path olvidados | Forces `return undefined` explicito |
+| `noUnusedLocals` | Limpieza de variables muertas | Falla con vars `// TODO` |
+| `noUnusedParameters` | Limpieza de params sin uso | Falla en callbacks de libs externas |
+| `verbatimModuleSyntax` | Obliga `import type` | Requiere diligencia |
+| `noFallthroughSwitchClause` | Catch missing `break` | Forces `break` o comment explicito |
+
+## Flags MUY estrictas (opcionales, NO recomendadas para portfolio)
+
+```jsonc
+{
+  // "exactOptionalPropertyTypes": true,  // Distingue field?:X vs field:X|undefined — rompe libs
+  // "noPropertyAccessFromIndexSignature": true  // MUY restrictivo
+}
+```
+
+Decision: el portfolio NO las activa. La complejidad excede el beneficio.
+
+## `unknown` vs `any` (politica del proyecto)
+
+`any` esta **PROHIBIDO** en codigo de aplicacion (rule
+`.claude/rules/typescript.md`).
+
+```typescript
+// ❌ PROHIBIDO
+function process(data: any) { /* ... */ }
+
+// ✅ Correcto: unknown + narrow
+function process(data: unknown) {
+  if (typeof data === 'string') {
+    return data.toUpperCase()
+  }
+  if (data && typeof data === 'object' && 'name' in data) {
+    return String(data.name)
+  }
+  throw new TypeError('Unsupported input')
+}
+
+// ✅ Correcto: tipo especifico
+function processUser(user: User) { /* ... */ }
+
+// ✅ Correcto: generic con constraint
+function first<T>(items: T[]): T | undefined { return items[0] }
+```
+
+## Manejo de catch
+
+`useUnknownInCatchVariables` obliga:
+
+```typescript
+try {
+  riskyOperation()
+} catch (e: unknown) {
+  if (e instanceof Error) {
+    console.error(e.message)
+  } else {
+    console.error('Unknown error', e)
+  }
+}
+```
+
+## Type assertions (cuando necesario)
+
+```typescript
+// ❌ EVITAR `as` casual
+const user = data as User  // bypassa checker
+
+// ✅ Preferir `satisfies` cuando aplica
+const config = { theme: 'dark' } satisfies Config
+
+// ✅ Type guards
+function isUser(x: unknown): x is User {
+  return !!x && typeof x === 'object' && 'id' in x && 'email' in x
+}
+
+// ✅ Schema validation (Zod)
+const user = userSchema.parse(data)  // tipo derivado + runtime check
+
+// ✅ `as` solo cuando hay invariante externa documentada
+// JSON parsing donde el shape esta garantizado por API contract
+const config = JSON.parse(text) as unknown
+// luego validar con Zod o type guard
+```
+
+## Anti-patterns del strict mode
+
+| Anti-pattern | Por que | Correccion |
+|--------------|---------|------------|
+| `any` "rapido para iterar" | Permanente, contamina toda la cadena | `unknown` + Zod |
+| `as Foo` para silenciar error | Oculta bug real | Type guard o `satisfies` |
+| `// @ts-ignore` permanente | Mascarea bugs | Fix root cause o `// @ts-expect-error` con razon |
+| `.toString()` sin null check | Crashea con `strictNullChecks` | Optional chaining `x?.toString()` |
+| Property sin init en class | `strictPropertyInitialization` falla | `prop!: Type` o init en constructor |
+| Catch sin tipo | TS 6 forza `unknown` | `catch (e: unknown)` + narrow |
+| Mutar parametros de funcion | Implica side effects ocultos | Aceptar readonly, retornar nuevo objeto |

--- a/.claude/docs/typescript-6/04-tsconfig.md
+++ b/.claude/docs/typescript-6/04-tsconfig.md
@@ -1,0 +1,214 @@
+# 04 — tsconfig.json Canonicos
+
+[< 03-strict-mode](03-strict-mode.md) | [Volver al README](README.md)
+
+> Plantillas concretas para los 3 contextos del portfolio: base
+> compartida del root, apps Astro 6, dashboard Next.js 16, packages
+> compartidos.
+
+## Base compartida (`tsconfig.base.json` en root)
+
+```jsonc
+{
+  "compilerOptions": {
+    // Lenguaje y libs
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+
+    // Module system
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+
+    // Strict (cubre 8 flags) + extras
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "noFallthroughSwitchClause": true,
+
+    // Interop
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+
+    // Quality of life
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true
+  },
+  "exclude": ["node_modules", "dist", "build", ".astro", ".next", "out"]
+}
+```
+
+## App Astro 6 (`apps/<niche>/tsconfig.json`)
+
+```jsonc
+{
+  "extends": ["astro/tsconfigs/strict", "../../tsconfig.base.json"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "jsx": "preserve",
+    "types": ["astro/astro-jsx", "vitest/globals", "@modyfi/vite-plugin-yaml/modules"]
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist", ".astro"]
+}
+```
+
+> Nota: `astro/tsconfigs/strict` ya setea `allowJs: false` y otros — el
+> extends en orden mezcla y el segundo gana donde hay overlap. El portfolio
+> mantiene la rule estricta de "no JS nativo" — ver
+> [.claude/rules/typescript.md](../../rules/typescript.md).
+
+## Dashboard Next.js 16 (`dashboard/tsconfig.json`)
+
+```jsonc
+{
+  "extends": ["@tsconfig/next", "../tsconfig.base.json"],
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "verbatimModuleSyntax": true,
+
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["node", "react", "react-dom", "vitest/globals"],
+
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["src/**/*", ".next/types/**/*", "tests/**/*"],
+  "exclude": ["node_modules", ".next", "build", "out"]
+}
+```
+
+## Package compartido (`packages/<X>/tsconfig.json`)
+
+```jsonc
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+
+    // Declaracion de tipos publicos
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    // Project references (paraleliza build entre packages)
+    "composite": true,
+    "incremental": true,
+
+    // isolatedDeclarations acelera build (10x) pero exige tipos explicitos
+    // en exports publicos. Activar package-por-package cuando este listo.
+    // "isolatedDeclarations": true,
+
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"],
+  "references": [
+    // Si depende de otros packages, listar aqui:
+    // { "path": "../content" }
+  ]
+}
+```
+
+## Root del monorepo (`tsconfig.json`) — solo project references
+
+```jsonc
+{
+  "files": [],
+  "references": [
+    { "path": "packages/content" },
+    { "path": "packages/ui" },
+    { "path": "packages/seo" },
+    { "path": "packages/cv-pdf" },
+    { "path": "packages/app-shared" }
+  ]
+}
+```
+
+Build paralelo con `pnpm exec tsc -b`.
+
+## Vitest config (`vitest.config.ts` por workspace)
+
+Vitest hereda tsconfig automaticamente. Si necesitas override:
+
+```typescript
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'happy-dom',
+    coverage: {
+      provider: 'v8',
+      thresholds: { perFile: { lines: 80, statements: 80, functions: 80, branches: 80 } }
+    }
+  }
+})
+```
+
+## Verificacion
+
+```bash
+# Typecheck por workspace
+pnpm --filter @portfolio/<X> typecheck
+
+# Astro check (apps)
+pnpm --filter @portfolio/<app> exec astro check
+
+# Build con project references
+pnpm exec tsc -b
+
+# Build con watch (dev local)
+pnpm exec tsc -b --watch
+
+# Limpiar artifacts
+pnpm exec tsc -b --clean
+```
+
+## Migracion desde tsconfig actual
+
+Si el `tsconfig.json` actual tiene `baseUrl` o `module: "CommonJS"`:
+
+```bash
+pnpm dlx @andrewbranch/ts5to6 .
+```
+
+El codemod actualiza todos los tsconfig del monorepo recursivamente
+(sigue extends chains).
+
+## Decision: `astro/tsconfigs/strict` vs base custom
+
+Astro provee 3 presets: `base`, `strict`, `strictest`. Usar `strict`
+(no `strictest` — activa `noUncheckedIndexedAccess` + otras pero el
+portfolio ya las setea desde su base custom).
+
+El extends en orden:
+
+```jsonc
+{ "extends": ["astro/tsconfigs/strict", "../../tsconfig.base.json"] }
+```
+
+El segundo (`../../tsconfig.base.json`) gana donde hay overlap (precedencia
+del ultimo). Asi el portfolio mantiene `noUncheckedIndexedAccess` +
+`verbatimModuleSyntax` aun si el preset Astro no los activa.

--- a/.claude/docs/typescript-6/README.md
+++ b/.claude/docs/typescript-6/README.md
@@ -1,0 +1,77 @@
+# TypeScript 6 — Knowledge Tree
+
+> Documentacion consolidada de TypeScript 6.0 (GA marzo 23, 2026) para el
+> portfolio. TS 6 es la ultima version JavaScript-based; TS 7.0 (finales
+> 2026) sera reescrita en Go con 10x mejor performance. Codigo escrito
+> hoy en TS 6 idiomatico = upgrade a TS 7 sin friccion.
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| Breaking changes 5.x -> 6.0 + codemod ts5to6 | [01-breaking-changes.md](01-breaking-changes.md) |
+| Features nuevos (native node .ts, isolatedDeclarations, using/await using, satisfies, project references, module Preserve) | [02-features.md](02-features.md) |
+| Strict mode + flags adicionales recomendados | [03-strict-mode.md](03-strict-mode.md) |
+| tsconfig canonicos por contexto (Astro / Next / package) | [04-tsconfig.md](04-tsconfig.md) |
+
+## Reglas criticas (enforced en `.claude/rules/typescript.md`)
+
+- **SIEMPRE TypeScript** — el portfolio prohibe JavaScript nativo (`.js`,
+  `.jsx`, `.mjs`, `.cjs`) excepto archivos de configuracion del root
+  cuando una herramienta lo requiera. Codigo de aplicacion siempre `.ts` /
+  `.tsx` / `.astro`.
+- **SIEMPRE typing explicito** — `any` esta PROHIBIDO. Usar `unknown` +
+  narrow, o tipos especificos.
+- **SIEMPRE strict mode** — `"strict": true` en todo tsconfig.json.
+- **SIEMPRE** `"noUncheckedIndexedAccess": true` y
+  `"verbatimModuleSyntax": true`.
+- **SIEMPRE** `"module": "ESNext"` + `"moduleResolution": "bundler"` para
+  apps Astro y dashboard Next.js.
+- **SIEMPRE** listar `@types/*` en `"types": [...]` (TS 6 sin auto-discovery).
+- **NUNCA** `any` en codigo de aplicacion. Test/mocks tampoco — usar tipos
+  reales del modulo bajo test.
+- **NUNCA** `baseUrl` (REMOVIDO en TS 6).
+- **NUNCA** `"target": "ES5"` (deprecated).
+- **NUNCA** `module Foo { }` syntax (error en TS 6).
+
+## Resumen de versiones
+
+| Hito | Fecha |
+|------|-------|
+| TS 5.9 (ultima v5) | enero 2026 |
+| TS 6.0 beta | 11 febrero 2026 |
+| TS 6.0 RC | 24 febrero 2026 |
+| **TS 6.0 GA** | **23 marzo 2026** |
+| TS 6.0.x patches | marzo-mayo 2026 |
+| TS 7.0 preview (Go port) | finales 2026 (TBD) |
+
+## Performance (TS 5.9 -> 6.0)
+
+| Aspecto | Mejora |
+|---------|--------|
+| Cold build | -47% |
+| Incremental rebuild | -40% a -60% |
+| Peak memory | -25% |
+| Language service latency | -30% |
+| `@types` discovery (con `types` listado) | -90% |
+
+## Ecosystem mayo 2026
+
+| Package | Version TS 6-ready |
+|---------|--------------------|
+| `@types/node` | 24.x |
+| `@types/react` | 19.x |
+| `astro` | 6.x |
+| `next` | 16.x |
+| `zod` | 4.x |
+| `vitest` | 3.x |
+| `biome` | 2.3+ (Biotype) |
+
+## Referencias externas
+
+- [Microsoft DevBlogs — Announcing TypeScript 6.0](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/)
+- [TypeScript Handbook — Modules](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html)
+- [Total TypeScript — tsconfig Cheat Sheet](https://www.totaltypescript.com/tsconfig-cheat-sheet)
+- [LogRocket — TypeScript v6 Migration Guide](https://blog.logrocket.com/typescript-v6-migration-guide/)
+- [ts5to6 codemod (Andrew Branch)](https://github.com/andrewbranch/ts5to6)
+- Research raw (efimero): `tmp/research/typescript-6.md` (992 lineas)

--- a/.claude/rules/astro-landing.md
+++ b/.claude/rules/astro-landing.md
@@ -146,11 +146,23 @@ const { role, company, startDate, endDate } = Astro.props
 
 ## TypeScript
 
+- **TypeScript-only** — todo codigo de aplicacion en `.ts`, `.tsx` o
+  bloques `<script lang="ts">` / frontmatter TS dentro de `.astro`.
+  **JavaScript nativo PROHIBIDO** (`.js`, `.jsx`, `.mjs`, `.cjs`) en
+  `src/` y `tests/`. La unica excepcion son configs de root que el
+  toolchain exige como `.mjs` (caso a caso, documentado).
 - `strict: true` obligatorio
-- `noImplicitAny`, `strictNullChecks`, `noUnusedLocals`, `noUnusedParameters`
+- `noImplicitAny`, `strictNullChecks`, `strictPropertyInitialization`,
+  `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`,
+  `verbatimModuleSyntax`
 - Type-only imports/exports: `import type { Foo } from './bar'`
-- NO usar `any` — usar `unknown` con narrow apropiado
-- `tsconfig.json` extiende de `astro/tsconfigs/strict` o `strictest`
+- **`any` PROHIBIDO** — sin excepciones, ni en tests ni en mocks. Usar
+  `unknown` con narrow (type guard, `typeof`, `instanceof`), `satisfies`
+  para preservar literal inference, o Zod `z.infer` cuando hay validacion
+  runtime.
+- `tsconfig.json` extiende de `astro/tsconfigs/strict` + base custom del
+  monorepo (que agrega `noUncheckedIndexedAccess` + `verbatimModuleSyntax`)
+- Detalle TS 6: `.claude/rules/typescript.md` + skill `typescript-6`
 
 ## Astro-specific gotchas
 

--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -1,0 +1,469 @@
+# Dashboard SPA (`dashboard/*`) — convenciones del portfolio
+
+> Reglas para el dashboard admin del portfolio: Next.js 16 SPA estatico
+> (`output: 'export'`) + React 18 + TypeScript 6 strict + Biome v2 +
+> Tailwind v4 + shadcn/ui + Tanstack Query + Zustand, deployado a
+> Cloudflare Pages en `admin.portfolio.{dev|stage|prod}.the-full-stack.com`.
+> Consume el Lambda `auth` (planes 01-02) + Lambda `analytics`
+> (plan analytics-dashboard-api) del backend serverless del repo.
+
+## Activacion
+
+Aplica SIEMPRE que se trabaje con:
+
+- Cualquier archivo bajo `dashboard/` (carpeta nueva en root del repo)
+- Configuracion de Cloudflare Pages del project `portfolio-dashboard*`
+  (3 projects, uno por env)
+- Subdominio `admin.portfolio.{dev|stage|prod}.the-full-stack.com`
+- Env vars `NEXT_PUBLIC_*` del dashboard en
+  `docker/env/client/.{env}` o en GH Environment Variables
+- Extension de `devtools/cloudflare_setup/config.py` para incluir el
+  app type `nextjs`
+- Extension de `.github/workflows/deploy-apps.yml` para incluir el
+  dashboard al matrix
+
+NO aplica a las 6 apps Astro (`apps/{generic,hub,fintech,architect,leader,vibe}/`).
+Esas siguen `.claude/rules/astro-landing.md`.
+
+## Reglas duras (SIEMPRE / NUNCA)
+
+### Estructura y stack
+
+- **SIEMPRE** el dashboard vive en `dashboard/` (no en `apps/dashboard/`).
+  Entra al pnpm workspace como `@portfolio/dashboard`.
+- **SIEMPRE** Next.js 16.x con `output: 'export'` en `next.config.ts`.
+  Sin SSR, sin RSC server-only, sin Server Actions, sin ISR, sin
+  middleware, sin Route Handlers.
+- **SIEMPRE** React 18.3.x (NO React 19). Los hooks de React 19
+  (`use()`, `useFormStatus`, `useActionState`) son para Server Components
+  + Server Actions, ambos NO disponibles en export mode.
+- **SIEMPRE** TypeScript 6.x con `strict: true`, `noUncheckedIndexedAccess`,
+  `noUnusedLocals`, `noUnusedParameters`. NO `any`; usar `unknown` con
+  narrow.
+- **SIEMPRE** App Router (`src/app/`), NO Pages Router. Todas las pages
+  y layouts son Client Components (`'use client'` en primera linea).
+- **SIEMPRE** Biome v2 (sin ESLint). El `biome.json` del dashboard
+  extiende del root con override para `src/components/ui/*.tsx`
+  (shadcn primitives no respetan reglas strict).
+- **NUNCA** API routes (`app/api/*/route.ts`) — fail build en export mode.
+  Todas las API calls van al backend Lambda.
+- **NUNCA** `middleware.ts`, `proxy.ts` — no corren en SPA estatica.
+- **NUNCA** `<Image>` con optimizacion. `images.unoptimized: true` en
+  config; usar `<img>` regular para casos simples.
+- **NUNCA** mezclar npm/yarn con pnpm. Solo pnpm 11.0.9.
+
+### Estructura de componentes — Hybrid Atomic Design
+
+```text
+dashboard/src/
+├── app/                                # Next App Router (export)
+│   ├── layout.tsx                      # Root: ThemeProvider, QueryProvider, Toaster
+│   ├── page.tsx                        # / -> redirect a /login o /dashboard
+│   ├── (auth)/                         # Route group (no layout compartido)
+│   │   ├── login/page.tsx              # /login
+│   │   ├── register/page.tsx           # /register
+│   │   ├── verify/page.tsx             # /verify (input de code)
+│   │   ├── callback/page.tsx           # /callback (decodea fragment del magic link)
+│   │   └── set-password/page.tsx       # /set-password
+│   ├── (dashboard)/                    # Route group (protected, layout compartido)
+│   │   ├── layout.tsx                  # AuthGuard + sidebar + header
+│   │   ├── page.tsx                    # /dashboard (overview)
+│   │   ├── analytics/page.tsx          # /dashboard/analytics
+│   │   ├── sessions/page.tsx           # /dashboard/sessions
+│   │   ├── events/page.tsx             # /dashboard/events
+│   │   ├── visits/page.tsx             # /dashboard/visits
+│   │   ├── geo/page.tsx                # /dashboard/geo
+│   │   ├── devices/page.tsx            # /dashboard/devices
+│   │   ├── funnel/page.tsx             # /dashboard/funnel
+│   │   ├── contacts/page.tsx           # /dashboard/contacts
+│   │   └── settings/                   # /dashboard/settings/*
+│   │       ├── page.tsx                # perfil
+│   │       └── security/page.tsx       # MFA setup (TOTP + WebAuthn)
+│   ├── error.tsx                       # global error boundary
+│   ├── not-found.tsx                   # 404
+│   └── global-error.tsx                # fallback ultimo
+├── components/
+│   └── ui/                             # shadcn primitives (copy-paste)
+│       ├── button.tsx                  # via `pnpm dlx shadcn add button`
+│       ├── input.tsx
+│       ├── form.tsx
+│       ├── table.tsx
+│       ├── chart.tsx                   # Recharts wrapper
+│       ├── ...
+│       └── index.ts                    # barrel export
+├── features/                           # 1 carpeta por dominio
+│   ├── auth/
+│   │   ├── components/                 # LoginForm, RegisterForm, VerifyCodeInput, MagicLinkPrompt
+│   │   ├── hooks/                      # useLogin, useRegister, useVerifyCode, useLogout
+│   │   ├── api/                        # auth-client.ts
+│   │   ├── store/                      # use-auth-store.ts (Zustand)
+│   │   ├── lib/                        # mutex.ts, broadcast.ts, token-expiry.ts
+│   │   └── types.ts
+│   ├── analytics/                      # overview, timeseries, top-pages, top-referrers, top-niches, active-now, retention
+│   │   ├── components/
+│   │   ├── hooks/
+│   │   ├── api/
+│   │   └── types.ts
+│   ├── sessions/                       # list, detail
+│   ├── events/                         # distribution, list, heatmap
+│   ├── visits/                         # list, landing-pages
+│   ├── geo/                            # by-country
+│   ├── devices/                        # breakdown
+│   ├── funnel/                         # conversion
+│   ├── contacts/                       # list, by-status
+│   └── settings/                       # profile, mfa
+├── lib/
+│   ├── api-client.ts                   # fetch wrapper con JWT + refresh rotation + mutex
+│   ├── utils.ts                        # cn() de shadcn
+│   ├── env.ts                          # valida NEXT_PUBLIC_* con Zod
+│   ├── routes.ts                       # constantes de rutas
+│   ├── format/                         # date, number, currency helpers
+│   └── validation/                     # Zod schemas compartidos
+├── hooks/                              # globales (no de feature)
+│   ├── use-theme.ts                    # next-themes wrapper
+│   ├── use-media-query.ts
+│   ├── use-debounce.ts
+│   └── use-protected-route.ts
+├── providers/
+│   ├── theme-provider.tsx              # next-themes
+│   ├── query-provider.tsx              # Tanstack Query + PersistQueryClient
+│   └── root-providers.tsx              # composicion de todos
+├── styles/
+│   ├── globals.css                     # @import tailwind + @theme + @layer base
+│   └── fonts.css                       # @fontsource/* (mismas fonts del DS)
+├── types/
+│   ├── api.ts                          # types de respuestas /auth y /analytics
+│   └── models.ts                       # User, Session, Event, Contact, AnalyticsMetric
+└── env.d.ts                            # type-safe NEXT_PUBLIC_*
+```
+
+Reglas duras del layout:
+
+- **SIEMPRE** un componente vive en `features/<X>/components/` SI tiene
+  conocimiento de dominio (referencia un API especifico, un hook de
+  Tanstack Query de la feature, un Zustand store de la feature).
+- **SIEMPRE** un componente se promueve a `components/ui/` SOLO cuando
+  2+ features lo usan Y no depende de un API especifico.
+- **SIEMPRE** state de feature en `features/<X>/store/` (Zustand).
+  Solo `auth` y `theme` son globales (viven en `features/auth/store/`
+  y `providers/theme-provider.tsx`).
+- **NUNCA** crear `components/atoms/`, `components/molecules/`,
+  `components/organisms/`. La estructura es Hybrid (ui + features), no
+  Atomic Design clasico.
+- **NUNCA** importar de `features/A/...` desde `features/B/...`. Si
+  necesitas compartir, mover a `lib/` o `components/ui/`.
+- **NUNCA** Server Components con `async`/`fetch` directo. Todo Client
+  Component con Tanstack Query.
+
+### Auth (consume Lambda `auth` de planes 01-02)
+
+- **SIEMPRE** access JWT en memoria (Zustand store, campo NO persisted).
+  Refresh JWT en HttpOnly cookie (preferido — backend setea
+  `Set-Cookie: refresh_token=...; HttpOnly; Secure; SameSite=Strict;
+  Path=/auth; Max-Age=2592000`). Fallback: `localStorage` con CSP
+  estricta + SRI documentado.
+- **SIEMPRE** fetch wrapper (`lib/api-client.ts`) implementa el mutex
+  de refresh: solo UN `/session/refresh` en vuelo a la vez; los demas
+  requests con 401 esperan el resultado y reintentan.
+- **SIEMPRE** magic link callback en `/callback`: decodifica
+  `window.location.hash` (fragment), extrae `access` y `refresh`,
+  guarda en Zustand, limpia el hash con `history.replaceState`,
+  redirect a `/dashboard`.
+- **SIEMPRE** Turnstile en `LoginForm` y `RegisterForm` (action
+  `start`). Sitekey de `NEXT_PUBLIC_TURNSTILE_SITEKEY` (mismo de las 6
+  apps; agregar hostname `admin.portfolio.*.the-full-stack.com` a la
+  whitelist del widget en Cloudflare).
+- **SIEMPRE** `(dashboard)/layout.tsx` envuelve children con
+  `<AuthGuard>`: si no hay accessToken o el JWT esta expirado, redirect
+  a `/login?next=<current-path>`.
+- **SIEMPRE** auto-refresh proactivo: timer client-side que dispara
+  `/session/refresh` 30s antes del `exp` del access. Si el refresh
+  falla → forzar logout.
+- **SIEMPRE** Page Visibility API: si la tab vuelve a foco y pasaron
+  >5 min, verificar JWT + refresh si hace falta.
+- **SIEMPRE** BroadcastChannel API: canal `portfolio_auth`, mensajes
+  `LOGOUT` y `TOKEN_REFRESH`. Logout en una tab = logout en todas.
+- **SIEMPRE** logout llama POST `/auth?operation=session&action=logout`
+  ANTES de limpiar el estado local (backend blacklistea la familia en
+  DynamoDB). Si la llamada al backend falla, igual se limpia el estado
+  local + redirect.
+- **SIEMPRE** el flujo de registro/login completo: ver
+  `.claude/docs/dashboard/04-auth.md` (10+ pages).
+- **NUNCA** tokens en URL query params (`?access=...`). Solo fragment
+  hash (`#access=...`) en el callback del magic link.
+- **NUNCA** persistir `accessToken` en localStorage o cookie no-HttpOnly.
+- **NUNCA** logear el JWT, refresh token, magic link token, email
+  completo, ni el contenido del codigo 8 chars.
+- **NUNCA** mostrar mensajes que filtren si un email existe o no fuera
+  de los endpoints permitidos (`register.start` 409 vs `login.start`
+  404 con `suggest_register: true` ya lo hace explicito el backend).
+- **NUNCA** llamar al refresh sin pasar por el mutex (race condition
+  garantizada con concurrent requests).
+
+### UI (shadcn + Tailwind v4 + theming)
+
+- **SIEMPRE** componentes shadcn via CLI: `pnpm dlx shadcn@latest add
+  <component>`. Modifican/copian en `src/components/ui/`.
+- **SIEMPRE** Tailwind v4 con `@theme` inline en `src/styles/globals.css`.
+  NO `tailwind.config.ts` (o solo minimo para overrides).
+- **SIEMPRE** los tokens CSS del dashboard reflejan los tokens del DS
+  del monorepo (`.claude/rules/design-system.md`). Mismos colores
+  neutrales, mismas escalas tipograficas, misma logica dark/light.
+- **SIEMPRE** dark/light via `next-themes` con `attribute="data-theme"`
+  (evita hydration mismatch). Default: `system`. Toggle ciclo
+  `dark -> light -> system`.
+- **SIEMPRE** iconografia `lucide-react`. NO heroicons, NO radix-icons.
+- **SIEMPRE** charts via `pnpm dlx shadcn add chart` (basa en Recharts).
+  Tokens de color via CSS vars para respetar dark/light.
+- **SIEMPRE** tablas: shadcn `Table` primitives + Tanstack Table v8.
+  Para listas grandes (events list, sessions list), agregar Tanstack
+  Virtual.
+- **SIEMPRE** forms: react-hook-form + Zod + shadcn `Form`,
+  `FormField`, `FormControl`, `FormMessage` components.
+- **SIEMPRE** toasts via `sonner` (Toaster en root layout).
+- **SIEMPRE** loading states con shadcn `Skeleton`. Layouts esqueleto
+  realistas (no spinner generico).
+- **SIEMPRE** errores con shadcn `Alert` (variant `destructive`) o
+  toast.
+- **NUNCA** crear `<PrimaryButton>` o wrappers triviales sobre primitivos
+  shadcn. Usar `<Button variant="primary">` directo.
+- **NUNCA** estilizar shadcn primitives inline con `className`
+  modificando comportamiento base. Crear nueva variant CVA si necesario.
+- **NUNCA** importar Radix directo (`@radix-ui/react-*`). Pasar por
+  shadcn (perdes el theming consistente).
+- **NUNCA** Framer Motion / GSAP / Motion One. Tailwind animate +
+  `@starting-style` + Radix transitions cubren 100%.
+- **NUNCA** hex colors inline en componentes. Usar `var(--color-*)` o
+  Tailwind class (`bg-primary`, `text-muted-foreground`).
+- **NUNCA** Google Fonts CDN. Self-hosted via `@fontsource/*` (mismas
+  fonts del DS: Space Grotesk + Space Mono).
+
+### Data fetching (Tanstack Query v5)
+
+- **SIEMPRE** todo data fetching via `useQuery` / `useMutation` de
+  Tanstack Query. NO `useEffect(() => fetch(...))`.
+- **SIEMPRE** queryKey estructurado: `['analytics', 'overview', {from,
+  to}]`, `['sessions', 'list', {page, page_size}]`. Helpers en
+  `features/<X>/api/query-keys.ts`.
+- **SIEMPRE** `staleTime` y `gcTime` definidos por endpoint segun cache
+  del backend:
+  - Analytics agregadas (overview, timeseries, top-pages, etc.):
+    `staleTime: 60_000` (matchea TTL backend).
+  - `analytics.active-now`: `staleTime: 10_000` + `refetchInterval:
+    15_000`.
+  - Listados crudos (sessions, events, contacts list): `staleTime:
+    30_000`.
+  - Detail (sessions/detail): `staleTime: 0` (siempre fresh).
+- **SIEMPRE** `refetchOnWindowFocus: false` por default (SPA, no
+  background refetches automaticos). Excepcion: queries que usan
+  `active-now` o similares.
+- **SIEMPRE** persister: `@tanstack/query-sync-storage-persister` con
+  compresion `lz-string` para queries `success`. Maxima edad 24h.
+- **SIEMPRE** `useMutation` con `onSuccess` que invalida queries
+  relacionadas (`queryClient.invalidateQueries`).
+- **SIEMPRE** errores rendered via `error` del hook + toast (sonner).
+- **NUNCA** llamar `fetch()` directo desde componentes. Pasar siempre
+  por `lib/api-client.ts` (que tiene auth interceptor + retry).
+- **NUNCA** persistir queries con datos sensibles (lista de contacts).
+  Usar `hydrateOptions.defaultShouldDehydrateQuery` para filtrar.
+
+### Forms (react-hook-form + Zod)
+
+- **SIEMPRE** Zod schema en `lib/validation/<feature>.ts` por form.
+  Inferir tipo TS con `z.infer<typeof schema>`.
+- **SIEMPRE** shadcn `<Form>` + `useForm({ resolver: zodResolver(...) })`.
+- **SIEMPRE** validacion async (ej. email unico en register) via
+  `mode: 'onBlur'` + `useMutation`.
+- **SIEMPRE** mostrar errores via `FormMessage` (shadcn).
+- **NUNCA** validacion inline con if/else. Solo Zod.
+
+### Tests
+
+- **SIEMPRE** mirror de `src/` en `tests/unit/`: `src/features/auth/
+  components/LoginForm.tsx` → `tests/unit/features/auth/components/
+  LoginForm.test.tsx`.
+- **SIEMPRE** Vitest + Testing Library + happy-dom.
+- **SIEMPRE** MSW para mockear el backend en dev y tests
+  (`tests/mocks/handlers.ts`).
+- **SIEMPRE** coverage >= 80% per-file en archivos modificados (igual
+  que el resto del repo).
+- **SIEMPRE** asserts exactos (`expect(x).toBe(42)`, NO
+  `toBeGreaterThan(0)`).
+- **SIEMPRE** patron AAA + BDD-style en `it()` (`Given/When/Then`).
+- **SIEMPRE** E2E con Playwright (suite del repo, `tests/feature/`).
+  Specs nuevas en `tests/feature/dashboard/*.spec.ts`.
+- **NUNCA** mockear `useAuthStore` directamente. Usar
+  `useAuthStore.setState(...)` en `beforeEach` para preparar estado.
+- **NUNCA** mockear Tanstack Query directamente. Crear un `QueryClient`
+  de test + envolver el componente.
+- **NUNCA** llamar al backend real en tests unit. Solo MSW.
+
+### Env vars (categoria client)
+
+- **SIEMPRE** las env vars del dashboard llevan prefijo `NEXT_PUBLIC_`
+  (requisito de Next 16 para exponer al bundle). Equivalencia con las
+  apps Astro (`PUBLIC_*`):
+
+  | Astro (apps) | Next.js (dashboard) | Fuente |
+  |--------------|---------------------|--------|
+  | `PUBLIC_API_ENDPOINT` | `NEXT_PUBLIC_API_ENDPOINT` | misma URL del Lambda |
+  | `PUBLIC_TURNSTILE_SITEKEY` | `NEXT_PUBLIC_TURNSTILE_SITEKEY` | mismo sitekey |
+  | (no aplica) | `NEXT_PUBLIC_DASHBOARD_URL` | `https://admin.portfolio.{env}.the-full-stack.com` |
+  | (no aplica) | `NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS` | `30000` (refresh 30s antes del exp) |
+
+- **SIEMPRE** validar `NEXT_PUBLIC_*` en cold start con Zod en
+  `src/lib/env.ts`. Si falta una, fail el build.
+- **SIEMPRE** las vars se publican via `python devtools/run.py
+  sync_secrets --env=<X> --category=client`. NUNCA `gh variable set` a
+  mano (ver `.claude/rules/client-env-sync.md`).
+- **SIEMPRE** el catalogo en `devtools/sync_secrets/catalog.py` lista
+  las nuevas keys del dashboard.
+- **NUNCA** marcar `NEXT_PUBLIC_*` como GH Secret. Son Variables
+  (publicas por contrato).
+- **NUNCA** leer `docker/env/client/.{env}` con Read tool. Extraer keys
+  puntuales con `grep -m1 ^KEY=` (ver `.claude/rules/env-files.md`).
+
+### Deploy (Cloudflare Pages)
+
+- **SIEMPRE** 3 projects Cloudflare Pages: `portfolio-dashboard-dev`,
+  `portfolio-dashboard-stage`, `portfolio-dashboard` (prod sin sufijo).
+- **SIEMPRE** branch mapping: `dev` -> dev project, `stage` -> stage,
+  `main` -> prod.
+- **SIEMPRE** custom domain attached al provisionar:
+  - `admin.portfolio.dev.the-full-stack.com` (dev)
+  - `admin.portfolio.stage.the-full-stack.com` (stage)
+  - `admin.portfolio.the-full-stack.com` (prod)
+- **SIEMPRE** SSL cert se emite automatico por Cloudflare ACM al
+  attach del custom domain (no manual).
+- **SIEMPRE** build command: `pnpm install --frozen-lockfile && pnpm
+  --filter @portfolio/dashboard... build` (`...` incluye deps del
+  workspace).
+- **SIEMPRE** output dir: `dashboard/out` (Next 16 export genera `out/`
+  por default).
+- **SIEMPRE** `dashboard/public/_redirects` con `/* /index.html 200`
+  para client-side routing (rutas dinamicas).
+- **SIEMPRE** `dashboard/public/_headers` con CSP estricta + cache
+  headers + HSTS. Ver capitulo deploy del knowledge tree.
+- **SIEMPRE** `devtools/cloudflare_setup/config.py` declara el
+  dashboard como nuevo `AppConfig` con `app_type='nextjs'` y
+  `build_output_dir='out'`. El comando `cloudflare_setup all
+  --env=<X>` deploya los 7 apps (6 Astro + 1 Next).
+- **SIEMPRE** `.github/workflows/deploy-apps.yml` extiende la matrix
+  con `include` para agregar el dashboard (dist-dir distinto).
+- **SIEMPRE** preview_branch_includes en `[<branch>]` para evitar que
+  cada project construya todas las ramas (ver memory
+  `cloudflare-pages-preview-branch-fix`).
+- **NUNCA** wrangler para crear el project (no soporta git-connected
+  con env vars correctos). Solo REST API via devtools.
+- **NUNCA** modificar la config del project en la consola Cloudflare:
+  el siguiente `cloudflare_setup projects` la revierte.
+
+### CI/CD
+
+- **SIEMPRE** el dashboard pasa por `ci.yml` (lint + build de las apps
+  incluyendo dashboard) en cada PR.
+- **SIEMPRE** `deploy-apps.yml` con `environment: <stage>` para leer
+  GH Variables correctas (NEXT_PUBLIC_*).
+- **SIEMPRE** branch-flow-guard sigue aplicando: PR `dev -> stage` y
+  `stage -> main` con merge commit (NO rebase — ver
+  `.claude/rules/git-workflow.md`).
+- **SIEMPRE** el dashboard se mergea junto al backend que consume
+  (auth + analytics) cuando ambas APIs esten en el mismo env. Hasta
+  entonces, el dashboard usa MSW.
+
+## Comando canonico (development)
+
+```bash
+# Setup inicial (una vez)
+cd dashboard
+pnpm dlx shadcn@latest init                       # crea components.json
+pnpm dlx shadcn@latest add button input form ...  # primeros componentes
+cd ..
+
+# Trabajo diario
+pnpm install                                      # desde root, workspace
+pnpm --filter @portfolio/dashboard dev            # localhost:3000
+pnpm --filter @portfolio/dashboard typecheck
+pnpm --filter @portfolio/dashboard lint
+pnpm --filter @portfolio/dashboard test
+pnpm --filter @portfolio/dashboard build          # genera dashboard/out/
+
+# Pre-push
+pnpm --filter @portfolio/dashboard lint:fix
+pnpm --filter @portfolio/dashboard typecheck
+pnpm --filter @portfolio/dashboard test:coverage
+pnpm --filter @portfolio/dashboard build
+
+# Sync env vars
+python devtools/run.py sync_secrets --env=dev --category=client --dry-run
+python devtools/run.py sync_secrets --env=dev --category=client
+
+# Provisionar Cloudflare Pages (primera vez por env)
+export CLOUDFLARE_API_TOKEN=$(grep -m1 ^CLOUDFLARE_API_TOKEN= docker/env/dev-cli/.prod | cut -d= -f2-)
+export ACCOUNT_ID=$(grep -m1 ^CLOUDFLARE_ACCOUNT_ID= docker/env/dev-cli/.prod | cut -d= -f2-)
+python devtools/run.py cloudflare_setup all --env=dev
+
+# Deploy diario
+git push origin dev   # auto-deploya via deploy-apps.yml
+```
+
+## Verificacion (antes de declarar listo)
+
+```bash
+# 1. Lint + format + typecheck
+pnpm --filter @portfolio/dashboard lint
+pnpm --filter @portfolio/dashboard typecheck
+
+# 2. Unit tests
+pnpm --filter @portfolio/dashboard test:coverage  # >= 80%
+
+# 3. Build estatico
+pnpm --filter @portfolio/dashboard build
+ls -lah dashboard/out/index.html dashboard/out/_next  # debe existir
+
+# 4. Preview manual (al menos los flujos golden path)
+pnpm --filter @portfolio/dashboard preview &
+curl -sI http://localhost:3000/ | head -3        # 200
+curl -sI http://localhost:3000/login/ | head -3  # 200 (trailingSlash)
+
+# 5. E2E si aplica (cuando el backend este vivo)
+python devtools/run.py test_runner --module=feature --type=feature --env=local
+```
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| `app/api/*/route.ts` | Static export fail al build | Llamar Lambda externo |
+| `middleware.ts` para auth | No corre en SPA | `AuthGuard` Client Component |
+| `<Image src=... unoptimized={false}>` | Necesita server runtime | `images.unoptimized: true` global |
+| `useEffect(() => fetch(...))` | Sin cache, sin invalidation, sin retry | Tanstack Query `useQuery` |
+| Concurrent refresh requests | Backend revoca familia por reuse | Mutex en `lib/api-client.ts` |
+| Tokens en query (`?access=...`) | Leak via Referer + browser history | Fragment hash en callback |
+| `localStorage.setItem('access_token', ...)` | XSS = robo total | Zustand in-memory, no persist del access |
+| Promote a `components/ui/` con 1 uso | Premature abstraction | Vive en `features/<X>/components/` |
+| Server Component async fetch | Build fail en export | `'use client'` + Tanstack Query |
+| Importar `@radix-ui/react-*` directo | Pierde theming shadcn | Pasar por `components/ui/<comp>` |
+| Framer Motion | 30KB+, no necesario | Tailwind animate + `@starting-style` |
+| Hex inline (`color: '#FF0000'`) | Rompe dark mode | `text-destructive` o `var(--color-destructive)` |
+| Google Fonts CDN | GDPR, CSP estricta | `@fontsource/*` |
+| `find` / `grep -E` / `grep -rn` en Bash | Aliases rotos en WSL2 | Glob/Grep/Read tools |
+
+## Referencias cruzadas
+
+- Skill: `/dashboard-stack` (resumen ejecutivo + decisiones)
+- Knowledge tree: `.claude/docs/dashboard/` (7 capitulos)
+- Plan: `docs/specs/dashboard/` (efimero, se elimina al mergear)
+- Backend auth: `docs/specs/01-auth-infra-basics/` + `02-auth-mfa/`
+  (pending de implementar)
+- Backend analytics: `docs/specs/analytics-dashboard-api/` (pending)
+- Estandar de subdominios: `.claude/docs/subdomain-standard/`
+- Cloudflare Pages: `.claude/docs/cloudflare/` + skill
+  `cloudflare-deploy`
+- Sync secrets categoria client: `.claude/rules/client-env-sync.md`
+- CI/CD pipeline: `.claude/rules/ci-cd-pipeline.md`
+- Design system: `.claude/rules/design-system.md`
+- Git workflow + branches: `.claude/rules/git-workflow.md`
+- Plan format: `.claude/rules/plan-format.md`
+- TDD obligatorio: `.claude/rules/tdd-workflow.md` (heredado)
+- Verify-before-done: `.claude/rules/verify-before-done.md`

--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -1,11 +1,36 @@
 # Dashboard SPA (`dashboard/*`) — convenciones del portfolio
 
-> Reglas para el dashboard admin del portfolio: Next.js 16 SPA estatico
-> (`output: 'export'`) + React 18 + TypeScript 6 strict + Biome v2 +
-> Tailwind v4 + shadcn/ui + Tanstack Query + Zustand, deployado a
-> Cloudflare Pages en `admin.portfolio.{dev|stage|prod}.the-full-stack.com`.
-> Consume el Lambda `auth` (planes 01-02) + Lambda `analytics`
-> (plan analytics-dashboard-api) del backend serverless del repo.
+> Reglas para el dashboard admin del portfolio: Next.js 16.2.6 SPA
+> estatico (`output: 'export'`) + React 19.2.6 + TypeScript 6 strict +
+> Biome v2 + Tailwind v4 + shadcn/ui + Tanstack Query v5 + Zustand 5,
+> deployado a Cloudflare Pages en
+> `admin.portfolio.{dev|stage|prod}.the-full-stack.com`. Consume el
+> Lambda `auth` (planes 01-02) + Lambda `analytics` (plan
+> analytics-dashboard-api) del backend serverless del repo.
+
+## Versiones canonicas (mayo 2026)
+
+| Capa | Version |
+|------|---------|
+| Next.js | **16.2.6** (May 7, 2026) — Turbopack default, async APIs, `proxy.ts` reemplaza `middleware.ts` |
+| React + React DOM | **19.2.6** (May 6, 2026) — obligatorio en Next 16.x |
+| TypeScript | **6.0.6** strict + `noUncheckedIndexedAccess` |
+| Biome | **2.0.0+** sin ESLint, override en `components/ui/**` |
+| Tailwind | **4.1.4** con `@tailwindcss/postcss` |
+| shadcn/ui | latest oct 2025+ (React 19 support, sin `forwardRef` en codegen) |
+| Tanstack Query / Persist / Table / Virtual | **5.52.3** / **8.20.5** / **3.5.1** |
+| Zustand | **5.0.14** (Jan 2026 state consistency fix) |
+| react-hook-form | **7.53.0** |
+| Zod | **3.24.1** |
+| Recharts | **2.14.2** (override `react-is@19.2.6` necesario) |
+| sonner | **1.7.2** |
+| lucide-react | **0.416.0** |
+| next-themes | **0.4.8** |
+| MSW | **2.3.2** |
+| Vitest | **2.2.5** + Testing Library v16 + happy-dom 16 |
+| Node | >=24, pnpm 11.0.9 |
+
+Tabla extendida en `.claude/skills/dashboard-stack/SKILL.md`.
 
 ## Activacion
 
@@ -31,26 +56,64 @@ Esas siguen `.claude/rules/astro-landing.md`.
 
 - **SIEMPRE** el dashboard vive en `dashboard/` (no en `apps/dashboard/`).
   Entra al pnpm workspace como `@portfolio/dashboard`.
-- **SIEMPRE** Next.js 16.x con `output: 'export'` en `next.config.ts`.
+- **SIEMPRE** Next.js 16.2.6 con `output: 'export'` en `next.config.ts`.
   Sin SSR, sin RSC server-only, sin Server Actions, sin ISR, sin
-  middleware, sin Route Handlers.
-- **SIEMPRE** React 18.3.x (NO React 19). Los hooks de React 19
-  (`use()`, `useFormStatus`, `useActionState`) son para Server Components
-  + Server Actions, ambos NO disponibles en export mode.
-- **SIEMPRE** TypeScript 6.x con `strict: true`, `noUncheckedIndexedAccess`,
-  `noUnusedLocals`, `noUnusedParameters`. NO `any`; usar `unknown` con
-  narrow.
+  middleware/proxy, sin Route Handlers.
+- **SIEMPRE** React 19.2.6 (obligatorio en Next 16.x). NUNCA pinear a
+  React 18 — Next 16 requiere React 19 minimo.
+- **SIEMPRE** TypeScript 6.x con `strict: true`,
+  `noUncheckedIndexedAccess`, `noUnusedLocals`, `noUnusedParameters`.
+  NO `any`; usar `unknown` con narrow.
 - **SIEMPRE** App Router (`src/app/`), NO Pages Router. Todas las pages
   y layouts son Client Components (`'use client'` en primera linea).
 - **SIEMPRE** Biome v2 (sin ESLint). El `biome.json` del dashboard
-  extiende del root con override para `src/components/ui/*.tsx`
-  (shadcn primitives no respetan reglas strict).
+  extiende del root con override para `src/components/ui/*.tsx`. En
+  `next.config.ts`: `eslint.ignoreDuringBuilds: true`.
+- **SIEMPRE** Turbopack (default en Next 16, sin config).
+- **SIEMPRE** `reactCompiler: true` en `next.config.ts` (Compiler stable
+  en Next 16). Opt-out per file con `'use no memo'` solo si rompe algo
+  medido.
 - **NUNCA** API routes (`app/api/*/route.ts`) — fail build en export mode.
-  Todas las API calls van al backend Lambda.
-- **NUNCA** `middleware.ts`, `proxy.ts` — no corren en SPA estatica.
+- **NUNCA** `middleware.ts`, `proxy.ts`, Server Components con `async
+  fetch`, Server Actions, `'use cache'`. Todo server-only.
 - **NUNCA** `<Image>` con optimizacion. `images.unoptimized: true` en
   config; usar `<img>` regular para casos simples.
 - **NUNCA** mezclar npm/yarn con pnpm. Solo pnpm 11.0.9.
+
+### React 19 patterns (obligatorios)
+
+- **SIEMPRE** componentes nuevos reciben `ref` como prop normal — NUNCA
+  `forwardRef`. shadcn 2.x ya migrado.
+- **SIEMPRE** Rules of React (el Compiler las enforces): components
+  pure, no mutar props/state, side effects en useEffect, hooks
+  unconditional.
+- **SIEMPRE** `useFormState` esta DEPRECADO: usar `useActionState` de
+  `react` (NO `react-dom`).
+- **SIEMPRE** forms simples (1-2 fields, single submit): usar
+  `useActionState` + `useFormStatus`. Forms complejos (auth, multi-step,
+  validation custom): react-hook-form + Zod + shadcn `<Form>` + Tanstack
+  `useMutation`.
+- **SIEMPRE** elegir UNO por mutation: `useOptimistic` (puntual, local)
+  O Tanstack `onMutate` (con cache, refetch, invalidation). NO mezclar.
+- **SIEMPRE** `useSuspenseQuery` cuando la data es required para
+  renderizar (Error Boundary cubre fails). `useQuery` cuando es
+  opcional o inline.
+- **SIEMPRE** `useDeferredValue(value, initialValue)` con
+  `initialValue` para evitar flicker en filtros / tabs.
+- **SIEMPRE** Document Metadata:
+  - Static metadata (titulo fijo): Next `metadata` export en pages.
+  - Dynamic metadata (depende de state/data): React 19 `<title>` /
+    `<meta>` dentro del componente (auto-hoist al `<head>`).
+- **SIEMPRE** `useSearchParams()` dentro de `<Suspense>` boundary (req
+  del export mode — sin Suspense, build fail).
+- **NUNCA** `forwardRef` en componentes nuevos.
+- **NUNCA** mezclar `useState` para `isPending` con `useActionState`
+  (conflict, doble state).
+- **NUNCA** mutar props/state ni en handlers ni en helpers (el Compiler
+  no optimiza + bugs de concurrent rendering).
+- **NUNCA** hooks en conditionals/loops/after early returns.
+- **NUNCA** `'use server'` (Server Actions, no aplican en export).
+- **NUNCA** `'use cache'` (Cache Components, server-only).
 
 ### Estructura de componentes — Hybrid Atomic Design
 
@@ -157,18 +220,36 @@ Reglas duras del layout:
 
 ### Auth (consume Lambda `auth` de planes 01-02)
 
-- **SIEMPRE** access JWT en memoria (Zustand store, campo NO persisted).
-  Refresh JWT en HttpOnly cookie (preferido — backend setea
-  `Set-Cookie: refresh_token=...; HttpOnly; Secure; SameSite=Strict;
-  Path=/auth; Max-Age=2592000`). Fallback: `localStorage` con CSP
-  estricta + SRI documentado.
+> **Contexto: el dashboard es un SPA estatico (Next.js `output:
+> 'export'`) deployado en Cloudflare Pages**. NO hay backend bajo el
+> mismo origen que pueda setear cookies HttpOnly del dominio del API
+> (`api.portfolio.{env}.the-full-stack.com`) — el dashboard vive en
+> `admin.portfolio.{env}.the-full-stack.com` y consume el Lambda
+> `auth` via fetch CORS cross-subdomain. Una cookie HttpOnly del API
+> tendria que ser `SameSite=None; Secure; Domain=.the-full-stack.com`,
+> lo que abre vectores CSRF en todos los subdominios y limita la
+> portabilidad si el dashboard se aloja en otro origin (mobile app,
+> embebido en widgets, etc.). **Decision**: tokens viajan en el body de
+> la respuesta del backend, el dashboard los persiste en
+> `localStorage`. Mitigaciones: CSP estricta `default-src 'self'` sin
+> `unsafe-inline`/`unsafe-eval` (Next 16 export lo soporta),
+> Subresource Integrity en todos los scripts third-party, access JWT
+> corto (15 min), refresh rotation + family detection en el backend.
+
+- **SIEMPRE** access JWT y refresh JWT en `localStorage`
+  (`access_token`, `refresh_token`, `user` como JSON). El store
+  Zustand espeja el valor para que `useAuthStore` lo exponga
+  reactivamente, con `persist({storage: localStorage})` o lectura
+  manual de `localStorage` en el bootstrap del provider.
 - **SIEMPRE** fetch wrapper (`lib/api-client.ts`) implementa el mutex
   de refresh: solo UN `/session/refresh` en vuelo a la vez; los demas
   requests con 401 esperan el resultado y reintentan.
+- **SIEMPRE** el access token viaja en `Authorization: Bearer <JWT>`
+  (header). NUNCA como query param.
 - **SIEMPRE** magic link callback en `/callback`: decodifica
   `window.location.hash` (fragment), extrae `access` y `refresh`,
-  guarda en Zustand, limpia el hash con `history.replaceState`,
-  redirect a `/dashboard`.
+  guarda en `localStorage` via Zustand, limpia el hash con
+  `history.replaceState`, redirect a `/dashboard`.
 - **SIEMPRE** Turnstile en `LoginForm` y `RegisterForm` (action
   `start`). Sitekey de `NEXT_PUBLIC_TURNSTILE_SITEKEY` (mismo de las 6
   apps; agregar hostname `admin.portfolio.*.the-full-stack.com` a la
@@ -183,15 +264,25 @@ Reglas duras del layout:
   >5 min, verificar JWT + refresh si hace falta.
 - **SIEMPRE** BroadcastChannel API: canal `portfolio_auth`, mensajes
   `LOGOUT` y `TOKEN_REFRESH`. Logout en una tab = logout en todas.
+  Tambien escuchar `storage` event de `localStorage` para tabs en
+  navegadores que no soportan BroadcastChannel.
 - **SIEMPRE** logout llama POST `/auth?operation=session&action=logout`
   ANTES de limpiar el estado local (backend blacklistea la familia en
   DynamoDB). Si la llamada al backend falla, igual se limpia el estado
   local + redirect.
+- **SIEMPRE** CSP estricta en `public/_headers`: `default-src 'self';
+  script-src 'self'; connect-src 'self' https://api.portfolio.*
+  https://challenges.cloudflare.com; ...`. Sin `unsafe-inline` ni
+  `unsafe-eval`. Bloquea robo de tokens via XSS de inline scripts.
 - **SIEMPRE** el flujo de registro/login completo: ver
   `.claude/docs/dashboard/04-auth.md` (10+ pages).
 - **NUNCA** tokens en URL query params (`?access=...`). Solo fragment
   hash (`#access=...`) en el callback del magic link.
-- **NUNCA** persistir `accessToken` en localStorage o cookie no-HttpOnly.
+- **NUNCA** intentar setear HttpOnly cookies desde el backend para el
+  dashboard: el origen es distinto, requeriria `SameSite=None` cross-
+  site + `Domain=.the-full-stack.com` (vector CSRF en los 6 niches
+  publicos) y rompe portabilidad. La defensa contra XSS es la CSP
+  estricta, NO HttpOnly cookies cross-origin.
 - **NUNCA** logear el JWT, refresh token, magic link token, email
   completo, ni el contenido del codigo 8 chars.
 - **NUNCA** mostrar mensajes que filtren si un email existe o no fuera
@@ -199,6 +290,9 @@ Reglas duras del layout:
   404 con `suggest_register: true` ya lo hace explicito el backend).
 - **NUNCA** llamar al refresh sin pasar por el mutex (race condition
   garantizada con concurrent requests).
+- **NUNCA** cargar scripts third-party sin SRI (`integrity` attribute).
+  Lista permitida hoy: `challenges.cloudflare.com/turnstile/v0/api.js`
+  (Cloudflare publica los hashes oficiales por version).
 
 ### UI (shadcn + Tailwind v4 + theming)
 
@@ -440,7 +534,9 @@ python devtools/run.py test_runner --module=feature --type=feature --env=local
 | `useEffect(() => fetch(...))` | Sin cache, sin invalidation, sin retry | Tanstack Query `useQuery` |
 | Concurrent refresh requests | Backend revoca familia por reuse | Mutex en `lib/api-client.ts` |
 | Tokens en query (`?access=...`) | Leak via Referer + browser history | Fragment hash en callback |
-| `localStorage.setItem('access_token', ...)` | XSS = robo total | Zustand in-memory, no persist del access |
+| Cargar script third-party sin `integrity` (SRI) | Script comprometido roba el token de localStorage | SRI obligatorio + CSP `script-src 'self' + allowlist con hash` |
+| HttpOnly cookie cross-origin del API al dashboard (`SameSite=None; Domain=.the-full-stack.com`) | Vector CSRF en los 6 niches publicos + rompe portabilidad | Tokens en `localStorage` + CSP estricta (decision documentada arriba) |
+| CSP con `unsafe-inline` o `unsafe-eval` | XSS de inline scripts = robo de tokens | CSP `script-src 'self'` con SRI para third-party |
 | Promote a `components/ui/` con 1 uso | Premature abstraction | Vive en `features/<X>/components/` |
 | Server Component async fetch | Build fail en export | `'use client'` + Tanstack Query |
 | Importar `@radix-ui/react-*` directo | Pierde theming shadcn | Pasar por `components/ui/<comp>` |

--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -36,11 +36,18 @@ pnpm exec playwright test  # E2E tests (si aplica)
 
 ## Codigo (resumen — ver rules especificas)
 
+- **Lenguaje obligatorio**: TypeScript en todo codigo de aplicacion (`.ts`,
+  `.tsx`, `<script lang="ts">` en `.astro`). JavaScript nativo (`.js`,
+  `.jsx`, `.mjs`, `.cjs`) PROHIBIDO salvo configs de root que el toolchain
+  exija como `.mjs` (excepcion acotada). Detalle: `.claude/rules/typescript.md`.
+- **Type safety**: TS 6 strict + `noUncheckedIndexedAccess` +
+  `verbatimModuleSyntax`. `any` PROHIBIDO sin excepciones — usar `unknown`
+  con narrow, `satisfies` para preservar inference, o Zod schema con
+  `z.infer`. Tests/mocks tampoco pueden usar `any`.
 - **Estructura**: convenciones en `.claude/rules/astro-landing.md`
 - **Design system**: tokens, fonts, theme dark/light en `.claude/rules/design-system.md`
 - **Docstrings**: estandar agnostico de lenguaje en `.claude/rules/docstring-standard.md`
 - **Naming**: componentes Astro PascalCase, utilities kebab-case, branches feature/fix con `/`
-- **Type safety**: TS strict, NO `any` (usar `unknown` con narrow), `import type` cuando aplica
 - **Tokens del DS**: nunca hex inline en componentes, usar CSS vars
 - **Fonts**: self-hosted via `@fontsource/*`, nunca Google Fonts CDN
 - **Archivos temporales**: en `./tmp/` del proyecto, NUNCA `/tmp/` del sistema

--- a/.claude/rules/lambda-controller.md
+++ b/.claude/rules/lambda-controller.md
@@ -28,8 +28,13 @@ legolambda-stacks).
 - **SIEMPRE** el evento de entrada tiene la forma
   `{operation, action, data}` — `operation` el dominio, `action` el
   verbo, `data` el payload (objeto).
-- **SIEMPRE** el nombre de la clase controller es `action.capitalize()`
-  (`create` -> `Create`, `check` -> `Check`).
+- **SIEMPRE** el archivo del controller es la forma snake_case de
+  `action` (`create` -> `create.py`, `verify-magic-link` ->
+  `verify_magic_link.py`).
+- **SIEMPRE** el nombre de la clase controller es la forma PascalCase
+  de `action` — capitaliza la primera letra de cada segmento separado
+  por guion (`create` -> `Create`, `verify-magic-link` ->
+  `VerifyMagicLink`, `set-password` -> `SetPassword`).
 - **SIEMPRE** todo controller hereda de `BaseController` e implementa
   `execute()`.
 - **SIEMPRE** la logica de negocio vive en `core/services/`, NUNCA en

--- a/.claude/rules/lambda-controller.md
+++ b/.claude/rules/lambda-controller.md
@@ -86,7 +86,7 @@ legolambda-stacks).
 ├── core/
 │   ├── handler.py                # ENTRYPOINT (router delgado)
 │   ├── controllers/<operation>/  # ORQUESTADORES por operation
-│   │   └── <action>.py           # clase <Action>(BaseController)
+│   │   └── <action_snake>.py     # clase <ActionPascal>(BaseController)
 │   ├── services/                 # LOGICA DE NEGOCIO
 │   │   └── <operation>_service.py
 │   ├── models/

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,229 @@
+# TypeScript 6 Standards
+
+> Reglas duras de TypeScript 6 (GA marzo 23, 2026) para el portfolio: strict
+> mode obligatorio, `module: ESNext` + `moduleResolution: bundler` para los
+> 6 apps Astro y el dashboard Next.js, `verbatimModuleSyntax`, `types` array
+> explicito, sin `baseUrl`. Pensado para el monorepo pnpm con 6 apps + 5
+> packages compartidos.
+>
+> El detalle (breaking changes, features nuevos, tsconfig canonicos,
+> migracion) vive en la skill `typescript-6` y en
+> `.claude/docs/typescript-6/`. Esta rule es la enforcement con
+> SIEMPRE/NUNCA.
+
+## Activacion
+
+Aplica SIEMPRE que se trabaje con:
+
+- Cualquier archivo `.ts` o `.tsx` del repo (incluye `.astro` con `<script>`).
+- Cualquier `tsconfig.json` (root, apps, packages).
+- `package.json` cuando cambia la dep `typescript` o `@tsconfig/*`.
+- Decidir entre `module`/`moduleResolution` para un workspace nuevo.
+- Resolver errores `tsc --noEmit` o `astro check` antes de commit/push.
+
+NO aplica al codigo Python de `devtools/` ni al codigo TypeScript de Lambdas
+(que estan en otro repo). Las Lambdas son Python 3.13.
+
+## Reglas duras (SIEMPRE / NUNCA)
+
+### TypeScript-only en codigo de aplicacion (POLITICA RAIZ)
+
+- **SIEMPRE TypeScript** — todo codigo de aplicacion del repo se escribe
+  en `.ts`, `.tsx` o como bloque `<script lang="ts">` / frontmatter TS
+  dentro de `.astro`. JavaScript nativo (`.js`, `.jsx`, `.mjs`, `.cjs`)
+  esta **PROHIBIDO** en codigo de aplicacion.
+- **SIEMPRE typing explicito** — toda funcion publica, parametro y campo
+  publico declara su tipo. La inferencia esta bien para variables locales
+  obvias; en interfaces publicas el tipo es explicito.
+- **NUNCA** `any` — bajo ninguna circunstancia, ni en codigo de
+  aplicacion, ni en tests, ni en mocks, ni en utilities. Si necesitas
+  escape del type checker, usar `unknown` + narrow (type guard o
+  `typeof`/`instanceof`), o `satisfies` para preservar inference, o un
+  schema runtime (Zod) que produce el tipo via `z.infer`.
+- **NUNCA** `.js` / `.jsx` / `.mjs` / `.cjs` en `src/`, `apps/<X>/src/`,
+  `packages/<X>/src/`, `dashboard/src/`, `tests/` ni en cualquier carpeta
+  de codigo de aplicacion.
+- **NUNCA** `@ts-ignore` permanente — usar `@ts-expect-error` con un
+  comentario explicando el motivo Y ticket/issue para resolverlo, o
+  arreglar el root cause.
+
+#### Excepciones (acotadas y documentadas)
+
+Solo se permite JavaScript nativo en estos casos puntuales:
+
+1. **Configs de root** que un toolchain requiere explicitamente como JS:
+   `astro.config.mjs` (si la version Astro lo exige), `postcss.config.mjs`,
+   `next.config.mjs` (si Next no aceptara `.ts`). Cuando el toolchain
+   acepta `.ts`, usar siempre `.ts` (ej. `astro.config.ts`,
+   `next.config.ts`).
+2. **Archivos generados por terceros** (codemod output, snapshots, etc.)
+   que viven en su carpeta de output y no se editan a mano.
+3. **Hooks Python o scripts shell** — quedan fuera del scope de esta rule
+   (son otros lenguajes).
+
+Toda excepcion es un archivo concreto, documentado por ubicacion. NO se
+acepta "tengo prisa, lo subo como .js y luego lo paso".
+
+### Configuracion del compiler
+
+- **SIEMPRE** `"strict": true` en todo tsconfig.json (root y apps). Cubre
+  `noImplicitAny`, `strictNullChecks`, `strictFunctionTypes`,
+  `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`,
+  `alwaysStrict`, `useUnknownInCatchVariables`.
+- **SIEMPRE** `"noUncheckedIndexedAccess": true` (previene `undefined` en
+  acceso por indice — critico para arrays/dicts).
+- **SIEMPRE** `"verbatimModuleSyntax": true` (obliga `import type` para
+  imports type-only). Biome enforza con `useImportType`.
+- **SIEMPRE** `"module": "ESNext"` + `"moduleResolution": "bundler"` para
+  apps Astro y el dashboard Next.js (los bundlers Vite/Turbopack lo esperan).
+- **SIEMPRE** listar `@types/*` en `"types": [...]`. En TS 6 NO hay
+  auto-discovery — sin `types` no se cargan tipos globales.
+- **SIEMPRE** `"target": "ES2023"` minimo (ES5 esta deprecado en TS 6).
+- **SIEMPRE** `"skipLibCheck": true` (acelera builds; los `@types` confiamos
+  que estan bien tipados).
+- **SIEMPRE** `"isolatedModules": true` (compatible con esbuild/swc/Turbopack).
+- **SIEMPRE** `"forceConsistentCasingInFileNames": true` (catch bugs en
+  filesystems case-insensitive).
+- **NUNCA** `"baseUrl"` — REMOVIDO en TS 6. Usar paths relativos en `"paths"`.
+- **NUNCA** `"module": "CommonJS"` con `"moduleResolution": "bundler"` —
+  combinacion invalida en TS 6.
+- **NUNCA** `"target": "ES5"` — deprecated, error en TS 6.
+- **NUNCA** `"esModuleInterop": false` ni `"allowSyntheticDefaultImports": false` —
+  removidos, ambos siempre `true` en TS 6.
+- **NUNCA** `"ignoreDeprecations": "6.0"` permanente — NO funcionara en TS 7.
+  Solo como mitigacion temporal durante migracion.
+
+### Sintaxis del codigo
+
+- **SIEMPRE** `import type { X } from 'pkg'` para imports type-only
+  (enforced por `verbatimModuleSyntax`).
+- **SIEMPRE** `unknown` en vez de `any`. Si necesitas escape, narrow con
+  type guard (`if (typeof x === 'string')`) o `satisfies`.
+- **SIEMPRE** `satisfies Foo` en vez de `as Foo` para validar contra tipo
+  sin perder literal inference.
+- **SIEMPRE** `namespace Foo { }` en vez de `module Foo { }` (este ultimo
+  es ERROR en TS 6 por conflicto con propuesta ECMAScript de module blocks).
+- **SIEMPRE** `using` / `await using` para resources con `Symbol.dispose`
+  / `Symbol.asyncDispose` (cleanup automatico).
+- **NUNCA** `any` (excepto en cast deliberado documentado con `// reason: X`).
+- **NUNCA** `as` cast sin razon explicita — bypassa el type checker.
+- **NUNCA** `module Foo { }` syntax.
+- **NUNCA** `Object.keys(obj)` sin cast — retorna `string[]`, no `keyof T`.
+  Usar `Object.keys(obj) as (keyof typeof obj)[]` cuando sea seguro.
+
+### Workspace y packages
+
+- **SIEMPRE** los packages compartidos (`packages/<X>/`) extienden de
+  `tsconfig.base.json` del root.
+- **SIEMPRE** los packages que se consumen entre si declaran `"composite": true`
+  + `"references": [...]` apuntando a los packages dependencia (project
+  references — TS 6 paraleliza `tsc -b`).
+- **SIEMPRE** los packages publicables (`@portfolio/content`, `@portfolio/ui`,
+  etc.) tienen `"declaration": true` + `"declarationMap": true` (genera
+  `.d.ts` consumibles).
+- **SIEMPRE** considerar `"isolatedDeclarations": true` para packages
+  internos (genera `.d.ts` sin invocar full type-checker, ~10x mas rapido).
+  Trade-off: obliga tipos explicitos en exports publicos.
+- **NUNCA** cross-import entre packages sin pasar por su `index.ts` (el
+  barrel re-exporta lo publico; los `internal/` quedan privados).
+
+### Performance
+
+- **SIEMPRE** `"incremental": true` en apps y packages para builds rapidos.
+  Genera `.tsbuildinfo` (gitignored).
+- **SIEMPRE** correr `tsc -b` (build mode) para project references — paraleliza.
+
+## tsconfig canonicos (referencia rapida)
+
+Plantillas completas en
+[.claude/docs/typescript-6/04-tsconfig.md](../docs/typescript-6/04-tsconfig.md).
+Resumen:
+
+| Contexto | Extends | Key settings |
+|----------|---------|--------------|
+| Root (`tsconfig.base.json`) | — | strict + verbatimModuleSyntax + bundler |
+| App Astro (`apps/<X>/tsconfig.json`) | `astro/tsconfigs/strict` + base | `paths`, `types: ['astro/astro-jsx', 'vitest/globals']` |
+| Dashboard Next.js (`dashboard/tsconfig.json`) | `@tsconfig/next` + base | `jsx: 'preserve'`, `incremental`, types React |
+| Package (`packages/<X>/tsconfig.json`) | base | `composite`, `declaration`, `outDir: './dist'` |
+
+## Migracion 5.x -> 6.0 (cuando aplique)
+
+```bash
+# 1. Upgrade typescript en root del workspace
+pnpm add -D -w typescript@^6.0.0
+
+# 2. Codemod oficial (Andrew Branch, TS team)
+pnpm dlx @andrewbranch/ts5to6 .
+# Elimina baseUrl, ajusta paths, setea rootDir, sigue extends chains
+
+# 3. Typecheck para ver errores nuevos (mayoria null checks)
+pnpm exec tsc --noEmit
+pnpm exec astro check  # apps Astro
+
+# 4. Listar @types/* en tsconfig "types" (antes auto-discovered)
+
+# 5. Arreglar errores strict
+# 6. Verificar builds + tests
+pnpm run build
+pnpm exec vitest run --coverage
+```
+
+## Verificacion (antes de declarar listo)
+
+```bash
+# Typecheck global
+pnpm run typecheck
+# o por workspace
+pnpm --filter <app-o-package> typecheck
+
+# Para apps Astro
+pnpm --filter <app> exec astro check
+
+# Build (detecta errores que typecheck no ve)
+pnpm --filter <app> run build
+
+# Tests
+pnpm exec vitest run --coverage
+```
+
+## Anti-patterns
+
+| Anti-pattern | Por que | Correccion |
+|--------------|---------|------------|
+| `any` en cualquier lugar | Bypassa type safety, oculta bugs | `unknown` + narrow / type guard |
+| `as Foo` sin razon | Bypassa type checker | `satisfies Foo` (preserva inference) |
+| Olvidar `import type` para tipos | `verbatimModuleSyntax` enforza, build falla | Biome `useImportType` auto-fix |
+| `@types/X` no listado en `types` | NO se carga en TS 6, intellisense roto | Agregar a `tsconfig.types` |
+| `baseUrl` en tsconfig nuevo | REMOVIDO en TS 6 | Solo `paths` relativos |
+| `module: "CommonJS"` en app frontend | Invalido con `moduleResolution: "bundler"` | `module: "ESNext"` |
+| `module Foo { }` legacy | ERROR en TS 6 | `namespace Foo { }` |
+| `Object.keys(obj)` sin cast | Retorna `string[]`, perdes type info | `as (keyof typeof obj)[]` |
+| Catch sin `unknown` | TS 6 fuerza `useUnknownInCatchVariables` | `catch (e: unknown) { if (e instanceof Error) ... }` |
+| `ignoreDeprecations: "6.0"` como solucion final | Falla en TS 7 | Arreglar el deprecation now |
+| Re-exportar tipos sin `export type` | `verbatimModuleSyntax` enforza | `export type { Foo }` |
+| Hardcodear ruta a `node_modules/@types/...` | Brittle | `types: [...]` en tsconfig |
+
+## Cuando esta rule SI aplica
+
+Cualquier cambio a:
+
+1. Archivos `*.ts` / `*.tsx` en `apps/`, `packages/`, `dashboard/`, `tests/`.
+2. Bloques `<script lang="ts">` o frontmatter TS en `*.astro`.
+3. Configuraciones: `tsconfig.json`, `tsconfig.base.json`, `tsconfig.*.json`.
+4. Dependency upgrade de `typescript` o `@tsconfig/*`.
+5. Creacion de un workspace nuevo (definir su `tsconfig.json` desde cero).
+
+## Cuando NO aplica
+
+- Codigo Python (`devtools/`, `.git-hooks/`) — usar rule `python.md`.
+- Codigo Lambda (en otro repo) — ese repo tiene su propio standard Python.
+- Archivos JSON / YAML puros — no involucran TypeScript.
+- Documentacion `.md` — sin tipos.
+
+## Referencias
+
+- Skill: [`typescript-6`](../skills/typescript-6/SKILL.md)
+- Docs (knowledge tree): [.claude/docs/typescript-6/](../docs/typescript-6/)
+- Rule del dashboard (consume TS 6): [.claude/rules/dashboard.md](dashboard.md)
+- Rule de Astro (consume TS 6): [.claude/rules/astro-landing.md](astro-landing.md)
+- Research raw (efimero): `tmp/research/typescript-6.md`

--- a/.claude/skills/dashboard-stack/SKILL.md
+++ b/.claude/skills/dashboard-stack/SKILL.md
@@ -3,119 +3,211 @@ name: dashboard-stack
 description: >
   Dashboard SPA stack reference for the portfolio admin dashboard
   (`admin.portfolio.{dev|stage|prod}.the-full-stack.com`). Covers
-  Next.js 16 static export (`output: 'export'`), React 18, TypeScript 6
-  strict, Biome v2 (no ESLint), Tailwind v4, shadcn/ui (Radix
-  primitives), Tanstack Query v5 + Tanstack Table v8 + Tanstack
-  Virtual, react-hook-form + Zod, Zustand (auth + theme), Recharts,
-  sonner, lucide-react, MSW for mocks, Vitest + Testing Library, the
-  Hybrid Atomic Design folder layout (`src/components/ui/` shared +
-  `src/features/<X>/` per domain), JWT auth integration with the
-  Lambda `auth` of plans 01/02 (access in-memory Zustand + refresh in
-  HttpOnly cookie OR fragment-based magic-link callback + mutex
-  refresh rotation + BroadcastChannel multi-tab logout sync),
-  Cloudflare Pages deploy via the same `devtools/cloudflare_setup` +
-  `deploy-apps.yml` pipeline as the 6 Astro apps (4th env: `admin`
-  becomes the 7th project per env, total 21 projects = 7 apps x 3
-  envs), per-env env vars with `NEXT_PUBLIC_*` prefix synced via
-  `sync_secrets --category=client`. ALWAYS invoke this skill BEFORE
-  answering ANY question about the dashboard, including questions
-  framed as "next.js spa", "static export", "shadcn dashboard",
-  "tanstack query auth", "atomic design react", "jwt en react",
-  "dashboard auth", "cloudflare pages nextjs", or "admin portfolio".
-  NEVER answer dashboard questions from training data alone — this
-  project has consolidated 2026 patterns (mutex refresh rotation,
-  fragment magic-link callback, hybrid Atomic Design, shadcn + Tailwind
-  v4 + Biome override, Next.js 16 SPA quirks, custom devtools
-  integration) that override generic advice.
+  Next.js 16.2.6 static export (`output: 'export'`), React 19.2.6
+  (with React Compiler stable, ref-as-prop, `useActionState`,
+  `useOptimistic`, `useDeferredValue` with initialValue, Document
+  Metadata nativo, View Transitions, `useEffectEvent`, Activity
+  Component), TypeScript 6 strict, Biome v2 (no ESLint), Tailwind v4
+  with `@tailwindcss/postcss`, shadcn/ui (Radix primitives, generated
+  without `forwardRef`), Tanstack Query v5 + Tanstack Table v8 +
+  Tanstack Virtual (with `useSuspenseQuery` patterns), react-hook-form
+  7 + Zod (for complex forms, coexists with `useActionState` for
+  simple ones), Zustand 5 (auth + theme), Recharts, sonner,
+  lucide-react, MSW v2 for mocks, Vitest + Testing Library v16 +
+  happy-dom + Playwright, the Hybrid Atomic Design folder layout
+  (`src/components/ui/` shared + `src/features/<X>/` per domain),
+  JWT auth integration with the Lambda `auth` of plans 01/02 (tokens
+  in `localStorage` via Zustand persist — SPA cross-origin makes
+  HttpOnly cookies non-viable; defense is strict CSP + SRI + short
+  access TTL 15min + family_id refresh rotation; fragment-based magic-
+  link callback + mutex refresh rotation + BroadcastChannel multi-tab
+  logout sync), Cloudflare Pages deploy via the same
+  `devtools/cloudflare_setup` + `deploy-apps.yml` pipeline as the 6
+  Astro apps (`admin` becomes the 7th project per env, total 21
+  projects = 7 apps x 3 envs), per-env env vars with `NEXT_PUBLIC_*`
+  prefix synced via `sync_secrets --category=client`. ALWAYS invoke
+  this skill BEFORE answering ANY question about the dashboard,
+  including questions framed as "next.js spa", "next 16 export",
+  "react 19 patterns", "react compiler", "useactionstate",
+  "useoptimistic", "shadcn dashboard", "tanstack query auth",
+  "atomic design react", "jwt en react", "dashboard auth",
+  "cloudflare pages nextjs", or "admin portfolio". NEVER answer
+  dashboard questions from training data alone — this project has
+  consolidated 2026 patterns (React 19.2.6 + Next 16.2.6 stable +
+  mutex refresh rotation + fragment magic-link callback + hybrid
+  Atomic Design + shadcn + Tailwind v4 + Biome override + custom
+  devtools integration) that override generic advice.
   Use when the user says "dashboard", "admin dashboard", "next 16",
-  "nextjs 16", "next.js 16", "spa", "static export", "output export",
-  "react 18 dashboard", "shadcn ui dashboard", "tanstack query",
-  "tanstack table", "zustand auth", "jwt refresh rotation", "jwt
-  storage spa", "magic link react", "refresh token mutex", "atomic
-  design react", "atomic design hibrido", "feature sliced",
-  "components ui features", "cloudflare pages nextjs", "admin
-  subdomain", "admin.portfolio", "dashboard analytics", "biome
-  nextjs", "tailwind v4 shadcn", "next themes", "broadcastchannel
-  logout", "dashboard auth", "dashboard estructura", "estructura
-  dashboard", "componentes dashboard", "dashboard plan",
-  "dashboard skill".
+  "nextjs 16", "next.js 16", "next 16.2", "spa", "static export",
+  "output export", "react 19", "react 19.2", "reactjs 19",
+  "react compiler", "useactionstate", "useformstatus",
+  "useoptimistic", "usedeferredvalue", "use hook react 19",
+  "ref as prop", "forwardref deprecated", "document metadata react",
+  "view transitions react", "useeffectevent", "activity component",
+  "shadcn ui dashboard", "shadcn react 19", "tanstack query",
+  "tanstack table", "usesuspensequery", "zustand auth", "zustand 5",
+  "jwt refresh rotation", "jwt storage spa", "magic link react",
+  "refresh token mutex", "atomic design react", "atomic design
+  hibrido", "feature sliced", "components ui features",
+  "cloudflare pages nextjs", "admin subdomain", "admin.portfolio",
+  "dashboard analytics", "biome nextjs", "tailwind v4 shadcn",
+  "next themes", "broadcastchannel logout", "dashboard auth",
+  "dashboard estructura", "estructura dashboard", "componentes
+  dashboard", "dashboard plan", "dashboard skill", "turbopack
+  default", "proxy.ts next 16".
 user-invocable: true
 allowed-tools: Read, Glob, Grep
-argument-hint: "optional subtopic: stack, structure, auth, ui, deploy, testing, mocks"
+argument-hint: "optional subtopic: stack, structure, auth, ui, deploy, testing, mocks, react-19, next-16"
 ---
 
 # Dashboard stack — admin.portfolio.the-full-stack.com
 
 Reference completa para construir y mantener el dashboard admin del
-portfolio. Si el subtopic no encaja, leer el indice completo.
+portfolio. Stack 100% 2026 (React 19.2.6 + Next.js 16.2.6).
+
+## Versiones canonicas (mayo 2026)
+
+| Capa | Version | Notas |
+|------|---------|-------|
+| Next.js | **16.2.6** (May 7, 2026 — LTS candidato, 13 security fixes) | Turbopack default + stable, async APIs, `proxy.ts` reemplaza `middleware.ts` |
+| React | **19.2.6** (May 6, 2026) | React Compiler stable, `ref` como prop, `useActionState`, `useOptimistic`, View Transitions, `useEffectEvent`, `Activity` |
+| React DOM | **19.2.6** | matches React |
+| TypeScript | **6.0.6** | strict + `noUncheckedIndexedAccess` |
+| Biome | **2.0.0+** | sin ESLint, override en `components/ui/**` |
+| Tailwind | **4.1.4** | `@tailwindcss/postcss` plugin, CSS-first config |
+| shadcn/ui | latest (oct 2025+) | React 19 support, sin `forwardRef` en codegen |
+| Tanstack Query | **5.52.3** | `useSuspenseQuery` patterns + `useOptimistic` |
+| Tanstack Query Persist | **5.52.3** | persister + sync-storage |
+| Tanstack Table | **8.20.5** | columnDef + sort + paginator |
+| Tanstack Virtual | **3.5.1** | listas grandes |
+| Zustand | **5.0.14** (Jan 2026 state consistency fix) | persist con partialize |
+| react-hook-form | **7.53.0** | uncontrolled inputs, coexiste con `useActionState` |
+| @hookform/resolvers | **3.4.2** | Zod resolver |
+| Zod | **3.24.1** | schemas + inferencia TS |
+| Recharts | **2.14.2** | charts (via shadcn add chart) |
+| sonner | **1.7.2** | toasts |
+| lucide-react | **0.416.0** | iconos |
+| next-themes | **0.4.8** | dark/light con `data-theme` |
+| MSW | **2.3.2** | mocks dev + tests |
+| Vitest | **2.2.5** | happy-dom + coverage v8 |
+| @testing-library/react | **16.1.0** | React 19 support |
+| @testing-library/user-event | **14.5.2** | |
+| Playwright | **1.48.2** | E2E (suite del monorepo) |
+| @marsidev/react-turnstile | **1.2.5** | Turnstile widget |
+| jwt-decode | **4.0.0** | solo decodificar (sin verificar firma) |
+| lz-string | **1.5.0** | compresion del persister |
+| babel-plugin-react-compiler | **19.0.0-beta.17** | si React Compiler habilitado |
+| class-variance-authority | **0.7.0** | CVA para variants |
+| clsx | **2.1.1** | helper |
+| tailwind-merge | **2.4.0** | helper |
+| Node | **>=24** | runtime build |
+| pnpm | **11.0.9** | package manager |
 
 ## Resumen ejecutivo (decisiones cerradas)
 
 | Tema | Decision | Razon |
 |------|----------|-------|
-| Framework | Next.js 16 con `output: 'export'` | Monorepo consistency + ecosystem; usuario lo eligio |
-| Runtime React | React 18.3.x (NO React 19) | `use()`, Server Actions hooks no aplican a SPA; libs (Tanstack) mas maduras en 18 |
+| Framework | Next.js 16.2.6 `output: 'export'` | Monorepo consistency + ecosystem; LTS candidato |
+| Runtime React | React 19.2.6 (obligatorio en Next 16.x) | Compiler stable, `useActionState`, `useOptimistic`, Document Metadata nativo |
+| Bundler | **Turbopack** (default + stable en 16, sin config) | 5-10x Fast Refresh, 2-5x build, filesystem caching en dev (16.1+) |
 | Routing | App Router (NO Pages Router) | Default 2026; layouts anidados; todo Client Components |
-| TypeScript | 6.x strict + `noUncheckedIndexedAccess` | Heredar politica del monorepo |
-| Linter/Formatter | Biome v2 (sin ESLint) | Heredar `biome.json` root con override para `components/ui/*.tsx` |
-| CSS | Tailwind v4 con `@theme` inline en CSS | v4 official desde feb 2025; shadcn lo soporta |
-| Componentes UI | shadcn/ui + Radix primitives | Copy-paste, no library; full control |
-| Iconos | lucide-react | 1500+ icons, tree-shakable, default de shadcn |
-| Charts | Recharts via `shadcn add chart` | Integration nativa de shadcn |
-| Tablas | Tanstack Table v8 + Tanstack Virtual | Estandar 2026; virtualizacion para listas grandes |
-| Data fetching | Tanstack Query v5 | Persister + mutex para refresh rotation |
-| Forms | react-hook-form + `@hookform/resolvers/zod` + Zod | shadcn `Form` component lo integra mejor que Tanstack Form |
-| State global | Zustand 5.x con `persist` middleware | auth (access in-memory, refresh persist) + theme |
+| TypeScript | 6.0.6 strict + `noUncheckedIndexedAccess` | Heredar politica del monorepo |
+| Linter/Formatter | Biome v2 (sin ESLint) | Heredar `biome.json` root con override para `components/ui/*.tsx`; `eslint.ignoreDuringBuilds: true` |
+| CSS | Tailwind v4 `@theme` inline + `@tailwindcss/postcss` | 5x faster builds, 100x incremental, CSS-first config |
+| Componentes UI | shadcn/ui (sin `forwardRef`, ref-as-prop) | Copy-paste, full control, React 19 support |
+| React Compiler | **Habilitado** via `reactCompiler: true` (stable en 16) | Auto-memoization sin `useMemo`/`useCallback` boilerplate |
+| Iconos | lucide-react | 1500+ icons, tree-shakable |
+| Charts | Recharts via `shadcn add chart` | Integration nativa de shadcn (req React 19 → `react-is@19.2.6` override) |
+| Tablas | Tanstack Table v8 + Tanstack Virtual | Estandar 2026 |
+| Data fetching | Tanstack Query v5 + **`useSuspenseQuery`** | Persister + mutex para refresh rotation |
+| Forms simples (1-2 fields) | `useActionState` + `useFormStatus` | Menos boilerplate, React 19 nativo |
+| Forms complejos (auth, multi-step) | react-hook-form + Zod + shadcn `<Form>` | Uncontrolled inputs, mejor DX, integracion shadcn |
+| Optimistic updates | `useOptimistic` (puntuales) o Tanstack `onMutate` (con cache) | Elegir UNO por mutation, no mezclar |
+| State global | Zustand 5.0.14 con `persist` middleware | auth + theme; partialize EXCLUYE `accessToken` |
 | Theme dark/light | next-themes con `attribute="data-theme"` | Evita hydration mismatch |
-| Toasts | sonner | Accesible, 9.1KB, tree-shakable |
-| Tests unit | Vitest + Testing Library + happy-dom | Reusa stack del monorepo |
+| Document Metadata | Static: Next `metadata` export. Dynamic: React 19 `<title>`/`<meta>` nativo | React 19 hoist al `<head>` automatico |
+| Toasts | sonner | Accesible, tree-shakable |
+| Tests unit | Vitest 2 + Testing Library v16 + happy-dom | Reusa stack del monorepo; `act()` warnings mas estrictos en R19 |
 | Tests E2E | Playwright (suite del monorepo) | Mismo runner que las apps Astro |
-| Mocks API | MSW (Mock Service Worker) | Para dev (sin backend live) + tests |
+| Mocks API | MSW v2 (con polyfill BroadcastChannel en happy-dom) | Para dev sin backend + tests |
 | Estructura | **Hibrido**: `src/components/ui/` + `src/features/<X>/` | Atomic Design sin nombres rigidos |
 | Carpeta | `dashboard/` en root del repo | Usuario lo pidio explicito; entra a pnpm workspace |
 | Subdominio | `admin.portfolio.{env}.the-full-stack.com` | Sigue subdomain-standard |
 | Deploy | Cloudflare Pages (REST API via `devtools/cloudflare_setup`) | Mismo pipeline que las 6 apps Astro |
 | Envs CI | dev/stage/prod (3 Cloudflare Pages projects) | Branch `dev`/`stage`/`main` mapping |
 | Auth backend | Lambda `auth` planes 01-02 (aun pending) | Dashboard usa MSW hasta que esten deployadas |
-| Auth storage | Access JWT in-memory (Zustand) + refresh HttpOnly cookie (preferido) o localStorage+CSP (fallback) | OWASP JWT Cheat Sheet + RFC 9700 Jan 2025 |
+| Auth storage | Access + refresh JWT en `localStorage` (Zustand persist). SPA cross-origin (admin → api) hace HttpOnly cookies no viables (requeriria `SameSite=None` cross-site + vector CSRF). Defensa: CSP estricta + SRI + access TTL 15min + family_id refresh rotation | OWASP JWT Cheat Sheet + RFC 9700 Jan 2025 |
 | Refresh rotation | Mutex pattern (1 sola refresh in-flight) + family_id detection | Backend ya lo implementa; client previene race conditions |
 | Magic link UX | Backend redirect 302 a `/auth/callback#access=X&refresh=Y` (fragment) | Tokens NO viajan a server logs ni Referer |
 | Multi-tab logout | BroadcastChannel API | Logout en una tab = logout en todas |
+
+## Features clave de React 19 que aplican al dashboard
+
+| Feature | Uso | Aplicable? |
+|---------|-----|-----------|
+| **React Compiler** | Auto-memoization sin `useMemo`/`useCallback` | ✅ habilitar via `reactCompiler: true` |
+| **`useActionState`** | Forms simples + state automatico (`isPending`, `error`, `data`) | ✅ para forms 1-2 fields |
+| **`useFormStatus`** | Hook que lee el `<form>` ancestor (pending, data) | ✅ para spinners en `<button>` dentro de `<form action={...}>` |
+| **`useOptimistic`** | Optimistic UI updates puntuales | ✅ para toggles, inline edits |
+| **`use(promise)`** | Read promise + Suspense en Client Components | ⚠ Tanstack `useSuspenseQuery` es mejor |
+| **`use(context)` condicional** | Llamar context dentro de `if` | ⚠ raro pero util cuando aplica |
+| **`useDeferredValue(value, initialValue?)`** | Defer renders sin flicker | ✅ para filtros / tabs / search |
+| **`useEffectEvent`** | Extraer logica no-reactiva de Effects | ✅ para handlers en effects |
+| **`Activity` component** | Render "background activity" con `display: none` manteniendo state | ✅ para mantener tabs ocultas vivas |
+| **View Transitions API** | Animaciones en navegacion / updates | ⚠ Nice-to-have, opcional |
+| **`ref` como prop normal** | Sin `forwardRef`, ref es prop como cualquier otra | ✅ todos los componentes nuevos |
+| **Document Metadata nativo** | `<title>`/`<meta>` en componentes se hoist al `<head>` | ✅ para metadata dynamic per page |
+| **Asset loading APIs** (`preload`, `preinit`) | Pre-cargar fonts / scripts | ✅ para fonts self-hosted opcional |
+| **`onCaughtError` / `onUncaughtError` en `createRoot`** | Error handling centralizado | ✅ para Sentry / error logging |
+| **`useId` con prefix custom** | IDs estables para SSR (no aplica) | ⚠ no critico en SPA |
+| **Server Components / Server Actions** | NO aplican en `output: 'export'` (no hay server runtime) | ❌ |
+| **Cache Components (`'use cache'`)** | Server-only | ❌ |
 
 ## Cuando leer cada capitulo del knowledge tree
 
 | Tema | Archivo | Cuando |
 |------|---------|--------|
 | Decisiones globales + diagramas | `.claude/docs/dashboard/README.md` | Primera lectura, decisiones no-reabribles, navegacion |
-| Next.js 16 + React 18 + TypeScript + Biome | `.claude/docs/dashboard/01-stack.md` | Antes de tocar config (next.config.ts, tsconfig, biome.json) o agregar dep |
+| Next.js 16.2.6 + React 19.2.6 + TypeScript + Biome + Tailwind v4 | `.claude/docs/dashboard/01-stack.md` | Antes de tocar config (`next.config.ts`, `tsconfig`, `biome.json`) o agregar dep |
 | Estructura Hybrid Atomic Design | `.claude/docs/dashboard/02-structure.md` | Antes de crear/mover un componente, decidir donde vive |
-| shadcn/ui + Tailwind v4 + theming | `.claude/docs/dashboard/03-ui.md` | Antes de agregar componente shadcn, modificar tema, crear variants CVA |
-| Auth JWT + Tanstack Query + Zustand | `.claude/docs/dashboard/04-auth.md` | Antes de tocar fetch wrapper, refresh rotation, magic link callback, protected routes |
+| shadcn/ui + Tailwind v4 + theming + React 19 patterns (`useActionState`, `useFormStatus`, `useOptimistic`) | `.claude/docs/dashboard/03-ui.md` | Antes de agregar componente shadcn, modificar tema, crear variants CVA, decidir form pattern |
+| Auth JWT + Tanstack Query + Zustand + React 19 | `.claude/docs/dashboard/04-auth.md` | Antes de tocar fetch wrapper, refresh rotation, magic link callback, protected routes |
 | Cloudflare Pages deploy + env vars | `.claude/docs/dashboard/05-deploy.md` | Antes de cambiar deploy-apps.yml, devtools/cloudflare_setup, env vars del dashboard |
-| Testing (Vitest + MSW + Playwright) | `.claude/docs/dashboard/06-testing.md` | Antes de escribir un test, configurar MSW handlers, setup de fixtures |
+| Testing (Vitest 2 + Testing Library v16 + MSW v2 + Playwright) | `.claude/docs/dashboard/06-testing.md` | Antes de escribir un test, configurar MSW handlers, setup de fixtures |
 
 ## Reglas duras del dashboard (SIEMPRE / NUNCA)
 
 - **SIEMPRE** usar Client Components (`'use client'` en cada page/layout). El export mode NO soporta async Server Components.
 - **SIEMPRE** todas las API calls van a `process.env.NEXT_PUBLIC_API_ENDPOINT`. NUNCA hardcodear hostnames.
-- **SIEMPRE** el access JWT vive en memoria (Zustand store sin `persist` del campo `accessToken`). El refresh va en HttpOnly cookie (preferido) o en `localStorage` con CSP estricta (fallback explicito).
+- **SIEMPRE** access + refresh + user persisten en `localStorage` via Zustand `persist`. El dashboard es SPA cross-origin (admin → api): HttpOnly cookies cross-site requieren `SameSite=None` + `Domain=.the-full-stack.com`, abriendo vectores CSRF en los 6 niches y rompiendo portabilidad. Defensa primaria: CSP estricta `script-src 'self'` sin `unsafe-inline`/`unsafe-eval` + SRI en third-party + access TTL 15min + refresh rotation con family_id reuse detection.
 - **SIEMPRE** el fetch wrapper usa el mutex de refresh: un solo `/session/refresh` in-flight, los demas requests esperan el resultado.
 - **SIEMPRE** rate-limit del client: si 429 → mostrar toast con `retry_after`, no reintentar automaticamente.
 - **SIEMPRE** Turnstile en register.start y login.start (mismo sitekey que las 6 apps, hostname `admin.portfolio.*` se agrega a la lista en Cloudflare).
 - **SIEMPRE** un componente vive en `src/features/<X>/components/` SI tiene logica de dominio. Solo se promueve a `src/components/ui/` cuando 2+ features lo usan y no depende de un API especifico.
-- **SIEMPRE** Biome `components/ui/*.tsx` esta exento de reglas strict (los patterns de shadcn con `any` para Slot composition chocan).
-- **SIEMPRE** tests unitarios espejan `src/<X>` -> `tests/unit/<X>.test.ts` (mismo patron que las apps Astro).
-- **SIEMPRE** Conventional Commits espanol (sigue rule git-workflow).
+- **SIEMPRE** componentes nuevos reciben `ref` como prop normal — **NUNCA** `forwardRef`. shadcn ya migrado.
+- **SIEMPRE** Biome `components/ui/*.tsx` esta exento de reglas strict (los patterns de shadcn chocan).
+- **SIEMPRE** tests unitarios espejan `src/<X>` -> `tests/unit/<X>.test.ts`.
+- **SIEMPRE** Conventional Commits espanol.
+- **SIEMPRE** React Compiler habilitado (`reactCompiler: true` en `next.config.ts`). Opt-out per file con `'use no memo'` solo si rompe algo medido.
+- **SIEMPRE** asegurar Rules of React (pure components, no mutar props/state, side effects en useEffect, hooks unconditional) — el Compiler las enforces.
+- **SIEMPRE** elegir UNO entre `useOptimistic` o Tanstack `onMutate` por mutation — NO mezclar.
+- **SIEMPRE** forms de auth (login/register/verify) usan **react-hook-form + Zod + shadcn `<Form>` + Tanstack `useMutation`**. NO `useActionState` solo (forms complejos con multi-step).
+- **SIEMPRE** `useSuspenseQuery` cuando la data es required para renderizar la page (Error Boundary cubre fails). `useQuery` cuando la data es opcional o inline.
+- **SIEMPRE** `useSearchParams()` dentro de `<Suspense>` boundary (limitacion del export mode).
 - **NUNCA** API routes (`app/api/*/route.ts`) — `output: 'export'` no las soporta. Todo backend = Lambdas externas.
 - **NUNCA** `middleware.ts` ni `proxy.ts` — no corren en export mode. Auth guard es Client Component.
-- **NUNCA** `<Image>` con optimizacion. Usar `images.unoptimized: true` en `next.config.ts` o `<img>` regular.
+- **NUNCA** `<Image>` con optimizacion. Usar `images.unoptimized: true` en `next.config.ts`.
 - **NUNCA** Server Components con `async fetch`. Cliente all the way.
+- **NUNCA** `'use cache'` directive — server-only.
+- **NUNCA** Server Actions — server-only.
 - **NUNCA** tokens JWT en URL query params (`?access=...`). Magic link callback usa fragment hash (`#access=...`).
-- **NUNCA** persistir el `accessToken` en localStorage. Solo refreshToken (si fallback) o nada (si HttpOnly cookie).
+- **NUNCA** intentar setear HttpOnly cookies cross-origin (`SameSite=None; Domain=.the-full-stack.com`): vector CSRF + perdida de portabilidad. Tokens en localStorage con CSP estricta.
+- **NUNCA** cargar scripts third-party sin `integrity` (SRI). Allowlist actual: `challenges.cloudflare.com/turnstile/v0/api.js`.
 - **NUNCA** logear el JWT, refresh token, magic link token, email completo. Solo hash truncado para diagnostico.
 - **NUNCA** crear "atom wrappers" sin valor (ej. `<PrimaryButton>` que solo wrappea `<Button variant="primary">`).
-- **NUNCA** Framer Motion en el dashboard. Tailwind animate + `@starting-style` + Radix transitions built-in cubren 100%.
-- **NUNCA** atribucion de IA en codigo, commits, PRs (sigue rule global del repo).
+- **NUNCA** Framer Motion en el dashboard. Tailwind animate + `@starting-style` + Radix transitions built-in + View Transitions API cubren 100%.
+- **NUNCA** atribucion de IA en codigo, commits, PRs.
+- **NUNCA** `forwardRef` en componentes nuevos — usar `ref` como prop.
 
 ## Comando canonico (development)
 
@@ -123,53 +215,66 @@ portfolio. Si el subtopic no encaja, leer el indice completo.
 # Instalar deps (desde root, pnpm workspace lo recoge)
 pnpm install
 
-# Dev server (HMR via Turbopack)
+# Dev server (Turbopack, HMR snappy)
 pnpm --filter @portfolio/dashboard dev
 # -> http://localhost:3000
 
-# Build estatico
+# Dev con MSW activado (mientras backend no esta vivo)
+NEXT_PUBLIC_USE_MSW=true pnpm --filter @portfolio/dashboard dev
+
+# Build estatico (Turbopack)
 pnpm --filter @portfolio/dashboard build
 # -> dashboard/out/
 
 # Preview del build
 pnpm --filter @portfolio/dashboard preview
-# (next start sirve dashboard/out/ como static)
 
-# Lint + format
+# Lint + format (Biome v2, sin ESLint)
 pnpm --filter @portfolio/dashboard lint
 pnpm --filter @portfolio/dashboard lint:fix
 
 # Typecheck
 pnpm --filter @portfolio/dashboard typecheck
 
-# Unit tests
+# Unit tests (Vitest 2 + happy-dom)
 pnpm --filter @portfolio/dashboard test
-pnpm --filter @portfolio/dashboard test:coverage
+pnpm --filter @portfolio/dashboard test:coverage  # >= 80% per-file
 
-# Agregar componente shadcn
-cd dashboard && pnpm dlx shadcn@latest add button form input select
+# Agregar componente shadcn (sin forwardRef, ya con React 19)
+cd dashboard && pnpm dlx shadcn@latest add button form input select chart
+
+# E2E Playwright (stack local arriba)
+python devtools/run.py docker up --env=local
+python devtools/run.py test_runner --module=feature --type=feature --env=local
 
 # Deploy
 git push origin dev   # CI auto-deploya admin.portfolio.dev.the-full-stack.com
 ```
 
-## Anti-patrones
+## Anti-patrones (resumen)
 
 | Anti-patron | Por que | Correccion |
 |-------------|---------|------------|
 | Usar `app/api/*/route.ts` | Static export no las soporta | Llamar al Lambda externo via `NEXT_PUBLIC_API_ENDPOINT` |
-| `middleware.ts` para auth | No corre en SPA estatica | `AuthGuard` Client Component en `(dashboard)/layout.tsx` |
-| Persistir accessToken en localStorage | XSS = token robado por 15 min completos | Zustand sin persist + refresh en HttpOnly cookie |
-| 2 refresh requests simultaneos | Race condition, backend revoca familia por reuse | Mutex pattern en fetch wrapper |
+| `middleware.ts` o `proxy.ts` para auth | No corre en SPA estatica | `AuthGuard` Client Component en `(dashboard)/layout.tsx` |
+| `forwardRef` en componentes nuevos | Deprecado en React 19 | `ref` como prop normal |
+| Mezclar `useState` para isPending con `useActionState` | Conflicto de state | Elegir uno; `useActionState` ya incluye `isPending` |
+| Mezclar `useOptimistic` con Tanstack `onMutate` | Dos sources of truth | Elegir uno por mutation |
+| Intentar HttpOnly cookies cross-origin del API al dashboard | Requiere `SameSite=None` + `Domain=.the-full-stack.com` (vector CSRF) | Tokens en localStorage con CSP estricta + SRI + access TTL 15min |
+| Cargar third-party JS sin SRI | Script comprometido lee localStorage | `integrity="sha384-..."` + CSP allowlist |
+| 2 refresh requests simultaneos | Backend revoca familia por reuse | Mutex pattern en fetch wrapper |
 | Magic link con tokens en query (`?access=X`) | Tokens en Referer + browser history | Backend redirect 302 a `/auth/callback#access=X&refresh=Y` (fragment) |
-| Crear `<PrimaryButton>` que wrappea `<Button variant="primary">` | Sin valor, fragmenta | Usar `<Button variant="primary">` directo |
+| `useSearchParams()` sin `<Suspense>` | Build fail en export mode | Wrappear en `<Suspense>` |
 | Mover componente a `components/ui/` con 1 sola feature usandolo | Premature abstraction | Vive en `features/<X>/components/` hasta que 2+ features lo usen |
 | Hardcodear colores Recharts | Rompe dark mode | Usar `var(--color-*)` tokens del DS |
-| Framer Motion / GSAP | 30KB+ overhead, no necesario | Tailwind animate + `@starting-style` |
-| `useEffect(() => fetch(...))` sin Tanstack Query | Sin cache, sin retry, sin invalidation | Tanstack Query `useQuery` |
-| Mockear `useAuthStore` en tests | Acopla test a impl | Usar `useAuthStore.setState()` para preparar el estado |
-| Olvidar `'use client'` en page con hooks | Build error (Server Component con useState) | Primera linea: `'use client'` |
+| Framer Motion / GSAP / Motion One | 30KB+ overhead | Tailwind animate + `@starting-style` + Radix + View Transitions |
+| `useEffect(() => fetch(...))` sin Tanstack Query | Sin cache, sin retry, sin invalidation | Tanstack Query `useSuspenseQuery` o `useQuery` |
+| Mockear `useAuthStore` con `vi.mock` | Acopla test a impl | Usar `useAuthStore.setState()` para preparar el estado |
+| Olvidar `'use client'` en page con hooks de React 19 | Build error | Primera linea: `'use client'` |
 | Atribucion IA en commits | Politica empresa | Sin co-authored, sin "generated with Claude" |
+| Mutar props/state en componentes | Compiler no optimiza + bugs concurrent | Usar spread, `Object.assign`, etc. |
+| Hooks en conditionals/loops | Rules of Hooks violation | Hooks top-level siempre |
+| Usar `useFormState` (deprecado) | Movido a `useActionState` en react (no react-dom) | `import {useActionState} from 'react'` |
 
 ## Bibliografia interna
 
@@ -184,12 +289,15 @@ git push origin dev   # CI auto-deploya admin.portfolio.dev.the-full-stack.com
 
 ## Research raw (efimero, en `tmp/research/dashboard/`)
 
-Los 5 archivos de research que generaron este knowledge tree:
-1. `tmp/research/dashboard/01-nextjs-16-spa.md` (1743 lineas)
-2. `tmp/research/dashboard/02-react-patterns.md` (1579 lineas)
-3. `tmp/research/dashboard/03-shadcn-atomic-design.md` (1943 lineas)
-4. `tmp/research/dashboard/04-jwt-auth-spa.md` (1533 lineas)
+8 archivos de research que generaron este knowledge tree:
+1. `tmp/research/dashboard/01-nextjs-16-spa.md` (1,743 lineas)
+2. `tmp/research/dashboard/02-react-patterns.md` (1,579 lineas)
+3. `tmp/research/dashboard/03-shadcn-atomic-design.md` (1,943 lineas)
+4. `tmp/research/dashboard/04-jwt-auth-spa.md` (1,533 lineas)
 5. `tmp/research/dashboard/05-cloudflare-deploy.md` (985 lineas)
+6. `tmp/research/dashboard/06-react-19.md` (1,368 lineas) — **React 19.2.6 deep dive**
+7. `tmp/research/dashboard/07-nextjs-16.md` (1,433 lineas) — **Next.js 16.2.6 deep dive**
+8. `tmp/research/dashboard/08-integrations.md` (1,418 lineas) — **Ecosystem 2026 integration**
 
-Total: 7783 lineas de research consolidado (mayo 2026). Se eliminan
+Total: 12,002 lineas de research consolidado (mayo 2026). Se eliminan
 con `rm -rf tmp/research/` cuando el plan se mergea.

--- a/.claude/skills/dashboard-stack/SKILL.md
+++ b/.claude/skills/dashboard-stack/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: dashboard-stack
+description: >
+  Dashboard SPA stack reference for the portfolio admin dashboard
+  (`admin.portfolio.{dev|stage|prod}.the-full-stack.com`). Covers
+  Next.js 16 static export (`output: 'export'`), React 18, TypeScript 6
+  strict, Biome v2 (no ESLint), Tailwind v4, shadcn/ui (Radix
+  primitives), Tanstack Query v5 + Tanstack Table v8 + Tanstack
+  Virtual, react-hook-form + Zod, Zustand (auth + theme), Recharts,
+  sonner, lucide-react, MSW for mocks, Vitest + Testing Library, the
+  Hybrid Atomic Design folder layout (`src/components/ui/` shared +
+  `src/features/<X>/` per domain), JWT auth integration with the
+  Lambda `auth` of plans 01/02 (access in-memory Zustand + refresh in
+  HttpOnly cookie OR fragment-based magic-link callback + mutex
+  refresh rotation + BroadcastChannel multi-tab logout sync),
+  Cloudflare Pages deploy via the same `devtools/cloudflare_setup` +
+  `deploy-apps.yml` pipeline as the 6 Astro apps (4th env: `admin`
+  becomes the 7th project per env, total 21 projects = 7 apps x 3
+  envs), per-env env vars with `NEXT_PUBLIC_*` prefix synced via
+  `sync_secrets --category=client`. ALWAYS invoke this skill BEFORE
+  answering ANY question about the dashboard, including questions
+  framed as "next.js spa", "static export", "shadcn dashboard",
+  "tanstack query auth", "atomic design react", "jwt en react",
+  "dashboard auth", "cloudflare pages nextjs", or "admin portfolio".
+  NEVER answer dashboard questions from training data alone — this
+  project has consolidated 2026 patterns (mutex refresh rotation,
+  fragment magic-link callback, hybrid Atomic Design, shadcn + Tailwind
+  v4 + Biome override, Next.js 16 SPA quirks, custom devtools
+  integration) that override generic advice.
+  Use when the user says "dashboard", "admin dashboard", "next 16",
+  "nextjs 16", "next.js 16", "spa", "static export", "output export",
+  "react 18 dashboard", "shadcn ui dashboard", "tanstack query",
+  "tanstack table", "zustand auth", "jwt refresh rotation", "jwt
+  storage spa", "magic link react", "refresh token mutex", "atomic
+  design react", "atomic design hibrido", "feature sliced",
+  "components ui features", "cloudflare pages nextjs", "admin
+  subdomain", "admin.portfolio", "dashboard analytics", "biome
+  nextjs", "tailwind v4 shadcn", "next themes", "broadcastchannel
+  logout", "dashboard auth", "dashboard estructura", "estructura
+  dashboard", "componentes dashboard", "dashboard plan",
+  "dashboard skill".
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "optional subtopic: stack, structure, auth, ui, deploy, testing, mocks"
+---
+
+# Dashboard stack — admin.portfolio.the-full-stack.com
+
+Reference completa para construir y mantener el dashboard admin del
+portfolio. Si el subtopic no encaja, leer el indice completo.
+
+## Resumen ejecutivo (decisiones cerradas)
+
+| Tema | Decision | Razon |
+|------|----------|-------|
+| Framework | Next.js 16 con `output: 'export'` | Monorepo consistency + ecosystem; usuario lo eligio |
+| Runtime React | React 18.3.x (NO React 19) | `use()`, Server Actions hooks no aplican a SPA; libs (Tanstack) mas maduras en 18 |
+| Routing | App Router (NO Pages Router) | Default 2026; layouts anidados; todo Client Components |
+| TypeScript | 6.x strict + `noUncheckedIndexedAccess` | Heredar politica del monorepo |
+| Linter/Formatter | Biome v2 (sin ESLint) | Heredar `biome.json` root con override para `components/ui/*.tsx` |
+| CSS | Tailwind v4 con `@theme` inline en CSS | v4 official desde feb 2025; shadcn lo soporta |
+| Componentes UI | shadcn/ui + Radix primitives | Copy-paste, no library; full control |
+| Iconos | lucide-react | 1500+ icons, tree-shakable, default de shadcn |
+| Charts | Recharts via `shadcn add chart` | Integration nativa de shadcn |
+| Tablas | Tanstack Table v8 + Tanstack Virtual | Estandar 2026; virtualizacion para listas grandes |
+| Data fetching | Tanstack Query v5 | Persister + mutex para refresh rotation |
+| Forms | react-hook-form + `@hookform/resolvers/zod` + Zod | shadcn `Form` component lo integra mejor que Tanstack Form |
+| State global | Zustand 5.x con `persist` middleware | auth (access in-memory, refresh persist) + theme |
+| Theme dark/light | next-themes con `attribute="data-theme"` | Evita hydration mismatch |
+| Toasts | sonner | Accesible, 9.1KB, tree-shakable |
+| Tests unit | Vitest + Testing Library + happy-dom | Reusa stack del monorepo |
+| Tests E2E | Playwright (suite del monorepo) | Mismo runner que las apps Astro |
+| Mocks API | MSW (Mock Service Worker) | Para dev (sin backend live) + tests |
+| Estructura | **Hibrido**: `src/components/ui/` + `src/features/<X>/` | Atomic Design sin nombres rigidos |
+| Carpeta | `dashboard/` en root del repo | Usuario lo pidio explicito; entra a pnpm workspace |
+| Subdominio | `admin.portfolio.{env}.the-full-stack.com` | Sigue subdomain-standard |
+| Deploy | Cloudflare Pages (REST API via `devtools/cloudflare_setup`) | Mismo pipeline que las 6 apps Astro |
+| Envs CI | dev/stage/prod (3 Cloudflare Pages projects) | Branch `dev`/`stage`/`main` mapping |
+| Auth backend | Lambda `auth` planes 01-02 (aun pending) | Dashboard usa MSW hasta que esten deployadas |
+| Auth storage | Access JWT in-memory (Zustand) + refresh HttpOnly cookie (preferido) o localStorage+CSP (fallback) | OWASP JWT Cheat Sheet + RFC 9700 Jan 2025 |
+| Refresh rotation | Mutex pattern (1 sola refresh in-flight) + family_id detection | Backend ya lo implementa; client previene race conditions |
+| Magic link UX | Backend redirect 302 a `/auth/callback#access=X&refresh=Y` (fragment) | Tokens NO viajan a server logs ni Referer |
+| Multi-tab logout | BroadcastChannel API | Logout en una tab = logout en todas |
+
+## Cuando leer cada capitulo del knowledge tree
+
+| Tema | Archivo | Cuando |
+|------|---------|--------|
+| Decisiones globales + diagramas | `.claude/docs/dashboard/README.md` | Primera lectura, decisiones no-reabribles, navegacion |
+| Next.js 16 + React 18 + TypeScript + Biome | `.claude/docs/dashboard/01-stack.md` | Antes de tocar config (next.config.ts, tsconfig, biome.json) o agregar dep |
+| Estructura Hybrid Atomic Design | `.claude/docs/dashboard/02-structure.md` | Antes de crear/mover un componente, decidir donde vive |
+| shadcn/ui + Tailwind v4 + theming | `.claude/docs/dashboard/03-ui.md` | Antes de agregar componente shadcn, modificar tema, crear variants CVA |
+| Auth JWT + Tanstack Query + Zustand | `.claude/docs/dashboard/04-auth.md` | Antes de tocar fetch wrapper, refresh rotation, magic link callback, protected routes |
+| Cloudflare Pages deploy + env vars | `.claude/docs/dashboard/05-deploy.md` | Antes de cambiar deploy-apps.yml, devtools/cloudflare_setup, env vars del dashboard |
+| Testing (Vitest + MSW + Playwright) | `.claude/docs/dashboard/06-testing.md` | Antes de escribir un test, configurar MSW handlers, setup de fixtures |
+
+## Reglas duras del dashboard (SIEMPRE / NUNCA)
+
+- **SIEMPRE** usar Client Components (`'use client'` en cada page/layout). El export mode NO soporta async Server Components.
+- **SIEMPRE** todas las API calls van a `process.env.NEXT_PUBLIC_API_ENDPOINT`. NUNCA hardcodear hostnames.
+- **SIEMPRE** el access JWT vive en memoria (Zustand store sin `persist` del campo `accessToken`). El refresh va en HttpOnly cookie (preferido) o en `localStorage` con CSP estricta (fallback explicito).
+- **SIEMPRE** el fetch wrapper usa el mutex de refresh: un solo `/session/refresh` in-flight, los demas requests esperan el resultado.
+- **SIEMPRE** rate-limit del client: si 429 → mostrar toast con `retry_after`, no reintentar automaticamente.
+- **SIEMPRE** Turnstile en register.start y login.start (mismo sitekey que las 6 apps, hostname `admin.portfolio.*` se agrega a la lista en Cloudflare).
+- **SIEMPRE** un componente vive en `src/features/<X>/components/` SI tiene logica de dominio. Solo se promueve a `src/components/ui/` cuando 2+ features lo usan y no depende de un API especifico.
+- **SIEMPRE** Biome `components/ui/*.tsx` esta exento de reglas strict (los patterns de shadcn con `any` para Slot composition chocan).
+- **SIEMPRE** tests unitarios espejan `src/<X>` -> `tests/unit/<X>.test.ts` (mismo patron que las apps Astro).
+- **SIEMPRE** Conventional Commits espanol (sigue rule git-workflow).
+- **NUNCA** API routes (`app/api/*/route.ts`) — `output: 'export'` no las soporta. Todo backend = Lambdas externas.
+- **NUNCA** `middleware.ts` ni `proxy.ts` — no corren en export mode. Auth guard es Client Component.
+- **NUNCA** `<Image>` con optimizacion. Usar `images.unoptimized: true` en `next.config.ts` o `<img>` regular.
+- **NUNCA** Server Components con `async fetch`. Cliente all the way.
+- **NUNCA** tokens JWT en URL query params (`?access=...`). Magic link callback usa fragment hash (`#access=...`).
+- **NUNCA** persistir el `accessToken` en localStorage. Solo refreshToken (si fallback) o nada (si HttpOnly cookie).
+- **NUNCA** logear el JWT, refresh token, magic link token, email completo. Solo hash truncado para diagnostico.
+- **NUNCA** crear "atom wrappers" sin valor (ej. `<PrimaryButton>` que solo wrappea `<Button variant="primary">`).
+- **NUNCA** Framer Motion en el dashboard. Tailwind animate + `@starting-style` + Radix transitions built-in cubren 100%.
+- **NUNCA** atribucion de IA en codigo, commits, PRs (sigue rule global del repo).
+
+## Comando canonico (development)
+
+```bash
+# Instalar deps (desde root, pnpm workspace lo recoge)
+pnpm install
+
+# Dev server (HMR via Turbopack)
+pnpm --filter @portfolio/dashboard dev
+# -> http://localhost:3000
+
+# Build estatico
+pnpm --filter @portfolio/dashboard build
+# -> dashboard/out/
+
+# Preview del build
+pnpm --filter @portfolio/dashboard preview
+# (next start sirve dashboard/out/ como static)
+
+# Lint + format
+pnpm --filter @portfolio/dashboard lint
+pnpm --filter @portfolio/dashboard lint:fix
+
+# Typecheck
+pnpm --filter @portfolio/dashboard typecheck
+
+# Unit tests
+pnpm --filter @portfolio/dashboard test
+pnpm --filter @portfolio/dashboard test:coverage
+
+# Agregar componente shadcn
+cd dashboard && pnpm dlx shadcn@latest add button form input select
+
+# Deploy
+git push origin dev   # CI auto-deploya admin.portfolio.dev.the-full-stack.com
+```
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Usar `app/api/*/route.ts` | Static export no las soporta | Llamar al Lambda externo via `NEXT_PUBLIC_API_ENDPOINT` |
+| `middleware.ts` para auth | No corre en SPA estatica | `AuthGuard` Client Component en `(dashboard)/layout.tsx` |
+| Persistir accessToken en localStorage | XSS = token robado por 15 min completos | Zustand sin persist + refresh en HttpOnly cookie |
+| 2 refresh requests simultaneos | Race condition, backend revoca familia por reuse | Mutex pattern en fetch wrapper |
+| Magic link con tokens en query (`?access=X`) | Tokens en Referer + browser history | Backend redirect 302 a `/auth/callback#access=X&refresh=Y` (fragment) |
+| Crear `<PrimaryButton>` que wrappea `<Button variant="primary">` | Sin valor, fragmenta | Usar `<Button variant="primary">` directo |
+| Mover componente a `components/ui/` con 1 sola feature usandolo | Premature abstraction | Vive en `features/<X>/components/` hasta que 2+ features lo usen |
+| Hardcodear colores Recharts | Rompe dark mode | Usar `var(--color-*)` tokens del DS |
+| Framer Motion / GSAP | 30KB+ overhead, no necesario | Tailwind animate + `@starting-style` |
+| `useEffect(() => fetch(...))` sin Tanstack Query | Sin cache, sin retry, sin invalidation | Tanstack Query `useQuery` |
+| Mockear `useAuthStore` en tests | Acopla test a impl | Usar `useAuthStore.setState()` para preparar el estado |
+| Olvidar `'use client'` en page con hooks | Build error (Server Component con useState) | Primera linea: `'use client'` |
+| Atribucion IA en commits | Politica empresa | Sin co-authored, sin "generated with Claude" |
+
+## Bibliografia interna
+
+- `.claude/rules/dashboard.md` — reglas duras (este resumen extendido)
+- `.claude/docs/dashboard/` — knowledge tree (7 capitulos)
+- `docs/specs/dashboard/` — plan de implementacion (efimero, se elimina al mergear)
+- `.claude/rules/lambda-controller.md` — formato del Lambda `auth` backend (referencia)
+- `.claude/rules/secrets-strategy.md` + `client-env-sync.md` — env vars categoria client
+- `.claude/rules/ci-cd-pipeline.md` — `deploy-apps.yml` workflow
+- `.claude/docs/cloudflare/` — Cloudflare Pages knowledge
+- `.claude/docs/subdomain-standard/` — patron de subdominios
+
+## Research raw (efimero, en `tmp/research/dashboard/`)
+
+Los 5 archivos de research que generaron este knowledge tree:
+1. `tmp/research/dashboard/01-nextjs-16-spa.md` (1743 lineas)
+2. `tmp/research/dashboard/02-react-patterns.md` (1579 lineas)
+3. `tmp/research/dashboard/03-shadcn-atomic-design.md` (1943 lineas)
+4. `tmp/research/dashboard/04-jwt-auth-spa.md` (1533 lineas)
+5. `tmp/research/dashboard/05-cloudflare-deploy.md` (985 lineas)
+
+Total: 7783 lineas de research consolidado (mayo 2026). Se eliminan
+con `rm -rf tmp/research/` cuando el plan se mergea.

--- a/.claude/skills/typescript-6/SKILL.md
+++ b/.claude/skills/typescript-6/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: typescript-6
+description: >
+  Reference for TypeScript 6.0 (GA march 23, 2026): breaking changes from 5.x,
+  new features (native node.js .ts support, isolatedDeclarations, module Preserve,
+  using/await using stable), strict mode obligatorio, module resolution defaults
+  (ESNext + bundler), tsconfig canonicos para Astro 6 / Next.js 16 / packages
+  compartidos del monorepo. Cubre verbatimModuleSyntax, noUncheckedIndexedAccess,
+  project references, codemod ts5to6, Biome v2.3 + Biotype type-aware linting.
+  Use when the user says "typescript 6", "ts 6", "tsconfig", "strict mode",
+  "module resolution", "moduleResolution bundler", "verbatimModuleSyntax",
+  "noUncheckedIndexedAccess", "isolatedDeclarations", "project references",
+  "ts 5 to 6 migration", "ts5to6 codemod", "upgrade typescript",
+  "typescript strict", "typescript performance", "import type",
+  "typescript 6", "typescript 6.0", "tipos typescript", "configurar typescript",
+  "actualizar typescript", "tsconfig estricto", "modo estricto", "tipos estrictos",
+  "migracion typescript", "actualizar tsc", "typescript monorepo",
+  "typescript breaking changes", "typescript pnpm workspace",
+  "typescript next.js 16", "typescript astro 6", "typescript dashboard",
+  "typescript portfolio".
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: Read, Glob, Grep, Bash, Edit, Write
+argument-hint: "(opcional) tema especifico: strict, modules, tsconfig, migration, performance"
+---
+
+# TypeScript 6 — Skill de referencia
+
+> TypeScript 6.0 GA (marzo 23, 2026) — ultima version JavaScript-based.
+> TypeScript 7.0 (late 2026) sera reescrita en Go (10x mas rapida) y
+> removera todos los deprecated flags. Preparar codigo en 6.0 hoy = upgrade
+> a 7.0 sin friccion.
+>
+> Esta skill consolida el research de mayo 2026: breaking changes 5.x->6.0,
+> features nuevos, tsconfig canonicos para los 3 contextos del repo (Astro 6,
+> Next.js 16 dashboard, packages compartidos), patrones obligatorios y
+> anti-patrones.
+
+## Cuando usar esta skill
+
+- Antes de tocar cualquier `tsconfig.json` o `tsconfig.base.json` del repo.
+- Al diagnosticar errores de TypeScript en CI o pre-push hooks.
+- Al planificar la migracion del repo de TS 5.x a 6.0.
+- Al elegir entre `module` + `moduleResolution` para un package nuevo.
+- Para revisar si un patron es idiomatico TS 6 o legacy TS 4/5.
+
+## Knowledge tree
+
+Detalle en `.claude/docs/typescript-6/`:
+
+| Tema | Archivo |
+|------|---------|
+| Indice + reglas criticas | [README](../../docs/typescript-6/README.md) |
+| Breaking changes 5.x -> 6.0 + codemod ts5to6 | [01-breaking-changes.md](../../docs/typescript-6/01-breaking-changes.md) |
+| Features nuevos (native node .ts, isolatedDeclarations, using/await using) | [02-features.md](../../docs/typescript-6/02-features.md) |
+| Strict mode + flags adicionales recomendados | [03-strict-mode.md](../../docs/typescript-6/03-strict-mode.md) |
+| tsconfig canonicos por contexto (Astro / Next / package) | [04-tsconfig.md](../../docs/typescript-6/04-tsconfig.md) |
+
+Rule de enforcement: [.claude/rules/typescript.md](../../rules/typescript.md).
+
+## Resumen ejecutivo
+
+### Versions
+
+- TypeScript 6.0 GA: 23 marzo 2026 (ultima version JS-based)
+- Patches 6.0.x: marzo-mayo 2026
+- TypeScript 7.0 preview (Go port): finales de 2026
+
+### Breaking changes que MAS impactan al portfolio
+
+1. **`strict: true` ahora es default implicito** — codigo sin `strict` ve cientos de errores nuevos. Mitigacion: setear `"strict": false` TEMPORAL (deprecado en TS 7).
+2. **`types` array OBLIGATORIO** — sin `"types": [...]` no se cargan `@types/*` globales. Cold builds 20-50% mas rapidos como contrapartida.
+3. **`baseUrl` removed** — solo `paths` relativos. El codemod `ts5to6` lo resuelve auto.
+4. **`module` default**: `commonjs` -> `ESNext`. **`moduleResolution` default**: `node` -> `bundler`.
+5. **`target` minimo ES2015** (ES5 deprecated).
+6. **`esModuleInterop` y `allowSyntheticDefaultImports` siempre `true`** — no se pueden setear `false`.
+7. **`namespace Foo { }` reemplaza `module Foo { }`** (conflicto con propuesta ECMAScript de module blocks).
+
+### Features nuevos clave
+
+- **Native node.js `.ts` support** (Node 22.18+ / 23.6+): `node script.ts` sin compilar (type stripping).
+- **`isolatedDeclarations`**: genera `.d.ts` sin full type-check (10x mas rapido para Bun/swc/tsup).
+- **`module: "Preserve"`**: preserva imports exactos como fueron escritos.
+- **`using` y `await using` stable** (Symbol.dispose / asyncDispose): cleanup automatico al salir scope.
+- **Project references mejoradas**: `tsc -b` en paralelo, monorepos 22-package 11min -> 3min.
+
+### Performance (TS 5.9 -> 6.0)
+
+| Aspecto | Mejora |
+|---------|--------|
+| Cold build | -47% (15s -> 8s) |
+| Incremental rebuild | -40 a -60% |
+| Peak memory codebases grandes | -25% |
+| Language service latency | -30% (200ms -> 140ms) |
+
+## tsconfig canonicos para el portfolio
+
+### Base compartida (`tsconfig.base.json` en root)
+
+```jsonc
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true
+  },
+  "exclude": ["node_modules", "dist", "build", ".astro", ".next"]
+}
+```
+
+### App Astro 6 (`apps/<niche>/tsconfig.json`)
+
+```jsonc
+{
+  "extends": ["astro/tsconfigs/strict", "../../tsconfig.base.json"],
+  "compilerOptions": {
+    "paths": { "@/*": ["./src/*"] },
+    "types": ["astro/astro-jsx", "vitest/globals"]
+  }
+}
+```
+
+### Dashboard Next.js 16 (`dashboard/tsconfig.json`)
+
+```jsonc
+{
+  "extends": ["@tsconfig/next", "../tsconfig.base.json"],
+  "compilerOptions": {
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": { "@/*": ["./src/*"] },
+    "types": ["node", "react", "react-dom", "vitest/globals"]
+  },
+  "include": ["src/**/*", ".next/types/**/*"]
+}
+```
+
+### Package compartido (`packages/<X>/tsconfig.json`)
+
+```jsonc
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "incremental": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}
+```
+
+## Migracion 5.x -> 6.0 (receta corta)
+
+```bash
+# 1. Upgrade
+pnpm add -D -w typescript@^6.0.0
+
+# 2. Codemod (elimina baseUrl, ajusta paths, setea rootDir)
+pnpm dlx @andrewbranch/ts5to6 .
+
+# 3. Typecheck para ver errores nuevos
+pnpm exec tsc --noEmit
+pnpm exec astro check  # apps Astro
+
+# 4. Listar @types en tsconfig.types (antes auto-discovered)
+# 5. Arreglar strict errors (mayoria null checks)
+# 6. Verificar builds
+pnpm run build
+
+# 7. Tests
+pnpm exec vitest run --coverage
+```
+
+## Anti-patterns prohibidos en TS 6
+
+| Anti-pattern | Por que | Alternativa |
+|--------------|---------|------------|
+| `any` | Bypassa type safety | `unknown` + narrow |
+| `as Foo` casual | Bypassa type checker | `satisfies Foo` (preserva inference) |
+| Olvidar `import type` | `verbatimModuleSyntax: true` lo detecta | Biome `useImportType` |
+| `@types/X` sin listar en `types` | NO se carga en TS 6 | Listar en `tsconfig.types` |
+| `module: "CommonJS"` con `moduleResolution: "bundler"` | Invalido en TS 6 | `module: "ESNext"` |
+| `baseUrl` en tsconfig | Removed en TS 6 | Paths relativos |
+| `module Foo { }` | Reemplazado por `namespace` | `namespace Foo { }` |
+| Mutaciones en tipos React 19 | Incompatible React Compiler | Patrones inmutables |
+| `target: "ES5"` | Deprecated | `target: "ES2023"` minimo |
+| `ignoreDeprecations: "6.0"` permanente | NO funcionara en TS 7 | Arreglar deprecations ahora |
+
+## Ecosystem mayo 2026
+
+| Package | Version TS 6-ready |
+|---------|-------------------|
+| `@types/node` | 24.x |
+| `@types/react` | 19.x |
+| `astro` | 6.x |
+| `next` | 16.x |
+| `zod` | 4.x (`z.infer` stable) |
+| `vitest` | 3.x |
+| `biome` | 2.3+ (Biotype type-aware linting) |
+
+## Comandos canonicos
+
+```bash
+# Typecheck local
+pnpm exec tsc --noEmit
+pnpm exec astro check                # apps Astro
+pnpm --filter <app> typecheck        # via script
+
+# Build con incremental
+pnpm exec tsc -b                      # project references
+pnpm exec tsc -b --watch              # watch mode
+pnpm exec tsc -b --clean              # limpiar artifacts
+
+# Codemod (una sola vez por migracion)
+pnpm dlx @andrewbranch/ts5to6 .
+```
+
+## Referencias
+
+- [Microsoft DevBlogs - Announcing TypeScript 6.0](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/)
+- [Total TypeScript - tsconfig Cheat Sheet](https://www.totaltypescript.com/tsconfig-cheat-sheet)
+- [TypeScript Handbook - Modules](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html)
+- Research raw (efimero): `tmp/research/typescript-6.md` (992 lineas)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,7 @@ Antes de trabajar, identifica que contexto necesitas:
 |------|---------|-------------|
 | Reglas generales | [.claude/rules/general.md](.claude/rules/general.md) | Indice de reglas + estructura del repo |
 | Astro + Biome + TS | [.claude/rules/astro-landing.md](.claude/rules/astro-landing.md) | Antes de crear componente / página / utility |
+| TypeScript 6 (politica raiz) | [.claude/rules/typescript.md](.claude/rules/typescript.md) o skill `typescript-6` | Antes de tocar cualquier `.ts`/`.tsx`/`tsconfig.json`. **Solo TypeScript** en codigo de aplicacion (JavaScript nativo prohibido). **`any` PROHIBIDO** sin excepciones — usar `unknown` con narrow, `satisfies` o Zod `z.infer`. Strict + `noUncheckedIndexedAccess` + `verbatimModuleSyntax`. tsconfig canonicos para Astro 6 / Next 16 / packages. Codemod `ts5to6` para migracion 5.x→6.0 |
 | Design System | [.claude/rules/design-system.md](.claude/rules/design-system.md) | Tokens CSS, dark/light, tipografia, fonts |
 | YAML data loading | [.claude/rules/yaml-data-loading.md](.claude/rules/yaml-data-loading.md) | Antes de agregar/modificar entry del CV o tocar plugin yaml |
 | Docstrings | [.claude/rules/docstring-standard.md](.claude/rules/docstring-standard.md) | Antes de documentar cualquier unidad de codigo |

--- a/docs/specs/01-auth-infra-basics/01-contexto-y-decision.md
+++ b/docs/specs/01-auth-infra-basics/01-contexto-y-decision.md
@@ -67,15 +67,16 @@ Estado:
   - `portfolio-jwt-blacklist-${stage}`: PK `jti`, columnas
     `revoked_at`, `reason`, `user_id`, TTL `exp`. Cubre temp + access +
     refresh.
-  - `portfolio-auth-codes-${stage}`: PK `pk` (formato
-    `<kind>#<user_id>` p. ej. `register#01H...`), columnas
-    `code_hash`, `attempts`, `created_at`, TTL `expires_at`. Espejo
-    rapido del row de Neon para chequeo O(1) sin tocar Neon en cada
-    intento. (Se inserta en paralelo; la fuente de verdad es Neon.)
 
-> Nota: mantenemos los 2 stores (Neon + DynamoDB) deliberadamente. Neon
-> guarda la auditoria + multi-device + queries relacionales; DynamoDB
-> da lookup O(1) en cada request HTTP sin pagar latencia de Neon.
+> Nota: los codes (`auth_email_codes`) viven SOLO en Neon. Plan
+> original consideraba un espejo en DynamoDB para lookup O(1); se
+> descarto en revision: a escala portfolio (~10-50 logins/dia) la
+> latencia de Neon Pooler us-east-1 (~10-30ms) es invisible y mantener
+> consistencia entre 2 stores agrega complejidad (¿que pasa si Neon OK
+> + DDB falla?) que no compensa el ahorro. La unica tabla DynamoDB
+> del dominio auth es `jwt-blacklist` (que SI necesita O(1) por cada
+> request autenticada). Si en produccion la latencia molesta, se
+> agrega DDB en plan posterior con datos reales.
 
 - **JWT HS256** firmado con secret leido de SSM en cold start de cada
   Lambda. 3 tipos:
@@ -157,7 +158,14 @@ niches deben poder consumirlo desde cualquier subdominio.
   (a) crea row `auth_users` con status=`pending`,
   (b) genera magic-link + code de 8 chars,
   (c) publica 1 mensaje SQS para email magic-link + 1 para email code,
-  (d) devuelve `201 {temp_token, user_id, expires_in: 300}`.
+  (d) devuelve `200 {temp_token, user_id, expires_in: 300}`.
+
+  > Nota: el HTTP status es `200` (no `201`) — uniforme para todo el
+  > lambda `auth` via `http_handler(success_status=200)`. AC-1
+  > anteriormente decia `201`; se cambio a `200` para no requerir
+  > override per-action del handler. La semantica de "registro
+  > iniciado pero no completo" se expresa en el body (`temp_token`
+  > significa que falta verificar).
 
 - **AC-2**: Given `register.start` con email ya `active` y mismo Turnstile,
   When se procesa, Then devuelve `409 {error: 'EMAIL_ALREADY_REGISTERED'}`
@@ -227,3 +235,47 @@ niches deben poder consumirlo desde cualquier subdominio.
   un branch Neon de prueba, When se ejecuta `downgrade -1` y luego
   `upgrade head`, Then el schema vuelve al estado original y vuelve a
   crear las 5 tablas `auth_*` sin errores.
+
+- **AC-16**: Given un POST `verify-magic-link` con un token cuyo
+  `consumed_at IS NOT NULL` en Neon, Then devuelve `400 {error:
+  'LINK_CONSUMED'}` y NO emite JWTs.
+
+- **AC-17**: Given un POST `verify-magic-link` con un token cuyo
+  `expires_at < now()`, Then devuelve `400 {error: 'LINK_EXPIRED'}` y
+  NO emite JWTs.
+
+- **AC-18**: Given un POST `verify-code` con un `temp_token` JWT cuyo
+  `exp < now`, Then devuelve `401 {error: 'TEMP_TOKEN_EXPIRED'}` antes
+  de tocar Neon o DDB.
+
+- **AC-19**: Given un POST `register.start` con email cuyo
+  `auth_users.status = 'pending'` (registro previo no verificado),
+  When Turnstile es valido, Then re-emite un magic-link y code
+  nuevos (idempotencia), devuelve `200 {temp_token, user_id,
+  expires_in: 300}` con el mismo `user_id`. Los magic links + codes
+  anteriores que no esten consumidos se marcan como `consumed_at = now`
+  para invalidarlos.
+
+- **AC-20**: Given un POST `register.start` o `login.start` con
+  email cuyo `auth_users.status = 'disabled'` o `'locked'`, Then
+  devuelve `404 {error: 'EMAIL_NOT_FOUND', suggest_register: false}`
+  para no revelar el status (anti-enumeration). Audit log registra el
+  intento con `error_code='ACCOUNT_DISABLED'` o `'ACCOUNT_LOCKED'`.
+
+- **AC-21**: Given un POST `verify.resend-code` con menos de 60 segs
+  desde la ultima emision para ese user/kind, Then devuelve `429
+  {error: 'RESEND_THROTTLED', retry_after: <segs>}`.
+
+- **AC-22**: Given un POST `login.verify-magic-link` o `verify-code`
+  para un user `active`, Then ademas de emitir access+refresh
+  actualiza `auth_users.last_login_at = now()` y resetea
+  `failed_attempts = 0`.
+
+- **AC-23**: Given un POST `session.logout` con un access JWT cuyo
+  `jti` YA esta en la blacklist (logout idempotente), Then devuelve
+  `204` sin error (idempotencia).
+
+- **AC-24**: Given un controller que recibe `niche` fuera de la lista
+  cerrada `['generic', 'hub', 'fintech', 'architect', 'leader', 'vibe']`,
+  Then devuelve `400 ValidationError` antes de tocar la logica de
+  negocio (Pydantic Literal lo rechaza).

--- a/docs/specs/01-auth-infra-basics/01-contexto-y-decision.md
+++ b/docs/specs/01-auth-infra-basics/01-contexto-y-decision.md
@@ -1,0 +1,229 @@
+# 01. Contexto y decision
+
+## 1. Contexto / Problema
+
+El portfolio (the-full-stack.com) hoy no tiene ningun mecanismo de
+autenticacion. El backend serverless cubre 4 dominios (`cv`, `contact_form`,
+`tracking_pixel`, `db` migration runner) + 2 workers async, todos
+publicos y sin usuario. Para habilitar:
+
+- Pago / dashboard de admin / area privada
+- Comentarios moderados o reactions en proyectos
+- API endpoints para terceros con scope/token
+- Multi-device session management (futuro)
+
+…hace falta un sistema de autenticacion completo: registro, login con
+multiples mecanismos (magic link, codigo al email, contrasena, MFA,
+passkeys), gestion de sesion via JWT con blacklist real (logout
+invalida el token) y un dominio relacional de usuarios.
+
+Este es el **plan 1 de 3**. Entrega los flujos basicos
+(register/login/verify/logout) y la infraestructura comun (schema Neon,
+shared subpackage, DynamoDB para blacklist + codes, cola SQS + worker
+de email). El plan 2 agrega MFA (TOTP + email-code + WebAuthn). El
+plan 3 agrega el Lambda `users` con CRUD de perfil y status.
+
+### Hallazgos de exploracion
+
+- El repo ya tiene la infraestructura compartida lista para reusar:
+  `shared.lambda_kit.http_handler` (con `cors_origin='echo'|'public'`,
+  `success_status`, `metric_names`), `shared.http.verify_turnstile_token`,
+  `shared.aws.send_email` (SES v2 helper), `shared.aws.get_secret_by_name`
+  (SSM con cache + KMS decrypt), `shared.rate_limit.check_or_raise`,
+  `shared.cache.cached`, `shared.db` (SQLAlchemy + Alembic con
+  `run_migrate`/`run_downgrade`).
+- El patron de cola SQS + worker async ya esta probado:
+  `contact_form` publica a `portfolio-contact-form-${stage}`, el
+  `contact_worker` la consume y envia via SES. Repetimos para `auth`.
+- El schema Neon usa prefijos por dominio (`cv_`, `vis_`, `tax_`,
+  `i18n_`). Agregamos `auth_*` como dominio nuevo.
+- No hay deps de auth declaradas en ningun pyproject de shared: hay
+  que agregar `pyjwt` + `argon2-cffi` desde cero. Para mantener el
+  contrato "un paquete externo = un shared portador", creamos el nuevo
+  subpackage `shared.auth`.
+- El SSM tiene KMS key `alias/portfolio-lambdas` y patron de paths
+  `/portfolio/${stage}/<nombre>`. Sumamos `/portfolio/${stage}/jwt-secret`.
+- `cv_profiles.email` ya existe (varchar). Sera el unico row con
+  `auth_users.profile_id` no nulo, manual.
+
+## 2. Solucion Propuesta
+
+Lambda `auth` HTTP POST `/auth` con `http_handler` del repo: el cliente
+envia `{operation, action, data, _meta}`. 5 operations:
+`register`, `login`, `verify`, `session`, y un futuro `mfa`/`webauthn`
+(plan 2).
+
+Estado:
+
+- **Relacional en Neon** (`auth_*`): tabla `auth_users` (id, email
+  CITEXT UK, status enum, profile_id FK nullable a cv_profiles,
+  timestamps), `auth_credentials` (user_id PK, password_hash nullable,
+  password_set_at, last_password_change), `auth_email_codes` (id, user_id
+  FK, code_hash, kind enum, attempts, expires_at, consumed_at),
+  `auth_magic_links` (id, user_id FK, token_hash, kind enum, expires_at,
+  consumed_at), `auth_audit_log` (id, user_id FK NULL, event, ip,
+  user_agent, niche, success bool, error_code, created_at).
+- **DynamoDB con TTL**:
+  - `portfolio-jwt-blacklist-${stage}`: PK `jti`, columnas
+    `revoked_at`, `reason`, `user_id`, TTL `exp`. Cubre temp + access +
+    refresh.
+  - `portfolio-auth-codes-${stage}`: PK `pk` (formato
+    `<kind>#<user_id>` p. ej. `register#01H...`), columnas
+    `code_hash`, `attempts`, `created_at`, TTL `expires_at`. Espejo
+    rapido del row de Neon para chequeo O(1) sin tocar Neon en cada
+    intento. (Se inserta en paralelo; la fuente de verdad es Neon.)
+
+> Nota: mantenemos los 2 stores (Neon + DynamoDB) deliberadamente. Neon
+> guarda la auditoria + multi-device + queries relacionales; DynamoDB
+> da lookup O(1) en cada request HTTP sin pagar latencia de Neon.
+
+- **JWT HS256** firmado con secret leido de SSM en cold start de cada
+  Lambda. 3 tipos:
+  - `typ=temp` (TTL 5 min, rolling). Claim extra `flow`
+    (`register`|`login`|`set-password`|`set-mfa`) y `step` (numerico).
+    Cada API del flujo blacklistea el `jti` recibido y emite uno nuevo.
+  - `typ=access` (TTL 15 min). Stateless. Verificacion = signature +
+    `exp` + blacklist lookup (DynamoDB GetItem por `jti`).
+  - `typ=refresh` (TTL 30 dias). Rotacion en cada uso: usar un refresh
+    consume su row de blacklist y emite uno nuevo. El claim `family_id`
+    detecta reuso (si llega un refresh ya consumido, se revoca toda la
+    familia — token theft detection).
+
+- **Cola SQS** `portfolio-auth-email-${stage}` (visibility 180s, MRT
+  4 dias, redrive a DLQ con `max_receive_count: 3`). El Lambda `auth`
+  publica `{kind, to, subject_id, data}` y el worker
+  `auth_email_worker` lo consume, renderiza la plantilla y manda con
+  `send_email(...)`.
+
+### Decisiones clave
+
+**Decision 1: shared subpackage nuevo `shared.auth`** — los paquetes
+externos `pyjwt`, `argon2-cffi`, `secrets` (stdlib pero documentado)
+necesitan portador segun la regla `lambda-shared-imports`. Se podria
+poner en `shared.core`, pero `core` ya carga 2 paquetes externos
+(pydantic, pydantic-settings). Crear `shared.auth` mantiene un dominio
+por subpackage. Internal-deps de `shared.auth`: `core` (para
+`new_uuidv7`, `Settings`), `aws` (para `get_secret_by_name` del
+JWT_SECRET), `observability` (logger).
+
+**Decision 2: token de magic-link es opaco, NO JWT** — un magic-link
+es un secret de proposito unico, 32 bytes random b64url-encoded.
+Guarda hash (SHA-256) en Neon `auth_magic_links.token_hash`. Verifica
+con `secrets.compare_digest(hash(received_token), stored_hash)`. NO
+firmamos el token para evitar que un atacante con el JWT secret pueda
+generar magic-links arbitrarios.
+
+**Decision 3: codigo de 8 chars con alfabeto Crockford-like sin
+confundibles** — alfabeto `'ABCDEFGHJKMNPQRSTUVWXYZ23456789'` (sin
+`O/0/I/1/L`). 30 chars, 8 posiciones = `30^8 ~ 6.5x10^11` espacio. Con
+5 intentos max, prob. de adivinar < `5 / 6.5x10^11 < 10^-11`. Bajo
+rate-limit estricto (5 intentos / 15 min), brute force inviable.
+Generador: `secrets.choice(ALPHABET)` (CSPRNG, no `random.choice`).
+
+**Decision 4: rolling temp JWT con blacklist + emision nueva** — cada
+API del flujo: (1) valida temp JWT (signature + exp + NOT in blacklist),
+(2) ejecuta el step, (3) blacklistea el `jti` viejo en
+`jwt-blacklist` con TTL = exp original, (4) emite un temp JWT NUEVO
+con `now+5min` y lo devuelve en el body. Frontend sustituye en cada
+response. Si el user esta inactivo 5 min, el JWT expira por `exp`. Si
+intenta replay (reusar el viejo), falla por blacklist.
+
+**Decision 5: login.start con email no-existente devuelve 404 +
+sugerencia** — el usuario pidio explicitamente esta UX. Tradeoff
+aceptado: permite user enumeration. Mitigaciones: Turnstile
+obligatorio en `login.start`, rate-limit 5/min/IP, no se devuelve
+detalle del status del user (solo "no existe" o "existe + metodos").
+
+**Decision 6: response final del flujo (post-validacion exitosa)** —
+devuelve `{access_token, refresh_token, expires_in, token_type:
+'Bearer', user: {id, email, status}}`. Los tokens vienen en el body
+para que el frontend los persista (localStorage / IndexedDB). NO
+usamos cookies HttpOnly aqui — el portfolio es API-first y los 6
+niches deben poder consumirlo desde cualquier subdominio.
+
+**Decision 7: status del usuario** — enum
+`pending|active|disabled|locked|deleted`:
+- `pending`: registro iniciado pero magic-link/code aun no verificado.
+- `active`: validado y operativo.
+- `disabled`: deshabilitado por admin (plan 3).
+- `locked`: bloqueo automatico tras 10 fallos consecutivos en 5 min.
+- `deleted`: soft-delete (no aplica en plan 1, futuro plan 3).
+
+## 3. Criterios de Aceptacion (AC)
+
+- **AC-1**: Given un POST `/auth` con `{operation: 'register', action: 'start',
+  data: {email: 'nuevo@x.com', cf_turnstile_response: 'valid'}}`,
+  When el email no existe y Turnstile valida, Then el endpoint:
+  (a) crea row `auth_users` con status=`pending`,
+  (b) genera magic-link + code de 8 chars,
+  (c) publica 1 mensaje SQS para email magic-link + 1 para email code,
+  (d) devuelve `201 {temp_token, user_id, expires_in: 300}`.
+
+- **AC-2**: Given `register.start` con email ya `active` y mismo Turnstile,
+  When se procesa, Then devuelve `409 {error: 'EMAIL_ALREADY_REGISTERED'}`
+  y registra fila en `auth_audit_log` con event=`register.start.duplicate`.
+
+- **AC-3**: Given el magic-link recibido por email (URL
+  `/auth?operation=register&action=verify-magic-link&token=<X>`),
+  When el user lo clickea (GET), Then el endpoint:
+  (a) verifica `token_hash` en Neon,
+  (b) actualiza `auth_users.status='active'`,
+  (c) marca `auth_magic_links.consumed_at=now()`,
+  (d) emite access + refresh JWT,
+  (e) devuelve un HTML 200 con auto-redirect + `localStorage.setItem`
+    de los tokens y redirect al hub (`hub.portfolio.{env}.the-full-stack.com`).
+
+- **AC-4**: Given POST `register.verify-code` con `{code, temp_token}`,
+  When el code matchea (hash + not expired + attempts<5), Then mismo
+  resultado que magic-link verify pero como JSON `200 {access_token,
+  refresh_token, expires_in, user}`.
+
+- **AC-5**: Given POST `login.start` con email NO existente y Turnstile
+  valido, Then devuelve `404 {error: 'EMAIL_NOT_FOUND', suggest_register:
+  true}`.
+
+- **AC-6**: Given POST `login.start` con email `active` sin password ni
+  MFA configurados, Then devuelve `200 {temp_token, methods: ['magic-link',
+  'email-code'], expires_in: 300}` y envia magic-link + code.
+
+- **AC-7**: Given POST `session.refresh` con un refresh JWT valido,
+  Then: (a) blacklistea el refresh viejo, (b) emite access + refresh
+  nuevos, (c) devuelve `200 {access_token, refresh_token, expires_in}`.
+
+- **AC-8**: Given POST `session.refresh` con un refresh JWT ya
+  consumido (reuso detectado), Then: (a) revoca toda la familia
+  (`family_id` -> todos los refresh JWT activos), (b) devuelve
+  `401 {error: 'TOKEN_REUSE_DETECTED'}`, (c) registra evento
+  `session.refresh.reuse_detected` en audit log.
+
+- **AC-9**: Given POST `session.logout` con access JWT, Then: (a)
+  blacklistea ese `jti`, (b) blacklistea el refresh JWT
+  asociado (via `family_id`), (c) devuelve `204`.
+
+- **AC-10**: Given una request a cualquier endpoint del flujo con JWT
+  temp ya blacklisteado (rolling refresh detecta replay), Then devuelve
+  `401 {error: 'TOKEN_BLACKLISTED'}`.
+
+- **AC-11**: Given >5 intentos fallidos en `verify-code` (cualquier
+  variante) en 5 min para el mismo user, Then `auth_users.status='locked'`
+  y proximas requests devuelven `423 {error: 'ACCOUNT_LOCKED',
+  unlock_at: <ts+1h>}`.
+
+- **AC-12**: Given una request a `register.start` o `login.start` sin
+  `cf_turnstile_response` o con token invalido, Then devuelve
+  `403 {error: 'TURNSTILE_FAILED'}` ANTES de tocar Neon o SQS.
+
+- **AC-13**: Given el rate-limit excedido (ej. 6ta request a
+  `login.start` desde misma IP en 60s), Then devuelve `429 {error:
+  'RATE_LIMITED', retry_after: <segs>}`.
+
+- **AC-14**: Given el Lambda `auth_email_worker` recibe un mensaje
+  SQS con `{kind: 'register-magic-link', to: 'x@y.com', user_id,
+  token, niche}`, Then: (a) renderiza la plantilla, (b) llama
+  `send_email(from=ses_from_address, to=[to], subject=..., text=...,
+  html=...)`, (c) registra `auth_audit_log` event=`email.sent.magic-link`.
+
+- **AC-15**: Given la migration `00000002_auth_schema.py` aplicada en
+  un branch Neon de prueba, When se ejecuta `downgrade -1` y luego
+  `upgrade head`, Then el schema vuelve al estado original y vuelve a
+  crear las 5 tablas `auth_*` sin errores.

--- a/docs/specs/01-auth-infra-basics/02-schema-neon.md
+++ b/docs/specs/01-auth-infra-basics/02-schema-neon.md
@@ -1,0 +1,302 @@
+# 02. Schema Neon — dominio `auth_*`
+
+## ER ASCII (solo tablas nuevas + relacion a cv_profiles)
+
+```text
+cv_profiles                       auth_users
+─────────────                     ──────────────────
+ id  uuid PK                      id              uuid PK
+ email varchar                    email           citext UK (lowercased)
+ name  varchar                    status          auth_user_status
+                                  profile_id     uuid FK NULL --> cv_profiles.id
+                                  email_verified_at  timestamptz NULL
+                                  password_set_at    timestamptz NULL
+                                  locked_until       timestamptz NULL
+                                  last_login_at      timestamptz NULL
+                                  failed_attempts    int default 0
+                                  created_at         timestamptz
+                                  updated_at         timestamptz
+                                       |
+                                       | 1
+                ┌──────────────────────┼──────────────────────────┐
+                | 0..1                 | 0..*                     | 0..*
+                v                      v                          v
+       auth_credentials       auth_email_codes           auth_magic_links
+       ──────────────────     ────────────────────       ────────────────────
+        user_id  uuid PK,FK    id              uuid PK    id           uuid PK
+        password_hash  text    user_id         uuid FK    user_id      uuid FK
+        algo varchar           code_hash       bytea      token_hash   bytea
+        password_set_at  ts    kind            code_kind  kind         link_kind
+        last_change_at ts      attempts        int        consumed_at  ts NULL
+                               expires_at      timestamptz expires_at  timestamptz
+                               consumed_at     timestamptz created_at  ts
+                               created_at      timestamptz ip          inet NULL
+                                                          user_agent   text NULL
+
+                                       auth_audit_log
+                                       ──────────────────
+                                        id              uuid PK
+                                        user_id         uuid FK NULL
+                                        event           varchar (e.g. 'register.start')
+                                        success         boolean
+                                        error_code      varchar NULL
+                                        ip              inet NULL
+                                        user_agent      text NULL
+                                        niche           varchar NULL
+                                        metadata        jsonb NULL
+                                        created_at      timestamptz
+```
+
+## DDL conceptual (la migration la genera Alembic autogenerate; el dev revisa)
+
+```python
+# serverless/lambda/shared/db/alembic/versions/00000002_auth_schema.py
+"""auth_schema
+
+Revision ID: 00000002
+Revises: 00000001
+Create Date: 2026-05-27
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '00000002'
+down_revision = '00000001'
+
+def upgrade() -> None:
+    op.execute('CREATE EXTENSION IF NOT EXISTS citext')
+
+    # 1. Enums
+    auth_user_status = postgresql.ENUM(
+        'pending', 'active', 'disabled', 'locked', 'deleted',
+        name='auth_user_status',
+    )
+    auth_user_status.create(op.get_bind())
+
+    code_kind = postgresql.ENUM(
+        'register', 'login', 'password_reset',
+        name='auth_code_kind',
+    )
+    code_kind.create(op.get_bind())
+
+    link_kind = postgresql.ENUM(
+        'register', 'login', 'password_reset',
+        name='auth_link_kind',
+    )
+    link_kind.create(op.get_bind())
+
+    # 2. auth_users
+    op.create_table(
+        'auth_users',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('email', postgresql.CITEXT(), nullable=False, unique=True),
+        sa.Column('status', auth_user_status, nullable=False,
+                  server_default='pending'),
+        sa.Column('profile_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('email_verified_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('password_set_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('locked_until', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('last_login_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('failed_attempts', sa.Integer(), nullable=False,
+                  server_default='0'),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['profile_id'], ['cv_profiles.id'],
+                                ondelete='SET NULL'),
+    )
+    op.create_index('ix_auth_users_status', 'auth_users', ['status'])
+    op.create_index('ix_auth_users_profile_id', 'auth_users', ['profile_id'])
+
+    # 3. auth_credentials (1-to-0..1 con auth_users)
+    op.create_table(
+        'auth_credentials',
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('password_hash', sa.Text(), nullable=False),
+        sa.Column('algo', sa.String(32), nullable=False, server_default='argon2id'),
+        sa.Column('password_set_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.Column('last_change_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'],
+                                ondelete='CASCADE'),
+    )
+
+    # 4. auth_email_codes
+    op.create_table(
+        'auth_email_codes',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('code_hash', postgresql.BYTEA(), nullable=False),
+        sa.Column('kind', code_kind, nullable=False),
+        sa.Column('attempts', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('consumed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'],
+                                ondelete='CASCADE'),
+    )
+    op.create_index('ix_auth_email_codes_user_kind',
+                    'auth_email_codes', ['user_id', 'kind', 'consumed_at'])
+
+    # 5. auth_magic_links
+    op.create_table(
+        'auth_magic_links',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('token_hash', postgresql.BYTEA(), nullable=False, unique=True),
+        sa.Column('kind', link_kind, nullable=False),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('consumed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.Column('ip', postgresql.INET(), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'],
+                                ondelete='CASCADE'),
+    )
+
+    # 6. auth_audit_log (insert-only, retencion via partitioning futuro)
+    op.create_table(
+        'auth_audit_log',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('event', sa.String(64), nullable=False),
+        sa.Column('success', sa.Boolean(), nullable=False),
+        sa.Column('error_code', sa.String(64), nullable=True),
+        sa.Column('ip', postgresql.INET(), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.Column('niche', sa.String(32), nullable=True),
+        sa.Column('metadata', postgresql.JSONB(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+    )
+    op.create_index('ix_auth_audit_log_user_event_ts',
+                    'auth_audit_log', ['user_id', 'event', 'created_at'])
+
+def downgrade() -> None:
+    op.drop_table('auth_audit_log')
+    op.drop_table('auth_magic_links')
+    op.drop_table('auth_email_codes')
+    op.drop_table('auth_credentials')
+    op.drop_table('auth_users')
+    op.execute('DROP TYPE IF EXISTS auth_link_kind')
+    op.execute('DROP TYPE IF EXISTS auth_code_kind')
+    op.execute('DROP TYPE IF EXISTS auth_user_status')
+```
+
+## SQLAlchemy models (esqueleto, ubicacion `shared/db/models/auth/`)
+
+```text
+serverless/lambda/shared/db/models/auth/
+├── __init__.py        # re-exporta los 5 modelos + los 3 enums
+├── enums.py           # AuthUserStatus, AuthCodeKind, AuthLinkKind (Python enums)
+├── user.py            # AuthUser
+├── credentials.py     # AuthCredentials
+├── email_code.py      # AuthEmailCode
+├── magic_link.py      # AuthMagicLink
+└── audit_log.py       # AuthAuditLog
+```
+
+Patron de cada modelo:
+
+```python
+# serverless/lambda/shared/db/models/auth/user.py
+from datetime import datetime
+from uuid import UUID
+from sqlalchemy import CheckConstraint, ForeignKey, Index
+from sqlalchemy.dialects.postgresql import CITEXT, ENUM as PgEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from shared.db.base import Base, UUIDPKMixin, TimestampMixin
+from .enums import AuthUserStatus
+
+
+class AuthUser(UUIDPKMixin, TimestampMixin, Base):
+    __tablename__ = 'auth_users'
+
+    email: Mapped[str] = mapped_column(CITEXT(), unique=True, nullable=False)
+    status: Mapped[AuthUserStatus] = mapped_column(
+        PgEnum(AuthUserStatus, name='auth_user_status'),
+        nullable=False, default=AuthUserStatus.PENDING,
+    )
+    profile_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey('cv_profiles.id', ondelete='SET NULL'), nullable=True,
+    )
+    email_verified_at: Mapped[datetime | None]
+    password_set_at: Mapped[datetime | None]
+    locked_until: Mapped[datetime | None]
+    last_login_at: Mapped[datetime | None]
+    failed_attempts: Mapped[int] = mapped_column(default=0, nullable=False)
+
+    credentials: Mapped['AuthCredentials | None'] = relationship(
+        back_populates='user', uselist=False, cascade='all, delete-orphan',
+    )
+
+    __table_args__ = (
+        Index('ix_auth_users_status', 'status'),
+        Index('ix_auth_users_profile_id', 'profile_id'),
+    )
+```
+
+## Repository helpers (`shared/db/repositories/auth.py`)
+
+Funciones puras sobre `Session`:
+
+```python
+def get_user_by_email(session: Session, email: str) -> AuthUser | None: ...
+def create_pending_user(session: Session, *, email: str) -> AuthUser: ...
+def mark_user_active(session: Session, user: AuthUser) -> None: ...
+def increment_failed_attempts(session: Session, user: AuthUser) -> int: ...
+def reset_failed_attempts(session: Session, user: AuthUser) -> None: ...
+def lock_user(session: Session, user: AuthUser, until: datetime) -> None: ...
+
+def insert_email_code(
+    session: Session, *, user_id: UUID, code_hash: bytes,
+    kind: AuthCodeKind, expires_at: datetime,
+) -> AuthEmailCode: ...
+def consume_email_code(
+    session: Session, *, user_id: UUID, kind: AuthCodeKind, code_hash: bytes,
+) -> AuthEmailCode | None:  # increments attempts, returns row if hash match + not expired
+    ...
+
+def insert_magic_link(...) -> AuthMagicLink: ...
+def consume_magic_link(session, *, token_hash: bytes) -> AuthMagicLink | None: ...
+
+def insert_audit_event(
+    session: Session, *, event: str, success: bool, user_id: UUID | None = None,
+    error_code: str | None = None, ip: str | None = None,
+    user_agent: str | None = None, niche: str | None = None,
+    metadata: dict | None = None,
+) -> None: ...
+```
+
+## Indices y queries planeadas
+
+| Query | Endpoint | Indice |
+|-------|----------|--------|
+| `SELECT ... FROM auth_users WHERE email = ?` | register.start, login.start | UNIQUE constraint sobre `email` (auto) |
+| `SELECT ... FROM auth_email_codes WHERE user_id = ? AND kind = ? AND consumed_at IS NULL ORDER BY created_at DESC LIMIT 1` | verify-code | `ix_auth_email_codes_user_kind` |
+| `SELECT ... FROM auth_magic_links WHERE token_hash = ? AND consumed_at IS NULL` | verify-magic-link | UNIQUE constraint sobre `token_hash` (auto) |
+| `INSERT INTO auth_audit_log ...` | siempre | n/a (insert-only) |
+
+## Que se VERIFICA contra el ER diagram general
+
+- `cv_profiles.id` queda intacto. La FK `auth_users.profile_id` agrega
+  una relacion opcional 0..1 -> 1.
+- No se introducen rupturas en relaciones existentes
+  (`cv_profile_niches`, `cv_profile_stats`, etc.).
+- El `down_revision = '00000001'` (la migration inicial).
+
+## Update al ER permanente
+
+Al finalizar el plan, agregar el cluster `auth_*` al
+`docs/diagrams/db-er.mmd` para mantener la fuente de verdad sincronizada.
+Esta tarea es parte del commit final de la fase 1.

--- a/docs/specs/01-auth-infra-basics/03-shared-auth.md
+++ b/docs/specs/01-auth-infra-basics/03-shared-auth.md
@@ -1,0 +1,274 @@
+# 03. Shared subpackage `shared.auth`
+
+> Portador unico de las dependencias de autenticacion: `pyjwt`,
+> `argon2-cffi`. Expone helpers puros (sin side-effects) que los
+> Lambdas `auth` y `auth_email_worker` (y mas adelante `users`)
+> consumen via `from shared.auth import ...`.
+
+## Justificacion del subpackage nuevo
+
+Segun `.claude/rules/lambda-shared-imports.md`, cada paquete externo
+nuevo debe tener UN portador shared. Hoy:
+
+| Paquete | Portador existente | Notas |
+|---------|--------------------|-------|
+| pyjwt | (no existe) | nuevo |
+| argon2-cffi | (no existe) | nuevo |
+| pydantic | shared.core | existente |
+| boto3 (ssm/ses/dynamodb) | shared.aws | existente |
+| sqlalchemy | shared.db | existente |
+
+Crear `shared.auth` mantiene el patron "un dominio, un subpackage".
+Alternativa rechazada: meter pyjwt/argon2 en `shared.core` rompe la
+cohesion (core es bootstrap/utilities transversales, no dominio).
+
+## Estructura
+
+```text
+serverless/lambda/shared/auth/
+├── __init__.py        # re-exports + __all__
+├── pyproject.toml     # [project.dependencies] + [tool.shared].internal-deps
+├── jwt.py             # issue_*, verify_*, JwtClaims (Pydantic), JwtError
+├── password.py        # hash_password, verify_password, NeedsRehashError
+├── codes.py           # generate_code (8 chars Crockford), hash_code, compare_code
+├── tokens.py          # generate_opaque_token (32 bytes), hash_token, compare_token
+└── constants.py       # JWT_ALGORITHM='HS256', CODE_ALPHABET, CODE_LENGTH=8, ...
+```
+
+## `pyproject.toml`
+
+```toml
+[project]
+name = "shared-auth"
+version = "0.1.0"
+requires-python = ">=3.13,<3.15"
+dependencies = [
+    "pyjwt>=2.9,<3.0",
+    "argon2-cffi>=23.1,<24.0",
+]
+
+[tool.shared]
+internal-deps = ["core", "aws", "observability"]
+```
+
+`internal-deps`:
+- `core` -> `BaseModel` / `Field` / `ApplicationError` / `new_uuidv7`.
+- `aws` -> `get_secret_by_name` (lee `/portfolio/${stage}/jwt-secret`).
+- `observability` -> `logger`, `metrics`.
+
+NOTA: el cierre transitivo arrastrara `pydantic` (de core), `boto3` (de aws),
+`aws-lambda-powertools` (de observability). Los Lambdas que ya tienen
+estos en su cierre NO los duplican (la regla D-3 lo enforza con
+`serverless lint-deps`).
+
+## `__init__.py` (re-exports)
+
+```python
+"""shared.auth — JWT, password hashing y generadores de codes/tokens."""
+
+from .codes import (
+    CODE_ALPHABET,
+    CODE_LENGTH,
+    compare_code,
+    generate_code,
+    hash_code,
+)
+from .jwt import (
+    JWT_ALGORITHM,
+    JwtClaims,
+    JwtError,
+    JwtExpiredError,
+    JwtInvalidError,
+    JwtRevokedError,
+    issue_access_jwt,
+    issue_refresh_jwt,
+    issue_temp_jwt,
+    verify_jwt,
+)
+from .password import (
+    NeedsRehashError,
+    PasswordError,
+    hash_password,
+    verify_password,
+)
+from .tokens import (
+    compare_token,
+    generate_opaque_token,
+    hash_token,
+)
+
+__all__ = [
+    'CODE_ALPHABET',
+    'CODE_LENGTH',
+    'JWT_ALGORITHM',
+    'JwtClaims',
+    'JwtError',
+    'JwtExpiredError',
+    'JwtInvalidError',
+    'JwtRevokedError',
+    'NeedsRehashError',
+    'PasswordError',
+    'compare_code',
+    'compare_token',
+    'generate_code',
+    'generate_opaque_token',
+    'hash_code',
+    'hash_password',
+    'hash_token',
+    'issue_access_jwt',
+    'issue_refresh_jwt',
+    'issue_temp_jwt',
+    'verify_jwt',
+    'verify_password',
+]
+```
+
+## `jwt.py` — API
+
+```python
+JWT_ALGORITHM = 'HS256'
+
+# Lifetimes (en segundos)
+TEMP_TTL = 300       # 5 min
+ACCESS_TTL = 900     # 15 min
+REFRESH_TTL = 30 * 24 * 3600  # 30 dias
+
+
+class JwtClaims(BaseModel):
+    """Claims canonicos. Subset de RFC 7519 + custom."""
+    sub: UUID                          # subject = user_id
+    jti: UUID                          # JWT ID (uuidv7)
+    typ: Literal['temp', 'access', 'refresh']
+    iat: int                           # issued at (unix)
+    exp: int                           # expires at (unix)
+    iss: str = 'portfolio-auth'
+    aud: str = 'portfolio'
+    # custom
+    flow: str | None = None            # solo en typ=temp
+    step: int | None = None            # solo en typ=temp
+    family_id: UUID | None = None      # solo en typ=refresh
+    email: str | None = None           # incluido en access para evitar lookup
+    niche: str | None = None           # opcional para tracking
+
+
+def issue_temp_jwt(
+    *, user_id: UUID, flow: str, step: int, secret: str,
+    ttl: int = TEMP_TTL, niche: str | None = None,
+) -> tuple[str, JwtClaims]:
+    """Emite un JWT temporal. Retorna (token_string, claims)."""
+
+def issue_access_jwt(
+    *, user_id: UUID, email: str, secret: str,
+    ttl: int = ACCESS_TTL, niche: str | None = None,
+) -> tuple[str, JwtClaims]:
+    """Emite un JWT access. Retorna (token_string, claims)."""
+
+def issue_refresh_jwt(
+    *, user_id: UUID, family_id: UUID, secret: str,
+    ttl: int = REFRESH_TTL,
+) -> tuple[str, JwtClaims]:
+    """Emite un JWT refresh. family_id agrupa todos los refresh
+    rotados del mismo session para detectar token reuse."""
+
+def verify_jwt(
+    token: str, *, secret: str, expected_typ: str | None = None,
+) -> JwtClaims:
+    """Valida signature + exp + aud. NO verifica blacklist (eso lo
+    hace el Lambda contra DynamoDB).
+
+    Raises:
+      JwtExpiredError: si exp < now
+      JwtInvalidError: si signature mismatch, aud mismatch, typ mismatch
+    """
+
+
+class JwtError(ApplicationError): ...
+class JwtExpiredError(JwtError): ...
+class JwtInvalidError(JwtError): ...
+class JwtRevokedError(JwtError): ...  # se levanta desde el Lambda tras DDB lookup
+```
+
+## `password.py` — API
+
+```python
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError, InvalidHash
+
+_hasher = PasswordHasher()  # defaults: time_cost=3, memory_cost=64MiB, parallelism=4
+
+class PasswordError(ApplicationError): ...
+class NeedsRehashError(PasswordError): ...  # password OK pero parametros cambiaron
+
+
+def hash_password(password: str) -> str:
+    """Retorna el hash argon2id en formato $argon2id$...$ ready para guardar."""
+
+def verify_password(*, password: str, hashed: str) -> bool:
+    """True si match. False si mismatch. Si hash usa params viejos,
+    levanta NeedsRehashError para forzar rehash en background."""
+```
+
+## `codes.py` — API
+
+```python
+CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'  # 30 chars, Crockford-like
+CODE_LENGTH = 8
+
+def generate_code() -> str:
+    """8 chars random del alfabeto. CSPRNG (secrets.choice)."""
+
+def hash_code(code: str) -> bytes:
+    """SHA-256 (32 bytes). Guardado en auth_email_codes.code_hash (BYTEA)."""
+
+def compare_code(*, code: str, stored_hash: bytes) -> bool:
+    """secrets.compare_digest(hash(code), stored_hash). Resistente a timing."""
+```
+
+## `tokens.py` — API
+
+```python
+def generate_opaque_token(num_bytes: int = 32) -> str:
+    """secrets.token_urlsafe(num_bytes). 32 bytes -> ~43 chars b64url."""
+
+def hash_token(token: str) -> bytes:
+    """SHA-256 del token. Guardado en auth_magic_links.token_hash."""
+
+def compare_token(*, token: str, stored_hash: bytes) -> bool:
+    """secrets.compare_digest(hash(token), stored_hash)."""
+```
+
+## Tests unit (`shared/tests/unit/shared/auth/`)
+
+| Archivo | Que testea |
+|---------|-----------|
+| `test_jwt_issue_and_verify.py` | Round-trip: issue_temp -> verify -> claims correctas |
+| `test_jwt_expired.py` | Token con `exp < now` levanta `JwtExpiredError` |
+| `test_jwt_wrong_typ.py` | `expected_typ='access'` sobre un temp levanta `JwtInvalidError` |
+| `test_jwt_signature_mismatch.py` | Cambiar 1 byte de la signature levanta `JwtInvalidError` |
+| `test_jwt_aud_mismatch.py` | Token con `aud='other'` levanta `JwtInvalidError` |
+| `test_jwt_refresh_family_id.py` | refresh JWT preserva `family_id` |
+| `test_password_hash_verify.py` | hash + verify -> True |
+| `test_password_verify_wrong.py` | verify con password incorrecta -> False |
+| `test_password_needs_rehash.py` | hash con params viejos -> verify levanta `NeedsRehashError` |
+| `test_codes_generate_alphabet.py` | 1000 codes -> todos en `CODE_ALPHABET`, todos length 8 |
+| `test_codes_generate_uniqueness.py` | 1000 codes -> >995 unicos (1-in-30^8 collision) |
+| `test_codes_hash_compare_ok.py` | hash + compare correcta -> True |
+| `test_codes_hash_compare_wrong.py` | compare con code incorrecto -> False |
+| `test_codes_compare_timing_safe.py` | (smoke) compara correcto e incorrecto en tiempo similar |
+| `test_tokens_generate.py` | length >= 32 chars, url-safe (sin `+/=`) |
+| `test_tokens_hash_compare.py` | round-trip |
+| `test_reexport_smoke.py` | from shared.auth import * y verifica `__all__` completo |
+
+Cada archivo = 1 funcion `test_<nombre>` con docstring Given/When/Then.
+
+## Anti-patrones aplicables a este modulo
+
+| Anti-patron | Correccion |
+|-------------|------------|
+| `import jwt` en el `core/` de un Lambda | `from shared.auth import issue_*, verify_jwt` |
+| `import argon2` en el `core/` de un Lambda | `from shared.auth import hash_password, verify_password` |
+| Guardar el code en plain text en Neon | Solo `code_hash` (BYTEA, SHA-256) |
+| Generar code con `random.choice` | `secrets.choice` obligatorio |
+| Comparar codes con `==` | `compare_code(...)` (timing-safe) |
+| Hardcodear el JWT secret en el codigo | Leer de SSM `get_secret_by_name('jwt-secret', ...)` en cold start |
+| Reusar el mismo `family_id` entre logout y nuevo login | Cada login emite un `family_id` nuevo (`uuidv7()`) |

--- a/docs/specs/01-auth-infra-basics/03-shared-auth.md
+++ b/docs/specs/01-auth-infra-basics/03-shared-auth.md
@@ -135,7 +135,15 @@ REFRESH_TTL = 30 * 24 * 3600  # 30 dias
 
 
 class JwtClaims(BaseModel):
-    """Claims canonicos. Subset de RFC 7519 + custom."""
+    """Claims canonicos. Subset de RFC 7519 + custom.
+
+    Diseno: el JWT contiene SOLO `sub` (user_id) como identificador
+    del usuario. El `email` y otros datos de perfil NO viajan en el
+    token — JWT no es secret (jwt.io lo decodifica), y filtrarlo via
+    Referer/logs/history expondria PII. Los Lambdas que necesiten
+    email hacen lookup a Neon (cacheable con `shared.cache.cached` si
+    el caller lo amerita).
+    """
     sub: UUID                          # subject = user_id
     jti: UUID                          # JWT ID (uuidv7)
     typ: Literal['temp', 'access', 'refresh']
@@ -143,25 +151,28 @@ class JwtClaims(BaseModel):
     exp: int                           # expires at (unix)
     iss: str = 'portfolio-auth'
     aud: str = 'portfolio'
-    # custom
+    # custom (NO incluyen PII)
     flow: str | None = None            # solo en typ=temp
     step: int | None = None            # solo en typ=temp
     family_id: UUID | None = None      # solo en typ=refresh
-    email: str | None = None           # incluido en access para evitar lookup
-    niche: str | None = None           # opcional para tracking
 
 
 def issue_temp_jwt(
     *, user_id: UUID, flow: str, step: int, secret: str,
-    ttl: int = TEMP_TTL, niche: str | None = None,
+    ttl: int = TEMP_TTL,
 ) -> tuple[str, JwtClaims]:
     """Emite un JWT temporal. Retorna (token_string, claims)."""
 
 def issue_access_jwt(
-    *, user_id: UUID, email: str, secret: str,
-    ttl: int = ACCESS_TTL, niche: str | None = None,
+    *, user_id: UUID, secret: str,
+    ttl: int = ACCESS_TTL,
 ) -> tuple[str, JwtClaims]:
-    """Emite un JWT access. Retorna (token_string, claims)."""
+    """Emite un JWT access. Retorna (token_string, claims).
+
+    El access NO incluye email ni otros datos de perfil. El consumidor
+    (dashboard) obtiene esos datos del response del endpoint de login
+    /verify y los persiste en su Zustand store.
+    """
 
 def issue_refresh_jwt(
     *, user_id: UUID, family_id: UUID, secret: str,

--- a/docs/specs/01-auth-infra-basics/04-infraestructura.md
+++ b/docs/specs/01-auth-infra-basics/04-infraestructura.md
@@ -4,8 +4,7 @@
 
 | Recurso | Archivo (resources/...) | Que es | Quien lo lee |
 |---------|------------------------|--------|--------------|
-| DynamoDB `portfolio-jwt-blacklist-${stage}` | `dynamodb/jwt-blacklist.yaml` | Blacklist de JWTs (temp/access/refresh) con TTL=exp | Lambda `auth` |
-| DynamoDB `portfolio-auth-codes-${stage}` | `dynamodb/auth-codes.yaml` | Cache O(1) de codes activos (espejo de auth_email_codes) | Lambda `auth` |
+| DynamoDB `portfolio-jwt-blacklist-${stage}` | `dynamodb/jwt-blacklist.yaml` | Blacklist de JWTs (temp/access/refresh) con TTL=exp + GSI by_family_id | Lambda `auth` |
 | SSM `/portfolio/${stage}/jwt-secret` | `resources/secrets/jwt-secret.yaml` | SecureString + KMS, secret del HS256 | Lambdas `auth`, futuro `users` |
 | SQS `portfolio-auth-email-${stage}` | `sqs/auth-email-queue.yaml` | Cola de emails a enviar (magic-link, code, ...) | productor: `auth`; consumidor: `auth_email_worker` |
 | SQS DLQ `portfolio-auth-email-dlq-${stage}` | `sqs/auth-email-dlq.yaml` | DLQ de la cola anterior | n/a |
@@ -77,54 +76,31 @@ Aclaracion: el GSI agrega ~2x write cost en items con `family_id`
 (refresh JWTs). En el modo PAY_PER_REQUEST esto es marginal a escala
 portfolio.
 
-## 2. DynamoDB — `portfolio-auth-codes-${stage}`
+**Family revoke — limite y atomicidad**: cuando se detecta reuso de un
+refresh (AC-8) o se hace logout total (AC-9), hay que revocar TODOS
+los refresh JWTs vivos de esa `family_id`. DynamoDB NO soporta
+`UPDATE WHERE family_id = X` atomico: el flujo es:
 
-`serverless/lambda/resources/dynamodb/auth-codes.yaml`:
+1. `Query` el GSI `by_family_id` con `KeyConditionExpression='family_id
+   = :fid'` (devuelve `[jti, ...]` por la projection KEYS_ONLY).
+2. Por cada `jti` devuelto, `PutItem`/`UpdateItem` marcando
+   `revoked_at=now`, `reason='reuse'|'logout'`, preservando TTL=`exp`.
+3. Si N > 25, usar `BatchWriteItem` paginando de a 25 por call
+   (limite duro de la API).
 
-```yaml
-kind: dynamodb-table
-name: portfolio-auth-codes-${stage}
-billing_mode: PAY_PER_REQUEST
-hash_key:
-  name: pk
-  type: S
-range_key: null
-stream: null
-ttl_attribute: expires_at
-encryption: true
-publishes_ssm:
-  name: /portfolio/${stage}/dynamodb/auth-codes/name
-  arn: /portfolio/${stage}/dynamodb/auth-codes/arn
-tags:
-  Project: portfolio
-  Module: auth
-  ManagedBy: devtools
-```
+Limites operativos:
 
-**Schema de item**:
+- **MAX_FAMILY_SIZE = 10**: cada login emite un `family_id` nuevo
+  (uuidv7), y cada uso del refresh rota a otro `jti` dentro de la
+  misma familia. En la practica una familia tiene 1-3 refresh activos
+  simultaneos (el actual + grace period del anterior); 10 es un cap
+  defensivo para detectar bug de rotation. Si el `Query` devuelve > 10,
+  loggear `family.oversized` y revocar igual.
+- **Timeout del controller**: con 30 items + `BatchWriteItem` de 25,
+  la operacion completa toma < 200ms (un round-trip + un batch). Bien
+  dentro del timeout de 15s del Lambda.
 
-```jsonc
-{
-  "pk": "register#01H9V...",      // PK (formato '<kind>#<user_id>')
-  "code_hash_b64": "...",         // SHA-256 b64
-  "attempts": 0,
-  "created_at": 1717000000,
-  "expires_at": 1717000900,       // TTL attribute
-  "neon_id": "01H9X..."           // referencia al row de Neon
-}
-```
-
-**Justificacion del doble store (Neon + DynamoDB)**:
-- Neon es la fuente de verdad y la auditoria (queries por user, por
-  kind, historial).
-- DynamoDB da lookup O(1) por `pk` en cada `verify-code` request sin
-  pagar latencia de Neon (~10-30ms a Neon Pooler us-east-1).
-- Cuando se inserta un code, el handler escribe ambos en paralelo. Si
-  Neon falla, abortamos toda la operacion. Si DynamoDB falla pero Neon
-  exito -> log warning, fallback a Neon en verify (degrada
-  graciosamente, ~10ms peor).
-
-## 3. SSM — `/portfolio/${stage}/jwt-secret`
+## 2. SSM — `/portfolio/${stage}/jwt-secret`
 
 `serverless/lambda/resources/secrets/jwt-secret.yaml`:
 
@@ -161,7 +137,7 @@ python devtools/run.py serverless sync-secrets --stage=prod --aws-profile=tfs-de
 Efecto: todos los JWTs vivos quedan invalidos (signature mismatch) y
 los users deben re-loguear. NO hacer en horario de uso real.
 
-## 4. SQS — `portfolio-auth-email-${stage}` + DLQ
+## 3. SQS — `portfolio-auth-email-${stage}` + DLQ
 
 `serverless/lambda/resources/sqs/auth-email-queue.yaml`:
 
@@ -217,7 +193,7 @@ tags:
 }
 ```
 
-## 5. Lambda `auth_email_worker` (manifest)
+## 4. Lambda `auth_email_worker` (manifest)
 
 `serverless/lambda/services/auth_email_worker/manifest.yaml`:
 
@@ -226,7 +202,11 @@ name: auth-email-worker
 trigger:
   type: sqs
   queue: portfolio-auth-email-${stage}
-  batch_size: 1
+  # batch_size=5: SES tolera batch (envia sequenciales en una
+  # invocacion). 5x menos invocaciones del Lambda a cambio de latencia
+  # ~ms que NO importa (worker async). ReportBatchItemFailures permite
+  # fallar uno y reintentar solo ese.
+  batch_size: 5
   function_response_types:
     - ReportBatchItemFailures
 runtime: python3.13
@@ -240,7 +220,11 @@ uses:
   tables: {}
   secrets:
     - ses-from-address
-    - owner-email                    # para BCC opcional al owner en eventos sensibles
+    # owner-email NO se incluye en plan 01. Plan original lo mencionaba
+    # para "BCC opcional al owner en eventos sensibles" pero ningun AC
+    # lo describe. Si en plan 02 (MFA) o 03 (users management) se
+    # decide notificar al owner ante eventos sensibles (ej. set-password,
+    # MFA reset), se agrega ahi con un AC explicito.
   sends-email: true
 env:
   default:
@@ -263,7 +247,7 @@ El worker:
 6. Si falla por motivo retryable (throttling), levanta excepcion ->
    SQS reintenta. Tras `max_receive_count=3` -> DLQ.
 
-## 6. Lambda `auth` (manifest)
+## 5. Lambda `auth` (manifest)
 
 `serverless/lambda/services/auth/manifest.yaml`:
 
@@ -286,8 +270,7 @@ uses:
     cache: read-write                # @cached SSM cache
     rate-limit-rules: read-write
     rate-limit-buckets: read-write
-    jwt-blacklist: read-write        # nueva
-    auth-codes: read-write           # nueva
+    jwt-blacklist: read-write        # nueva (con GSI by_family_id)
   secrets:
     - turnstile-secret
     - turnstile-bypass-secret
@@ -303,19 +286,31 @@ env:
     JWT_ISSUER: portfolio-auth
     JWT_AUDIENCE: portfolio
     MAGIC_LINK_BASE_URL: https://api.portfolio.dev.the-full-stack.com/auth
+    # Paths SSM publicados por el provisioner al crear los recursos
+    # compartidos (resources/dynamodb/jwt-blacklist.yaml + auth-email).
+    # AppConfig los lee en cold start con `get_parameter()`.
+    SSM_JWT_BLACKLIST_TABLE_PATH: /portfolio/${stage}/dynamodb/jwt-blacklist/name
+    SSM_AUTH_EMAIL_QUEUE_URL_PATH: /portfolio/${stage}/sqs/auth-email/url
+    # Callback URL del dashboard (admin SPA), donde el magic-link
+    # redirige con `#access=&refresh=&user_id=&email=`. El controller
+    # construye la URL final concatenando el fragment.
+    DASHBOARD_CALLBACK_URL: https://admin.portfolio.dev.the-full-stack.com/callback
   dev:
-    CORS_ALLOWED_ORIGINS: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com,http://localhost:9970'
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com,https://admin.portfolio.dev.the-full-stack.com,http://localhost:9970'
     MAGIC_LINK_BASE_URL: https://api.portfolio.dev.the-full-stack.com/auth
+    DASHBOARD_CALLBACK_URL: https://admin.portfolio.dev.the-full-stack.com/callback
   stage:
-    CORS_ALLOWED_ORIGINS: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com'
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com,https://admin.portfolio.stage.the-full-stack.com'
     MAGIC_LINK_BASE_URL: https://api.portfolio.stage.the-full-stack.com/auth
+    DASHBOARD_CALLBACK_URL: https://admin.portfolio.stage.the-full-stack.com/callback
   prod:
     LOG_LEVEL: WARNING
-    CORS_ALLOWED_ORIGINS: 'https://the-full-stack.com,https://www.the-full-stack.com,https://portfolio.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com'
+    CORS_ALLOWED_ORIGINS: 'https://the-full-stack.com,https://www.the-full-stack.com,https://portfolio.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com,https://admin.portfolio.the-full-stack.com'
     MAGIC_LINK_BASE_URL: https://api.portfolio.the-full-stack.com/auth
+    DASHBOARD_CALLBACK_URL: https://admin.portfolio.the-full-stack.com/callback
 ```
 
-## 7. IAM scopes esperados (los genera el provisioner desde el manifest)
+## 6. IAM scopes esperados (los genera el provisioner desde el manifest)
 
 `auth` IAM role:
 - `dynamodb:GetItem`, `PutItem`, `Query` sobre las 5 tablas declaradas en `uses.tables`.
@@ -326,45 +321,72 @@ env:
 
 `auth_email_worker` IAM role:
 - `sqs:ReceiveMessage`, `DeleteMessage`, `GetQueueAttributes` sobre
-  `portfolio-auth-email-${stage}`.
-- `ssm:GetParameter` sobre `ses-from-address`, `owner-email`.
-- `ses:SendEmail`, `SendRawEmail` sobre la identidad
-  `no-reply@the-full-stack.com` (scoped por condition Resource).
+  `portfolio-auth-email-${stage}` (ARN exacto, NO wildcard).
+- `ssm:GetParameter` sobre el ARN exacto
+  `arn:aws:ssm:us-east-1:<account-id>:parameter/portfolio/ses-from-address`.
+- `ses:SendEmail`, `ses:SendRawEmail` scoped por **identity ARN exacto**:
+  `Resource: arn:aws:ses:us-east-1:<account-id>:identity/the-full-stack.com`.
+  NUNCA `Resource: *` ni `ses:*`. La identity es la del domain
+  verificado; cubre cualquier `From` con sufijo `@the-full-stack.com`
+  (incl. `no-reply@`). El provisioner debe generar la policy con el
+  ARN explicito leyendo `account_id` de
+  `aws sts get-caller-identity` y `domain` del `manifest.yaml`.
 
-## 8. Rate-limit rules (seed)
+## 7. Rate-limit rules (seed)
 
-Insertar 5 reglas en la tabla `portfolio-rate-limit-rules-${stage}`
+Insertar 7 reglas en la tabla `portfolio-rate-limit-rules-${stage}`
 via el subcomando `serverless rate-limit set` (existente). Hacer 1 vez
-por stage:
+por stage.
+
+**Formato del endpoint key**: `<operation>.<action>` literal — el
+controller pasa `endpoint=f"{operation}.{action}"` a
+`shared.rate_limit.check_or_raise()`. El matching es **exacto** (NO
+prefix). Por eso `verify-magic-link` no comparte rate-limit con
+`verify-code`: cada operacion+action tiene su key propia.
 
 ```bash
 # register.start: 3 req/h/IP, blacklist 24h si excede 10/h
 python devtools/run.py serverless rate-limit set --stage=dev \
-  --endpoint='/auth#register.start' --limit=3 --window=3600 \
+  --endpoint='register.start' --limit=3 --window=3600 \
   --hard-cap=10 --hard-cap-action=blacklist-24h --aws-profile=tfs-dev
 
 # login.start: 5/min/IP
 python devtools/run.py serverless rate-limit set --stage=dev \
-  --endpoint='/auth#login.start' --limit=5 --window=60 \
+  --endpoint='login.start' --limit=5 --window=60 \
   --hard-cap=20 --hard-cap-action=blacklist-1h --aws-profile=tfs-dev
 
-# verify.*: 10/min/IP (incluye verify-magic-link, verify-code,
-#   set-password, resend-code)
+# register.verify-magic-link, register.verify-code: 10/min/IP cada uno
 python devtools/run.py serverless rate-limit set --stage=dev \
-  --endpoint='/auth#verify' --limit=10 --window=60 --aws-profile=tfs-dev
+  --endpoint='register.verify-magic-link' --limit=10 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='register.verify-code' --limit=10 --window=60 --aws-profile=tfs-dev
+
+# login.verify-magic-link, login.verify-code: 10/min/IP cada uno
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='login.verify-magic-link' --limit=10 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='login.verify-code' --limit=10 --window=60 --aws-profile=tfs-dev
+
+# verify.set-password: 5/min/IP (operacion sensible)
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='verify.set-password' --limit=5 --window=60 --aws-profile=tfs-dev
+
+# verify.resend-code: 3/5min/IP (anti-spam de emails)
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='verify.resend-code' --limit=3 --window=300 --aws-profile=tfs-dev
 
 # session.refresh: 30/min/IP
 python devtools/run.py serverless rate-limit set --stage=dev \
-  --endpoint='/auth#session.refresh' --limit=30 --window=60 --aws-profile=tfs-dev
+  --endpoint='session.refresh' --limit=30 --window=60 --aws-profile=tfs-dev
 
 # session.logout: 30/min/IP
 python devtools/run.py serverless rate-limit set --stage=dev \
-  --endpoint='/auth#session.logout' --limit=30 --window=60 --aws-profile=tfs-dev
+  --endpoint='session.logout' --limit=30 --window=60 --aws-profile=tfs-dev
 ```
 
 Repetir para `stage` y `prod`. Idempotente (overwrite).
 
-## 9. Como se aplica todo
+## 8. Como se aplica todo
 
 Orden de provisioning:
 

--- a/docs/specs/01-auth-infra-basics/04-infraestructura.md
+++ b/docs/specs/01-auth-infra-basics/04-infraestructura.md
@@ -1,0 +1,381 @@
+# 04. Infraestructura — DynamoDB + SSM + SQS + IAM
+
+## Resumen
+
+| Recurso | Archivo (resources/...) | Que es | Quien lo lee |
+|---------|------------------------|--------|--------------|
+| DynamoDB `portfolio-jwt-blacklist-${stage}` | `dynamodb/jwt-blacklist.yaml` | Blacklist de JWTs (temp/access/refresh) con TTL=exp | Lambda `auth` |
+| DynamoDB `portfolio-auth-codes-${stage}` | `dynamodb/auth-codes.yaml` | Cache O(1) de codes activos (espejo de auth_email_codes) | Lambda `auth` |
+| SSM `/portfolio/${stage}/jwt-secret` | `resources/secrets/jwt-secret.yaml` | SecureString + KMS, secret del HS256 | Lambdas `auth`, futuro `users` |
+| SQS `portfolio-auth-email-${stage}` | `sqs/auth-email-queue.yaml` | Cola de emails a enviar (magic-link, code, ...) | productor: `auth`; consumidor: `auth_email_worker` |
+| SQS DLQ `portfolio-auth-email-dlq-${stage}` | `sqs/auth-email-dlq.yaml` | DLQ de la cola anterior | n/a |
+| Rate-limit rules (data en tabla existente) | seed via `serverless rate-limit set ...` | 5 reglas: register.start/login.start/verify.*/session.refresh/session.logout | Lambda `auth` (via shared.rate_limit) |
+
+NO se crea API Gateway nuevo. Se reusa `portfolio-api` existente. Las
+rutas `/auth` y (plan 3) `/users` se agregan automaticamente por
+devtools provisioner a partir del `manifest.yaml` de cada Lambda.
+
+## 1. DynamoDB — `portfolio-jwt-blacklist-${stage}`
+
+`serverless/lambda/resources/dynamodb/jwt-blacklist.yaml`:
+
+```yaml
+kind: dynamodb-table
+name: portfolio-jwt-blacklist-${stage}
+billing_mode: PAY_PER_REQUEST
+hash_key:
+  name: jti
+  type: S
+range_key: null
+stream: null
+ttl_attribute: exp
+encryption: true
+publishes_ssm:
+  name: /portfolio/${stage}/dynamodb/jwt-blacklist/name
+  arn: /portfolio/${stage}/dynamodb/jwt-blacklist/arn
+tags:
+  Project: portfolio
+  Module: auth
+  ManagedBy: devtools
+```
+
+**Schema de item**:
+
+```jsonc
+{
+  "jti": "01H9X...uuid",         // PK (UUID v7 string)
+  "user_id": "01H9V...",          // sort no, solo atributo
+  "typ": "access",                // 'temp'|'access'|'refresh'
+  "family_id": "01H9W...",        // solo si typ=refresh
+  "revoked_at": 1717000000,       // unix
+  "reason": "logout",             // 'logout'|'rotation'|'reuse'|'forced'
+  "exp": 1717003600               // unix; TTL attribute, AWS borra el item
+}
+```
+
+**Operaciones**:
+- `PutItem` cuando se blacklistea un JWT (incl. rotacion de refresh).
+- `GetItem` por `jti` en cada request protegida (verificacion).
+- `Query` por `family_id` cuando se detecta reuso (requiere GSI; ver
+  abajo).
+
+**GSI `by_family_id`** (necesario para AC-8 token reuse detection):
+
+```yaml
+hash_key:
+  name: jti
+  type: S
+global_secondary_indexes:
+  - name: by_family_id
+    hash_key:
+      name: family_id
+      type: S
+    projection: KEYS_ONLY  # ahorra storage; solo necesitamos jti para borrar
+```
+
+Aclaracion: el GSI agrega ~2x write cost en items con `family_id`
+(refresh JWTs). En el modo PAY_PER_REQUEST esto es marginal a escala
+portfolio.
+
+## 2. DynamoDB — `portfolio-auth-codes-${stage}`
+
+`serverless/lambda/resources/dynamodb/auth-codes.yaml`:
+
+```yaml
+kind: dynamodb-table
+name: portfolio-auth-codes-${stage}
+billing_mode: PAY_PER_REQUEST
+hash_key:
+  name: pk
+  type: S
+range_key: null
+stream: null
+ttl_attribute: expires_at
+encryption: true
+publishes_ssm:
+  name: /portfolio/${stage}/dynamodb/auth-codes/name
+  arn: /portfolio/${stage}/dynamodb/auth-codes/arn
+tags:
+  Project: portfolio
+  Module: auth
+  ManagedBy: devtools
+```
+
+**Schema de item**:
+
+```jsonc
+{
+  "pk": "register#01H9V...",      // PK (formato '<kind>#<user_id>')
+  "code_hash_b64": "...",         // SHA-256 b64
+  "attempts": 0,
+  "created_at": 1717000000,
+  "expires_at": 1717000900,       // TTL attribute
+  "neon_id": "01H9X..."           // referencia al row de Neon
+}
+```
+
+**Justificacion del doble store (Neon + DynamoDB)**:
+- Neon es la fuente de verdad y la auditoria (queries por user, por
+  kind, historial).
+- DynamoDB da lookup O(1) por `pk` en cada `verify-code` request sin
+  pagar latencia de Neon (~10-30ms a Neon Pooler us-east-1).
+- Cuando se inserta un code, el handler escribe ambos en paralelo. Si
+  Neon falla, abortamos toda la operacion. Si DynamoDB falla pero Neon
+  exito -> log warning, fallback a Neon en verify (degrada
+  graciosamente, ~10ms peor).
+
+## 3. SSM — `/portfolio/${stage}/jwt-secret`
+
+`serverless/lambda/resources/secrets/jwt-secret.yaml`:
+
+```yaml
+short_name: jwt-secret
+description: HS256 secret for JWT signing/verification (auth + users lambdas)
+type: SecureString
+kms_key: alias/portfolio-lambdas
+ssm_path: /portfolio/${stage}/jwt-secret
+source_env_var: JWT_SECRET            # docker/env/server/.{stage}
+local_env_var: JWT_SECRET             # mismo nombre en local
+rotation_interval_days: 90
+consumers:
+  - lambda: auth
+  - lambda: users        # futuro plan 3
+```
+
+**Generacion del valor**: 64 bytes random b64url:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+```
+
+Pegar en `docker/env/server/.{dev,stage,prod}` como
+`JWT_SECRET=<valor>`. Sincronizar a SSM con:
+
+```bash
+python devtools/run.py serverless sync-secrets --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless sync-secrets --stage=stage --aws-profile=tfs-dev
+python devtools/run.py serverless sync-secrets --stage=prod --aws-profile=tfs-dev
+```
+
+**Rotacion**: cambiar el valor en `docker/env/server/.{stage}` + sync.
+Efecto: todos los JWTs vivos quedan invalidos (signature mismatch) y
+los users deben re-loguear. NO hacer en horario de uso real.
+
+## 4. SQS — `portfolio-auth-email-${stage}` + DLQ
+
+`serverless/lambda/resources/sqs/auth-email-queue.yaml`:
+
+```yaml
+kind: sqs-queue
+name: portfolio-auth-email-${stage}
+message_retention_seconds: 345600      # 4 dias
+visibility_timeout_seconds: 180        # 6x el timeout del worker (30s)
+redrive_policy:
+  target: portfolio-auth-email-dlq-${stage}
+  max_receive_count: 3
+publishes_ssm:
+  arn: /portfolio/${stage}/sqs/auth-email/arn
+  url: /portfolio/${stage}/sqs/auth-email/url
+tags:
+  Project: portfolio
+  Module: auth
+  ManagedBy: devtools
+```
+
+`serverless/lambda/resources/sqs/auth-email-dlq.yaml`:
+
+```yaml
+kind: sqs-queue
+name: portfolio-auth-email-dlq-${stage}
+message_retention_seconds: 1209600     # 14 dias (DLQ guarda mas)
+visibility_timeout_seconds: 30
+publishes_ssm:
+  arn: /portfolio/${stage}/sqs/auth-email-dlq/arn
+  url: /portfolio/${stage}/sqs/auth-email-dlq/url
+tags:
+  Project: portfolio
+  Module: auth
+  ManagedBy: devtools
+```
+
+**Schema del mensaje** (JSON en el body):
+
+```jsonc
+{
+  "kind": "register-magic-link",   // 'register-magic-link'|'register-code'|'login-magic-link'|'login-code'|'password-reset'
+  "to": "user@example.com",
+  "user_id": "01H9V...",
+  "niche": "fintech",              // opcional, para template branding
+  "subject_id": "auth.register.magic-link.subject",  // i18n key
+  "data": {
+    "token": "abc...",             // SOLO para magic-link
+    "code": "ABCD2345",            // SOLO para code
+    "expires_in_min": 15,
+    "verify_url": "https://api..." // SOLO para magic-link, ya construida
+  },
+  "audit_event_id": "01H9Y..."     // para correlacionar con auth_audit_log
+}
+```
+
+## 5. Lambda `auth_email_worker` (manifest)
+
+`serverless/lambda/services/auth_email_worker/manifest.yaml`:
+
+```yaml
+name: auth-email-worker
+trigger:
+  type: sqs
+  queue: portfolio-auth-email-${stage}
+  batch_size: 1
+  function_response_types:
+    - ReportBatchItemFailures
+runtime: python3.13
+handler: core.handler.lambda_handler
+memory: 384
+timeout: 30
+uses:
+  queues:
+    - name: portfolio-auth-email-${stage}
+      access: consumer
+  tables: {}
+  secrets:
+    - ses-from-address
+    - owner-email                    # para BCC opcional al owner en eventos sensibles
+  sends-email: true
+env:
+  default:
+    LOG_LEVEL: INFO
+    AWS_SES_REGION: us-east-1
+    POWERTOOLS_SERVICE_NAME: auth-email-worker
+    POWERTOOLS_METRICS_NAMESPACE: Portfolio/Auth
+  prod:
+    LOG_LEVEL: WARNING
+```
+
+El worker:
+1. Recibe el mensaje.
+2. Resuelve la plantilla por `kind` (5 plantillas en `core/templates/`).
+3. Llama `send_email(...)`.
+4. Inserta `auth_audit_log` event=`email.sent.<kind>` (success=true).
+5. Si falla SES por motivo no-retryable (email rebotado dominio
+   invalido), inserta `email.send.failed` y RETURN normal (no
+   reintenta).
+6. Si falla por motivo retryable (throttling), levanta excepcion ->
+   SQS reintenta. Tras `max_receive_count=3` -> DLQ.
+
+## 6. Lambda `auth` (manifest)
+
+`serverless/lambda/services/auth/manifest.yaml`:
+
+```yaml
+name: auth
+trigger:
+  type: http
+  method: POST
+  path: /auth
+runtime: python3.13
+handler: core.handler.lambda_handler
+memory: 384
+timeout: 15
+snap_start: true
+uses:
+  queues:
+    - name: portfolio-auth-email-${stage}
+      access: producer
+  tables:
+    cache: read-write                # @cached SSM cache
+    rate-limit-rules: read-write
+    rate-limit-buckets: read-write
+    jwt-blacklist: read-write        # nueva
+    auth-codes: read-write           # nueva
+  secrets:
+    - turnstile-secret
+    - turnstile-bypass-secret
+    - neon-url
+    - jwt-secret                     # nueva
+    - ses-from-address               # publica mensajes con este from
+  sends-email: false                 # publica a SQS, NO envia directo
+env:
+  default:
+    LOG_LEVEL: INFO
+    POWERTOOLS_SERVICE_NAME: auth
+    POWERTOOLS_METRICS_NAMESPACE: Portfolio/Auth
+    JWT_ISSUER: portfolio-auth
+    JWT_AUDIENCE: portfolio
+    MAGIC_LINK_BASE_URL: https://api.portfolio.dev.the-full-stack.com/auth
+  dev:
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com,http://localhost:9970'
+    MAGIC_LINK_BASE_URL: https://api.portfolio.dev.the-full-stack.com/auth
+  stage:
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com'
+    MAGIC_LINK_BASE_URL: https://api.portfolio.stage.the-full-stack.com/auth
+  prod:
+    LOG_LEVEL: WARNING
+    CORS_ALLOWED_ORIGINS: 'https://the-full-stack.com,https://www.the-full-stack.com,https://portfolio.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com'
+    MAGIC_LINK_BASE_URL: https://api.portfolio.the-full-stack.com/auth
+```
+
+## 7. IAM scopes esperados (los genera el provisioner desde el manifest)
+
+`auth` IAM role:
+- `dynamodb:GetItem`, `PutItem`, `Query` sobre las 5 tablas declaradas en `uses.tables`.
+- `sqs:SendMessage` sobre `portfolio-auth-email-${stage}`.
+- `ssm:GetParameter` sobre los 5 paths declarados en `uses.secrets`.
+- `kms:Decrypt` sobre `alias/portfolio-lambdas` (necesario para los 2
+  SecureString: `turnstile-secret`, `jwt-secret`).
+
+`auth_email_worker` IAM role:
+- `sqs:ReceiveMessage`, `DeleteMessage`, `GetQueueAttributes` sobre
+  `portfolio-auth-email-${stage}`.
+- `ssm:GetParameter` sobre `ses-from-address`, `owner-email`.
+- `ses:SendEmail`, `SendRawEmail` sobre la identidad
+  `no-reply@the-full-stack.com` (scoped por condition Resource).
+
+## 8. Rate-limit rules (seed)
+
+Insertar 5 reglas en la tabla `portfolio-rate-limit-rules-${stage}`
+via el subcomando `serverless rate-limit set` (existente). Hacer 1 vez
+por stage:
+
+```bash
+# register.start: 3 req/h/IP, blacklist 24h si excede 10/h
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='/auth#register.start' --limit=3 --window=3600 \
+  --hard-cap=10 --hard-cap-action=blacklist-24h --aws-profile=tfs-dev
+
+# login.start: 5/min/IP
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='/auth#login.start' --limit=5 --window=60 \
+  --hard-cap=20 --hard-cap-action=blacklist-1h --aws-profile=tfs-dev
+
+# verify.*: 10/min/IP (incluye verify-magic-link, verify-code,
+#   set-password, resend-code)
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='/auth#verify' --limit=10 --window=60 --aws-profile=tfs-dev
+
+# session.refresh: 30/min/IP
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='/auth#session.refresh' --limit=30 --window=60 --aws-profile=tfs-dev
+
+# session.logout: 30/min/IP
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='/auth#session.logout' --limit=30 --window=60 --aws-profile=tfs-dev
+```
+
+Repetir para `stage` y `prod`. Idempotente (overwrite).
+
+## 9. Como se aplica todo
+
+Orden de provisioning:
+
+1. `serverless deploy --lambda=db --stage=dev` (asegura migration runner up).
+2. `serverless run --stage=dev --lambda=db --event=events/migrate.json`
+   (aplica `00000002_auth_schema.py`).
+3. `serverless provision-infra --stage=dev` (crea las 2 DynamoDB nuevas + las 2 SQS nuevas + el SSM jwt-secret).
+4. `serverless sync-secrets --stage=dev` (publica el JWT_SECRET a SSM).
+5. `serverless deploy --lambda=auth_email_worker --stage=dev`.
+6. `serverless deploy --lambda=auth --stage=dev`.
+7. Seed de rate-limit rules (paso 8 arriba).
+
+Mismo orden en `stage` y `prod`. El CI auto-detecta los cambios via
+`change_detector.py` y arma el matrix correcto.

--- a/docs/specs/01-auth-infra-basics/05-lambda-auth-arquitectura.md
+++ b/docs/specs/01-auth-infra-basics/05-lambda-auth-arquitectura.md
@@ -188,10 +188,6 @@ class AppConfig(Settings):
         return _resolve_table_name_from_ssm('SSM_JWT_BLACKLIST_TABLE_PATH')
 
     @cached_property
-    def auth_codes_table(self) -> str:
-        return _resolve_table_name_from_ssm('SSM_AUTH_CODES_TABLE_PATH')
-
-    @cached_property
     def auth_email_queue_url(self) -> str:
         return _resolve_from_ssm('SSM_AUTH_EMAIL_QUEUE_URL_PATH')
 
@@ -243,7 +239,16 @@ EVENT_MODEL = build_event_model({
 `models/register.py`:
 
 ```python
+from typing import Literal
+
 from shared.core import BaseModel, EmailStr, Field, model_validator
+
+
+# Lista cerrada: los 6 niches del portfolio. Cualquier otro valor en
+# el payload del cliente -> ValidationError 400. Esto evita que un
+# atacante meta strings arbitrarios (incluyendo HTML/script) en el
+# audit log o templates de email.
+Niche = Literal['generic', 'hub', 'fintech', 'architect', 'leader', 'vibe']
 
 
 class _Meta(BaseModel):
@@ -258,7 +263,7 @@ class RegisterStartIn(BaseModel):
     """POST /auth operation=register action=start."""
     email: EmailStr
     cf_turnstile_response: str = Field(min_length=1)
-    niche: str | None = Field(default=None, max_length=32)
+    niche: Niche | None = None
     meta: _Meta = Field(default_factory=_Meta, alias='_meta')
 
     model_config = {'populate_by_name': True}
@@ -450,72 +455,110 @@ else:
     return {'temp_token': new_temp, 'expires_in': 300, ...}
 ```
 
-## Flujo de magic-link (GET)
+## Flujo de magic-link (GET → 302 redirect al dashboard)
 
 El magic-link es una URL que el user clickea desde su email. API
 Gateway recibe `GET /auth?operation=register&action=verify-magic-link&token=<X>`.
-La Lambda devuelve un HTML 200 inline (no redirect):
+La Lambda **responde con HTTP 302** y un header `Location:` que apunta
+al dashboard con los tokens en el **fragment hash**.
 
-```html
-<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="utf-8">
-  <title>Verificando tu correo...</title>
-  <style>body{font-family:system-ui;padding:2rem;text-align:center}</style>
-</head>
-<body>
-  <h1>Correo verificado</h1>
-  <p>Te estamos redirigiendo a tu portfolio...</p>
-  <script>
-    const data = /* JSON con access/refresh tokens, inyectado por la lambda */;
-    localStorage.setItem('access_token', data.access_token);
-    localStorage.setItem('refresh_token', data.refresh_token);
-    localStorage.setItem('user', JSON.stringify(data.user));
-    window.location.replace(
-      'https://hub.portfolio.{env}.the-full-stack.com/dashboard'
-    );
-  </script>
-  <noscript>
-    <p>Tu navegador no soporta JS. Continua manualmente:</p>
-    <a href="https://hub.portfolio.{env}.the-full-stack.com/login">Continuar</a>
-  </noscript>
-</body>
-</html>
+```text
+HTTP/1.1 302 Found
+Location: https://admin.portfolio.{env}.the-full-stack.com/callback#access=<JWT>&refresh=<JWT>&user_id=<X>&email=<Y>
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
 ```
 
-> NOTA seguridad: inyectar tokens via `localStorage` en HTML servido
-> por API Gateway acepta el tradeoff de NO usar HttpOnly cookies (decidido
-> en la fase de preguntas — el portfolio es API-first multi-subdomain).
-> Mitigaciones: CSP `default-src 'self'` en el HTML, tokens cortos
-> (access 15min), refresh con rotation + family detection.
+Por que **fragment hash** y NO query string:
 
-El handler de este GET es un caso especial: devuelve `Content-Type:
-text/html` en vez de `application/json`. Para soportarlo, el controller
-`register.verify_magic_link.VerifyMagicLink` setea un flag en el
-DispatchResult que `http_handler` interpreta como "envuelve esto en
-HTML". Implementacion: agregar un `Literal['json'|'html']` opcional al
-DispatchResult o usar un nuevo campo `content_type` en el data.
++ El fragment (`#...`) NUNCA se envia al servidor en el siguiente
+  request — vive solo en el browser.
++ NO aparece en logs de CloudFront / CloudWatch / nginx / proxies
+  intermedios.
++ NO se incluye en `Referer` headers de subsequent navigations.
++ El dashboard lee `window.location.hash` desde JS, decodifica los
+  tokens, los guarda en `localStorage` via Zustand, limpia el hash con
+  `history.replaceState`, y redirige a `/dashboard`.
 
-> **Refinamiento**: por simplicidad, podemos publicar el magic-link
-> apuntando a un endpoint POST y servir SOLO JSON. La pagina HTML
-> intermedia la genera apps/hub en plan futuro. Esto evita complicar el
-> http_handler. **Decision: el magic-link apunta a `GET` y la Lambda
-> devuelve HTML inline. El http_handler se extiende con soporte HTML en
-> esta fase.**
+Ventajas vs servir HTML inline desde la Lambda:
+
++ **El handler `http_handler` NO se extiende**. Sigue devolviendo
+  JSON-only para el resto de actions. El 302 lo expresa el controller
+  retornando un `DispatchResult` con el header `Location` populated
+  (patron que `http_handler` ya soporta — solo agrega el header al
+  response final, sin tocar `content_type`).
++ Cero HTML servido por API Gateway: si el dashboard tiene XSS, el
+  blast radius esta acotado al dashboard (no a la API).
++ El callback del dashboard se reusa para el flujo de login y
+  password-reset (mismo handler `/callback` del dashboard).
+
+Implementacion del controller (`register.verify_magic_link.VerifyMagicLink`):
+
+```python
+def execute(self):
+    # ... verificar token, marcar consumido, emitir JWT ...
+    callback_url = (
+        f"https://admin.portfolio.{stage_to_env_label(app_config.stage)}"
+        f".the-full-stack.com/callback"
+        f"#access={access_token}&refresh={refresh_token}"
+        f"&user_id={user.id}&email={user.email}"
+    )
+    return {
+        'is_valid': True,
+        'code': 0,
+        'data': {},
+        'redirect': {
+            'status': 302,
+            'location': callback_url,
+            'cache_control': 'no-store, no-cache, must-revalidate',
+        },
+    }
+```
+
+`http_handler` interpreta el campo opcional `redirect` del
+DispatchResult y, en lugar de devolver el JSON estandar, construye:
+
+```python
+{
+    'statusCode': dispatch.redirect['status'],
+    'headers': {
+        'Location': dispatch.redirect['location'],
+        'Cache-Control': dispatch.redirect['cache_control'],
+        # CORS sigue aplicando segun cors_origin del handler
+    },
+    'body': '',
+}
+```
+
+Este cambio es **aditivo** (campo opcional `redirect`) y NO rompe el
+contrato JSON existente del resto de actions. Se documenta en
+`shared.lambda_kit.http_handler` y se cubre con un test unit nuevo
+(`test_http_handler_redirect.py` en `shared/tests/unit/shared/lambda_kit/`).
+
+### Por que el redirect apunta a admin (no a un niche)
+
+Antes de plan auth no habia "dashboard" — los usuarios del portfolio
+son visitantes anonimos de las 6 apps publicas. El **dashboard
+(`admin.portfolio.{env}.the-full-stack.com`)** es el unico contexto
+autenticado del proyecto (admin de Pablo, futuras areas privadas).
+Los magic-links siempre llevan ahi.
+
+Si un futuro plan agrega areas autenticadas en algun niche (ej.
+`fintech.portfolio.../app/dashboard`), se parametrizara via `niche`
+en el payload del controller — pero ese cambio NO entra en plan 01.
 
 ## Que toca cada controller (matriz resumen)
 
 | Controller | Neon (lectura/escritura) | DDB (lectura/escritura) | SQS publish | JWT issue/verify/blacklist |
 |------------|--------------------------|-------------------------|-------------|----------------------------|
-| register.start | R/W auth_users, W auth_email_codes/links, W audit | W auth-codes | 2 (magic-link + code) | issue temp |
-| register.verify-magic-link | R/W links, R/W user, W audit | R/W blacklist (temp), R auth-codes | 0 | verify temp, issue access+refresh, blacklist temp |
-| register.verify-code | R/W codes, R/W user, W audit | R/W blacklist (temp), R/W auth-codes | 0 | idem |
-| login.start | R user, W audit, W codes/links | W auth-codes | 0..2 | issue temp (si user existe) |
+| register.start | R/W auth_users, W auth_email_codes/links, W audit | (ninguna) | 2 (magic-link + code) | issue temp |
+| register.verify-magic-link | R/W links, R/W user, W audit | R/W blacklist (temp) | 0 | verify temp, issue access+refresh, blacklist temp |
+| register.verify-code | R/W codes, R/W user, W audit | R/W blacklist (temp) | 0 | idem |
+| login.start | R user, W audit, W codes/links | (ninguna) | 0..2 | issue temp (si user existe) |
 | login.verify-magic-link | mismo que register | mismo | 0 | idem |
 | login.verify-code | mismo | mismo | 0 | idem |
 | verify.set-password | R user, W auth_credentials, W audit | R/W blacklist (temp) | 0 | verify temp, issue temp nuevo |
-| verify.resend-code | R/W codes/links, W audit | W auth-codes | 1-2 | verify temp, issue temp nuevo |
+| verify.resend-code | R/W codes/links, W audit | (ninguna) | 1-2 | verify temp, issue temp nuevo |
 | session.refresh | R user, W audit | R/W blacklist | 0 | verify refresh, issue access+refresh rotado |
 | session.logout | W audit | W blacklist (jti + family_id) | 0 | verify access, blacklist access+refresh |
 

--- a/docs/specs/01-auth-infra-basics/05-lambda-auth-arquitectura.md
+++ b/docs/specs/01-auth-infra-basics/05-lambda-auth-arquitectura.md
@@ -1,0 +1,537 @@
+# 05. Lambda `auth` — arquitectura
+
+> Aplica el formato lambda-controller: handler delgado, controllers
+> orquestan, services tienen la logica de negocio, models Pydantic
+> validan estructura. EventModel armado con `build_event_model(OPERATIONS)`
+> de shared.lambda_kit. http_handler del repo procesa CORS, request
+> extraction, _meta injection, dispatch y serializacion.
+
+## Estructura de carpetas
+
+```text
+serverless/lambda/services/auth/
+├── manifest.yaml
+├── pyproject.toml             # PEP 621; deps: solo lo que NO aporta shared
+├── uv.lock
+├── .gitignore                 # build/ + build.zip
+├── core/
+│   ├── handler.py             # lambda_handler -> http_handler(...)
+│   ├── settings/
+│   │   ├── config.py          # AppConfig (env vars + SSM lazy)
+│   │   └── operations.py      # OPERATIONS dict
+│   ├── models/
+│   │   ├── event.py           # EventModel armado con build_event_model
+│   │   ├── register.py        # RegisterStartIn, RegisterVerifyMagicLinkIn, ...
+│   │   ├── login.py           # LoginStartIn, LoginVerifyMagicLinkIn, ...
+│   │   ├── verify.py          # VerifySetPasswordIn, VerifyResendCodeIn
+│   │   └── session.py         # SessionRefreshIn, SessionLogoutIn
+│   ├── controllers/
+│   │   ├── __init__.py
+│   │   ├── register/
+│   │   │   ├── start.py             # Start(BaseController)
+│   │   │   ├── verify_magic_link.py # VerifyMagicLink(BaseController)
+│   │   │   └── verify_code.py       # VerifyCode(BaseController)
+│   │   ├── login/
+│   │   │   ├── start.py
+│   │   │   ├── verify_magic_link.py
+│   │   │   └── verify_code.py
+│   │   ├── verify/
+│   │   │   ├── set_password.py
+│   │   │   └── resend_code.py
+│   │   └── session/
+│   │       ├── refresh.py
+│   │       └── logout.py
+│   ├── services/
+│   │   ├── __init__.py
+│   │   ├── user_service.py          # lookup, create, lock, unlock
+│   │   ├── code_service.py          # generate + persist (Neon + DDB)
+│   │   ├── magic_link_service.py    # generate + persist + verify
+│   │   ├── jwt_service.py           # issue temp/access/refresh + rotate + blacklist
+│   │   ├── blacklist_service.py     # DDB ops (PutItem, GetItem por jti, Query por family_id)
+│   │   ├── email_dispatch_service.py # publica a SQS auth-email-queue
+│   │   ├── audit_service.py         # auth_audit_log inserts
+│   │   ├── rate_limit_service.py    # wrapper de shared.rate_limit.check_or_raise
+│   │   └── flow_service.py          # orquestador de pasos del flujo (verify -> set-password -> ...)
+│   └── utils/
+│       └── __init__.py              # vacio; el kit ya esta en shared.lambda_kit
+├── events/                          # JSONs de prueba para `serverless run`
+│   ├── register-start.json
+│   ├── register-verify-magic-link.json
+│   ├── register-verify-code.json
+│   ├── login-start.json
+│   ├── login-verify-magic-link.json
+│   ├── login-verify-code.json
+│   ├── verify-set-password.json
+│   ├── verify-resend-code.json
+│   ├── session-refresh.json
+│   └── session-logout.json
+└── tests/
+    ├── conftest.py
+    ├── unit/
+    │   ├── _helpers.py              # builders compartidos
+    │   ├── controllers/             # 1 archivo por test
+    │   ├── services/
+    │   └── models/
+    └── integration/
+        ├── conftest.py
+        ├── _fixtures/
+        ├── test_register_start_e2e.py
+        ├── test_login_start_e2e.py
+        ├── test_full_register_flow_e2e.py
+        └── test_logout_blacklists_jwt_e2e.py
+```
+
+## `handler.py` (esqueleto)
+
+```python
+"""Lambda auth — entrypoint."""
+
+from typing import Any
+
+from shared.lambda_kit import http_handler
+
+from .models.event import EVENT_MODEL
+
+
+def lambda_handler(event: dict[str, Any], _context: object) -> dict[str, Any]:
+    return http_handler(
+        event,
+        event_model=EVENT_MODEL,
+        cors_origin='echo',
+        success_status=200,
+        metric_names={
+            'submitted': 'AuthRequestAccepted',
+            'rejected':  'AuthRequestRejected',
+            'error':     'AuthRequestError',
+        },
+    )
+```
+
+## `settings/operations.py`
+
+```python
+"""Registro de operations -> {controller_module, action -> Class}."""
+
+from shared.lambda_kit import resolve_operation
+
+
+OPERATIONS = {
+    'register': {
+        'actions': ['start', 'verify-magic-link', 'verify-code'],
+    },
+    'login': {
+        'actions': ['start', 'verify-magic-link', 'verify-code'],
+    },
+    'verify': {
+        'actions': ['set-password', 'resend-code'],
+    },
+    'session': {
+        'actions': ['refresh', 'logout'],
+    },
+}
+```
+
+El controller se descubre por convencion:
+`core.controllers.<operation>.<action_snake>.<ActionPascal>`. Ej:
+`verify-magic-link` -> module `controllers/register/verify_magic_link.py`
++ clase `VerifyMagicLink(BaseController)`.
+
+## `settings/config.py` (AppConfig)
+
+```python
+from functools import cached_property
+from shared.core import Settings
+from shared.aws import get_secret_by_name
+
+
+class AppConfig(Settings):
+    """Env vars + lazy secrets en cold start."""
+
+    log_level: str = 'INFO'
+    powertools_service_name: str = 'auth'
+    powertools_metrics_namespace: str = 'Portfolio/Auth'
+
+    # Env vars
+    jwt_issuer: str = 'portfolio-auth'
+    jwt_audience: str = 'portfolio'
+    magic_link_base_url: str            # ej. https://api.portfolio.dev.the-full-stack.com/auth
+    cors_allowed_origins: str
+    stage: str                          # 'dev'|'stage'|'prod'|'local'
+
+    # SSM lazy (paths del manifest)
+    @cached_property
+    def jwt_secret(self) -> str:
+        return get_secret_by_name('jwt-secret', local_env='JWT_SECRET')
+
+    @cached_property
+    def turnstile_secret(self) -> str:
+        return get_secret_by_name('turnstile-secret', local_env='TURNSTILE_SECRET_KEY')
+
+    @cached_property
+    def turnstile_bypass_secret(self) -> str | None:
+        return get_secret_by_name(
+            'turnstile-bypass-secret', local_env='TURNSTILE_BYPASS_SECRET',
+            optional=True,
+        )
+
+    @cached_property
+    def neon_url(self) -> str:
+        return get_secret_by_name('neon-url', local_env='DATABASE_URL')
+
+    @cached_property
+    def ses_from_address(self) -> str:
+        return get_secret_by_name('ses-from-address', local_env='SES_FROM_ADDRESS')
+
+    # DynamoDB table names (resueltos en cold start desde SSM)
+    @cached_property
+    def jwt_blacklist_table(self) -> str:
+        return _resolve_table_name_from_ssm('SSM_JWT_BLACKLIST_TABLE_PATH')
+
+    @cached_property
+    def auth_codes_table(self) -> str:
+        return _resolve_table_name_from_ssm('SSM_AUTH_CODES_TABLE_PATH')
+
+    @cached_property
+    def auth_email_queue_url(self) -> str:
+        return _resolve_from_ssm('SSM_AUTH_EMAIL_QUEUE_URL_PATH')
+
+
+app_config = AppConfig()
+```
+
+## `models/event.py`
+
+```python
+"""EventModel armado con shared.lambda_kit.build_event_model."""
+
+from shared.lambda_kit import build_event_model
+
+from .login import LoginStartIn, LoginVerifyCodeIn, LoginVerifyMagicLinkIn
+from .register import (
+    RegisterStartIn,
+    RegisterVerifyCodeIn,
+    RegisterVerifyMagicLinkIn,
+)
+from .session import SessionLogoutIn, SessionRefreshIn
+from .verify import VerifyResendCodeIn, VerifySetPasswordIn
+
+
+EVENT_MODEL = build_event_model({
+    'register': {
+        'start': RegisterStartIn,
+        'verify-magic-link': RegisterVerifyMagicLinkIn,
+        'verify-code': RegisterVerifyCodeIn,
+    },
+    'login': {
+        'start': LoginStartIn,
+        'verify-magic-link': LoginVerifyMagicLinkIn,
+        'verify-code': LoginVerifyCodeIn,
+    },
+    'verify': {
+        'set-password': VerifySetPasswordIn,
+        'resend-code': VerifyResendCodeIn,
+    },
+    'session': {
+        'refresh': SessionRefreshIn,
+        'logout': SessionLogoutIn,
+    },
+})
+```
+
+## Modelos Pydantic (ejemplos)
+
+`models/register.py`:
+
+```python
+from shared.core import BaseModel, EmailStr, Field, model_validator
+
+
+class _Meta(BaseModel):
+    ip: str | None = None
+    country: str | None = None
+    user_agent: str | None = None
+    bypass_secret: str | None = None
+    origin: str | None = None
+
+
+class RegisterStartIn(BaseModel):
+    """POST /auth operation=register action=start."""
+    email: EmailStr
+    cf_turnstile_response: str = Field(min_length=1)
+    niche: str | None = Field(default=None, max_length=32)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = {'populate_by_name': True}
+
+
+class RegisterVerifyMagicLinkIn(BaseModel):
+    """GET callback of the magic-link OR POST."""
+    token: str = Field(min_length=32, max_length=128)
+    temp_token: str | None = None        # opcional (si el user lo trae al GET)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = {'populate_by_name': True}
+
+
+class RegisterVerifyCodeIn(BaseModel):
+    code: str = Field(min_length=8, max_length=8, pattern=r'^[A-HJ-NP-Z2-9]{8}$')
+    temp_token: str = Field(min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = {'populate_by_name': True}
+```
+
+`models/session.py`:
+
+```python
+class SessionRefreshIn(BaseModel):
+    refresh_token: str = Field(min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+class SessionLogoutIn(BaseModel):
+    access_token: str = Field(min_length=20)
+    refresh_token: str | None = None   # logout invalida ambos si llega
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+```
+
+## Patron de controller (ejemplo: `register.start`)
+
+`controllers/register/start.py`:
+
+```python
+"""Register.Start — inicia el flujo de registro.
+
+Flujo:
+  1. preload: nada (config ya en cold start)
+  2. validate: Pydantic + Turnstile + rate-limit
+  3. execute:
+     a. lookup user por email -> si existe + active -> 409
+     b. crear/upsert user pendiente
+     c. generar code + magic-link
+     d. persistir (Neon + DDB en paralelo via TaskGroup)
+     e. publicar 2 mensajes SQS
+     f. emitir temp JWT (flow='register', step=1)
+     g. audit log success
+     h. devolver {temp_token, user_id, expires_in: 300}
+"""
+
+from shared.lambda_kit import BaseController, ErrorCode
+from shared.observability import logger, metrics
+
+from ...services.audit_service import AuditService
+from ...services.code_service import CodeService
+from ...services.email_dispatch_service import EmailDispatchService
+from ...services.jwt_service import JwtService
+from ...services.magic_link_service import MagicLinkService
+from ...services.rate_limit_service import RateLimitService
+from ...services.user_service import UserService
+from ...settings.config import app_config
+
+
+class Start(BaseController):
+    def preload(self):
+        return {'is_valid': True, 'data': {}, 'code': 0}
+
+    def validate(self):
+        # http_handler ya valido Pydantic. Aqui aplicamos validaciones de negocio:
+        meta = self.data['_meta']
+        RateLimitService(app_config).check_or_raise(
+            ip=meta['ip'], endpoint='/auth#register.start',
+            country=meta['country'],
+        )
+        # Turnstile
+        from shared.http import verify_turnstile_token
+        verify_turnstile_token(
+            self.data['cf_turnstile_response'],
+            remote_ip=meta['ip'],
+            bypass_secret=meta['bypass_secret'],
+        )
+        return {'is_valid': True, 'data': {}, 'code': 0}
+
+    def execute(self):
+        user_svc = UserService(app_config)
+        code_svc = CodeService(app_config)
+        link_svc = MagicLinkService(app_config)
+        jwt_svc  = JwtService(app_config)
+        email_svc = EmailDispatchService(app_config)
+        audit = AuditService(app_config)
+        meta = self.data['_meta']
+
+        # 1. Idempotency
+        existing = user_svc.get_by_email(self.data['email'])
+        if existing and existing.status == 'active':
+            audit.log(event='register.start', success=False,
+                      error_code='EMAIL_ALREADY_REGISTERED',
+                      user_id=existing.id, ip=meta['ip'])
+            return {
+                'is_valid': False, 'code': 4001,
+                'data': {'error': 'EMAIL_ALREADY_REGISTERED'},
+            }
+
+        # 2. Crear/upsert pending
+        user = existing or user_svc.create_pending(email=self.data['email'])
+
+        # 3. Generar + persistir
+        code, code_hash = code_svc.generate_and_persist(
+            user_id=user.id, kind='register',
+        )
+        token, token_hash = link_svc.generate_and_persist(
+            user_id=user.id, kind='register',
+            ip=meta['ip'], user_agent=meta['user_agent'],
+        )
+
+        # 4. Publicar emails a SQS
+        verify_url = (
+            f"{app_config.magic_link_base_url}"
+            f"?operation=register&action=verify-magic-link&token={token}"
+        )
+        email_svc.publish_magic_link(
+            to=user.email, user_id=user.id, niche=self.data.get('niche'),
+            kind='register-magic-link', token=token, verify_url=verify_url,
+        )
+        email_svc.publish_code(
+            to=user.email, user_id=user.id, niche=self.data.get('niche'),
+            kind='register-code', code=code,
+        )
+
+        # 5. Temp JWT (rolling)
+        temp_token, claims = jwt_svc.issue_temp(
+            user_id=user.id, flow='register', step=1,
+        )
+
+        # 6. Audit
+        audit.log(event='register.start', success=True, user_id=user.id,
+                  ip=meta['ip'], user_agent=meta['user_agent'])
+
+        return {
+            'is_valid': True, 'code': 0,
+            'data': {
+                'temp_token': temp_token,
+                'user_id': str(user.id),
+                'expires_in': 300,
+            },
+        }
+```
+
+## Rolling temp JWT — patron implementado en cada controller del flujo
+
+`verify.set-password`, `register.verify-code`, `register.verify-magic-link`,
+`verify.resend-code` siguen este patron:
+
+```python
+# 1. Recibe temp_token en data
+temp_token = self.data['temp_token']
+
+# 2. Verifica signature + exp + typ='temp' + NOT in blacklist
+claims = jwt_svc.verify_temp(temp_token, expected_flow='register')
+
+# 3. Blacklistea el jti viejo
+jwt_svc.blacklist(jti=claims.jti, exp=claims.exp,
+                  user_id=claims.sub, reason='rotation')
+
+# 4. Ejecuta la accion (verify code, set password, ...)
+
+# 5. Si el flujo terminal -> emite access + refresh (NO temp).
+#    Si el flujo continua -> emite un NUEVO temp con step+1
+if is_terminal_step:
+    access, _  = jwt_svc.issue_access(user_id=claims.sub, email=user.email)
+    refresh, _ = jwt_svc.issue_refresh(user_id=claims.sub,
+                                        family_id=uuidv7())
+    return {'access_token': access, 'refresh_token': refresh,
+            'expires_in': 900, 'token_type': 'Bearer',
+            'user': {'id': str(user.id), 'email': user.email,
+                     'status': user.status}}
+else:
+    new_temp, _ = jwt_svc.issue_temp(user_id=claims.sub,
+                                      flow=claims.flow, step=claims.step + 1)
+    return {'temp_token': new_temp, 'expires_in': 300, ...}
+```
+
+## Flujo de magic-link (GET)
+
+El magic-link es una URL que el user clickea desde su email. API
+Gateway recibe `GET /auth?operation=register&action=verify-magic-link&token=<X>`.
+La Lambda devuelve un HTML 200 inline (no redirect):
+
+```html
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Verificando tu correo...</title>
+  <style>body{font-family:system-ui;padding:2rem;text-align:center}</style>
+</head>
+<body>
+  <h1>Correo verificado</h1>
+  <p>Te estamos redirigiendo a tu portfolio...</p>
+  <script>
+    const data = /* JSON con access/refresh tokens, inyectado por la lambda */;
+    localStorage.setItem('access_token', data.access_token);
+    localStorage.setItem('refresh_token', data.refresh_token);
+    localStorage.setItem('user', JSON.stringify(data.user));
+    window.location.replace(
+      'https://hub.portfolio.{env}.the-full-stack.com/dashboard'
+    );
+  </script>
+  <noscript>
+    <p>Tu navegador no soporta JS. Continua manualmente:</p>
+    <a href="https://hub.portfolio.{env}.the-full-stack.com/login">Continuar</a>
+  </noscript>
+</body>
+</html>
+```
+
+> NOTA seguridad: inyectar tokens via `localStorage` en HTML servido
+> por API Gateway acepta el tradeoff de NO usar HttpOnly cookies (decidido
+> en la fase de preguntas — el portfolio es API-first multi-subdomain).
+> Mitigaciones: CSP `default-src 'self'` en el HTML, tokens cortos
+> (access 15min), refresh con rotation + family detection.
+
+El handler de este GET es un caso especial: devuelve `Content-Type:
+text/html` en vez de `application/json`. Para soportarlo, el controller
+`register.verify_magic_link.VerifyMagicLink` setea un flag en el
+DispatchResult que `http_handler` interpreta como "envuelve esto en
+HTML". Implementacion: agregar un `Literal['json'|'html']` opcional al
+DispatchResult o usar un nuevo campo `content_type` en el data.
+
+> **Refinamiento**: por simplicidad, podemos publicar el magic-link
+> apuntando a un endpoint POST y servir SOLO JSON. La pagina HTML
+> intermedia la genera apps/hub en plan futuro. Esto evita complicar el
+> http_handler. **Decision: el magic-link apunta a `GET` y la Lambda
+> devuelve HTML inline. El http_handler se extiende con soporte HTML en
+> esta fase.**
+
+## Que toca cada controller (matriz resumen)
+
+| Controller | Neon (lectura/escritura) | DDB (lectura/escritura) | SQS publish | JWT issue/verify/blacklist |
+|------------|--------------------------|-------------------------|-------------|----------------------------|
+| register.start | R/W auth_users, W auth_email_codes/links, W audit | W auth-codes | 2 (magic-link + code) | issue temp |
+| register.verify-magic-link | R/W links, R/W user, W audit | R/W blacklist (temp), R auth-codes | 0 | verify temp, issue access+refresh, blacklist temp |
+| register.verify-code | R/W codes, R/W user, W audit | R/W blacklist (temp), R/W auth-codes | 0 | idem |
+| login.start | R user, W audit, W codes/links | W auth-codes | 0..2 | issue temp (si user existe) |
+| login.verify-magic-link | mismo que register | mismo | 0 | idem |
+| login.verify-code | mismo | mismo | 0 | idem |
+| verify.set-password | R user, W auth_credentials, W audit | R/W blacklist (temp) | 0 | verify temp, issue temp nuevo |
+| verify.resend-code | R/W codes/links, W audit | W auth-codes | 1-2 | verify temp, issue temp nuevo |
+| session.refresh | R user, W audit | R/W blacklist | 0 | verify refresh, issue access+refresh rotado |
+| session.logout | W audit | W blacklist (jti + family_id) | 0 | verify access, blacklist access+refresh |
+
+## Donde NO va la logica
+
+- `handler.py`: solo router via `http_handler`. Cero negocio.
+- `controllers/`: orquestan. Cero queries SQL ni boto3 directo. Solo
+  llamadas a `services/`.
+- `models/`: solo Pydantic schemas. Sin negocio.
+- `services/`: TODA la logica. Acceso a `shared.db.repositories.auth.*`,
+  `shared.aws.get_resource`, `shared.aws.get_table`, `shared.auth.*`.
+
+## Cierre de la arquitectura
+
+La forma del Lambda `auth` clona `contact_form` (HTTP write + SQS
+publisher + Turnstile + rate-limit + Neon + DDB) pero con mas operations
+y un dominio nuevo. No introduce patrones nuevos al backend. SnapStart
+habilitado para reducir cold start (~10x mejora segun la skill
+`aws-lambda-python`).

--- a/docs/specs/01-auth-infra-basics/06-testing.md
+++ b/docs/specs/01-auth-infra-basics/06-testing.md
@@ -94,29 +94,32 @@ Ya listado en [03-shared-auth.md](03-shared-auth.md) — 17 archivos.
 | `test_register_start_turnstile_invalid_403.py` | Turnstile fail -> 403 antes de tocar Neon | AC-12 |
 | `test_register_start_rate_limited_429.py` | 4ta request en 1h -> 429 | AC-13 |
 | `test_register_verify_magic_link_ok.py` | token valido -> 200 con access+refresh | AC-3 |
-| `test_register_verify_magic_link_consumed.py` | ya consumido -> 400 LINK_CONSUMED |  |
-| `test_register_verify_magic_link_expired.py` | expirado -> 400 LINK_EXPIRED |  |
+| `test_register_verify_magic_link_consumed.py` | ya consumido -> 400 LINK_CONSUMED | AC-16 |
+| `test_register_verify_magic_link_expired.py` | expirado -> 400 LINK_EXPIRED | AC-17 |
 | `test_register_verify_code_ok.py` | code correcto + temp_token valido -> 200 con access+refresh | AC-4 |
-| `test_register_verify_code_wrong_increments.py` | code wrong -> 400 + attempts incremented |  |
+| `test_register_verify_code_wrong_increments.py` | code wrong -> 400 + attempts incremented | AC-11 |
 | `test_register_verify_code_locks_after_5_fail.py` | 5to fail -> 423 ACCOUNT_LOCKED | AC-11 |
-| `test_register_verify_code_temp_token_expired.py` | temp_token exp pasado -> 401 |  |
+| `test_register_verify_code_temp_token_expired.py` | temp_token exp pasado -> 401 | AC-18 |
 | `test_register_verify_code_temp_token_blacklisted.py` | replay del viejo -> 401 TOKEN_BLACKLISTED | AC-10 |
+| `test_register_start_email_pending_reemits.py` | pending -> re-emite magic + code (idempotente) | AC-19 |
+| `test_register_start_email_disabled_404.py` | disabled -> 404 EMAIL_NOT_FOUND (anti-enumeration) | AC-20 |
 | `test_login_start_email_not_found_404.py` | email no existe -> 404 + suggest_register | AC-5 |
 | `test_login_start_email_active_no_password.py` | active sin password -> 200 + methods=[magic-link, email-code] | AC-6 |
-| `test_login_start_email_locked_423.py` | locked -> 423 ACCOUNT_LOCKED |  |
-| `test_login_start_email_pending_409.py` | pending -> 409 (debe completar register) |  |
-| `test_login_verify_magic_link_ok.py` | login flow magic-link OK -> access+refresh |  |
-| `test_login_verify_code_ok.py` | login flow code OK -> access+refresh |  |
-| `test_verify_set_password_ok.py` | password seteada en auth_credentials |  |
-| `test_verify_set_password_too_short.py` | < 12 chars -> 400 |  |
-| `test_verify_resend_code_ok.py` | nuevo code + sqs publish |  |
-| `test_verify_resend_code_throttled.py` | menos de 60s desde el ultimo -> 429 RESEND_THROTTLED |  |
+| `test_login_start_email_locked_404.py` | locked -> 404 EMAIL_NOT_FOUND (anti-enumeration) | AC-20 |
+| `test_login_start_email_disabled_404.py` | disabled -> 404 EMAIL_NOT_FOUND (anti-enumeration) | AC-20 |
+| `test_login_start_email_pending_409.py` | pending -> 409 PENDING_VERIFICATION (debe completar register) | AC-6 |
+| `test_login_verify_magic_link_ok_updates_last_login.py` | login flow magic-link OK -> access+refresh + `last_login_at` updated + `failed_attempts=0` | AC-22 |
+| `test_login_verify_code_ok_updates_last_login.py` | login flow code OK -> idem | AC-22 |
+| `test_verify_set_password_ok.py` | password seteada en auth_credentials | AC-4 |
+| `test_verify_set_password_too_short.py` | < 12 chars -> 400 | AC-4 |
+| `test_verify_resend_code_ok.py` | nuevo code + sqs publish | AC-19 |
+| `test_verify_resend_code_throttled.py` | menos de 60s desde el ultimo -> 429 RESEND_THROTTLED | AC-21 |
 | `test_session_refresh_ok.py` | refresh valido -> nuevo access+refresh, viejo blacklisted | AC-7 |
 | `test_session_refresh_reuse_detected.py` | refresh ya consumed -> 401 + revoca family | AC-8 |
-| `test_session_refresh_invalid_signature.py` | signature wrong -> 401 |  |
+| `test_session_refresh_invalid_signature.py` | signature wrong -> 401 | AC-10 |
 | `test_session_logout_access_ok.py` | access valido -> 204 + blacklist | AC-9 |
-| `test_session_logout_access_and_refresh.py` | ambos -> 204 + blacklist ambos + family |  |
-| `test_session_logout_already_blacklisted.py` | jti ya blacklisted -> 204 (idempotente) |  |
+| `test_session_logout_access_and_refresh.py` | ambos -> 204 + blacklist ambos + family | AC-9 |
+| `test_session_logout_already_blacklisted.py` | jti ya blacklisted -> 204 (idempotente) | AC-23 |
 
 ### `models/` (`tests/unit/models/`)
 
@@ -182,7 +185,7 @@ CORS_ALLOWED_ORIGINS=http://localhost:9999
 TURNSTILE_BYPASS_SECRET=<test-bypass-placeholder>
 DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/test
 SSM_JWT_BLACKLIST_TABLE_PATH=/portfolio/test/dynamodb/jwt-blacklist/name
-SSM_AUTH_CODES_TABLE_PATH=/portfolio/test/dynamodb/auth-codes/name
+SSM_AUTH_EMAIL_QUEUE_URL_PATH=/portfolio/test/sqs/auth-email/url
 ```
 
 Los placeholders `<...>` se sustituyen por valores aleatorios generados

--- a/docs/specs/01-auth-infra-basics/06-testing.md
+++ b/docs/specs/01-auth-infra-basics/06-testing.md
@@ -1,0 +1,220 @@
+# 06. Estrategia de testing
+
+> Sigue el "Estandar de testing" de `.claude/rules/lambda-controller.md`:
+> dos niveles (`tests/unit/`, `tests/integration/`), un archivo por
+> escenario, docstring Given/When/Then + cuerpo AAA, asserts EXACTOS.
+
+## Niveles
+
+### Unit (`tests/unit/`)
+
+Aislado, sin red. Mockea SOLO E/S externa: SES, SSM, DynamoDB
+(via `shared.aws.get_resource` -> patcheado), SQS publish (`boto3`
+sqs client), Neon (sessionmaker patcheado). NO se mockean
+`controllers`, `services`, `models`, `shared.auth.*`, `shared.rate_limit.*`
+propios.
+
+`conftest.py` raiz:
+- Inyecta env vars (`JWT_ISSUER`, `JWT_AUDIENCE`, `MAGIC_LINK_BASE_URL`,
+  `CORS_ALLOWED_ORIGINS`, etc.).
+- Mockea `get_secret_by_name('jwt-secret', ...)` con un valor fijo
+  para reproducibilidad (cualquier string >32 chars sirve).
+- Mockea `boto3.client('dynamodb')`, `boto3.resource('dynamodb')`,
+  `boto3.client('sqs')`, `boto3.client('sesv2')` con `botocore.stub`.
+- Patches `shared.db.db_session` con un `Session` en memoria
+  (SQLite-compatible si los modelos lo permiten, sino mocks).
+
+### Integration (`tests/integration/`)
+
+E2E con recursos reales en `local` (RIE + dynamodb-local + neon branch
+de prueba). `conftest.py`:
+- Cleanup `autouse`: borra el row de `auth_users` con email
+  `test+<timestamp>@example.com` antes y despues.
+- Fixtures de `_fixtures/`: crean users en distintos estados (pending,
+  active, locked).
+- NO mockea nada.
+
+## Cobertura objetivo
+
+- Coverage per-file >= 80% en `core/services/`, `core/controllers/`,
+  `core/models/`.
+- `shared/auth/` cubre 100% (modulo pequeno, criticidad alta).
+- `core/handler.py` excluido del coverage threshold (es boilerplate
+  con `http_handler`).
+
+## Tabla de tests unit por archivo (1 archivo = 1 escenario)
+
+### `shared.auth` (en `shared/tests/unit/shared/auth/`)
+
+Ya listado en [03-shared-auth.md](03-shared-auth.md) — 17 archivos.
+
+### `services/` del Lambda auth (`tests/unit/services/`)
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_user_service_get_by_email_found.py` | email existente -> retorna AuthUser |
+| `test_user_service_get_by_email_not_found.py` | email inexistente -> None |
+| `test_user_service_create_pending_new.py` | crea row con status=pending |
+| `test_user_service_create_pending_duplicate.py` | email duplicado -> IntegrityError handled (re-fetch) |
+| `test_user_service_increment_failed_attempts.py` | incrementa contador, NO bloquea hasta 10 |
+| `test_user_service_lock_user_after_10_failed.py` | locked_until = now+1h, status=locked |
+| `test_user_service_reset_failed_attempts.py` | resetea a 0 + status active |
+| `test_code_service_generate_and_persist.py` | genera, persiste en Neon + DDB, retorna (code, hash) |
+| `test_code_service_verify_correct.py` | code correcto -> consume, retorna user_id |
+| `test_code_service_verify_wrong_increments.py` | code incorrecto -> increment attempts |
+| `test_code_service_verify_expired.py` | expired -> retorna None, NO consume |
+| `test_code_service_verify_max_attempts_locks.py` | 5th wrong -> locks user |
+| `test_magic_link_service_generate_persist.py` | genera token 32 bytes, persiste hash en Neon |
+| `test_magic_link_service_verify_correct.py` | token correcto -> consume |
+| `test_magic_link_service_verify_consumed.py` | ya consumido -> retorna None |
+| `test_magic_link_service_verify_expired.py` | expirado -> None |
+| `test_jwt_service_issue_temp.py` | claims correctas (flow, step, typ='temp') |
+| `test_jwt_service_issue_access.py` | claims correctas (typ='access', email) |
+| `test_jwt_service_issue_refresh_family.py` | family_id presente, uuidv7 |
+| `test_jwt_service_verify_temp.py` | OK + retorna claims |
+| `test_jwt_service_verify_blacklisted.py` | jti en blacklist -> JwtRevokedError |
+| `test_jwt_service_blacklist_jti.py` | PutItem en DDB con TTL=exp |
+| `test_jwt_service_blacklist_family.py` | Query GSI by_family_id -> blacklist todos |
+| `test_blacklist_service_get_revoked.py` | jti revoked -> True |
+| `test_blacklist_service_get_not_revoked.py` | jti no existe -> False |
+| `test_email_dispatch_service_publish_magic_link.py` | SQS SendMessage con body correcto |
+| `test_email_dispatch_service_publish_code.py` | idem para code |
+| `test_audit_service_log_success.py` | INSERT INTO auth_audit_log success=true |
+| `test_audit_service_log_failure.py` | success=false + error_code presente |
+| `test_rate_limit_service_check_or_raise_under.py` | bajo limite -> retorna |
+| `test_rate_limit_service_check_or_raise_over.py` | excedido -> levanta RateLimitExceededError |
+| `test_flow_service_advance_step.py` | recibe claims temp, emite nuevo +1, blacklistea viejo |
+
+### `controllers/` del Lambda auth (`tests/unit/controllers/`)
+
+| Archivo | Escenario | AC |
+|---------|-----------|-----|
+| `test_register_start_new_email_ok.py` | email nuevo + Turnstile valido -> 201 + temp_token | AC-1 |
+| `test_register_start_email_active_409.py` | email ya active -> 409 EMAIL_ALREADY_REGISTERED | AC-2 |
+| `test_register_start_turnstile_invalid_403.py` | Turnstile fail -> 403 antes de tocar Neon | AC-12 |
+| `test_register_start_rate_limited_429.py` | 4ta request en 1h -> 429 | AC-13 |
+| `test_register_verify_magic_link_ok.py` | token valido -> 200 con access+refresh | AC-3 |
+| `test_register_verify_magic_link_consumed.py` | ya consumido -> 400 LINK_CONSUMED |  |
+| `test_register_verify_magic_link_expired.py` | expirado -> 400 LINK_EXPIRED |  |
+| `test_register_verify_code_ok.py` | code correcto + temp_token valido -> 200 con access+refresh | AC-4 |
+| `test_register_verify_code_wrong_increments.py` | code wrong -> 400 + attempts incremented |  |
+| `test_register_verify_code_locks_after_5_fail.py` | 5to fail -> 423 ACCOUNT_LOCKED | AC-11 |
+| `test_register_verify_code_temp_token_expired.py` | temp_token exp pasado -> 401 |  |
+| `test_register_verify_code_temp_token_blacklisted.py` | replay del viejo -> 401 TOKEN_BLACKLISTED | AC-10 |
+| `test_login_start_email_not_found_404.py` | email no existe -> 404 + suggest_register | AC-5 |
+| `test_login_start_email_active_no_password.py` | active sin password -> 200 + methods=[magic-link, email-code] | AC-6 |
+| `test_login_start_email_locked_423.py` | locked -> 423 ACCOUNT_LOCKED |  |
+| `test_login_start_email_pending_409.py` | pending -> 409 (debe completar register) |  |
+| `test_login_verify_magic_link_ok.py` | login flow magic-link OK -> access+refresh |  |
+| `test_login_verify_code_ok.py` | login flow code OK -> access+refresh |  |
+| `test_verify_set_password_ok.py` | password seteada en auth_credentials |  |
+| `test_verify_set_password_too_short.py` | < 12 chars -> 400 |  |
+| `test_verify_resend_code_ok.py` | nuevo code + sqs publish |  |
+| `test_verify_resend_code_throttled.py` | menos de 60s desde el ultimo -> 429 RESEND_THROTTLED |  |
+| `test_session_refresh_ok.py` | refresh valido -> nuevo access+refresh, viejo blacklisted | AC-7 |
+| `test_session_refresh_reuse_detected.py` | refresh ya consumed -> 401 + revoca family | AC-8 |
+| `test_session_refresh_invalid_signature.py` | signature wrong -> 401 |  |
+| `test_session_logout_access_ok.py` | access valido -> 204 + blacklist | AC-9 |
+| `test_session_logout_access_and_refresh.py` | ambos -> 204 + blacklist ambos + family |  |
+| `test_session_logout_already_blacklisted.py` | jti ya blacklisted -> 204 (idempotente) |  |
+
+### `models/` (`tests/unit/models/`)
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_register_start_in_email_required.py` | sin email -> ValidationError |
+| `test_register_start_in_email_invalid.py` | email mal formado -> ValidationError |
+| `test_register_start_in_turnstile_required.py` | sin cf_turnstile_response -> ValidationError |
+| `test_register_verify_code_in_pattern.py` | code con O/0/I/1/L -> ValidationError |
+| `test_register_verify_code_in_length.py` | code != 8 -> ValidationError |
+| `test_session_refresh_in_short_token.py` | refresh_token < 20 chars -> ValidationError |
+| `test_meta_injection.py` | `_meta` se mapea a `meta` campo |
+
+### `tests/unit/` raiz
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_handler_routes_register_start.py` | event -> http_handler -> controller correcto |
+| `test_handler_invalid_operation_404.py` | operation desconocido -> 404 |
+| `test_handler_invalid_action_404.py` | action no en OPERATIONS -> 404 |
+| `test_event_model_register_actions.py` | EVENT_MODEL acepta los 3 actions de register |
+
+## Tests unit del Lambda `auth_email_worker`
+
+Path: `serverless/lambda/services/auth_email_worker/tests/unit/`
+
+| Archivo | Escenario | AC |
+|---------|-----------|-----|
+| `test_worker_handles_magic_link.py` | recibe mensaje -> renderiza template -> send_email called con args correctos | AC-14 |
+| `test_worker_handles_code.py` | mismo para email-code |  |
+| `test_worker_handles_password_reset.py` | mismo |  |
+| `test_worker_ses_error_retries.py` | SES throttle -> levanta excepcion (SQS reintenta) |  |
+| `test_worker_ses_permanent_failure.py` | bounce permanente -> log + audit + return (no reintenta) |  |
+| `test_worker_invalid_kind_dlq.py` | kind desconocido -> error -> termina en DLQ |  |
+| `test_worker_template_rendering_es.py` | locale=es -> contenido en espanol |  |
+| `test_worker_template_rendering_en.py` | locale=en -> contenido en ingles |  |
+
+## Tests integration (`tests/integration/`)
+
+Solo escenarios E2E criticos. Cada uno levanta dependencias locales
+(dynamodb-local + Neon branch + LocalStack-style SQS via moto si se
+quiere offline; alternativa: dev real con stage=local apuntando a AWS
+de pruebas).
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_register_full_flow_e2e.py` | start -> verify-code -> set-password -> session.refresh -> logout (todo verde) |
+| `test_register_then_login_e2e.py` | tras register, login.start devuelve methods. login.verify-code -> JWT |
+| `test_login_unknown_email_returns_suggest_register_e2e.py` | login.start con email aleatorio -> 404 |
+| `test_token_reuse_detection_e2e.py` | usar refresh dos veces -> 2da llamada revoca toda la familia |
+| `test_account_lock_after_5_fails_e2e.py` | 5 verify-code wrong -> status=locked |
+| `test_email_worker_publishes_to_ses_e2e.py` | publica mensaje a auth-email-queue -> el worker lo procesa y envia a SES sandbox (verifica MessageId no vacio) |
+| `test_migration_up_and_down_e2e.py` | aplica 00000002 + downgrade + upgrade idempotente | AC-15 |
+
+## Stub config (env vars por test)
+
+```ini
+JWT_ISSUER=portfolio-auth-test
+JWT_AUDIENCE=portfolio-test
+JWT_SECRET=<test-placeholder-min-32-bytes>
+MAGIC_LINK_BASE_URL=http://localhost:9999/auth
+CORS_ALLOWED_ORIGINS=http://localhost:9999
+TURNSTILE_BYPASS_SECRET=<test-bypass-placeholder>
+DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/test
+SSM_JWT_BLACKLIST_TABLE_PATH=/portfolio/test/dynamodb/jwt-blacklist/name
+SSM_AUTH_CODES_TABLE_PATH=/portfolio/test/dynamodb/auth-codes/name
+```
+
+Los placeholders `<...>` se sustituyen por valores aleatorios generados
+con `secrets.token_urlsafe(32)` al inicio de cada test run via
+`conftest.py` (no se hardcodean).
+
+## Reglas duras de testing
+
+- **SIEMPRE** asserts exactos: `assert response['statusCode'] == 200`
+  NO `assert response['statusCode'] >= 200`.
+- **SIEMPRE** Given/When/Then en el docstring del test.
+- **SIEMPRE** 1 archivo = 1 funcion `test_*` = 1 escenario.
+- **SIEMPRE** los builders compartidos viven en `_helpers.py` /
+  `_fixtures/` con prefijo `_` (no recolectados por pytest).
+- **NUNCA** mockear `controllers/`, `services/` o `models/` propios.
+- **NUNCA** assert sobre el contenido del email (la plantilla cambia;
+  testear que `send_email` fue llamado con `to=[expected]` es
+  suficiente).
+- **NUNCA** test que dependa de un email real (incluso en
+  integration). Usar SES sandbox + email `success@simulator.amazonses.com`.
+
+## Comandos
+
+```bash
+# unit
+python devtools/run.py serverless tests --type=unit --lambda=auth
+python devtools/run.py serverless tests --type=unit --lambda=auth_email_worker
+python devtools/run.py serverless tests --type=unit --shared
+
+# coverage
+python devtools/run.py serverless tests --type=coverage --lambda=auth
+
+# integration (requiere recursos)
+python devtools/run.py serverless tests --type=integration --lambda=auth
+```

--- a/docs/specs/01-auth-infra-basics/07-archivos-afectados.md
+++ b/docs/specs/01-auth-infra-basics/07-archivos-afectados.md
@@ -1,0 +1,199 @@
+# 07. Archivos Afectados
+
+> Paths relativos desde root. Cada archivo tiene su comando de
+> verificacion explicito. Las secciones se ordenan por capa (schema ->
+> shared -> infra -> services).
+
+## Crear
+
+### Migration Alembic + modelos Neon
+
+- `serverless/lambda/shared/db/alembic/versions/00000002_auth_schema.py`
+  — migracion con upgrade + downgrade idempotente para `auth_*`.
+  - Verificar (en branch Neon de prueba):
+    `alembic -c shared/db/alembic.ini upgrade head`
+    `alembic -c shared/db/alembic.ini downgrade -1`
+    `alembic -c shared/db/alembic.ini upgrade head`
+  - Aplicar a dev: `serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev`
+- `serverless/lambda/shared/db/models/auth/__init__.py` — re-exports.
+- `serverless/lambda/shared/db/models/auth/enums.py` — `AuthUserStatus`,
+  `AuthCodeKind`, `AuthLinkKind`.
+- `serverless/lambda/shared/db/models/auth/user.py` — `AuthUser`.
+- `serverless/lambda/shared/db/models/auth/credentials.py` — `AuthCredentials`.
+- `serverless/lambda/shared/db/models/auth/email_code.py` — `AuthEmailCode`.
+- `serverless/lambda/shared/db/models/auth/magic_link.py` — `AuthMagicLink`.
+- `serverless/lambda/shared/db/models/auth/audit_log.py` — `AuthAuditLog`.
+- `serverless/lambda/shared/db/repositories/auth.py` — helpers puros
+  sobre `Session`.
+  - Verificar todos los anteriores: `serverless lint-deps --shared`
+    + `serverless tests --type=unit --shared` verde.
+
+### Shared subpackage `shared.auth`
+
+- `serverless/lambda/shared/auth/__init__.py` — re-exports + `__all__`.
+- `serverless/lambda/shared/auth/pyproject.toml` — `pyjwt>=2.9`,
+  `argon2-cffi>=23.1`. `internal-deps: [core, aws, observability]`.
+- `serverless/lambda/shared/auth/uv.lock` — generado por `uv lock`.
+- `serverless/lambda/shared/auth/constants.py` — `CODE_ALPHABET`,
+  `CODE_LENGTH`, `JWT_ALGORITHM`, lifetimes.
+- `serverless/lambda/shared/auth/jwt.py` — `issue_temp_jwt`,
+  `issue_access_jwt`, `issue_refresh_jwt`, `verify_jwt`, `JwtClaims`,
+  excepciones.
+- `serverless/lambda/shared/auth/password.py` — `hash_password`,
+  `verify_password`, `NeedsRehashError`.
+- `serverless/lambda/shared/auth/codes.py` — `generate_code`, `hash_code`,
+  `compare_code`.
+- `serverless/lambda/shared/auth/tokens.py` — `generate_opaque_token`,
+  `hash_token`, `compare_token`.
+- `serverless/lambda/shared/tests/unit/shared/auth/test_*.py` — 17 archivos
+  listados en [03-shared-auth.md](03-shared-auth.md).
+  - Verificar todo lo anterior:
+    `serverless lint-deps --shared`
+    `serverless tests --type=unit --shared`
+
+### Infra (resources/)
+
+- `serverless/lambda/resources/dynamodb/jwt-blacklist.yaml` — tabla +
+  GSI by_family_id, TTL=`exp`.
+- `serverless/lambda/resources/dynamodb/auth-codes.yaml` — tabla,
+  TTL=`expires_at`.
+- `serverless/lambda/resources/sqs/auth-email-queue.yaml` — cola
+  principal.
+- `serverless/lambda/resources/sqs/auth-email-dlq.yaml` — DLQ.
+- `serverless/lambda/resources/secrets/jwt-secret.yaml` — entrada del
+  catalogo de secretos (SecureString + KMS).
+  - Verificar todos los anteriores:
+    `serverless validate-catalog --stage=dev`
+    `serverless list-resources --stage=dev`
+    `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
+
+### Lambda `auth_email_worker` (services/)
+
+- `serverless/lambda/services/auth_email_worker/manifest.yaml`.
+- `serverless/lambda/services/auth_email_worker/pyproject.toml`.
+- `serverless/lambda/services/auth_email_worker/uv.lock`.
+- `serverless/lambda/services/auth_email_worker/.gitignore`
+  (`build/`, `build.zip`).
+- `serverless/lambda/services/auth_email_worker/core/handler.py`
+  (entry, `run_controller(event, EVENT_MODEL)`).
+- `serverless/lambda/services/auth_email_worker/core/settings/config.py`.
+- `serverless/lambda/services/auth_email_worker/core/settings/operations.py`
+  (un solo operation `email`, action por `kind`).
+- `serverless/lambda/services/auth_email_worker/core/models/event.py`.
+- `serverless/lambda/services/auth_email_worker/core/models/email.py`
+  (Pydantic schemas por kind).
+- `serverless/lambda/services/auth_email_worker/core/controllers/email/`
+  (un controller por kind: `RegisterMagicLink`, `RegisterCode`,
+  `LoginMagicLink`, `LoginCode`, `PasswordReset`).
+- `serverless/lambda/services/auth_email_worker/core/services/template_service.py`
+  (renderiza Jinja2-like simple).
+- `serverless/lambda/services/auth_email_worker/core/services/send_service.py`
+  (wrapper de `shared.aws.send_email`).
+- `serverless/lambda/services/auth_email_worker/core/services/audit_service.py`.
+- `serverless/lambda/services/auth_email_worker/core/templates/{es,en}/{register-magic-link,register-code,login-magic-link,login-code,password-reset}.{txt,html}`.
+- `serverless/lambda/services/auth_email_worker/events/*.json` (eventos
+  SQS de prueba para `serverless run`).
+- `serverless/lambda/services/auth_email_worker/tests/unit/...` (8 archivos).
+  - Verificar:
+    `serverless lint-deps --lambda=auth_email_worker`
+    `serverless tests --type=unit --lambda=auth_email_worker`
+    `serverless run --stage=local --lambda=auth_email_worker --event=events/register-magic-link.json`
+
+### Lambda `auth` (services/)
+
+Estructura completa listada en [05-lambda-auth-arquitectura.md](05-lambda-auth-arquitectura.md):
+
+- `serverless/lambda/services/auth/manifest.yaml`.
+- `serverless/lambda/services/auth/pyproject.toml`.
+- `serverless/lambda/services/auth/uv.lock`.
+- `serverless/lambda/services/auth/.gitignore`.
+- `serverless/lambda/services/auth/core/handler.py`.
+- `serverless/lambda/services/auth/core/settings/{config,operations}.py`.
+- `serverless/lambda/services/auth/core/models/{event,register,login,verify,session}.py`.
+- `serverless/lambda/services/auth/core/controllers/register/{start,verify_magic_link,verify_code}.py`.
+- `serverless/lambda/services/auth/core/controllers/login/{start,verify_magic_link,verify_code}.py`.
+- `serverless/lambda/services/auth/core/controllers/verify/{set_password,resend_code}.py`.
+- `serverless/lambda/services/auth/core/controllers/session/{refresh,logout}.py`.
+- `serverless/lambda/services/auth/core/services/{user,code,magic_link,jwt,blacklist,email_dispatch,audit,rate_limit,flow}_service.py`.
+- `serverless/lambda/services/auth/events/*.json` (10 archivos: uno por action).
+- `serverless/lambda/services/auth/tests/unit/...` (60+ archivos listados
+  en [06-testing.md](06-testing.md)).
+- `serverless/lambda/services/auth/tests/integration/...` (7 archivos).
+  - Verificar:
+    `serverless lint-deps --lambda=auth`
+    `serverless tests --type=unit --lambda=auth`
+    `serverless tests --type=coverage --lambda=auth` (>= 80% per-file)
+    `serverless run --stage=local --lambda=auth --event=events/register-start.json`
+
+### Diagrama ER (actualizacion del existente)
+
+- `docs/diagrams/db-er.mmd` — agregar el cluster `auth_*` (5 tablas)
+  + relacion `cv_profiles --o| auth_users : owns_account`.
+  - Verificar: `cat docs/diagrams/db-er.mmd | head -50` muestra
+    cluster nuevo.
+
+### Documentacion permanente que sobrevive al merge
+
+- `.claude/docs/auth-system/README.md` — overview del sistema auth
+  (decisiones de arquitectura, JWT lifecycle, schema, flujos). Sirve
+  como referencia tras eliminar la carpeta `docs/specs/01-auth-infra-basics/`.
+- `.claude/docs/auth-system/01-jwt-lifecycle.md` — JWT temp / access /
+  refresh, rotation, blacklist, family detection.
+- `.claude/docs/auth-system/02-flows.md` — diagramas ASCII de cada flujo
+  (register, login, verify, refresh, logout).
+- `.claude/docs/auth-system/03-rate-limit-rules.md` — reglas activas.
+- `.claude/rules/auth-system.md` — rule para futuras modificaciones
+  (links a la skill, reglas duras, anti-patterns).
+- `.claude/skills/auth-system/SKILL.md` — skill invocable
+  `/auth-system` con keywords ES/EN para futuras consultas.
+  - Verificar: lint + 5 prompts de validacion segun
+    `.claude/rules/claude-config-testing.md`.
+
+## Modificar
+
+- `docs/specs/01-auth-infra-basics/` — esta carpeta del plan (efimera,
+  se elimina en commit final).
+- `serverless/lambda/shared/db/__init__.py` — agregar re-exports si
+  los nuevos modelos requieren simbolos publicos no expuestos hoy
+  (probable: ningun cambio porque los modelos se importan via
+  `shared.db.models.auth`).
+- `serverless/lambda/shared/db/models/__init__.py` — agregar import
+  del subpaquete `auth` para que Alembic autogenerate lo detecte.
+  - Verificar: `serverless tests --type=unit --shared` y migration
+    autogenerate produce un diff vacio tras aplicar la migration.
+- `docs/diagrams/db-er.mmd` — ya listado en "Crear" (update del archivo
+  existente).
+
+## Eliminar
+
+(nada en este plan — todo es agregar)
+
+## NO se toca (defensa)
+
+- Frontend Astro (`apps/*`).
+- Lambdas existentes (`cv`, `contact_form`, `tracking_pixel`,
+  `contact_worker`, `tracking_worker`, `stream_processor`, `db`).
+- `shared/` subpaquetes existentes (`core`, `aws`, `db` excepto el
+  add-on de models/auth/, `http`, `observability`, `rate_limit`,
+  `cache`, `dynamodb`, `lambda_kit`).
+- `.github/workflows/*.yml` — el CI auto-detecta los nuevos
+  `services/auth/` y `services/auth_email_worker/` via
+  `change_detector.py`. Cero cambio en workflows.
+- `docker/env/server/.*` — solo se agrega manualmente la nueva key
+  `JWT_SECRET` antes del primer deploy (paso operativo, no tracked).
+
+## Resumen contable
+
+| Categoria | Crear | Modificar | Eliminar | Total |
+|-----------|-------|-----------|----------|-------|
+| Migration Alembic | 1 | 0 | 0 | 1 |
+| Modelos SQLAlchemy `auth/` | 7 | 1 | 0 | 8 |
+| Repository `auth` | 1 | 0 | 0 | 1 |
+| `shared.auth/` (impl + tests) | 24 | 0 | 0 | 24 |
+| `resources/` (dynamodb + sqs + secrets) | 5 | 0 | 0 | 5 |
+| `services/auth_email_worker/` | ~25 | 0 | 0 | ~25 |
+| `services/auth/` | ~80 | 0 | 0 | ~80 |
+| Documentacion permanente (.claude/) | 6 | 0 | 0 | 6 |
+| Plan efimero (`docs/specs/01-...`) | 12 | 0 | -12 (al cerrar) | 0 |
+| Diagrama ER | 0 | 1 | 0 | 1 |
+| **Total neto** |  |  |  | **~151 archivos nuevos** |

--- a/docs/specs/01-auth-infra-basics/07-archivos-afectados.md
+++ b/docs/specs/01-auth-infra-basics/07-archivos-afectados.md
@@ -55,8 +55,6 @@
 
 - `serverless/lambda/resources/dynamodb/jwt-blacklist.yaml` — tabla +
   GSI by_family_id, TTL=`exp`.
-- `serverless/lambda/resources/dynamodb/auth-codes.yaml` — tabla,
-  TTL=`expires_at`.
 - `serverless/lambda/resources/sqs/auth-email-queue.yaml` — cola
   principal.
 - `serverless/lambda/resources/sqs/auth-email-dlq.yaml` — DLQ.

--- a/docs/specs/01-auth-infra-basics/08-descomposicion-paralelizacion.md
+++ b/docs/specs/01-auth-infra-basics/08-descomposicion-paralelizacion.md
@@ -1,0 +1,299 @@
+# 08. Descomposicion para Paralelizacion
+
+> Plan **Large** (~151 archivos). 14 tareas atomicas. Limite practico
+> 5-7 worktrees concurrentes. Las tareas pasan los 3 checks (File
+> Exclusivity, Interface Stability, Bounded Scope).
+
+## Grafo de dependencias (alto nivel)
+
+```text
+T1 plan                                  (raiz, sin codigo)
+  |
+  +--> T2 shared.auth subpackage         (raiz tras T1)
+  |
+  +--> T3 schema Neon + models           (raiz tras T1, indep de T2)
+  |     |
+  |     +--> T4 repository helpers
+  |
+  +--> T5 resources (ddb + sqs + ssm)    (raiz tras T1, indep de T2/T3)
+  |
+  +--> T6 auth_email_worker              (depende de T5 sqs)
+  |
+  +--> T7 auth scaffold (manifest+config+handler+EventModel)
+  |     | depende de: T2 (jwt/codes), T3 (models), T4 (repositories), T5 (tables/queues)
+  |     |
+  |     +--> T8 services (user, code, magic_link, jwt, blacklist, email_dispatch, audit, rate_limit, flow)
+  |     |
+  |     +--> T9 operation register (3 controllers + models)        (paralelo con T10, T11, T12)
+  |     +--> T10 operation login (3 controllers + models)          (paralelo con T9, T11, T12)
+  |     +--> T11 operation verify (2 controllers + models)         (paralelo con T9, T10, T12)
+  |     +--> T12 operation session (2 controllers + models)        (paralelo con T9, T10, T11)
+  |
+  +--> T13 documentacion permanente (.claude/docs/auth-system/, rule, skill)
+  |     paralelo con todo lo anterior tras T1
+  |
+  +--> T14 verificacion E2E + actualizacion ER + limpieza spec     (seccion 11; SIEMPRE ultimo)
+```
+
+## Tareas (orden topologico)
+
+### T1: Plan (carpeta `docs/specs/01-auth-infra-basics/`)
+
+- **Archivos**: `docs/specs/01-auth-infra-basics/*.md` (12 archivos, este plan).
+- **AC referenciados**: ninguna (meta).
+- **Depende de**: ninguna.
+- **Paralelizable con**: ninguna (raiz, base).
+- **Verify**: `markdownlint docs/specs/01-auth-infra-basics/*.md` sin errores.
+- **Done**: carpeta commiteada en `feature/auth-infra-basics`.
+
+### T2: Shared subpackage `shared.auth`
+
+- **Archivos**:
+  - `serverless/lambda/shared/auth/__init__.py`
+  - `serverless/lambda/shared/auth/pyproject.toml`
+  - `serverless/lambda/shared/auth/uv.lock`
+  - `serverless/lambda/shared/auth/{constants,jwt,password,codes,tokens}.py`
+  - `serverless/lambda/shared/tests/unit/shared/auth/test_*.py` (17 archivos)
+- **AC referenciados**: (transversal, soporta AC-1..AC-10)
+- **Depende de**: T1.
+- **Paralelizable con**: T3, T5, T13.
+- **Verify**:
+  `serverless lint-deps --shared`
+  `serverless tests --type=unit --shared` (incluye los 17 tests nuevos)
+- **Done**: 17 tests verdes, coverage `shared/auth/` >= 95%,
+  `lint-deps` reporta el cierre transitivo de auth (sin duplicados).
+
+### T3: Schema Neon (migration + modelos)
+
+- **Archivos**:
+  - `serverless/lambda/shared/db/alembic/versions/00000002_auth_schema.py`
+  - `serverless/lambda/shared/db/models/auth/__init__.py`
+  - `serverless/lambda/shared/db/models/auth/{enums,user,credentials,email_code,magic_link,audit_log}.py`
+  - `serverless/lambda/shared/db/models/__init__.py` (1 linea agregada)
+- **AC referenciados**: AC-15 (downgrade up idempotente).
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T5, T13.
+- **Verify**:
+  - `python -m compileall -q serverless/lambda/shared/db`
+  - En branch Neon de prueba: `alembic upgrade head` -> `downgrade -1`
+    -> `upgrade head`. Cero diff con `alembic check`.
+  - `serverless tests --type=unit --shared` verde.
+- **Done**: migration aplica + reverte sin error; 5 tablas creadas con
+  las columnas/indices del archivo 02; FK a `cv_profiles` valida.
+
+### T4: Repository helpers `shared.db.repositories.auth`
+
+- **Archivos**: `serverless/lambda/shared/db/repositories/auth.py` +
+  tests `shared/tests/unit/shared/db/repositories/test_auth_*.py`
+  (~10 tests).
+- **AC referenciados**: soporta AC-1..AC-11.
+- **Depende de**: T3.
+- **Paralelizable con**: T2 (paquetes diferentes), T5, T13.
+- **Verify**:
+  `serverless tests --type=unit --shared` cubriendo los nuevos tests
+  (con DB en memoria via SQLAlchemy `:memory:` o mock de Session).
+- **Done**: 11 helpers implementados, tests verdes.
+
+### T5: Resources (DynamoDB + SQS + SSM)
+
+- **Archivos**:
+  - `serverless/lambda/resources/dynamodb/jwt-blacklist.yaml`
+  - `serverless/lambda/resources/dynamodb/auth-codes.yaml`
+  - `serverless/lambda/resources/sqs/auth-email-queue.yaml`
+  - `serverless/lambda/resources/sqs/auth-email-dlq.yaml`
+  - `serverless/lambda/resources/secrets/jwt-secret.yaml`
+- **AC referenciados**: (transversal — infra)
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T3, T13.
+- **Verify**:
+  `serverless validate-catalog --stage=dev`
+  `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
+  `serverless list-resources --stage=dev` muestra los 5 nuevos.
+- **Done**: las 2 DDB tables + GSI + SQS + DLQ + SSM publicados en
+  AWS dev. SSM paths
+  `/portfolio/dev/dynamodb/{jwt-blacklist,auth-codes}/name`
+  resolvibles. Cola DLQ asociada con `redrive_policy`.
+
+### T6: Lambda `auth_email_worker`
+
+- **Archivos**: ~25 (manifest + pyproject + handler + 5 controllers +
+  3 services + 10 templates + tests + events).
+- **AC referenciados**: AC-14.
+- **Depende de**: T1, T5 (cola). NO depende de T2/T3 (worker no usa
+  shared.auth ni el schema auth; solo dispara SES).
+- **Paralelizable con**: T7+ tras T5 lista.
+- **Verify**:
+  `serverless lint-deps --lambda=auth_email_worker`
+  `serverless tests --type=unit --lambda=auth_email_worker` (8 tests)
+  `serverless run --stage=local --lambda=auth_email_worker --event=events/register-magic-link.json` (SES mock o sandbox)
+  `serverless deploy --lambda=auth_email_worker --stage=dev --aws-profile=tfs-dev`
+- **Done**: tests verdes, deploy OK, primer mensaje E2E enviado a
+  SES sandbox (`success@simulator.amazonses.com`).
+
+### T7: Lambda `auth` — scaffold
+
+- **Archivos**:
+  - `serverless/lambda/services/auth/manifest.yaml`
+  - `serverless/lambda/services/auth/pyproject.toml`
+  - `serverless/lambda/services/auth/uv.lock`
+  - `serverless/lambda/services/auth/.gitignore`
+  - `serverless/lambda/services/auth/core/handler.py`
+  - `serverless/lambda/services/auth/core/settings/{config,operations}.py`
+  - `serverless/lambda/services/auth/core/models/event.py` (placeholder
+    con build_event_model({}) -> se llena en T9-T12)
+- **AC referenciados**: ninguna (scaffold).
+- **Depende de**: T2, T3, T4, T5.
+- **Paralelizable con**: T6, T13 si ya completados los predecesores.
+- **Verify**:
+  `python -m compileall -q serverless/lambda/services/auth`
+  `serverless lint-deps --lambda=auth`
+  `serverless tests --type=unit --lambda=auth` (handler tests minimos)
+- **Done**: el lambda compila, `serverless run` con event vacio
+  responde 404 (sin operations registrados aun).
+
+### T8: Services del Lambda auth (8 services)
+
+- **Archivos**:
+  - `serverless/lambda/services/auth/core/services/{user,code,magic_link,jwt,blacklist,email_dispatch,audit,rate_limit,flow}_service.py`
+  - `serverless/lambda/services/auth/tests/unit/services/test_*.py` (~32 tests)
+- **AC referenciados**: transversal.
+- **Depende de**: T7.
+- **Paralelizable con**: T9, T10, T11, T12 (los controllers consumen
+  estos services; pero a nivel files NO se solapan — los services
+  son archivos propios). Decision: ejecutar T8 ANTES de T9-T12 para
+  reducir merge churn (controllers terminan importando estos modulos).
+- **Verify**:
+  `serverless tests --type=unit --lambda=auth` (los services verdes;
+  controllers no existen aun).
+- **Done**: 8 services implementados, 32 tests verdes, coverage >= 80%.
+
+### T9: Operation `register` (paralelizable con T10, T11, T12)
+
+- **Archivos**:
+  - `serverless/lambda/services/auth/core/models/register.py`
+  - `serverless/lambda/services/auth/core/controllers/register/{__init__,start,verify_magic_link,verify_code}.py`
+  - `serverless/lambda/services/auth/tests/unit/controllers/test_register_*.py` (~12 tests)
+  - `serverless/lambda/services/auth/events/register-*.json` (3 archivos)
+- **AC referenciados**: AC-1, AC-2, AC-3, AC-4, AC-11, AC-12.
+- **Depende de**: T7, T8.
+- **Paralelizable con**: T10, T11, T12 (archivos disjuntos).
+- **Verify**:
+  `serverless tests --type=unit --lambda=auth` cubriendo los 12 tests
+  `serverless run --stage=local --lambda=auth --event=events/register-start.json`
+- **Done**: 3 controllers verdes, 12 tests verdes, run local devuelve
+  201 con temp_token.
+
+### T10: Operation `login` (paralelizable con T9, T11, T12)
+
+- **Archivos**:
+  - `serverless/lambda/services/auth/core/models/login.py`
+  - `serverless/lambda/services/auth/core/controllers/login/{__init__,start,verify_magic_link,verify_code}.py`
+  - `serverless/lambda/services/auth/tests/unit/controllers/test_login_*.py` (~6 tests)
+  - `serverless/lambda/services/auth/events/login-*.json` (3 archivos)
+- **AC referenciados**: AC-5, AC-6.
+- **Depende de**: T7, T8.
+- **Paralelizable con**: T9, T11, T12.
+- **Verify**: idem T9.
+- **Done**: idem T9 para login.
+
+### T11: Operation `verify` (paralelizable con T9, T10, T12)
+
+- **Archivos**:
+  - `serverless/lambda/services/auth/core/models/verify.py`
+  - `serverless/lambda/services/auth/core/controllers/verify/{__init__,set_password,resend_code}.py`
+  - `serverless/lambda/services/auth/tests/unit/controllers/test_verify_*.py` (~4 tests)
+  - `serverless/lambda/services/auth/events/verify-*.json` (2 archivos)
+- **AC referenciados**: AC-11 (parcial).
+- **Depende de**: T7, T8.
+- **Paralelizable con**: T9, T10, T12.
+- **Verify**: idem.
+- **Done**: 2 controllers, 4 tests verdes.
+
+### T12: Operation `session` (paralelizable con T9, T10, T11)
+
+- **Archivos**:
+  - `serverless/lambda/services/auth/core/models/session.py`
+  - `serverless/lambda/services/auth/core/controllers/session/{__init__,refresh,logout}.py`
+  - `serverless/lambda/services/auth/tests/unit/controllers/test_session_*.py` (~6 tests)
+  - `serverless/lambda/services/auth/events/session-*.json` (2 archivos)
+- **AC referenciados**: AC-7, AC-8, AC-9, AC-10.
+- **Depende de**: T7, T8.
+- **Paralelizable con**: T9, T10, T11.
+- **Verify**: idem.
+- **Done**: 2 controllers, 6 tests verdes.
+
+### T13: Documentacion permanente
+
+- **Archivos**:
+  - `.claude/docs/auth-system/README.md`
+  - `.claude/docs/auth-system/01-jwt-lifecycle.md`
+  - `.claude/docs/auth-system/02-flows.md`
+  - `.claude/docs/auth-system/03-rate-limit-rules.md`
+  - `.claude/rules/auth-system.md`
+  - `.claude/skills/auth-system/SKILL.md`
+- **AC referenciados**: ninguna (meta-documentacion).
+- **Depende de**: T1 (visibilidad), idealmente T2/T3 cerrados para
+  documentar la interfaz real.
+- **Paralelizable con**: T2-T12 (archivos disjuntos del codigo).
+- **Verify**:
+  `markdownlint .claude/docs/auth-system/*.md .claude/rules/auth-system.md`
+  `claude --permission-mode bypassPermissions ... -p "como funciona el flujo de magic link"`
+  (debe activar la skill, num_turns > 1)
+- **Done**: 5 prompts de validacion pasan, link checks OK.
+
+### T14: Verificacion E2E + actualizacion ER + limpieza spec (= seccion 11)
+
+- **Archivos**:
+  - `docs/diagrams/db-er.mmd` (actualizar)
+  - `docs/specs/01-auth-infra-basics/` (eliminar con `git rm -r`)
+  - Posibles ajustes finales tras integrar todo.
+- **AC referenciados**: TODOS (verificacion consolidada).
+- **Depende de**: T2..T13 todos completos.
+- **Paralelizable con**: ninguna (es el cierre).
+- **Verify**: ver [11-verificacion-e2e.md](11-verificacion-e2e.md).
+- **Done**: bateria E2E verde, ER actualizado, spec borrada.
+
+## Tabla resumen de paralelismo
+
+| Tarea | Depende de | Paralelizable con |
+|-------|------------|--------------------|
+| T1  plan                | —                 | — |
+| T2  shared.auth          | T1                | T3, T5, T13 |
+| T3  schema Neon          | T1                | T2, T5, T13 |
+| T4  repository auth      | T3                | T2, T5, T13 |
+| T5  resources            | T1                | T2, T3, T13 |
+| T6  auth_email_worker    | T5                | T7+ tras T2/T3/T4/T5 |
+| T7  auth scaffold        | T2, T3, T4, T5    | T6, T13 |
+| T8  auth services        | T7                | T13 |
+| T9  register             | T7, T8            | T10, T11, T12, T13 |
+| T10 login                | T7, T8            | T9, T11, T12, T13 |
+| T11 verify               | T7, T8            | T9, T10, T12, T13 |
+| T12 session              | T7, T8            | T9, T10, T11, T13 |
+| T13 docs permanentes     | T1                | T2..T12 |
+| T14 verificacion E2E     | T2..T13           | — |
+
+## Maximo paralelismo util
+
+- Tras T1: lanzar **T2 + T3 + T5 + T13** en 4 worktrees (raices,
+  archivos disjuntos).
+- Tras T7+T8: lanzar **T9 + T10 + T11 + T12** en 4 worktrees
+  (operaciones disjuntas).
+- T6 puede correr tan pronto T5 este lista (puede solaparse con T7
+  scaffold).
+
+Recomendacion practica: 4 worktrees concurrentes maximo. Pasa los 3
+checks por construccion.
+
+## Anti-patrones evitados
+
+- T9, T10, T11, T12 tocan archivos disjuntos (cada una su carpeta
+  `controllers/<op>/` + su `models/<op>.py` + tests propios). File
+  Exclusivity OK.
+- T8 services se completa ANTES de T9-T12 para que los controllers
+  no inventen interfaces (Interface Stability OK).
+- T14 verificacion E2E NO se paraleliza — toca archivos transversales
+  (ER diagram, ajustes finales) y consolida todo.
+- Las tareas T9-T12 NO modifican `core/models/event.py` (lo crea T7
+  con el dict de OPERATIONS completo desde el inicio). Cada operation
+  ya esta registrada en el scaffold, solo no tiene controllers (que
+  aparecen al integrar).

--- a/docs/specs/01-auth-infra-basics/08-descomposicion-paralelizacion.md
+++ b/docs/specs/01-auth-infra-basics/08-descomposicion-paralelizacion.md
@@ -98,7 +98,6 @@ T1 plan                                  (raiz, sin codigo)
 
 - **Archivos**:
   - `serverless/lambda/resources/dynamodb/jwt-blacklist.yaml`
-  - `serverless/lambda/resources/dynamodb/auth-codes.yaml`
   - `serverless/lambda/resources/sqs/auth-email-queue.yaml`
   - `serverless/lambda/resources/sqs/auth-email-dlq.yaml`
   - `serverless/lambda/resources/secrets/jwt-secret.yaml`
@@ -108,11 +107,10 @@ T1 plan                                  (raiz, sin codigo)
 - **Verify**:
   `serverless validate-catalog --stage=dev`
   `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
-  `serverless list-resources --stage=dev` muestra los 5 nuevos.
-- **Done**: las 2 DDB tables + GSI + SQS + DLQ + SSM publicados en
-  AWS dev. SSM paths
-  `/portfolio/dev/dynamodb/{jwt-blacklist,auth-codes}/name`
-  resolvibles. Cola DLQ asociada con `redrive_policy`.
+  `serverless list-resources --stage=dev` muestra los 4 nuevos.
+- **Done**: DDB table + GSI by_family_id + SQS + DLQ + SSM publicados en
+  AWS dev. SSM path `/portfolio/dev/dynamodb/jwt-blacklist/name`
+  resolvible. Cola DLQ asociada con `redrive_policy`.
 
 ### T6: Lambda `auth_email_worker`
 

--- a/docs/specs/01-auth-infra-basics/09-commits.md
+++ b/docs/specs/01-auth-infra-basics/09-commits.md
@@ -1,0 +1,416 @@
+# 09. Commits
+
+> Rama base: `feature/auth-infra-basics` desde `dev`. PRs incrementales
+> a `dev` (el usuario eligio "multiples PRs incrementales, uno por
+> fase"). Conventional Commits espanol, sin atribucion de IA.
+
+## Modelo de PRs
+
+El usuario eligio **multiples PRs incrementales** (uno por fase del
+plan). Cada PR:
+
+- Tiene como base `dev`.
+- Es atomico (cierra una fase completa, deja el repo deployable).
+- Pasa el gate de la seccion 11 (lint + typecheck + tests + build).
+- Se mergea con merge commit (`gh pr merge --merge --delete-branch`).
+
+Esto da ~7-10 PRs en total (uno por tarea atomica significativa).
+Algunas tareas chicas se combinan en un solo PR (T3+T4, T5+T6).
+
+### Ramas
+
+```text
+dev
+ ├── feature/auth-infra-basics-1-spec               (T1 + T13 docs base)
+ ├── feature/auth-infra-basics-2-shared-auth        (T2)
+ ├── feature/auth-infra-basics-3-schema-neon        (T3 + T4)
+ ├── feature/auth-infra-basics-4-resources          (T5)
+ ├── feature/auth-infra-basics-5-email-worker       (T6)
+ ├── feature/auth-infra-basics-6-auth-scaffold      (T7 + T8)
+ ├── feature/auth-infra-basics-7-register-login     (T9 + T10)
+ ├── feature/auth-infra-basics-8-verify-session     (T11 + T12)
+ └── feature/auth-infra-basics-9-verificacion-e2e   (T14 + limpieza)
+```
+
+Cada rama parte de `dev` actualizada (NO de la rama anterior — para
+mantener PRs independientes en lo posible). Donde haya dependencia
+estricta (ej. T7 necesita T2 + T3 mergeados), se espera el merge antes
+de partir la siguiente rama.
+
+## Lista completa de commits por PR
+
+> **Recordatorio**: ANTES del primer commit verificar la rama actual.
+> Si es `dev`/`stage`/`main`, crear la rama `feature/auth-infra-basics-N-<x>`
+> partiendo de `dev`.
+
+### PR 1 — `feat(specs): plan 01-auth-infra-basics`
+
+Rama: `feature/auth-infra-basics-1-spec`.
+
+#### Commit 1.1 — `docs(specs): plan 01-auth-infra-basics`
+
+- Agrega `docs/specs/01-auth-infra-basics/` (12 archivos: README +
+  01..11).
+- Sin cambios de codigo.
+- **Verificacion incremental**: `markdownlint docs/specs/01-auth-infra-basics/`
+- **AC**: ninguna (meta).
+
+#### Commit 1.2 — `docs(claude): rule + skill + docs/auth-system del sistema auth`
+
+- Agrega `.claude/docs/auth-system/` (4 archivos).
+- Agrega `.claude/rules/auth-system.md`.
+- Agrega `.claude/skills/auth-system/SKILL.md`.
+- **Verificacion incremental**:
+  - `markdownlint .claude/docs/auth-system/ .claude/rules/auth-system.md`
+  - Validacion de la skill segun `.claude/rules/claude-config-testing.md`
+    (5 prompts ES con `claude --permission-mode bypassPermissions ... -p`).
+- **AC**: ninguna (meta).
+
+> Merge PR 1 a `dev` antes de PR 2.
+
+---
+
+### PR 2 — `feat(shared): subpackage shared.auth con JWT + argon2 + codes`
+
+Rama: `feature/auth-infra-basics-2-shared-auth` desde `dev` (post PR 1).
+
+#### Commit 2.1 — `feat(shared/auth): scaffold del subpackage + pyproject + constants`
+
+- Agrega `shared/auth/__init__.py`, `pyproject.toml`, `uv.lock`,
+  `constants.py`.
+- `internal-deps: [core, aws, observability]`.
+- Sin tests aun.
+- **Verificacion incremental**:
+  - `cd serverless/lambda/shared/auth && uv sync`
+  - `serverless lint-deps --shared`
+
+#### Commit 2.2 — `feat(shared/auth): jwt issue/verify temp/access/refresh`
+
+- Implementa `shared/auth/jwt.py` con `JwtClaims`, `issue_temp_jwt`,
+  `issue_access_jwt`, `issue_refresh_jwt`, `verify_jwt`, excepciones.
+- Tests: `shared/tests/unit/shared/auth/test_jwt_*.py` (6 archivos).
+- **Verificacion incremental**:
+  `serverless tests --type=unit --shared` (los 6 nuevos verdes).
+- **AC**: (transversal, soporta AC-1..AC-10).
+
+#### Commit 2.3 — `feat(shared/auth): password hashing argon2id`
+
+- Implementa `shared/auth/password.py`.
+- Tests: `test_password_hash_verify.py`, `test_password_verify_wrong.py`,
+  `test_password_needs_rehash.py`.
+- **Verificacion incremental**: idem.
+
+#### Commit 2.4 — `feat(shared/auth): generador de codes 8 chars Crockford`
+
+- Implementa `shared/auth/codes.py` + `tokens.py`.
+- Tests: 7 archivos (`test_codes_*`, `test_tokens_*`).
+- **Verificacion incremental**:
+  `serverless tests --type=coverage --shared` debe reportar
+  `shared/auth/*.py` >= 95%.
+- **AC**: (transversal).
+
+> Merge PR 2 a `dev`.
+
+---
+
+### PR 3 — `feat(db): schema auth_* + models SQLAlchemy + repositories`
+
+Rama: `feature/auth-infra-basics-3-schema-neon` desde `dev` (post PR 2).
+
+#### Commit 3.1 — `feat(db/models): modelos SQLAlchemy del dominio auth`
+
+- Agrega `shared/db/models/auth/__init__.py`,
+  `{enums,user,credentials,email_code,magic_link,audit_log}.py`.
+- Actualiza `shared/db/models/__init__.py` agregando import del
+  subpaquete `auth` (necesario para Alembic autogenerate).
+- **Verificacion incremental**:
+  `python -m compileall -q serverless/lambda/shared/db`.
+- **AC**: ninguna (base).
+
+#### Commit 3.2 — `feat(db/alembic): migration 00000002 schema auth`
+
+- Agrega `shared/db/alembic/versions/00000002_auth_schema.py`.
+- **Verificacion incremental** (en branch Neon de prueba):
+  - `neon branches create --name test-00000002 --parent main`
+  - apuntar `DATABASE_URL` al branch
+  - `alembic upgrade head` -> tablas creadas
+  - `alembic downgrade -1` -> tablas borradas
+  - `alembic upgrade head` -> recreadas (idempotente)
+  - `neon branches delete test-00000002`
+- **AC**: AC-15.
+
+#### Commit 3.3 — `feat(db/repositories): helpers de auth (CRUD + audit)`
+
+- Agrega `shared/db/repositories/auth.py` con 11 helpers.
+- Agrega tests `shared/tests/unit/shared/db/repositories/test_auth_*.py`
+  (~10 tests, mock de Session).
+- **Verificacion incremental**: `serverless tests --type=unit --shared`
+  pasa con los nuevos tests.
+- **AC**: (transversal, soporta AC-1..AC-11).
+
+#### Commit 3.4 — `chore(db): aplica migration 00000002 en dev`
+
+- Operativo, sin cambio de codigo.
+- Comando ejecutado:
+  `serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev`
+- Verificacion:
+  `serverless run --stage=dev --lambda=db --event=events/current.json` muestra `00000002`.
+- **AC**: AC-15.
+
+> Merge PR 3 a `dev`.
+
+---
+
+### PR 4 — `feat(resources): DynamoDB jwt-blacklist + auth-codes + SQS auth-email + SSM jwt-secret`
+
+Rama: `feature/auth-infra-basics-4-resources` desde `dev` (post PR 3).
+
+#### Commit 4.1 — `feat(resources/dynamodb): jwt-blacklist y auth-codes`
+
+- Agrega `resources/dynamodb/jwt-blacklist.yaml` (con GSI by_family_id)
+  y `resources/dynamodb/auth-codes.yaml`.
+- **Verificacion incremental**: `serverless validate-catalog --stage=dev`.
+
+#### Commit 4.2 — `feat(resources/sqs): auth-email-queue + DLQ`
+
+- Agrega `resources/sqs/auth-email-queue.yaml` y `auth-email-dlq.yaml`.
+- **Verificacion incremental**: idem.
+
+#### Commit 4.3 — `feat(resources/secrets): jwt-secret SecureString + KMS`
+
+- Agrega `resources/secrets/jwt-secret.yaml`.
+- **Verificacion incremental**: `serverless validate-catalog --stage=dev`.
+
+#### Commit 4.4 — `chore(infra): provision dev + sync jwt-secret`
+
+- Operativo: genera `JWT_SECRET` con `python -c "import secrets;
+  print(secrets.token_urlsafe(64))"`, pega en `docker/env/server/.dev`
+  (NO commiteado), sync a SSM, provisiona en AWS.
+- Comandos:
+  `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
+  `serverless sync-secrets --stage=dev --aws-profile=tfs-dev`
+- Verificacion:
+  `serverless secrets-status --stage=dev` reporta `SKIP` en
+  `jwt-secret` (match).
+  `serverless list-resources --stage=dev` muestra las 2 DDB y la cola
+  + DLQ.
+- **AC**: (transversal — infra).
+
+> Merge PR 4 a `dev`.
+
+---
+
+### PR 5 — `feat(serverless/auth_email_worker): SQS consumer + SES sender + 5 plantillas`
+
+Rama: `feature/auth-infra-basics-5-email-worker` desde `dev` (post PR 4).
+
+#### Commit 5.1 — `feat(auth_email_worker): scaffold + manifest + pyproject`
+
+- Agrega `services/auth_email_worker/{manifest.yaml,pyproject.toml,uv.lock,.gitignore}`
+  + `core/{handler,settings/{config,operations}}.py` + `core/models/event.py`
+  con `build_event_model({...vacio o un solo operation 'email'})`.
+- **Verificacion incremental**: `python -m compileall -q`,
+  `serverless lint-deps --lambda=auth_email_worker`.
+
+#### Commit 5.2 — `feat(auth_email_worker): 5 controllers + template + send services`
+
+- Agrega controllers: `RegisterMagicLink`, `RegisterCode`,
+  `LoginMagicLink`, `LoginCode`, `PasswordReset`.
+- Agrega services: `template_service.py`, `send_service.py`,
+  `audit_service.py`.
+- Agrega templates `{es,en}/{kind}.{txt,html}` (10 archivos).
+- Agrega events JSON (5 archivos).
+- Tests unit: 8 archivos (1 por escenario).
+- **Verificacion incremental**:
+  `serverless tests --type=unit --lambda=auth_email_worker` verde.
+  `serverless run --stage=local --lambda=auth_email_worker --event=events/register-magic-link.json` exito.
+- **AC**: AC-14.
+
+#### Commit 5.3 — `chore(deploy): auth_email_worker -> dev`
+
+- Operativo.
+- Comando: `serverless deploy --lambda=auth_email_worker --stage=dev --aws-profile=tfs-dev`.
+- Verificacion: `serverless status --lambda=auth_email_worker --stage=dev` -> Active.
+- E2E manual: publicar un mensaje a la cola via `aws sqs send-message`
+  con un kind `register-magic-link` y `to=success@simulator.amazonses.com`.
+  Verificar en CloudWatch logs que el worker ejecuto y devolvio
+  MessageId no vacio.
+
+> Merge PR 5 a `dev`.
+
+---
+
+### PR 6 — `feat(serverless/auth): scaffold lambda + services internos`
+
+Rama: `feature/auth-infra-basics-6-auth-scaffold` desde `dev` (post PR 5).
+
+#### Commit 6.1 — `feat(auth): scaffold manifest + AppConfig + handler + EventModel`
+
+- Agrega `services/auth/{manifest.yaml,pyproject.toml,uv.lock,.gitignore}`.
+- `core/handler.py` con `http_handler`.
+- `core/settings/{config,operations}.py`.
+- `core/models/event.py` con `build_event_model(OPERATIONS)` (operations
+  declaradas, controllers se agregan en commits siguientes).
+- Tests minimos: 4 archivos handler/event.
+- **Verificacion incremental**:
+  `serverless lint-deps --lambda=auth`
+  `serverless tests --type=unit --lambda=auth` (4 tests verdes).
+
+#### Commit 6.2 — `feat(auth/services): 8 services (user/code/magic_link/jwt/blacklist/email_dispatch/audit/rate_limit/flow)`
+
+- Implementa los 8 services + flow_service.
+- Tests unit: 32 archivos.
+- **Verificacion incremental**:
+  `serverless tests --type=coverage --lambda=auth` cubriendo services
+  con coverage >= 80%.
+- **AC**: (transversal — soporta AC-1..AC-11).
+
+#### Commit 6.3 — `feat(auth): models Pydantic + register/login/verify/session input schemas`
+
+- Agrega `models/{register,login,verify,session}.py` (sin controllers
+  todavia).
+- Tests unit de validacion: 7 archivos.
+- **Verificacion incremental**:
+  `serverless tests --type=unit --lambda=auth`.
+- **AC**: (transversal — validacion).
+
+> Merge PR 6 a `dev`.
+
+---
+
+### PR 7 — `feat(auth): operations register + login (worktrees paralelos)`
+
+Rama: `feature/auth-infra-basics-7-register-login` desde `dev` (post PR 6).
+
+#### Commit 7.1 — `feat(auth/register): controllers start + verify-magic-link + verify-code`
+
+- Implementa `controllers/register/{start,verify_magic_link,verify_code}.py`.
+- 3 events JSON + 12 tests unit.
+- **Verificacion incremental**:
+  `serverless tests --type=unit --lambda=auth`
+  `serverless run --stage=local --lambda=auth --event=events/register-start.json`
+  responde 201 con `temp_token`.
+- **AC**: AC-1, AC-2, AC-3, AC-4, AC-11, AC-12.
+
+#### Commit 7.2 — `feat(auth/login): controllers start + verify-magic-link + verify-code`
+
+- Implementa `controllers/login/{start,verify_magic_link,verify_code}.py`.
+- 3 events JSON + 6 tests unit.
+- **Verificacion incremental**: idem.
+- **AC**: AC-5, AC-6.
+
+> Merge PR 7 a `dev`.
+
+---
+
+### PR 8 — `feat(auth): operations verify + session + rate-limit rules seed`
+
+Rama: `feature/auth-infra-basics-8-verify-session` desde `dev` (post PR 7).
+
+#### Commit 8.1 — `feat(auth/verify): controllers set-password + resend-code`
+
+- Implementa `controllers/verify/{set_password,resend_code}.py`.
+- 2 events JSON + 4 tests unit.
+- **Verificacion incremental**: idem.
+- **AC**: AC-11 (parcial).
+
+#### Commit 8.2 — `feat(auth/session): controllers refresh + logout`
+
+- Implementa `controllers/session/{refresh,logout}.py`.
+- 2 events JSON + 6 tests unit.
+- **Verificacion incremental**: idem.
+- **AC**: AC-7, AC-8, AC-9, AC-10.
+
+#### Commit 8.3 — `chore(rate-limit): seed reglas para /auth en dev/stage/prod`
+
+- Operativo. Inserta 5 reglas (register.start, login.start, verify.*,
+  session.refresh, session.logout) via
+  `serverless rate-limit set` (3 envs).
+- **Verificacion incremental**:
+  `serverless rate-limit list --stage=dev` muestra las 5 reglas.
+
+#### Commit 8.4 — `chore(deploy): auth lambda -> dev/stage/prod`
+
+- Operativo.
+- Comandos:
+  `serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev`
+  (stage y prod se hacen tras merge a `stage` y `main` via CI).
+- E2E manual en dev tras deploy: ver [11-verificacion-e2e.md](11-verificacion-e2e.md).
+
+> Merge PR 8 a `dev`.
+
+---
+
+### PR 9 — `chore(specs): verificacion E2E + cierre del plan auth-infra-basics`
+
+Rama: `feature/auth-infra-basics-9-verificacion-e2e` desde `dev`
+(post PR 8). Esto es la seccion 11. Detalle en
+[11-verificacion-e2e.md](11-verificacion-e2e.md).
+
+#### Commit 9.1 — `test(auth): integration tests E2E del flujo completo`
+
+- Agrega `services/auth/tests/integration/test_*.py` (7 archivos).
+- **Verificacion incremental**:
+  `serverless tests --type=integration --lambda=auth` (verde, con
+  recursos AWS dev disponibles).
+
+#### Commit 9.2 — `docs(diagrams): actualiza db-er.mmd con cluster auth_*`
+
+- Modifica `docs/diagrams/db-er.mmd` agregando las 5 tablas + la
+  relacion `cv_profiles --o| auth_users`.
+- **Verificacion incremental**: render manual del .mmd OK
+  (`mermaid-cli` opcional).
+
+#### Commit 9.3 — `chore(specs): elimina la carpeta efimera del plan`
+
+- `git rm -r docs/specs/01-auth-infra-basics/`.
+- **Verificacion incremental**:
+  - Bateria completa de la Parte B de la seccion 11 en verde.
+  - El "Como probar" del PR usa esa bateria.
+- **AC**: TODOS (consolidacion).
+
+> Merge PR 9 a `dev`. Promociones `dev -> stage -> main` segun
+> `.claude/rules/git-workflow.md`.
+
+## Resumen de la secuencia
+
+```text
+PR 1  spec + claude docs/rule/skill            (sin codigo de prod)
+PR 2  shared.auth (JWT+argon2+codes)           cubre base AC-1..AC-10
+PR 3  schema Neon + repositories               cubre AC-15
+PR 4  resources DynamoDB + SQS + SSM           infra
+PR 5  auth_email_worker                        cubre AC-14
+PR 6  auth scaffold + services                 base
+PR 7  register + login                         cubre AC-1..AC-6, 11, 12
+PR 8  verify + session + rate-limit seed       cubre AC-7..AC-13
+PR 9  E2E integration + ER + limpieza spec     consolida
+```
+
+## PRs body — template
+
+Cada PR sigue `.claude/rules/git-workflow.md`:
+
+```markdown
+## Problema
+
+<1-3 bullets explicando el subscope del plan auth-infra-basics que
+este PR resuelve.>
+
+## Solucion
+
+<numerada paralela a Problema>
+
+## Como probar
+
+```bash
+# Bateria especifica del PR
+<comandos del bloque "Verificacion incremental" de los commits>
+```
+
+## TODO
+
+<vacio o pendientes que escapan del scope del PR pero no afectan>
+```
+
+NUNCA atribucion de IA. Lenguaje espanol. Body en `gh pr create` via
+HEREDOC.

--- a/docs/specs/01-auth-infra-basics/09-commits.md
+++ b/docs/specs/01-auth-infra-basics/09-commits.md
@@ -161,14 +161,14 @@ Rama: `feature/auth-infra-basics-3-schema-neon` desde `dev` (post PR 2).
 
 ---
 
-### PR 4 — `feat(resources): DynamoDB jwt-blacklist + auth-codes + SQS auth-email + SSM jwt-secret`
+### PR 4 — `feat(resources): DynamoDB jwt-blacklist + SQS auth-email + SSM jwt-secret`
 
 Rama: `feature/auth-infra-basics-4-resources` desde `dev` (post PR 3).
 
-#### Commit 4.1 — `feat(resources/dynamodb): jwt-blacklist y auth-codes`
+#### Commit 4.1 — `feat(resources/dynamodb): jwt-blacklist con GSI by_family_id`
 
-- Agrega `resources/dynamodb/jwt-blacklist.yaml` (con GSI by_family_id)
-  y `resources/dynamodb/auth-codes.yaml`.
+- Agrega `resources/dynamodb/jwt-blacklist.yaml` (con GSI by_family_id
+  KEYS_ONLY, TTL `exp`).
 - **Verificacion incremental**: `serverless validate-catalog --stage=dev`.
 
 #### Commit 4.2 — `feat(resources/sqs): auth-email-queue + DLQ`

--- a/docs/specs/01-auth-infra-basics/10-paralelizacion-worktrees.md
+++ b/docs/specs/01-auth-infra-basics/10-paralelizacion-worktrees.md
@@ -1,0 +1,170 @@
+# 10. Paralelizacion con git worktrees
+
+> Plan Large con dependencias estrictas + 4 operaciones (register,
+> login, verify, session) que son worktree-safe entre si tras T7+T8.
+
+## Base secuencial (no se paraleliza)
+
+```text
+PR 1   T1 + T13                         <-- BASE 1: spec + docs/claude
+PR 2   T2                               <-- BASE 2: shared.auth (todos importan de aqui)
+PR 3   T3 + T4                          <-- BASE 3: schema Neon + repositories
+PR 4   T5                               <-- BASE 4: resources AWS (DDB + SQS + SSM)
+PR 6.1+6.2  T7 + T8 (scaffold+services) <-- BASE 5: handlers/services del lambda auth
+
+       hasta aqui TODO secuencial
+```
+
+PR 1 -> PR 4 son secuenciales por dependencia logica: cada uno apoya
+al siguiente. PR 5 (`auth_email_worker`) puede correr paralelo a PR 6
+porque toca un Lambda distinto, pero por simplicidad de revision se
+hacen secuenciales tambien.
+
+## Fase paralela: worktrees lanzables tras PR 6 mergeado
+
+Tras PR 6 mergeado en `dev`, el repo tiene `services/auth/` con
+`handler.py` + 8 services + EventModel registrando 4 operations. Los
+controllers no existen aun. Aqui se abre la ventana de paralelizacion:
+
+| Worktree | Tarea | Archivos nuevos | Archivos modificados | Colision? |
+|----------|-------|-----------------|----------------------|-----------|
+| WT-A | T9 register | `controllers/register/*` + `models/register.py` + `tests/unit/controllers/test_register_*.py` + `events/register-*.json` | ninguno | no |
+| WT-B | T10 login | `controllers/login/*` + `models/login.py` + `tests/unit/controllers/test_login_*.py` + `events/login-*.json` | ninguno | no |
+| WT-C | T11 verify | `controllers/verify/*` + `models/verify.py` + `tests/unit/controllers/test_verify_*.py` + `events/verify-*.json` | ninguno | no |
+| WT-D | T12 session | `controllers/session/*` + `models/session.py` + `tests/unit/controllers/test_session_*.py` + `events/session-*.json` | ninguno | no |
+
+**Por que NO hay colision**:
+
+- Cada worktree crea SU PROPIA subcarpeta en `controllers/` y SU
+  archivo en `models/`.
+- `core/models/event.py` (potencial choke point) NO se modifica en
+  estos worktrees: T7 (en el scaffold) ya registro las 4 operations
+  con sus 10 actions en el `build_event_model({...})`. Cada operation
+  tiene sus Pydantic schemas declaradas en el `models/<op>.py` que
+  cada worktree crea. **NO hay edicion concurrente del event.py**.
+- Los services (T8) ya existen y son interfaces estables (Interface
+  Stability check OK).
+- `controllers/__init__.py` por operation existe (lo crea el worktree
+  responsable). NO hay un `controllers/__init__.py` raiz que requiera
+  edicion concurrente (la descubrimiento es dinamico via
+  `import_controller`).
+
+Limite practico: **4 worktrees** (uno por operation). Cumple las
+recomendaciones del estandar (5-7 max).
+
+## Fase secuencial final tras worktrees
+
+Tras integrar WT-A..WT-D en `dev` (uno por PR: PR 7 con WT-A+WT-B y
+PR 8 con WT-C+WT-D — decision combinada para reducir overhead de
+review):
+
+```text
+PR 8.3  rate-limit seed                       (operativo, toca AWS dev)
+PR 8.4  deploy auth -> dev                    (operativo)
+PR 9    integration tests + ER + limpieza     (verificacion E2E)
+```
+
+Todo secuencial.
+
+## Como lanzar un worktree
+
+Tras PR 6 mergeado:
+
+```bash
+# 1. Actualizar la rama base
+git checkout dev
+git pull origin dev
+
+# 2. Crear el worktree (por ejemplo para WT-A register)
+git worktree add ../portfolio-wt-register feature/auth-infra-basics-7-register
+cd ../portfolio-wt-register
+git checkout -b feature/auth-infra-basics-7-register
+
+# 3. Instalar deps si hace falta (pnpm + uv sync para el lambda)
+pnpm install
+cd serverless/lambda/services/auth && uv sync
+
+# 4. Implementar la tarea (T9 en este caso)
+#    - Crear controllers/register/{start,verify_magic_link,verify_code}.py
+#    - Crear models/register.py
+#    - Crear tests + events
+
+# 5. Verificar
+serverless tests --type=unit --lambda=auth
+serverless run --stage=local --lambda=auth --event=events/register-start.json
+
+# 6. Commitear y push (cuando la fase este verde)
+git add -A
+git commit -m "feat(auth/register): controllers start + verify-magic-link + verify-code"
+git push -u origin feature/auth-infra-basics-7-register
+gh pr create --base dev --title "..." --body "..."
+```
+
+### Con subagentes en paralelo
+
+Para lanzar las 4 ramas en paralelo a partir del mismo punto base
+(post PR 6), usar 4 instancias de `Agent` con `isolation: "worktree"`
+y prompts que apunten cada uno a su .md de fase:
+
+```text
+Agent A: prompt = "Implementar T9 segun docs/specs/01-auth-infra-basics/05-...md seccion register + 08-...md tarea T9"
+Agent B: prompt = "Implementar T10 segun ... operation login"
+Agent C: prompt = "Implementar T11 segun ... operation verify"
+Agent D: prompt = "Implementar T12 segun ... operation session"
+```
+
+Cada uno crea su rama, implementa, verifica, hace push y abre su PR
+independiente (o uno por par segun el agrupamiento PR 7 / PR 8).
+
+## Que NO se paraleliza
+
+- T1, T2, T3, T4, T5, T6, T7, T8: dependencias estrictas, secuenciales.
+- T13: docs/claude — paralelizable con T2-T12 pero por simplicidad va
+  en PR 1 (junto con T1).
+- T14 (seccion 11): es el cierre, toca archivos transversales
+  (`docs/diagrams/db-er.mmd`) y consolida E2E. SIEMPRE secuencial al
+  final.
+- `core/models/event.py`: editado SOLO una vez en T7. Cada worktree
+  asume ese archivo ya tiene las 4 operations registradas.
+- `manifest.yaml`, `pyproject.toml`, `uv.lock` del lambda auth:
+  editados SOLO en T7 (scaffold). Si una operation nueva requiere una
+  dep nueva (no esperado: todas las deps ya estan en `shared.auth` o
+  `shared.lambda_kit`), se hace en un commit secuencial al final.
+
+## Anti-patrones evitados
+
+| Anti-patron | Como lo evitamos |
+|-------------|------------------|
+| Lanzar worktrees antes de la base | PR 1..PR 6 secuenciales, mergeados antes de empezar PR 7 |
+| Dos worktrees editan `models/event.py` | T7 lo deja completo desde el scaffold; los worktrees NO lo tocan |
+| Conflicto en `controllers/__init__.py` raiz | NO existe — descubrimiento dinamico por `import_controller` |
+| Conflicto en `pyproject.toml` del lambda | NO se edita en los worktrees (todas las deps via shared) |
+| Worktree D depende de C | Cada operation es 100% independiente (services ya implementados en T8) |
+| Mas de 7 worktrees concurrentes | Maximo 4 |
+
+## Resumen visual
+
+```text
+PR 1 spec+claude  ─────────────┐
+PR 2 shared.auth  ─────────────┤  (BASE secuencial)
+PR 3 schema Neon  ─────────────┤
+PR 4 resources    ─────────────┤
+PR 5 email worker ─────────────┤
+PR 6 auth scaffold+services ───┘
+                               │
+       ┌───────────┬───────────┼───────────┬───────────┐
+       │           │           │           │           │
+     WT-A        WT-B        WT-C        WT-D       (T13 ya hecho en PR 1)
+   register    login       verify      session
+       │           │           │           │
+       └───────────┴───────────┴───────────┘
+                               │
+                  PR 7 (WT-A + WT-B mergeados)
+                  PR 8 (WT-C + WT-D mergeados + rate-limit + deploy)
+                               │
+                               v
+                  PR 9 verificacion E2E + limpieza (SEC. 11)
+```
+
+Maximo paralelismo util: **4 worktrees concurrentes** durante la fase
+de operations. El resto secuencial.

--- a/docs/specs/01-auth-infra-basics/11-verificacion-e2e.md
+++ b/docs/specs/01-auth-infra-basics/11-verificacion-e2e.md
@@ -1,0 +1,345 @@
+# 11. Verificacion E2E iterativa (fase final, gate del PR)
+
+> Ultima fase del plan. Dos partes obligatorias: (A) refactor de tests
+> + (B) bateria de comandos reales en bucle "no parar hasta que
+> funcione". NO se marca completa con un comando fallando o coverage
+> < 80%. Es el gate del PR 9.
+
+## Parte A — refactor de tests
+
+### Que cambia
+
+| Archivo | Accion |
+|---------|--------|
+| `serverless/lambda/services/auth/tests/integration/*.py` (7 archivos) | CREAR — listados en [06-testing.md](06-testing.md) |
+| `serverless/lambda/services/auth/tests/unit/*` | sin cambio (creados en PR 7+8) |
+| `serverless/lambda/shared/tests/unit/shared/auth/*` | sin cambio (creados en PR 2) |
+| `serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_*.py` | sin cambio (PR 3) |
+| `docs/diagrams/db-er.mmd` | MODIFICAR — agregar cluster `auth_*` |
+| `docs/specs/01-auth-infra-basics/` | ELIMINAR (`git rm -r`) — la spec es efimera |
+
+### Barrido global (cero resultados esperados)
+
+```bash
+# Ningun test viejo referencia codigo eliminado (no hay eliminacion en este plan)
+rg -l "auth_users.*deprecated|legacy_auth|old_jwt" serverless/
+
+# Ningun TODO/FIXME relacionado quedo abierto
+rg -l "TODO.*auth|FIXME.*auth|XXX.*auth" serverless/lambda/services/auth/
+
+# La carpeta del plan esta eliminada en el ultimo commit
+ls docs/specs/01-auth-infra-basics/ 2>&1 | grep -q "No such file" && echo OK || echo FAIL
+```
+
+## Parte B — bateria de comandos reales
+
+Dividida en bloques. Cada bloque debe pasar antes del siguiente.
+
+### Bloque 1 — sintaxis + lint
+
+```bash
+# Sintaxis Python global de los nuevos paths
+python -m compileall -q \
+  serverless/lambda/shared/auth \
+  serverless/lambda/shared/db/models/auth \
+  serverless/lambda/shared/db/repositories \
+  serverless/lambda/services/auth \
+  serverless/lambda/services/auth_email_worker
+
+# Lint Python (Ruff)
+python devtools/run.py serverless lint --lambda=auth
+python devtools/run.py serverless lint --lambda=auth_email_worker
+python devtools/run.py serverless lint --shared
+
+# Shared-only imports + dedup D-3
+python devtools/run.py serverless lint-deps --lambda=auth
+python devtools/run.py serverless lint-deps --lambda=auth_email_worker
+python devtools/run.py serverless lint-deps --shared
+
+# Lint del repo (markdown del plan, mientras existe)
+pnpm exec biome check serverless/
+```
+
+### Bloque 2 — tests unit + coverage
+
+```bash
+# Shared (incluye los 17 tests de shared.auth + 10 de repositories.auth)
+python devtools/run.py serverless tests --type=unit --shared
+
+# Auth lambda (60+ tests unit)
+python devtools/run.py serverless tests --type=unit --lambda=auth
+python devtools/run.py serverless tests --type=coverage --lambda=auth
+# Verificar: coverage per-file >= 80% en core/services/, core/controllers/,
+# core/models/
+
+# Email worker (8 tests)
+python devtools/run.py serverless tests --type=unit --lambda=auth_email_worker
+python devtools/run.py serverless tests --type=coverage --lambda=auth_email_worker
+```
+
+### Bloque 3 — run local (RIE) por endpoint
+
+```bash
+# Los eventos de events/ deben dar resultado esperado
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/register-start.json
+# Esperado: 201 con {temp_token, user_id, expires_in: 300}
+
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/register-verify-code.json
+# Esperado: 400 (code wrong porque el event tiene un code estatico) o
+# 200 si el event refleja un code valido seedeado
+
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/login-start.json
+# Esperado: 404 EMAIL_NOT_FOUND con suggest_register=true
+
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/session-refresh.json
+# Esperado: 401 (token expirado en el event estatico)
+
+# Worker
+python devtools/run.py serverless run --stage=local --lambda=auth_email_worker \
+  --event=events/register-magic-link.json
+# Esperado: log "email.sent.register-magic-link" + return OK
+```
+
+### Bloque 4 — migration end-to-end en branch Neon
+
+```bash
+# 1. Crear branch
+neon branches create --name verify-auth-plan --parent main
+
+# 2. Apuntar DATABASE_URL al branch (extraer del Neon CLI output)
+BRANCH_URL="$(neon connection-string verify-auth-plan)"
+
+# 3. Run migration UP
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/migrate.json
+
+# 4. Verificar tablas
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/tables.json | \
+  grep -E "auth_(users|credentials|email_codes|magic_links|audit_log)"
+
+# 5. Run DOWN -1
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/downgrade.json
+
+# 6. Re-run UP (idempotencia)
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/migrate.json
+
+# 7. Cleanup
+neon branches delete verify-auth-plan
+```
+
+AC verificada: **AC-15**.
+
+### Bloque 5 — tests integration con AWS dev
+
+(Requiere acceso a AWS dev y al branch Neon dev.)
+
+```bash
+# Asegurar deploy actualizado
+python devtools/run.py serverless deploy --lambda=auth_email_worker --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
+
+# Migration aplicada en dev
+python devtools/run.py serverless run --stage=dev --lambda=db \
+  --event=events/migrate.json --aws-profile=tfs-dev
+python devtools/run.py serverless run --stage=dev --lambda=db \
+  --event=events/current.json --aws-profile=tfs-dev
+# Esperado: revision 00000002
+
+# Tests integration
+python devtools/run.py serverless tests --type=integration --lambda=auth
+```
+
+### Bloque 6 — smoke E2E HTTP en dev
+
+```bash
+# Variables (no commitear)
+API="https://api.portfolio.dev.the-full-stack.com/auth"
+EMAIL="test-$(date +%s)@example.com"
+TURNSTILE_BYPASS="$(grep -m1 '^TURNSTILE_BYPASS_SECRET=' docker/env/server/.dev | cut -d= -f2-)"
+
+# 1. register.start (con bypass de Turnstile en dev)
+RESP=$(curl -sS -X POST "$API" \
+  -H "Content-Type: application/json" \
+  -H "X-Turnstile-Bypass-Secret: $TURNSTILE_BYPASS" \
+  -d "{
+    \"operation\": \"register\",
+    \"action\": \"start\",
+    \"data\": {
+      \"email\": \"$EMAIL\",
+      \"cf_turnstile_response\": \"\"
+    }
+  }")
+echo "$RESP" | jq .
+TEMP_TOKEN=$(echo "$RESP" | jq -r .data.temp_token)
+USER_ID=$(echo "$RESP" | jq -r .data.user_id)
+
+# Verificar: code = 0 (success), temp_token presente, expires_in = 300
+# AC-1 verificada
+
+# 2. Confirmar que se publico mensaje SQS (CloudWatch del worker)
+sleep 5
+aws logs tail /aws/lambda/portfolio-auth-email-worker-dev \
+  --since 1m --region us-east-1 \
+  --filter-pattern '"email.sent.register-magic-link"' --aws-profile tfs-dev
+
+# 3. login.start con email inexistente -> 404 + suggest_register
+RESP=$(curl -sS -X POST "$API" \
+  -H "Content-Type: application/json" \
+  -H "X-Turnstile-Bypass-Secret: $TURNSTILE_BYPASS" \
+  -d '{
+    "operation": "login",
+    "action": "start",
+    "data": {
+      "email": "noexiste-XXXXXX@example.com",
+      "cf_turnstile_response": ""
+    }
+  }')
+echo "$RESP" | jq .
+# Esperado: statusCode 404, data.error = EMAIL_NOT_FOUND, data.suggest_register = true
+# AC-5 verificada
+
+# 4. Rate-limit: 6ta request a login.start desde misma IP en 60s -> 429
+for i in 1 2 3 4 5 6; do
+  curl -sS -o /dev/null -w "%{http_code}\n" -X POST "$API" \
+    -H "Content-Type: application/json" \
+    -H "X-Turnstile-Bypass-Secret: $TURNSTILE_BYPASS" \
+    -d '{"operation":"login","action":"start","data":{"email":"a@b.com","cf_turnstile_response":""}}'
+done
+# Esperado: 5x [200 o 404] + 1x 429
+# AC-13 verificada
+
+# 5. Sin Turnstile token ni bypass -> 403
+curl -sS -X POST "$API" \
+  -H "Content-Type: application/json" \
+  -d '{"operation":"register","action":"start","data":{"email":"x@y.com","cf_turnstile_response":""}}' \
+  | jq .data.error
+# Esperado: TURNSTILE_FAILED
+# AC-12 verificada
+```
+
+### Bloque 7 — verificacion del PR 9 (cierre)
+
+```bash
+# 1. La spec esta eliminada
+test ! -d docs/specs/01-auth-infra-basics && echo "spec borrada" || echo "FAIL"
+
+# 2. El ER tiene el cluster auth
+grep -q "auth_users" docs/diagrams/db-er.mmd && echo "ER actualizado" || echo "FAIL"
+
+# 3. La rule + skill estan presentes
+test -f .claude/rules/auth-system.md && echo "rule OK" || echo "FAIL"
+test -f .claude/skills/auth-system/SKILL.md && echo "skill OK" || echo "FAIL"
+
+# 4. La validacion de la skill
+claude --permission-mode bypassPermissions \
+  --disallowedTools "WebSearch" "WebFetch" \
+  --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
+  --output-format json \
+  -p "como funciona el flujo de magic link en el portfolio" 2>&1 | tail -10
+# Esperado: num_turns > 1 (skill activada)
+```
+
+## Parte C — bucle de correccion ("no parar hasta que funcione")
+
+```text
+ejecutar bloque N
+   |
+   v
+{pasa todo?}--si--> bloque N+1
+   |
+   no
+   |
+   v
+diagnosticar (leer stderr, logs CloudWatch, queries DB)
+   |
+   v
+corregir codigo / test / config
+   |
+   v
+re-ejecutar el bloque que fallo + bloques previos relevantes
+   |
+   +-----------> volver a "ejecutar bloque N"
+```
+
+### Errores tipicos y su correccion
+
+| Sintoma | Diagnostico | Correccion |
+|---------|-------------|------------|
+| `serverless tests` falla con `ImportError: shared.auth` | uv lock desactualizado en el lambda | `cd serverless/lambda/services/auth && uv sync` |
+| `verify_jwt` falla con `Signature verification failed` | JWT_SECRET en local != el usado al firmar | `serverless secrets-status --stage=local` y resincronizar |
+| `lint-deps` reporta dep duplicada | El lambda declaro algo que `shared.auth` ya aporta | Retirar la dep del `pyproject.toml` del lambda |
+| `register.start` falla con `TURNSTILE_FAILED` aun con bypass | El header `X-Turnstile-Bypass-Secret` no llega | Verificar CORS_ALLOWED_ORIGINS + Postman config |
+| Migration falla con `relation cv_profiles does not exist` | El branch Neon no tiene el schema base | Crear desde `main` con `--parent main` |
+| `429 RATE_LIMITED` siempre, incluso primera request | Regla de rate-limit con limit=0 o IP whitelisted erronea | `serverless rate-limit list --stage=dev` y corregir |
+| GSI `by_family_id` no responde a Query | El index aun esta `BUILDING` | Esperar 1-3 min tras `provision-infra` |
+| `arg parse error: --aws-profile` | comando viejo o tipeo | Usar la forma con `=` (`--aws-profile=tfs-dev`) |
+
+## Regla de cierre
+
+Esta fase NO se marca completa mientras:
+
+- Algun bloque (1 a 7) falle,
+- Algun test este rojo,
+- Coverage per-file < 80% en `core/services/` o `core/controllers/`,
+- La carpeta `docs/specs/01-auth-infra-basics/` siga viva en el commit
+  final del PR 9.
+
+Iterar — corregir, re-ejecutar, repetir — hasta que toda la bateria
+pase. Solo entonces:
+
+1. `git add -A && git commit -m "chore(specs): elimina la carpeta efimera del plan"` (incluye el `git rm -r` y los ajustes finales).
+2. `git push -u origin feature/auth-infra-basics-9-verificacion-e2e`.
+3. `gh pr create --base dev --title "chore(specs): verificacion E2E + cierre del plan auth-infra-basics" --body "$(cat <<'EOF'`...
+
+`gh pr merge --merge --delete-branch` solo cuando la CI verde + el
+reviewer aprobo.
+
+## Promocion dev -> stage -> main
+
+Tras PR 9 mergeado a `dev`:
+
+```bash
+# Promover a stage
+gh pr create --base stage --head dev --title "chore: promover plan-01-auth-infra-basics a stage"
+gh pr merge --merge  # NO --delete-branch (stage es permanente)
+
+# Promover a main
+gh pr create --base main --head stage --title "chore: promover plan-01-auth-infra-basics a main"
+gh pr merge --merge
+```
+
+Tras cada promocion, CI ejecuta `deploy-backend.yml` con auto-detect
+de los lambdas afectados (`auth`, `auth_email_worker`, `db` por la
+migration que ya esta aplicada — el workflow corre `migrate-db` antes
+de redeploy).
+
+Verificacion post-prod:
+
+```bash
+# Smoke check en prod (sin Turnstile bypass — Turnstile real)
+curl -sS -X POST "https://api.portfolio.the-full-stack.com/auth" \
+  -H "Content-Type: application/json" \
+  -d '{"operation":"login","action":"start","data":{"email":"smoke-prod-$(date +%s)@example.com","cf_turnstile_response":"<token-real-cliente>"}}'
+# Esperado: 404 EMAIL_NOT_FOUND (probablemente, si el email no existe)
+```
+
+## Pendientes que el PR 9 NO cubre
+
+(quedan para plan 02-auth-mfa o plan 03-auth-users-management):
+
+- Configurar MFA (TOTP setup, WebAuthn registration).
+- CRUD de usuarios (profile/status/admin).
+- UI Astro de signup/signin/verify.
+- Password reset flow completo (los emails de `password-reset` ya
+  estan en el worker; el handler de `verify.set-password` ya existe;
+  pero el endpoint POST `/auth?operation=verify&action=request-password-reset`
+  se agrega en plan 02 o 03 segun convenga).
+
+Estos pendientes se documentan en el body del PR 9 bajo `## TODO`.

--- a/docs/specs/01-auth-infra-basics/11-verificacion-e2e.md
+++ b/docs/specs/01-auth-infra-basics/11-verificacion-e2e.md
@@ -83,7 +83,7 @@ python devtools/run.py serverless tests --type=coverage --lambda=auth_email_work
 # Los eventos de events/ deben dar resultado esperado
 python devtools/run.py serverless run --stage=local --lambda=auth \
   --event=events/register-start.json
-# Esperado: 201 con {temp_token, user_id, expires_in: 300}
+# Esperado: 200 con {temp_token, user_id, expires_in: 300}
 
 python devtools/run.py serverless run --stage=local --lambda=auth \
   --event=events/register-verify-code.json

--- a/docs/specs/01-auth-infra-basics/README.md
+++ b/docs/specs/01-auth-infra-basics/README.md
@@ -1,0 +1,183 @@
+# Plan 01: Auth infra basics — Lambda `auth` con register / login / verify / logout
+
+> **Orden en la serie auth**: este es el **1 de 3** planes secuenciales.
+>
+> ```text
+> 01 — auth-infra-basics       <-- ESTE PLAN (infra + register/login/verify/logout)
+> 02 — auth-mfa                (TOTP + email-code MFA + WebAuthn / Passkeys)
+> 03 — auth-users-management   (Lambda `users` con profile/status/admin)
+> ```
+>
+> Los planes son secuenciales: el plan 02 depende del 01 (shared.auth, schema
+> Neon, lambda auth con flujo basico), y el plan 03 del 01+02 (status del
+> usuario, login con MFA validado). NO se ejecutan en paralelo entre si.
+>
+> Entrega el esqueleto del dominio de autenticacion del portfolio: schema Neon
+> `auth_*`, nuevo shared subpackage `shared.auth` (JWT HS256 + argon2 +
+> generador de codigos), 2 tablas DynamoDB nuevas (`jwt-blacklist`,
+> `auth-codes`), cola SQS `auth-email-queue` + Lambda worker
+> `auth_email_worker`, y Lambda HTTP `auth` con SOLO los flujos basicos (sin
+> MFA, sin WebAuthn, sin CRUD de users): `register`, `login`, `verify`
+> (magic-link + email-code), `logout`, `refresh-token`.
+
+## Que entrega este plan
+
+- Schema Neon: tablas `auth_users`, `auth_credentials`, `auth_email_codes`,
+  `auth_magic_links`, `auth_audit_log` (Alembic migration `00000002`).
+- Shared subpackage `shared.auth`: portador unico de `pyjwt` y
+  `argon2-cffi`; funciones `issue_temp_jwt`, `issue_access_jwt`,
+  `issue_refresh_jwt`, `verify_jwt`, `hash_password`, `verify_password`,
+  `generate_code` (8 chars Crockford-like sin O/0/I/1/L), `generate_token`.
+- DynamoDB: tablas `portfolio-jwt-blacklist-${stage}` (TTL `exp`) y
+  `portfolio-auth-codes-${stage}` (TTL `expires_at`, hash bcrypt-style).
+- SSM: parametro nuevo `/portfolio/${stage}/jwt-secret` (SecureString +
+  KMS `alias/portfolio-lambdas`).
+- SQS: cola `portfolio-auth-email-${stage}` + DLQ.
+- Lambda `auth_email_worker`: consume la cola, envia via SES (template
+  texto + HTML) magic link, register-code, login-code, otp-code,
+  password-reset.
+- Lambda `auth`: HTTP POST `/auth`. Operations + actions:
+  - `register.start` (email -> envia magic-link + code, JWT temp)
+  - `register.verify-magic-link` (token -> JWT final)
+  - `register.verify-code` (code -> JWT final)
+  - `login.start` (email -> 404 + suggest_register o lista de metodos)
+  - `login.verify-magic-link` (token -> JWT final)
+  - `login.verify-code` (code -> JWT final)
+  - `verify.set-password` (JWT temp + password -> guarda hash)
+  - `verify.resend-code` (JWT temp -> regenera + reenvia)
+  - `session.refresh` (refresh JWT -> nuevo access + refresh rotado)
+  - `session.logout` (access JWT -> blacklist + invalida refresh)
+- Rate-limit estricto: `register.start` 3/h/IP, `login.start` 5/min/IP,
+  `verify.*` 10/min/IP, `session.refresh` 30/min/IP.
+- Turnstile obligatorio en `register.start` y `login.start`.
+- 1 commit por fase, cada uno con verificacion incremental. PR a `dev`.
+
+## Que NO entrega este plan (queda para plan 2 y 3)
+
+- MFA (TOTP), email-code-como-MFA, WebAuthn / Passkeys → **plan 2**.
+- Lambda `users` (profile, status, admin, deshabilitar usuario) → **plan 3**.
+- Frontend Astro de signup / signin / verify / dashboard → plan futuro.
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| Problema, solucion, AC numerados | [01-contexto-y-decision.md](01-contexto-y-decision.md) |
+| Schema Neon `auth_*` + ER ASCII | [02-schema-neon.md](02-schema-neon.md) |
+| Shared subpackage `shared.auth` (JWT, argon2, code gen) | [03-shared-auth.md](03-shared-auth.md) |
+| Infraestructura: DynamoDB nuevas, SSM, SQS, cola + worker | [04-infraestructura.md](04-infraestructura.md) |
+| Arquitectura del Lambda `auth`: operations, actions, controllers, services | [05-lambda-auth-arquitectura.md](05-lambda-auth-arquitectura.md) |
+| Estrategia de testing (unit por capa + integration por endpoint) | [06-testing.md](06-testing.md) |
+| Listado de archivos afectados con verificacion por archivo | [07-archivos-afectados.md](07-archivos-afectados.md) |
+| Descomposicion en tareas atomicas paralelizables | [08-descomposicion-paralelizacion.md](08-descomposicion-paralelizacion.md) |
+| Commits incrementales (Conventional Commits espanol) | [09-commits.md](09-commits.md) |
+| Paralelizacion con git worktrees | [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md) |
+| Verificacion E2E iterativa (fase final, gate del PR) | [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Estado por fase
+
+| Fase | Descripcion | Estado |
+|------|-------------|--------|
+| 0 | Plan escrito + carpeta `docs/specs/auth-infra-basics/` commiteada | pending |
+| 1 | Schema Neon `auth_*` + Alembic migration 00000002 | pending |
+| 2 | `shared.auth` subpackage (pyjwt + argon2-cffi + code/token gen + tests) | pending |
+| 3 | DynamoDB tables (`jwt-blacklist`, `auth-codes`) + SSM `jwt-secret` + SQS `auth-email-queue` | pending |
+| 4 | Lambda `auth_email_worker` (consume cola, envia SES) | pending |
+| 5 | Lambda `auth` scaffold (manifest + AppConfig + handler + EventModel + OPERATIONS) | pending |
+| 6 | Operation `register` (start + verify-magic-link + verify-code) | pending |
+| 7 | Operation `login` (start + verify-magic-link + verify-code) | pending |
+| 8 | Operation `verify` (set-password + resend-code) | pending |
+| 9 | Operation `session` (refresh + logout) | pending |
+| 10 | Rate-limit rules + integracion `check_or_raise` por endpoint | pending |
+| 11 | Verificacion E2E + limpieza de `docs/specs/auth-infra-basics/` | pending |
+
+## Decisiones no-reabribles
+
+Cerradas en el dialogo previo y NO se vuelven a discutir:
+
+1. **Split de lambdas**: `auth` + `users`. Este plan entrega `auth`. `users` -> plan 3.
+2. **Persistencia hibrida**: estado relacional en Neon (`auth_*`),
+   estado efimero con TTL en DynamoDB (`jwt-blacklist`, `auth-codes`).
+3. **JWT**: HS256 + secret en SSM SecureString. Tres tipos:
+   - **temp** (`typ=temp`): 5 min, rolling refresh (cada API del flujo
+     emite uno nuevo y blacklistea el anterior).
+   - **access** (`typ=access`): 15 min. Stateless. Blacklisteable.
+   - **refresh** (`typ=refresh`): 30 dias. Stateful (row en
+     `jwt-blacklist` con TTL = exp). Rotacion en cada uso.
+4. **Codigo de 8 chars**: alfabeto Crockford-like (`A-Z` + `0-9` sin
+   `O/0/I/1/L`). TTL 15 min. Max 5 intentos por code (`auth_email_codes.attempts`).
+5. **Magic link**: token opaco 32 bytes b64url (URL-safe). TTL 15 min,
+   single-use. URL: `https://api.portfolio.{env}.the-full-stack.com/auth?operation=register&action=verify-magic-link&token=<X>` (API directa, devuelve HTML 200 con redirect + auto-submit del JWT).
+6. **Email async**: cola SQS dedicada `portfolio-auth-email-${stage}` +
+   worker dedicado `auth_email_worker` (NO reusar `contact_worker` —
+   aislamiento de dominios).
+7. **Turnstile**: solo en `register.start` y `login.start`. El resto del
+   flujo confia en el JWT temp + rate-limit.
+8. **Login UX (email no existe)**: 404 + `{suggest_register: true,
+   methods: []}`. Si existe: 200 + `{methods: [...]}` con la lista
+   habilitada (en este plan solo `magic-link` y `email-code` ya que
+   password/MFA llegan en fases posteriores y plan 2).
+9. **Link cv_profiles**: `auth_users.profile_id` FK NULLABLE a
+   `cv_profiles(id)` (ON DELETE SET NULL). Default `NULL`; solo el row
+   de Pablo apuntara cuando se setee a mano.
+10. **Hash de password**: argon2id (parametros defaults de argon2-cffi
+    `PasswordHasher()`: `time_cost=3`, `memory_cost=65536`, `parallelism=4`).
+11. **Rate-limit**: reusar `shared.rate_limit` con reglas nuevas por
+    endpoint (insertadas en la tabla `portfolio-rate-limit-rules` via
+    `serverless rate-limit` command, no codigo).
+12. **CI**: `change_detector.py` auto-detecta los nuevos `services/auth/`,
+    `services/auth_email_worker/` — cero cambio en `deploy-backend.yml`.
+
+## Reglas criticas (siempre activas)
+
+- **SIEMPRE** los services importan paquetes externos via
+  `shared.<subpaquete>` (ver
+  [.claude/rules/lambda-shared-imports.md](../../.claude/rules/lambda-shared-imports.md)).
+- **SIEMPRE** un controller por action; nombre de clase
+  `action.capitalize()` con palabra simple (ej. `Start`, `VerifyMagicLink` ->
+  pero el verbo se separa con guion en el wire y la clase es la version
+  capitalizada del segmento `<action>`: `verify-magic-link` -> `VerifyMagicLink`
+  en `controllers/register/verify_magic_link.py`).
+- **SIEMPRE** la logica de negocio vive en `core/services/`, NUNCA en el
+  handler ni en los controllers.
+- **SIEMPRE** `auth_users.email` se guarda lowercased (`email.lower().strip()`).
+- **SIEMPRE** logs NO incluyen: email completo (solo hash truncado),
+  password, JWT, magic-link token, code. Auditoria queda en
+  `auth_audit_log`.
+- **SIEMPRE** verificar antes de commitear (lint + tests unit del scope).
+- **NUNCA** devolver `404` con body distinto entre "email no existe" y
+  "email existe pero esta deshabilitado". Solo `register.start` y
+  `login.start` distinguen (y solo si Turnstile valido).
+- **NUNCA** loguear el valor de `JWT_SECRET`, Neon URL, codigo de email
+  o token de magic-link.
+- **NUNCA** firmar un JWT con un secret distinto del leido de SSM en
+  cold start (NO env var directa).
+
+## Matriz de verificacion (rapida)
+
+| Capa | Comando |
+|------|---------|
+| Sintaxis Python | `python -m compileall -q serverless/lambda/services/auth serverless/lambda/services/auth_email_worker serverless/lambda/shared/auth` |
+| Imports shared-only | `python devtools/run.py serverless lint-deps --lambda=auth` |
+| Tests unit `shared.auth` | `python devtools/run.py serverless tests --type=unit --shared` |
+| Tests unit `auth` | `python devtools/run.py serverless tests --type=unit --lambda=auth` |
+| Tests unit `auth_email_worker` | `python devtools/run.py serverless tests --type=unit --lambda=auth_email_worker` |
+| Coverage | `python devtools/run.py serverless tests --type=coverage --lambda=auth` |
+| Migration up (dev) | `python devtools/run.py serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev` |
+| Run local (RIE) | `python devtools/run.py serverless run --stage=local --lambda=auth --event=events/register-start.json` |
+| Deploy dev | `python devtools/run.py serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev` |
+| Smoke E2E | ver [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Bibliografia interna
+
+- [.claude/rules/lambda-controller.md](../../.claude/rules/lambda-controller.md) — formato Lambda Python
+- [.claude/rules/lambda-shared-imports.md](../../.claude/rules/lambda-shared-imports.md) — catalogo de portadores
+- [.claude/rules/neon-management.md](../../.claude/rules/neon-management.md) — Neon en runtime + migrations
+- [.claude/rules/serverless-secrets.md](../../.claude/rules/serverless-secrets.md) — SSM + IAM scopes
+- [.claude/rules/ci-cd-pipeline.md](../../.claude/rules/ci-cd-pipeline.md) — `deploy-backend.yml` auto-detect
+- [.claude/docs/serverless-backend/README.md](../../.claude/docs/serverless-backend/README.md) — arquitectura general
+- [.claude/docs/serverless-rate-limit/README.md](../../.claude/docs/serverless-rate-limit/README.md) — sliding window
+- [.claude/docs/dynamodb-cache/README.md](../../.claude/docs/dynamodb-cache/README.md) — @cached
+- [docs/diagrams/db-er.mmd](../../diagrams/db-er.mmd) — schema Neon actual
+- [serverless/lambda/services/contact_form/](../../../serverless/lambda/services/contact_form/) — analogo (HTTP + Turnstile + SQS publish)
+- [serverless/lambda/services/contact_worker/](../../../serverless/lambda/services/contact_worker/) — analogo (SQS consumer + SES send)

--- a/docs/specs/01-auth-infra-basics/README.md
+++ b/docs/specs/01-auth-infra-basics/README.md
@@ -14,8 +14,8 @@
 >
 > Entrega el esqueleto del dominio de autenticacion del portfolio: schema Neon
 > `auth_*`, nuevo shared subpackage `shared.auth` (JWT HS256 + argon2 +
-> generador de codigos), 2 tablas DynamoDB nuevas (`jwt-blacklist`,
-> `auth-codes`), cola SQS `auth-email-queue` + Lambda worker
+> generador de codigos), 1 tabla DynamoDB nueva (`jwt-blacklist` con GSI
+> `by_family_id`), cola SQS `auth-email-queue` + Lambda worker
 > `auth_email_worker`, y Lambda HTTP `auth` con SOLO los flujos basicos (sin
 > MFA, sin WebAuthn, sin CRUD de users): `register`, `login`, `verify`
 > (magic-link + email-code), `logout`, `refresh-token`.
@@ -28,8 +28,9 @@
   `argon2-cffi`; funciones `issue_temp_jwt`, `issue_access_jwt`,
   `issue_refresh_jwt`, `verify_jwt`, `hash_password`, `verify_password`,
   `generate_code` (8 chars Crockford-like sin O/0/I/1/L), `generate_token`.
-- DynamoDB: tablas `portfolio-jwt-blacklist-${stage}` (TTL `exp`) y
-  `portfolio-auth-codes-${stage}` (TTL `expires_at`, hash bcrypt-style).
+- DynamoDB: tabla `portfolio-jwt-blacklist-${stage}` (TTL `exp`) con
+  GSI `by_family_id` (KEYS_ONLY) para revocar familias de refresh
+  tokens.
 - SSM: parametro nuevo `/portfolio/${stage}/jwt-secret` (SecureString +
   KMS `alias/portfolio-lambdas`).
 - SQS: cola `portfolio-auth-email-${stage}` + DLQ.
@@ -81,7 +82,7 @@
 | 0 | Plan escrito + carpeta `docs/specs/auth-infra-basics/` commiteada | pending |
 | 1 | Schema Neon `auth_*` + Alembic migration 00000002 | pending |
 | 2 | `shared.auth` subpackage (pyjwt + argon2-cffi + code/token gen + tests) | pending |
-| 3 | DynamoDB tables (`jwt-blacklist`, `auth-codes`) + SSM `jwt-secret` + SQS `auth-email-queue` | pending |
+| 3 | DynamoDB table (`jwt-blacklist` + GSI `by_family_id`) + SSM `jwt-secret` + SQS `auth-email-queue` | pending |
 | 4 | Lambda `auth_email_worker` (consume cola, envia SES) | pending |
 | 5 | Lambda `auth` scaffold (manifest + AppConfig + handler + EventModel + OPERATIONS) | pending |
 | 6 | Operation `register` (start + verify-magic-link + verify-code) | pending |
@@ -96,8 +97,12 @@
 Cerradas en el dialogo previo y NO se vuelven a discutir:
 
 1. **Split de lambdas**: `auth` + `users`. Este plan entrega `auth`. `users` -> plan 3.
-2. **Persistencia hibrida**: estado relacional en Neon (`auth_*`),
-   estado efimero con TTL en DynamoDB (`jwt-blacklist`, `auth-codes`).
+2. **Persistencia hibrida minima**: estado relacional + codes + magic
+   links en Neon (`auth_*`), blacklist de JWTs en DynamoDB
+   (`jwt-blacklist` con GSI `by_family_id`). Solo blacklist va a DDB
+   porque cada request autenticada hace lookup O(1) por `jti`; codes y
+   magic links se verifican una sola vez por flow, latencia Neon
+   ~10-30ms es invisible. Decision documentada en el contexto.
 3. **JWT**: HS256 + secret en SSM SecureString. Tres tipos:
    - **temp** (`typ=temp`): 5 min, rolling refresh (cada API del flujo
      emite uno nuevo y blacklistea el anterior).
@@ -143,7 +148,9 @@ Cerradas en el dialogo previo y NO se vuelven a discutir:
 - **SIEMPRE** `auth_users.email` se guarda lowercased (`email.lower().strip()`).
 - **SIEMPRE** logs NO incluyen: email completo (solo hash truncado),
   password, JWT, magic-link token, code. Auditoria queda en
-  `auth_audit_log`.
+  `auth_audit_log`. Aplica la politica general de
+  [.claude/rules/security.md](../../../.claude/rules/security.md)
+  ("Credenciales y secretos").
 - **SIEMPRE** verificar antes de commitear (lint + tests unit del scope).
 - **NUNCA** devolver `404` con body distinto entre "email no existe" y
   "email existe pero esta deshabilitado". Solo `register.start` y

--- a/docs/specs/02-auth-mfa/01-contexto-y-decision.md
+++ b/docs/specs/02-auth-mfa/01-contexto-y-decision.md
@@ -29,10 +29,13 @@ Este plan agrega:
 
 - python-fido2 (`>=1.1`) es la lib mas mantenida (mantenida por
   Yubico). Cubre WebAuthn L2 + parcial L3 (multi-device, conditional
-  UI).
+  UI). **Pendiente spike**: validar firma actual de `Fido2Server`
+  (`register_begin`/`authenticate_begin` retornan `(options, state)`
+  donde `state` es dict JSON-serializable, no bytes).
 - pyotp (`>=2.9`) es trivial y standard.
-- AWS KMS GenerateDataKey + AES-256-GCM en Python via `cryptography`
-  (>=42) es el patron canonico para envelope encryption.
+- AWS KMS `kms:Encrypt`/`kms:Decrypt` con CMK directa soporta hasta
+  4 KB de plaintext — el secret TOTP de 20 bytes entra de sobra. No
+  hace falta envelope encryption con DataKey.
 - Plan 01 dejo `auth_users` + el lambda `auth` listos para extension.
   Agregar operations `mfa` + `webauthn` es escalable (el handler ya
   enruta por operation/action).
@@ -45,24 +48,35 @@ Extension del Lambda `auth`. Sin cambios estructurales — solo
 agregamos:
 
 - Modulos en `shared/auth/`: `totp.py`, `webauthn.py`,
-  `recovery_codes.py`, `encryption.py` (envelope encryption).
-- Tablas Neon: `auth_mfa_methods`, `auth_webauthn_credentials`,
-  `auth_mfa_recovery_codes`.
+  `recovery_codes.py`. Wrappers KMS en `shared.aws.kms`
+  (`kms_encrypt`, `kms_decrypt` con `EncryptionContext`).
+- Tablas Neon: `auth_mfa_methods` (1 columna BYTEA para el ciphertext
+  TOTP, sin nonce ni data_key), `auth_mfa_recovery_codes`,
+  `auth_webauthn_credentials`.
 - DDB: `portfolio-webauthn-challenges-${stage}`.
-- KMS DataKey-based encryption para el secret TOTP.
+- KMS CMK directa para el secret TOTP (`alias/portfolio-lambdas`).
 - 14 nuevas actions en el lambda (entre `mfa.*` y `webauthn.*`).
 - Extension de `login.start` y nuevas `login.verify-password`,
   `login.verify-totp`.
 
 ### Decisiones clave
 
-**Decision 1: TOTP secret cifrado con envelope encryption** —
-generar un DataKey nuevo por user (o reusar uno comun) con KMS
-`alias/portfolio-lambdas`, cifrar el secret TOTP de 20 bytes random
-con AES-256-GCM, guardar `(ciphertext, nonce, data_key_ciphertext)` en
-Neon. Decision: **un DataKey por user** (mas costoso pero mas seguro:
-si una key se compromete solo afecta un user). KMS GenerateDataKey
-cuesta ~$0.03/10000 ops, total negligible.
+**Decision 1: TOTP secret cifrado con KMS CMK directa (NO envelope)** —
+el secret TOTP es 20 bytes random (160 bits, RFC 6238). Entra holgado
+en el limite de 4 KB de `kms:Encrypt`. Llamamos
+`kms:Encrypt(KeyId='alias/portfolio-lambdas', Plaintext=secret_b32_bytes,
+EncryptionContext={'user_id': str(user.id), 'purpose': 'totp'})` y
+guardamos UNICAMENTE el ciphertext (BYTEA) en
+`auth_mfa_methods.totp_secret_ciphertext`. Para verificar:
+`kms:Decrypt(CiphertextBlob=..., EncryptionContext=...)`. Razon del
+cambio respecto a la version inicial del plan (envelope con DataKey
+por user): la envelope encryption no aporta seguridad adicional
+sobre CMK directa con `EncryptionContext` — el CMK sigue siendo el
+unico punto de compromiso. Bajo costo (~$0.03 por 10000 `kms:Decrypt`,
+cacheable in-memory dentro del cold start del Lambda con TTL 5 min).
+Schema mas chico (1 columna vs 3), 1 sola llamada KMS por op (vs 1
+`GenerateDataKey` + 1 `Decrypt` por verify), sin manejo de nonce ni
+AESGCM en codigo propio.
 
 **Decision 2: recovery codes en tabla separada** —
 `auth_mfa_recovery_codes (id, user_id, code_hash UNIQUE, consumed_at)`
@@ -73,13 +87,17 @@ viejos, emite 10 nuevos) con `mfa.recovery-codes-generate` de nuevo.
 
 **Decision 3: login flow con password opcional** —
 `login.start` body acepta `{email, cf_turnstile_response, password?}`:
+
 - Si `password` ausente: comportamiento del plan 01 (envia
   magic-link/code, devuelve methods).
 - Si `password` presente y match: evalua MFA:
   - Si user NO tiene MFA -> emite access+refresh directo.
-  - Si user TIENE MFA -> emite temp JWT step=2 + `methods=[totp,
-    email-code, webauthn]`. Cliente llama
-    `mfa.verify-totp`/`mfa.verify-email-code`/`webauthn.login-verify`.
+  - Si user TIENE MFA -> emite temp JWT step=2 con claim
+    `prev=password` + `methods=[totp, webauthn]`. Cliente llama
+    `login.verify-totp` / `webauthn.login-verify` /
+    `mfa.recovery-codes-consume`. NUNCA incluye `email-code` en
+    `methods` post-password (decision 10 — recovery solo
+    post-password/webauthn).
 
 **Decision 4: WebAuthn con RP_ID = apex** — `the-full-stack.com` como
 RP ID permite que cualquier subdomain (`hub.portfolio.the-full-stack.com`,
@@ -117,9 +135,11 @@ queda bypassed). Recovery codes son el unico bypass.
 
 - **AC-1**: Given un user autenticado (access JWT valido) sin TOTP
   configurado, When llama `POST /auth operation=mfa action=setup-totp`,
-  Then la response trae: `{secret_b32, otpauth_url, qr_code_svg}` y
-  guarda un row `auth_mfa_methods` con `kind=totp`, `confirmed_at=NULL`.
-  El secret se cifra antes de persistir.
+  Then la response trae: `{secret_b32, otpauth_url}` (sin
+  `qr_code_svg` — el frontend renderiza el QR del `otpauth_url`) y
+  guarda un row `auth_mfa_methods` con `kind=totp`,
+  `confirmed_at=NULL`. El secret se cifra con `kms:Encrypt`
+  (`EncryptionContext={user_id, purpose:totp}`) antes de persistir.
 
 - **AC-2**: Given un row TOTP pendiente confirmacion (confirmed_at=NULL),
   When llama `mfa.confirm-totp` con `code=<6-digit>` correcto, Then
@@ -136,10 +156,17 @@ queda bypassed). Recovery codes son el unico bypass.
   `auth_mfa_methods.preferred=false` en el TOTP row y `=true` en el
   email_code row.
 
-- **AC-5**: Given un user con UN solo metodo MFA activo, When llama
-  `mfa.disable` con ese kind, Then devuelve `409 MUST_KEEP_ONE_METHOD`.
+- **AC-5**: Given un user con `total_mfa == 1` (un solo metodo MFA
+  considerando `auth_mfa_methods` activos + `auth_webauthn_credentials`
+  activos), When llama `mfa.disable` con ese metodo, Then devuelve
+  `409 MUST_KEEP_ONE_MFA_METHOD`. La cuenta es transversal (mismo
+  principio que AC-17).
 
-- **AC-6**: Given un user con 2+ metodos activos, When llama
+- **AC-5b**: Given un user A, When intenta `mfa.disable` con `kind`
+  que existe SOLO para user B, Then devuelve `404 NOT_FOUND` (sin
+  revelar la existencia ajena — simetria con AC-25).
+
+- **AC-6**: Given un user con `total_mfa >= 2`, When llama
   `mfa.disable` con uno de ellos, Then marca `disabled_at=now()` y si
   era el preferred, asciende otro a preferred (FIFO por
   `confirmed_at`).
@@ -156,10 +183,16 @@ queda bypassed). Recovery codes son el unico bypass.
   (DELETE rows) y emite 10 nuevos. Audit log
   `mfa.recovery-codes.regenerated`.
 
-- **AC-9**: Given un user con MFA configurado + temp JWT step=2 (post
-  password), When llama `mfa.recovery-codes-consume` con un code
-  valido, Then marca `consumed_at=now()` y emite access+refresh JWT.
-  Devuelve `200 {access_token, refresh_token, ...}`.
+- **AC-9**: Given un user con MFA configurado + temp JWT step=2 con
+  claim `prev=password` (o `prev=webauthn`), When llama
+  `mfa.recovery-codes-consume` con un code valido, Then marca
+  `consumed_at=now()` y emite access+refresh JWT. Devuelve
+  `200 {access_token, refresh_token, ...}`.
+
+- **AC-9b**: Given un temp JWT step=2 con `prev=magic-link` o
+  `prev=email-code`, When llama `mfa.recovery-codes-consume`, Then
+  devuelve `403 RECOVERY_REQUIRES_STRONG_FACTOR` (defense in depth —
+  decision 10).
 
 - **AC-10**: Given un recovery code ya consumido, When se intenta
   consumir de nuevo, Then devuelve `400 RECOVERY_CODE_CONSUMED`.
@@ -195,19 +228,27 @@ queda bypassed). Recovery codes son el unico bypass.
 - **AC-15**: Given un assertion con `sign_count` <= stored, When se
   procesa `webauthn.login-verify`, Then devuelve
   `401 WEBAUTHN_CLONE_DETECTED`, audit log
-  `webauthn.login.clone_detected`, y se considera el credential
-  comprometido (deja `disabled_at=now()` opcional).
+  `webauthn.login.clone_detected`, Y marca el credential
+  `disabled_at=now()` SIEMPRE (no opcional — decision 14). La
+  reactivacion solo via endpoint admin futuro.
 
 - **AC-16**: Given un user con N credentials, When llama
   `webauthn.list-credentials`, Then devuelve la lista
   `[{credential_id, nickname, created_at, last_used_at, transports}, ...]`
   ordenada por last_used_at DESC.
 
-- **AC-17**: Given un user con N credentials >=2, When llama
-  `webauthn.delete-credential` con un credential_id valido, Then DELETE
-  del row. Si N=1, devuelve `409 MUST_KEEP_ONE_CREDENTIAL`. Si N>=2 y el
-  borrado deja al user sin otro MFA configurado, devuelve `409
-  MUST_KEEP_ONE_MFA_METHOD`.
+- **AC-17**: Given un user con `total_mfa = N` (suma de
+  `auth_mfa_methods` activos confirmados + `auth_webauthn_credentials`
+  activos), When llama `webauthn.delete-credential` con un
+  credential_id valido, Then:
+  - si `total_mfa - 1 >= 1` -> DELETE del row + 204.
+  - si `total_mfa - 1 == 0` -> `409 MUST_KEEP_ONE_MFA_METHOD`
+    (el user no se queda sin MFA).
+  La cuenta es transversal: un user con 1 TOTP + 1 passkey puede
+  borrar el passkey (le queda TOTP). Un user con 2 passkeys y nada mas
+  puede borrar 1. Solo si la operacion deja al user en 0 metodos
+  totales se bloquea. Mismo principio aplica a `mfa.disable` (AC-5
+  reescrito).
 
 ### Login con MFA
 
@@ -227,12 +268,14 @@ queda bypassed). Recovery codes son el unico bypass.
   `login.start` con password INCORRECTA, Then incrementa
   `failed_attempts`, devuelve `401 INVALID_PASSWORD`, NO revela si el
   email existe o no (en este caso ya existe, pero el response es
-  identico al de email no encontrado en cuanto a info filtrable).
+  identico al de email no encontrado en cuanto a info filtrable). El
+  rate-limit aplica por IP (no por user_id) para evitar enumeration
+  via timing — decision 13.
 
 - **AC-22**: Given un user con password + MFA + recovery codes, When
   el user llama `mfa.recovery-codes-consume` con un code valido tras
-  pasar password, Then emite access+refresh y marca el code consumed.
-  AC-9 reforzada.
+  pasar password (temp JWT step=2 `prev=password`), Then emite
+  access+refresh y marca el code consumed. AC-9 reforzada.
 
 ### Migration
 
@@ -245,10 +288,29 @@ queda bypassed). Recovery codes son el unico bypass.
 
 - **AC-24**: Given que el TOTP secret se persiste en
   `auth_mfa_methods`, When se inspecciona la fila en Neon, Then NUNCA
-  aparece el secret en plain — solo `totp_secret_ciphertext` (BYTEA),
-  `totp_secret_nonce` (BYTEA 12 bytes), `data_key_ciphertext` (BYTEA).
+  aparece el secret en plain — solo `totp_secret_ciphertext` (BYTEA,
+  output de `kms:Encrypt` con CMK `alias/portfolio-lambdas` +
+  `EncryptionContext={user_id, purpose:totp}`). Sin columnas
+  `nonce` ni `data_key_ciphertext` (decision 1).
 
 - **AC-25**: Given una request con access JWT de un user, When intenta
   llamar `webauthn.delete-credential` con un credential_id de OTRO
   user, Then devuelve `404 NOT_FOUND` (no `403 FORBIDDEN` para evitar
   enumeration).
+
+- **AC-26**: Given un passkey registrado en env `dev` (RP_ID
+  `portfolio.dev.the-full-stack.com`), When el browser intenta
+  `webauthn.login-options` en `prod` (origin
+  `the-full-stack.com`), Then la lista `allowCredentials` queda vacia
+  y `navigator.credentials.get()` falla en el cliente. Los passkeys
+  NO migran entre envs (decision 5). Test E2E lo demuestra con
+  fixtures separados de SoftWebauthnDevice por env.
+
+- **AC-27**: Given un user con MFA recien confirmado (primera vez —
+  transicion de 0 metodos a 1), When `mfa.confirm-totp` o
+  `webauthn.register-verify` retorna OK, Then se revoca la familia
+  de refresh tokens activa del user (mismo efecto que
+  `session.logout-all`). El proximo `/session/refresh` con el
+  refresh anterior devuelve `401 TOKEN_FAMILY_REVOKED`. Razon:
+  cerrar la ventana donde un atacante con refresh previo seguiria
+  operando sin pasar MFA (decision 15).

--- a/docs/specs/02-auth-mfa/01-contexto-y-decision.md
+++ b/docs/specs/02-auth-mfa/01-contexto-y-decision.md
@@ -1,0 +1,254 @@
+# 01. Contexto y decision
+
+## 1. Contexto / Problema
+
+El plan 01 entrego el flujo basico de auth (register/login/verify/logout)
+con dos metodos de identificacion del email del usuario: magic-link y
+code de 8 chars al email. Esto es suficiente para validar email pero NO
+es MFA verdadero: cualquier atacante con acceso al inbox del usuario
+puede tomar la cuenta.
+
+Este plan agrega:
+
+1. **TOTP** (RFC 6238): el clasico Google Authenticator / Authy /
+   1Password. Estandar de la industria. Bajo costo ($0). Funciona
+   offline. Resistente a phishing parcialmente (no protege contra
+   real-time MitM con reverse proxy estilo evilginx, pero si contra
+   credential stuffing y phishing pasivo).
+2. **Email-code como MFA**: el mismo mecanismo del plan 01 pero
+   "promovido" a 2do factor cuando el user ya esta autenticado por
+   password / passkey. Util si el user pierde acceso al TOTP pero
+   sigue con su email.
+3. **WebAuthn / Passkeys**: el futuro. Passkey sincronizado via
+   iCloud Keychain / Google Password Manager / 1Password permite
+   passwordless real con phishing-resistance criptografico (origin
+   binding). YubiKey hardware tambien. Soportado nativamente por
+   Chrome/Edge/Safari/Firefox modernos (>97% market share 2026).
+
+### Hallazgos de exploracion
+
+- python-fido2 (`>=1.1`) es la lib mas mantenida (mantenida por
+  Yubico). Cubre WebAuthn L2 + parcial L3 (multi-device, conditional
+  UI).
+- pyotp (`>=2.9`) es trivial y standard.
+- AWS KMS GenerateDataKey + AES-256-GCM en Python via `cryptography`
+  (>=42) es el patron canonico para envelope encryption.
+- Plan 01 dejo `auth_users` + el lambda `auth` listos para extension.
+  Agregar operations `mfa` + `webauthn` es escalable (el handler ya
+  enruta por operation/action).
+- DDB con TTL nativo es ideal para WebAuthn challenges (5 min, single
+  use, alto throughput potencial).
+
+## 2. Solucion Propuesta
+
+Extension del Lambda `auth`. Sin cambios estructurales — solo
+agregamos:
+
+- Modulos en `shared/auth/`: `totp.py`, `webauthn.py`,
+  `recovery_codes.py`, `encryption.py` (envelope encryption).
+- Tablas Neon: `auth_mfa_methods`, `auth_webauthn_credentials`,
+  `auth_mfa_recovery_codes`.
+- DDB: `portfolio-webauthn-challenges-${stage}`.
+- KMS DataKey-based encryption para el secret TOTP.
+- 14 nuevas actions en el lambda (entre `mfa.*` y `webauthn.*`).
+- Extension de `login.start` y nuevas `login.verify-password`,
+  `login.verify-totp`.
+
+### Decisiones clave
+
+**Decision 1: TOTP secret cifrado con envelope encryption** —
+generar un DataKey nuevo por user (o reusar uno comun) con KMS
+`alias/portfolio-lambdas`, cifrar el secret TOTP de 20 bytes random
+con AES-256-GCM, guardar `(ciphertext, nonce, data_key_ciphertext)` en
+Neon. Decision: **un DataKey por user** (mas costoso pero mas seguro:
+si una key se compromete solo afecta un user). KMS GenerateDataKey
+cuesta ~$0.03/10000 ops, total negligible.
+
+**Decision 2: recovery codes en tabla separada** —
+`auth_mfa_recovery_codes (id, user_id, code_hash UNIQUE, consumed_at)`
+permite auditar consumo individual y agregar audit log
+"recovery_code.consumed". 10 codes generados al primer
+`mfa.recovery-codes-generate`; el user puede regenerar (descarta los
+viejos, emite 10 nuevos) con `mfa.recovery-codes-generate` de nuevo.
+
+**Decision 3: login flow con password opcional** —
+`login.start` body acepta `{email, cf_turnstile_response, password?}`:
+- Si `password` ausente: comportamiento del plan 01 (envia
+  magic-link/code, devuelve methods).
+- Si `password` presente y match: evalua MFA:
+  - Si user NO tiene MFA -> emite access+refresh directo.
+  - Si user TIENE MFA -> emite temp JWT step=2 + `methods=[totp,
+    email-code, webauthn]`. Cliente llama
+    `mfa.verify-totp`/`mfa.verify-email-code`/`webauthn.login-verify`.
+
+**Decision 4: WebAuthn con RP_ID = apex** — `the-full-stack.com` como
+RP ID permite que cualquier subdomain (`hub.portfolio.the-full-stack.com`,
+`fintech...`, etc.) use la misma credencial. WebAuthn requiere que el
+RP_ID sea sufijo del origin. Para dev/stage que usan
+`portfolio.dev.the-full-stack.com`, el RP_ID es
+`portfolio.dev.the-full-stack.com` (configurable por env).
+
+**Decision 5: challenges en DynamoDB con TTL** — cada
+`webauthn.register-options` y `webauthn.login-options` genera un
+challenge (16 bytes random), lo guarda en DDB con TTL=5min, y devuelve
+al frontend. Cuando llega `webauthn.*-verify`, lee + valida + DELETE
+del challenge. PK = `challenge_id` (UUIDv7 string). Atributos:
+`user_id`, `kind` (`register|login`), `expires_at`.
+
+**Decision 6: sign_count monotonico** — el WebAuthn standard pide
+guardar el `sign_count` y validar que la nueva assertion lo trae mayor
+que el guardado. Si llega menor o igual -> rechazar (token clonado).
+Tabla `auth_webauthn_credentials.sign_count INT NOT NULL DEFAULT 0`,
+update en cada login-verify exitoso.
+
+**Decision 7: WebAuthn user verification (UV) required en login** —
+`UserVerificationRequirement.REQUIRED` en login-options. En register,
+`PREFERRED`. Trade-off: algunos YubiKeys hardware-only (sin biometric)
+fallan en login si no soportan UV; pero la seguridad lo justifica.
+
+**Decision 8: backup MFA = recovery codes** — si user pierde
+TOTP/WebAuthn devices, debe poder usar 1 de los 10 recovery codes. NO
+implementamos email-only-recovery flow (riesgo: si email se hackea, MFA
+queda bypassed). Recovery codes son el unico bypass.
+
+## 3. Criterios de Aceptacion (AC)
+
+### MFA TOTP
+
+- **AC-1**: Given un user autenticado (access JWT valido) sin TOTP
+  configurado, When llama `POST /auth operation=mfa action=setup-totp`,
+  Then la response trae: `{secret_b32, otpauth_url, qr_code_svg}` y
+  guarda un row `auth_mfa_methods` con `kind=totp`, `confirmed_at=NULL`.
+  El secret se cifra antes de persistir.
+
+- **AC-2**: Given un row TOTP pendiente confirmacion (confirmed_at=NULL),
+  When llama `mfa.confirm-totp` con `code=<6-digit>` correcto, Then
+  marca `confirmed_at=now()` y `auth_mfa_methods.preferred=true` si era
+  el primer metodo. Devuelve 204.
+
+- **AC-3**: Given un row TOTP confirmado, When llama
+  `mfa.confirm-totp` con code incorrecto 3 veces, Then la 3ra devuelve
+  `400 INVALID_TOTP_CODE` y registra audit log
+  `mfa.confirm-totp.failed`.
+
+- **AC-4**: Given un user con TOTP configurado, When llama
+  `mfa.set-preferred` con `kind=email_code`, Then actualiza
+  `auth_mfa_methods.preferred=false` en el TOTP row y `=true` en el
+  email_code row.
+
+- **AC-5**: Given un user con UN solo metodo MFA activo, When llama
+  `mfa.disable` con ese kind, Then devuelve `409 MUST_KEEP_ONE_METHOD`.
+
+- **AC-6**: Given un user con 2+ metodos activos, When llama
+  `mfa.disable` con uno de ellos, Then marca `disabled_at=now()` y si
+  era el preferred, asciende otro a preferred (FIFO por
+  `confirmed_at`).
+
+### Recovery codes
+
+- **AC-7**: Given un user con MFA recien confirmado, When llama
+  `mfa.recovery-codes-generate`, Then genera 10 codes
+  `[A-HJ-NP-Z2-9]{10}` y devuelve la lista UNA vez. Guarda los 10
+  hashes en `auth_mfa_recovery_codes`.
+
+- **AC-8**: Given un user que ya tiene 10 codes activos, When llama
+  `mfa.recovery-codes-generate` de nuevo, Then borra los 10 viejos
+  (DELETE rows) y emite 10 nuevos. Audit log
+  `mfa.recovery-codes.regenerated`.
+
+- **AC-9**: Given un user con MFA configurado + temp JWT step=2 (post
+  password), When llama `mfa.recovery-codes-consume` con un code
+  valido, Then marca `consumed_at=now()` y emite access+refresh JWT.
+  Devuelve `200 {access_token, refresh_token, ...}`.
+
+- **AC-10**: Given un recovery code ya consumido, When se intenta
+  consumir de nuevo, Then devuelve `400 RECOVERY_CODE_CONSUMED`.
+
+### WebAuthn / Passkeys
+
+- **AC-11**: Given un user autenticado, When llama
+  `webauthn.register-options`, Then devuelve la lista de parametros
+  WebAuthn (challenge b64, rp_id, user.id, user.name, pubKeyCredParams,
+  excludeCredentials, attestation='none', authenticatorSelection,
+  timeout=300000). Guarda challenge en DDB con TTL 5min.
+
+- **AC-12**: Given el frontend completo el WebAuthn ceremony con
+  navigator.credentials.create(), When llama `webauthn.register-verify`
+  con `{attestation_response, client_data_json, attestation_object}`,
+  Then valida attestation, guarda
+  `auth_webauthn_credentials(user_id, credential_id, public_key,
+  sign_count=0, transports, ...)`, borra el challenge de DDB,
+  devuelve `201 {credential_id, nickname}`.
+
+- **AC-13**: Given un user con >=1 credential WebAuthn, When llama
+  `webauthn.login-options` con `email=<X>`, Then devuelve `{challenge,
+  allowCredentials=[{id, type, transports}, ...]}`. Guarda challenge en
+  DDB.
+
+- **AC-14**: Given el frontend completa
+  navigator.credentials.get(), When llama `webauthn.login-verify` con
+  `{assertion_response}`, Then valida assertion (signature contra
+  public_key, sign_count > stored), actualiza `sign_count`, borra
+  challenge, emite access+refresh JWT, audit log
+  `webauthn.login.success`.
+
+- **AC-15**: Given un assertion con `sign_count` <= stored, When se
+  procesa `webauthn.login-verify`, Then devuelve
+  `401 WEBAUTHN_CLONE_DETECTED`, audit log
+  `webauthn.login.clone_detected`, y se considera el credential
+  comprometido (deja `disabled_at=now()` opcional).
+
+- **AC-16**: Given un user con N credentials, When llama
+  `webauthn.list-credentials`, Then devuelve la lista
+  `[{credential_id, nickname, created_at, last_used_at, transports}, ...]`
+  ordenada por last_used_at DESC.
+
+- **AC-17**: Given un user con N credentials >=2, When llama
+  `webauthn.delete-credential` con un credential_id valido, Then DELETE
+  del row. Si N=1, devuelve `409 MUST_KEEP_ONE_CREDENTIAL`. Si N>=2 y el
+  borrado deja al user sin otro MFA configurado, devuelve `409
+  MUST_KEEP_ONE_MFA_METHOD`.
+
+### Login con MFA
+
+- **AC-18**: Given un user con password seteada + TOTP configurado,
+  When llama `login.start` con `{email, password, cf_turnstile}`, Then
+  valida password con argon2.verify. Si match: emite temp JWT
+  flow=`login-mfa` step=2 + devuelve `{methods: ['totp',
+  'webauthn']}`. NO emite access+refresh aun.
+
+- **AC-19**: Given el step 2 del login (temp JWT step=2), When llama
+  `login.verify-totp` con `code` correcto, Then emite access+refresh.
+
+- **AC-20**: Given un user sin MFA, When llama `login.start` con
+  password correcta, Then emite access+refresh directo (skip step 2).
+
+- **AC-21**: Given un user con password seteada, When llama
+  `login.start` con password INCORRECTA, Then incrementa
+  `failed_attempts`, devuelve `401 INVALID_PASSWORD`, NO revela si el
+  email existe o no (en este caso ya existe, pero el response es
+  identico al de email no encontrado en cuanto a info filtrable).
+
+- **AC-22**: Given un user con password + MFA + recovery codes, When
+  el user llama `mfa.recovery-codes-consume` con un code valido tras
+  pasar password, Then emite access+refresh y marca el code consumed.
+  AC-9 reforzada.
+
+### Migration
+
+- **AC-23**: Given la migration `00000003_auth_mfa.py` aplicada en un
+  branch Neon de prueba, When se ejecuta `downgrade -1` y luego
+  `upgrade head`, Then el schema vuelve al de plan 01 y se recrean
+  las 3 tablas `auth_mfa_*` + `auth_webauthn_credentials` sin error.
+
+### Seguridad
+
+- **AC-24**: Given que el TOTP secret se persiste en
+  `auth_mfa_methods`, When se inspecciona la fila en Neon, Then NUNCA
+  aparece el secret en plain — solo `totp_secret_ciphertext` (BYTEA),
+  `totp_secret_nonce` (BYTEA 12 bytes), `data_key_ciphertext` (BYTEA).
+
+- **AC-25**: Given una request con access JWT de un user, When intenta
+  llamar `webauthn.delete-credential` con un credential_id de OTRO
+  user, Then devuelve `404 NOT_FOUND` (no `403 FORBIDDEN` para evitar
+  enumeration).

--- a/docs/specs/02-auth-mfa/02-schema-neon-mfa.md
+++ b/docs/specs/02-auth-mfa/02-schema-neon-mfa.md
@@ -1,0 +1,208 @@
+# 02. Schema Neon — extension `auth_mfa_*` + `auth_webauthn_credentials`
+
+## ER ASCII (delta sobre plan 01)
+
+```text
+auth_users
+─────────────
+ id  uuid PK
+ email citext
+ status auth_user_status
+ ...
+   |
+   | 1
+   ├──────────────────────────┬──────────────────────────┬──────────────────────┐
+   | 0..*                     | 0..*                     | 0..*                 | (de plan 01)
+   v                          v                          v                      v
+auth_mfa_methods    auth_mfa_recovery_codes    auth_webauthn_credentials   auth_credentials
+───────────────     ─────────────────────       ──────────────────────       (ya existe)
+ id  uuid PK         id  uuid PK                 id              uuid PK
+ user_id  uuid FK    user_id uuid FK             user_id         uuid FK
+ kind  mfa_kind      code_hash bytea UK          credential_id   bytea UK
+ preferred  bool     consumed_at ts NULL         public_key      bytea
+ confirmed_at ts     created_at  ts              sign_count      int default 0
+ disabled_at ts                                  transports      jsonb
+ last_used_at ts                                 attestation_format varchar
+ -- TOTP-only:                                   aaguid          uuid NULL
+ totp_secret_ciphertext bytea NULL               nickname        varchar
+ totp_secret_nonce       bytea NULL              created_at      ts
+ totp_data_key_ciphertext bytea NULL             last_used_at    ts NULL
+ totp_algorithm           varchar NULL           disabled_at     ts NULL
+ totp_digits              int NULL  (default 6)
+ totp_period              int NULL  (default 30)
+ created_at  ts
+```
+
+## Migration 00000003
+
+```python
+"""auth_mfa
+
+Revision ID: 00000003
+Revises: 00000002
+Create Date: 2026-05-27
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '00000003'
+down_revision = '00000002'
+
+
+def upgrade() -> None:
+    mfa_kind = postgresql.ENUM('totp', 'email_code', name='auth_mfa_kind')
+    mfa_kind.create(op.get_bind())
+
+    op.create_table(
+        'auth_mfa_methods',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('kind', mfa_kind, nullable=False),
+        sa.Column('preferred', sa.Boolean(), nullable=False,
+                  server_default=sa.text('false')),
+        sa.Column('confirmed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('disabled_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('last_used_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('totp_secret_ciphertext', postgresql.BYTEA(), nullable=True),
+        sa.Column('totp_secret_nonce', postgresql.BYTEA(), nullable=True),
+        sa.Column('totp_data_key_ciphertext', postgresql.BYTEA(), nullable=True),
+        sa.Column('totp_algorithm', sa.String(16), nullable=True,
+                  server_default='SHA1'),
+        sa.Column('totp_digits', sa.Integer(), nullable=True,
+                  server_default='6'),
+        sa.Column('totp_period', sa.Integer(), nullable=True,
+                  server_default='30'),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'],
+                                ondelete='CASCADE'),
+        sa.UniqueConstraint('user_id', 'kind', name='uq_auth_mfa_user_kind'),
+    )
+    op.create_index('ix_auth_mfa_methods_user', 'auth_mfa_methods', ['user_id'])
+
+    op.create_table(
+        'auth_mfa_recovery_codes',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('code_hash', postgresql.BYTEA(), nullable=False, unique=True),
+        sa.Column('consumed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'],
+                                ondelete='CASCADE'),
+    )
+    op.create_index('ix_auth_mfa_recovery_user_active',
+                    'auth_mfa_recovery_codes', ['user_id', 'consumed_at'])
+
+    op.create_table(
+        'auth_webauthn_credentials',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('credential_id', postgresql.BYTEA(), nullable=False, unique=True),
+        sa.Column('public_key', postgresql.BYTEA(), nullable=False),
+        sa.Column('sign_count', sa.Integer(), nullable=False,
+                  server_default='0'),
+        sa.Column('transports', postgresql.JSONB(), nullable=True),
+        sa.Column('attestation_format', sa.String(32), nullable=True),
+        sa.Column('aaguid', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('nickname', sa.String(64), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.Column('last_used_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('disabled_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'],
+                                ondelete='CASCADE'),
+    )
+    op.create_index('ix_webauthn_credentials_user', 'auth_webauthn_credentials',
+                    ['user_id', 'disabled_at'])
+
+
+def downgrade() -> None:
+    op.drop_table('auth_webauthn_credentials')
+    op.drop_table('auth_mfa_recovery_codes')
+    op.drop_table('auth_mfa_methods')
+    op.execute('DROP TYPE IF EXISTS auth_mfa_kind')
+```
+
+## Modelos SQLAlchemy
+
+```text
+serverless/lambda/shared/db/models/auth/
+├── mfa_method.py            # AuthMfaMethod
+├── recovery_code.py         # AuthMfaRecoveryCode
+└── webauthn_credential.py   # AuthWebauthnCredential
+```
+
+```python
+# mfa_method.py
+class AuthMfaMethod(UUIDPKMixin, Base):
+    __tablename__ = 'auth_mfa_methods'
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey('auth_users.id', ondelete='CASCADE'), nullable=False)
+    kind: Mapped[AuthMfaKind] = mapped_column(
+        PgEnum(AuthMfaKind, name='auth_mfa_kind'), nullable=False)
+    preferred: Mapped[bool] = mapped_column(default=False, nullable=False)
+    confirmed_at: Mapped[datetime | None]
+    disabled_at: Mapped[datetime | None]
+    last_used_at: Mapped[datetime | None]
+
+    # TOTP-only campos (NULL para email_code)
+    totp_secret_ciphertext: Mapped[bytes | None]
+    totp_secret_nonce: Mapped[bytes | None]
+    totp_data_key_ciphertext: Mapped[bytes | None]
+    totp_algorithm: Mapped[str | None] = mapped_column(default='SHA1')
+    totp_digits: Mapped[int | None] = mapped_column(default=6)
+    totp_period: Mapped[int | None] = mapped_column(default=30)
+
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=sa.text('now()'), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'kind', name='uq_auth_mfa_user_kind'),
+        Index('ix_auth_mfa_methods_user', 'user_id'),
+    )
+```
+
+## Repository extensions
+
+`shared/db/repositories/auth_mfa.py`:
+
+```python
+def list_mfa_methods(session, *, user_id) -> list[AuthMfaMethod]: ...
+def get_mfa_method(session, *, user_id, kind) -> AuthMfaMethod | None: ...
+def upsert_totp_method(session, *, user_id, ciphertext, nonce, dk_ct) -> AuthMfaMethod: ...
+def confirm_mfa(session, *, method_id) -> None: ...
+def disable_mfa(session, *, user_id, kind) -> None: ...
+def set_preferred(session, *, user_id, kind) -> None: ...
+
+def insert_recovery_codes(session, *, user_id, code_hashes: list[bytes]) -> None: ...
+def consume_recovery_code(session, *, user_id, code_hash) -> bool: ...
+def regenerate_recovery_codes(session, *, user_id) -> None: ...
+
+def insert_webauthn_credential(session, *, user_id, credential_id, public_key,
+                                transports, attestation_format, aaguid, nickname) -> ...: ...
+def get_webauthn_credentials(session, *, user_id) -> list[AuthWebauthnCredential]: ...
+def get_webauthn_credential_by_id(session, *, credential_id: bytes) -> AuthWebauthnCredential | None: ...
+def update_sign_count(session, *, credential_id, new_count) -> None: ...
+def delete_webauthn_credential(session, *, user_id, credential_id) -> bool: ...
+```
+
+## Indices justificacion
+
+| Indice | Justificacion |
+|--------|---------------|
+| `uq_auth_mfa_user_kind` | Un user no puede tener 2 TOTP a la vez (o 2 email_code) |
+| `ix_auth_mfa_methods_user` | Lookup en cada login con MFA: `SELECT ... WHERE user_id = ? AND disabled_at IS NULL` |
+| `ix_auth_mfa_recovery_user_active` | `... WHERE user_id = ? AND consumed_at IS NULL` |
+| `auth_webauthn_credentials.credential_id` UNIQUE | Lookup por credential_id en login-verify |
+| `ix_webauthn_credentials_user` | Listar credentials del user activos |
+
+## Update al ER permanente
+
+Al cerrar plan 02: actualizar `docs/diagrams/db-er.mmd` con las 3
+tablas nuevas + relacion FK.

--- a/docs/specs/02-auth-mfa/02-schema-neon-mfa.md
+++ b/docs/specs/02-auth-mfa/02-schema-neon-mfa.md
@@ -25,11 +25,9 @@ auth_mfa_methods    auth_mfa_recovery_codes    auth_webauthn_credentials   auth_
  last_used_at ts                                 attestation_format varchar
  -- TOTP-only:                                   aaguid          uuid NULL
  totp_secret_ciphertext bytea NULL               nickname        varchar
- totp_secret_nonce       bytea NULL              created_at      ts
- totp_data_key_ciphertext bytea NULL             last_used_at    ts NULL
- totp_algorithm           varchar NULL           disabled_at     ts NULL
- totp_digits              int NULL  (default 6)
- totp_period              int NULL  (default 30)
+ totp_algorithm   varchar NULL                   created_at      ts
+ totp_digits      int NULL  (default 6)          last_used_at    ts NULL
+ totp_period      int NULL  (default 30)         disabled_at     ts NULL
  created_at  ts
 ```
 
@@ -65,9 +63,8 @@ def upgrade() -> None:
         sa.Column('confirmed_at', sa.DateTime(timezone=True), nullable=True),
         sa.Column('disabled_at', sa.DateTime(timezone=True), nullable=True),
         sa.Column('last_used_at', sa.DateTime(timezone=True), nullable=True),
-        sa.Column('totp_secret_ciphertext', postgresql.BYTEA(), nullable=True),
-        sa.Column('totp_secret_nonce', postgresql.BYTEA(), nullable=True),
-        sa.Column('totp_data_key_ciphertext', postgresql.BYTEA(), nullable=True),
+        sa.Column('totp_secret_ciphertext', postgresql.BYTEA(), nullable=True,
+                  comment='kms:Encrypt output (CMK alias/portfolio-lambdas + EncryptionContext={user_id, purpose:totp}). Sin nonce — KMS lo gestiona internamente.'),
         sa.Column('totp_algorithm', sa.String(16), nullable=True,
                   server_default='SHA1'),
         sa.Column('totp_digits', sa.Integer(), nullable=True,
@@ -151,10 +148,12 @@ class AuthMfaMethod(UUIDPKMixin, Base):
     disabled_at: Mapped[datetime | None]
     last_used_at: Mapped[datetime | None]
 
-    # TOTP-only campos (NULL para email_code)
+    # TOTP-only campos (NULL para email_code). El ciphertext es la
+    # salida de `kms:Encrypt` con la CMK `alias/portfolio-lambdas` +
+    # `EncryptionContext={user_id, purpose:totp}`. NO envelope
+    # encryption — sin nonce, sin data_key. Ver `.claude/rules/
+    # serverless-secrets.md` y la decision 1 del README del plan.
     totp_secret_ciphertext: Mapped[bytes | None]
-    totp_secret_nonce: Mapped[bytes | None]
-    totp_data_key_ciphertext: Mapped[bytes | None]
     totp_algorithm: Mapped[str | None] = mapped_column(default='SHA1')
     totp_digits: Mapped[int | None] = mapped_column(default=6)
     totp_period: Mapped[int | None] = mapped_column(default=30)
@@ -175,8 +174,12 @@ class AuthMfaMethod(UUIDPKMixin, Base):
 ```python
 def list_mfa_methods(session, *, user_id) -> list[AuthMfaMethod]: ...
 def get_mfa_method(session, *, user_id, kind) -> AuthMfaMethod | None: ...
-def upsert_totp_method(session, *, user_id, ciphertext, nonce, dk_ct) -> AuthMfaMethod: ...
+def upsert_totp_method(session, *, user_id, ciphertext: bytes) -> AuthMfaMethod: ...
 def confirm_mfa(session, *, method_id) -> None: ...
+def count_active_mfa(session, *, user_id) -> int:
+    """Cuenta transversal: auth_mfa_methods activos (confirmed_at NOT NULL,
+    disabled_at NULL) + auth_webauthn_credentials activos (disabled_at NULL).
+    Usada por AC-5 y AC-17 para validar MUST_KEEP_ONE_MFA_METHOD."""
 def disable_mfa(session, *, user_id, kind) -> None: ...
 def set_preferred(session, *, user_id, kind) -> None: ...
 

--- a/docs/specs/02-auth-mfa/03-shared-auth-extension.md
+++ b/docs/specs/02-auth-mfa/03-shared-auth-extension.md
@@ -1,4 +1,9 @@
-# 03. Shared.auth extension — TOTP + WebAuthn + recovery codes + envelope encryption
+# 03. Shared.auth extension — TOTP + WebAuthn + recovery codes (KMS via shared.aws)
+
+> El cifrado del TOTP secret NO vive en `shared.auth/encryption.py`:
+> se hace con `kms:Encrypt` / `kms:Decrypt` directos via los wrappers
+> `kms_encrypt` / `kms_decrypt` de `shared.aws.kms` (CMK directa,
+> sin envelope encryption — decision 1 del plan).
 
 ## Que se agrega al subpackage
 
@@ -7,11 +12,18 @@ serverless/lambda/shared/auth/
 ├── ... (archivos del plan 01)
 ├── totp.py             # NUEVO: pyotp wrappers
 ├── webauthn.py         # NUEVO: fido2 wrappers
-├── recovery_codes.py   # NUEVO: generate_recovery_codes + hash + compare
-└── encryption.py       # NUEVO: envelope encryption KMS + AES-256-GCM
+└── recovery_codes.py   # NUEVO: generate_recovery_codes + hash + compare
 ```
 
-## Update al `pyproject.toml`
+Y, separado, en `shared.aws/`:
+
+```text
+serverless/lambda/shared/aws/
+├── ... (archivos existentes)
+└── kms.py              # NUEVO: kms_encrypt + kms_decrypt
+```
+
+## Update al `pyproject.toml` (shared.auth)
 
 ```toml
 [project]
@@ -20,18 +32,14 @@ dependencies = [
     "argon2-cffi>=23.1,<24.0",
     "pyotp>=2.9,<3.0",               # NUEVO
     "python-fido2>=1.1,<2.0",        # NUEVO
-    "cryptography>=42.0,<43.0",       # NUEVO (para AES-GCM)
+    # NO `cryptography`: el cifrado lo hace KMS server-side (CMK directa).
+    # NO `segno`: el QR lo renderiza el frontend desde el otpauth_url.
 ]
 ```
 
-## Update al `__init__.py` (re-exports)
+## Update al `shared/auth/__init__.py` (re-exports)
 
 ```python
-from .encryption import (
-    EnvelopeEncryptionError,
-    decrypt_envelope,
-    encrypt_envelope,
-)
 from .recovery_codes import (
     RECOVERY_CODE_ALPHABET,
     RECOVERY_CODE_LENGTH,
@@ -43,23 +51,19 @@ from .totp import (
     TotpError,
     build_otpauth_url,
     generate_totp_secret_b32,
-    qr_code_svg,
     verify_totp_code,
 )
 from .webauthn import (
     WebauthnError,
     WebauthnVerifyError,
-    build_register_options,
     build_login_options,
-    verify_registration,
+    build_register_options,
     verify_authentication,
+    verify_registration,
 )
 
 __all__ = [
-    # ... existentes
-    'EnvelopeEncryptionError',
-    'decrypt_envelope',
-    'encrypt_envelope',
+    # ... existentes del plan 01
     'RECOVERY_CODE_ALPHABET',
     'RECOVERY_CODE_LENGTH',
     'compare_recovery_code',
@@ -68,94 +72,119 @@ __all__ = [
     'TotpError',
     'build_otpauth_url',
     'generate_totp_secret_b32',
-    'qr_code_svg',
     'verify_totp_code',
     'WebauthnError',
     'WebauthnVerifyError',
-    'build_register_options',
     'build_login_options',
-    'verify_registration',
+    'build_register_options',
     'verify_authentication',
+    'verify_registration',
 ]
 ```
 
-## `encryption.py` — envelope encryption con KMS DataKey
+## Update al `shared/aws/__init__.py` (re-exports)
 
 ```python
-"""Envelope encryption usando AWS KMS GenerateDataKey + AES-256-GCM.
+from .kms import KmsError, kms_decrypt, kms_encrypt
 
-NO usar para mas de 2^32 mensajes con la misma DataKey (limite GCM).
-Para TOTP, una DataKey por user => safe.
+__all__ = [
+    # ... existentes (DynamoDB, SES, SSM, etc.)
+    'KmsError',
+    'kms_decrypt',
+    'kms_encrypt',
+]
+```
+
+## `shared/aws/kms.py` — wrappers KMS Encrypt/Decrypt directos
+
+```python
+"""AWS KMS Encrypt/Decrypt con CMK directa.
+
+Para secretos <= 4 KB (limite de kms:Encrypt). EncryptionContext es
+obligatorio para audit + binding criptografico al user_id.
+
+NO envelope encryption — el secret TOTP es 20 bytes, entra holgado.
 """
 
 import boto3
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 from shared.core import ApplicationError
 
 
-class EnvelopeEncryptionError(ApplicationError): ...
+class KmsError(ApplicationError): ...
 
 
 _KMS = boto3.client('kms')
 
 
-def encrypt_envelope(
-    *, plaintext: bytes, kms_key_id: str,
-    encryption_context: dict[str, str] | None = None,
-) -> dict:
-    """Genera DataKey y cifra plaintext con AES-256-GCM.
-
-    Retorna {ciphertext, nonce, data_key_ciphertext}.
-    """
-    resp = _KMS.generate_data_key(
-        KeyId=kms_key_id, KeySpec='AES_256',
-        EncryptionContext=encryption_context or {},
-    )
-    plain_dk = resp['Plaintext']
-    ct_dk = resp['CiphertextBlob']
-
-    nonce = os.urandom(12)
-    cipher = AESGCM(plain_dk)
-    aad = b''  # opcional; mantener vacio o derivar del contexto
-    ciphertext = cipher.encrypt(nonce, plaintext, aad)
-
-    # Zero out la key plana en memoria (best-effort)
-    plain_dk = b'\x00' * len(plain_dk)
-
-    return {
-        'ciphertext': ciphertext,
-        'nonce': nonce,
-        'data_key_ciphertext': ct_dk,
-    }
-
-
-def decrypt_envelope(
-    *, ciphertext: bytes, nonce: bytes, data_key_ciphertext: bytes,
-    encryption_context: dict[str, str] | None = None,
+def kms_encrypt(
+    *,
+    plaintext: bytes,
+    key_id: str,
+    encryption_context: dict[str, str],
 ) -> bytes:
-    resp = _KMS.decrypt(
-        CiphertextBlob=data_key_ciphertext,
-        EncryptionContext=encryption_context or {},
-    )
-    plain_dk = resp['Plaintext']
-    cipher = AESGCM(plain_dk)
-    plaintext = cipher.decrypt(nonce, ciphertext, b'')
-    plain_dk = b'\x00' * len(plain_dk)
-    return plaintext
+    """Cifra plaintext con la CMK key_id. Retorna ciphertext (BYTEA).
+
+    encryption_context queda bindeado al ciphertext; el decrypt debe
+    pasar el MISMO encryption_context o falla con `InvalidCiphertextException`.
+    Convention: {'user_id': str(user.id), 'purpose': 'totp'}.
+    """
+    try:
+        resp = _KMS.encrypt(
+            KeyId=key_id,
+            Plaintext=plaintext,
+            EncryptionContext=encryption_context,
+        )
+    except _KMS.exceptions.ClientError as exc:
+        raise KmsError(f'kms_encrypt failed: {exc.response["Error"]["Code"]}') from exc
+    return resp['CiphertextBlob']
+
+
+def kms_decrypt(
+    *,
+    ciphertext: bytes,
+    encryption_context: dict[str, str],
+    key_id: str | None = None,
+) -> bytes:
+    """Descifra ciphertext. encryption_context DEBE matchear el del encrypt.
+
+    El `key_id` es opcional (KMS lo deriva del ciphertext); pasarlo
+    explicitamente cuando se sabe es defensa en profundidad.
+    """
+    kwargs = {
+        'CiphertextBlob': ciphertext,
+        'EncryptionContext': encryption_context,
+    }
+    if key_id is not None:
+        kwargs['KeyId'] = key_id
+    try:
+        resp = _KMS.decrypt(**kwargs)
+    except _KMS.exceptions.ClientError as exc:
+        raise KmsError(f'kms_decrypt failed: {exc.response["Error"]["Code"]}') from exc
+    return resp['Plaintext']
 ```
 
-> NOTA importante: el cliente boto3 KMS debe venir de `shared.aws`
-> (catalogo de portadores). En la version implementada,
-> `encryption.py` importa `from shared.aws import kms` o agrega un
-> wrapper en `shared.aws` que expone `generate_data_key` /
-> `decrypt`. **Update al catalogo de portadores** (rule
-> `lambda-shared-imports.md`) sera parte de este plan.
+> Cache de plaintext: `shared.cache` (TTL 5 min, scope cold-start del
+> Lambda) sobre `(ciphertext_hash, user_id)` para evitar martillar
+> KMS en cada `login.verify-totp` consecutivo. La cache se purga al
+> rotar el secret TOTP (re-`setup-totp`).
+>
+> **Update al catalogo de portadores** (rule
+> `.claude/rules/lambda-shared-imports.md`): `boto3.client('kms')`
+> -> portador `shared.aws`, exportado como `kms_encrypt` /
+> `kms_decrypt`. La actualizacion se hace en PR 2 (commit 2.2), NO
+> en PR 1 — para evitar incoherencia entre catalogo y codigo
+> publicado.
 
 ## `totp.py` — pyotp wrappers
 
 ```python
 import pyotp
+
+from shared.core import ApplicationError
+
+
+class TotpError(ApplicationError): ...
 
 
 def generate_totp_secret_b32() -> str:
@@ -171,31 +200,34 @@ def build_otpauth_url(
         name=account_email, issuer_name=issuer)
 
 
-def qr_code_svg(otpauth_url: str) -> str:
-    """SVG inline del QR (sin dependencias extras: usar `qrcode[pil]` o
-    derivar matriz manual). Decision: usar `segno` (~7KB pure-python)."""
-    import segno
-    qr = segno.make(otpauth_url, error='M')
-    buf = io.StringIO()
-    qr.save(buf, kind='svg', xmldecl=False, omitsize=True, scale=4)
-    return buf.getvalue()
-
-
 def verify_totp_code(*, secret_b32: str, code: str, valid_window: int = 1) -> bool:
     """valid_window=1 acepta el code actual + el anterior + el siguiente
     (cubre clock drift hasta 30s)."""
     return pyotp.TOTP(secret_b32).verify(code, valid_window=valid_window)
-
-
-class TotpError(ApplicationError): ...
 ```
 
-Decision: la libreria `segno` se agrega como dep ADICIONAL a
-`shared.auth` (es trivial, 0 deps externas). Alternativa: pre-generar
-el SVG en el frontend desde el `otpauth_url` con `qrcode-svg` JS.
-Preferimos backend para no depender del frontend.
+> El QR lo renderiza el frontend desde el `otpauth_url` (decision 8):
+> el cliente usa `qrcode` JS (~5KB gzipped) y muestra el QR inline.
+> Razon: evita una dep mas (`segno`) en el Lambda, ahorra ~3-5 KB
+> de response y mejora el cold start.
 
 ## `webauthn.py` — fido2 wrappers
+
+> **PRE-IMPLEMENTACION OBLIGATORIA**: spike de 30 min validando la API
+> actual de `python-fido2` 1.x (decision 4 del README). Verificar:
+>
+> - shape exacto de `Fido2Server.register_begin` / `register_complete` /
+>   `authenticate_begin` / `authenticate_complete` (el `state` retornado
+>   suele ser un `dict` JSON-serializable, NO `bytes` — guardarlo en DDB
+>   como `Map` o `json.dumps`).
+> - import paths reales de `AttestedCredentialData`, `PublicKey`,
+>   `AuthenticatorData`.
+> - signatura de `register_complete` (acepta `state` + `response` o
+>   acepta otros parametros adicionales).
+>
+> El codigo de abajo es PSEUDOCODE que refleja la intencion; la
+> implementacion final se ajusta tras el spike. Si la firma difiere
+> significativamente, este archivo se actualiza ANTES del PR 2.
 
 ```python
 from fido2.webauthn import (
@@ -334,6 +366,8 @@ def compare_recovery_code(*, code: str, stored_hash: bytes) -> bool:
 
 Path: `serverless/lambda/shared/tests/unit/shared/auth/`.
 
+Path `shared/auth/`:
+
 | Archivo | Escenario |
 |---------|-----------|
 | `test_totp_secret_b32_length.py` | secret > 16 chars, todos en alfabeto base32 |
@@ -342,7 +376,6 @@ Path: `serverless/lambda/shared/tests/unit/shared/auth/`.
 | `test_totp_verify_wrong.py` | code aleatorio -> False |
 | `test_totp_verify_drift_acceptable.py` | code de hace 30s -> True (valid_window=1) |
 | `test_totp_verify_drift_too_old.py` | code de hace 90s -> False |
-| `test_qr_svg_renders.py` | output contiene `<svg`, `</svg>`, sin errores |
 | `test_webauthn_register_options.py` | options dict tiene `challenge`, `rp.id`, `user.id` |
 | `test_webauthn_register_verify_ok.py` | con fixture de fido2 stubs -> verifica + retorna credential_id |
 | `test_webauthn_login_options.py` | retorna allowCredentials con stored IDs |
@@ -350,19 +383,27 @@ Path: `serverless/lambda/shared/tests/unit/shared/auth/`.
 | `test_webauthn_login_verify_sign_count_clone.py` | new <= old -> raises WebauthnVerifyError |
 | `test_recovery_codes_generate_10.py` | exactly 10 codes, todos length=10, en alfabeto |
 | `test_recovery_codes_hash_compare.py` | round-trip |
-| `test_envelope_encrypt_decrypt_roundtrip.py` | (con KMS local-stack o moto) round-trip exitoso |
-| `test_envelope_decrypt_with_wrong_context_fails.py` | mismatch encryption_context -> KMS levanta error |
-| `test_envelope_decrypt_corrupted_ciphertext.py` | flipear 1 byte del ciphertext -> AESGCM levanta InvalidTag |
+
+Path `shared/aws/` (KMS):
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_kms_encrypt_returns_ciphertext.py` | (moto.mock_aws) encrypt retorna bytes |
+| `test_kms_encrypt_decrypt_roundtrip.py` | round-trip con el mismo encryption_context |
+| `test_kms_decrypt_wrong_context_fails.py` | mismatch encryption_context -> KmsError |
+| `test_kms_decrypt_invalid_ciphertext.py` | ciphertext aleatorio -> KmsError |
 
 ## Update al catalogo de portadores
 
-En `.claude/rules/lambda-shared-imports.md` agregar (al cierre del
-plan):
+En `.claude/rules/lambda-shared-imports.md` agregar (al cierre del PR 2 —
+NO en PR 1, para evitar incoherencia entre catalogo declarativo y codigo
+publicado):
 
 | Paquete externo | Portador shared | Como se importa |
 |-----------------|-----------------|------------------|
-| `pyotp` | `shared.auth` | `from shared.auth import generate_totp_secret_b32, verify_totp_code, build_otpauth_url, qr_code_svg` |
+| `pyotp` | `shared.auth` | `from shared.auth import generate_totp_secret_b32, verify_totp_code, build_otpauth_url` |
 | `python-fido2` | `shared.auth` | `from shared.auth import build_register_options, verify_registration, build_login_options, verify_authentication` |
-| `cryptography` (AESGCM) | `shared.auth` | `from shared.auth import encrypt_envelope, decrypt_envelope` |
-| `segno` (QR svg) | `shared.auth` | re-exportada via `qr_code_svg` solamente |
-| `boto3.client('kms')` | `shared.aws` | wrapper `kms_generate_data_key`, `kms_decrypt` agregados a `shared.aws/__init__.py` |
+| `boto3.client('kms')` | `shared.aws` | wrappers `kms_encrypt`, `kms_decrypt` agregados a `shared.aws/__init__.py` |
+
+NO se agrega `cryptography` (no se usa — CMK directa sustituye AES-GCM
+propio). NO se agrega `segno` (el QR lo renderiza el frontend).

--- a/docs/specs/02-auth-mfa/03-shared-auth-extension.md
+++ b/docs/specs/02-auth-mfa/03-shared-auth-extension.md
@@ -1,0 +1,368 @@
+# 03. Shared.auth extension — TOTP + WebAuthn + recovery codes + envelope encryption
+
+## Que se agrega al subpackage
+
+```text
+serverless/lambda/shared/auth/
+├── ... (archivos del plan 01)
+├── totp.py             # NUEVO: pyotp wrappers
+├── webauthn.py         # NUEVO: fido2 wrappers
+├── recovery_codes.py   # NUEVO: generate_recovery_codes + hash + compare
+└── encryption.py       # NUEVO: envelope encryption KMS + AES-256-GCM
+```
+
+## Update al `pyproject.toml`
+
+```toml
+[project]
+dependencies = [
+    "pyjwt>=2.9,<3.0",
+    "argon2-cffi>=23.1,<24.0",
+    "pyotp>=2.9,<3.0",               # NUEVO
+    "python-fido2>=1.1,<2.0",        # NUEVO
+    "cryptography>=42.0,<43.0",       # NUEVO (para AES-GCM)
+]
+```
+
+## Update al `__init__.py` (re-exports)
+
+```python
+from .encryption import (
+    EnvelopeEncryptionError,
+    decrypt_envelope,
+    encrypt_envelope,
+)
+from .recovery_codes import (
+    RECOVERY_CODE_ALPHABET,
+    RECOVERY_CODE_LENGTH,
+    compare_recovery_code,
+    generate_recovery_codes,
+    hash_recovery_code,
+)
+from .totp import (
+    TotpError,
+    build_otpauth_url,
+    generate_totp_secret_b32,
+    qr_code_svg,
+    verify_totp_code,
+)
+from .webauthn import (
+    WebauthnError,
+    WebauthnVerifyError,
+    build_register_options,
+    build_login_options,
+    verify_registration,
+    verify_authentication,
+)
+
+__all__ = [
+    # ... existentes
+    'EnvelopeEncryptionError',
+    'decrypt_envelope',
+    'encrypt_envelope',
+    'RECOVERY_CODE_ALPHABET',
+    'RECOVERY_CODE_LENGTH',
+    'compare_recovery_code',
+    'generate_recovery_codes',
+    'hash_recovery_code',
+    'TotpError',
+    'build_otpauth_url',
+    'generate_totp_secret_b32',
+    'qr_code_svg',
+    'verify_totp_code',
+    'WebauthnError',
+    'WebauthnVerifyError',
+    'build_register_options',
+    'build_login_options',
+    'verify_registration',
+    'verify_authentication',
+]
+```
+
+## `encryption.py` — envelope encryption con KMS DataKey
+
+```python
+"""Envelope encryption usando AWS KMS GenerateDataKey + AES-256-GCM.
+
+NO usar para mas de 2^32 mensajes con la misma DataKey (limite GCM).
+Para TOTP, una DataKey por user => safe.
+"""
+
+import boto3
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from shared.core import ApplicationError
+
+
+class EnvelopeEncryptionError(ApplicationError): ...
+
+
+_KMS = boto3.client('kms')
+
+
+def encrypt_envelope(
+    *, plaintext: bytes, kms_key_id: str,
+    encryption_context: dict[str, str] | None = None,
+) -> dict:
+    """Genera DataKey y cifra plaintext con AES-256-GCM.
+
+    Retorna {ciphertext, nonce, data_key_ciphertext}.
+    """
+    resp = _KMS.generate_data_key(
+        KeyId=kms_key_id, KeySpec='AES_256',
+        EncryptionContext=encryption_context or {},
+    )
+    plain_dk = resp['Plaintext']
+    ct_dk = resp['CiphertextBlob']
+
+    nonce = os.urandom(12)
+    cipher = AESGCM(plain_dk)
+    aad = b''  # opcional; mantener vacio o derivar del contexto
+    ciphertext = cipher.encrypt(nonce, plaintext, aad)
+
+    # Zero out la key plana en memoria (best-effort)
+    plain_dk = b'\x00' * len(plain_dk)
+
+    return {
+        'ciphertext': ciphertext,
+        'nonce': nonce,
+        'data_key_ciphertext': ct_dk,
+    }
+
+
+def decrypt_envelope(
+    *, ciphertext: bytes, nonce: bytes, data_key_ciphertext: bytes,
+    encryption_context: dict[str, str] | None = None,
+) -> bytes:
+    resp = _KMS.decrypt(
+        CiphertextBlob=data_key_ciphertext,
+        EncryptionContext=encryption_context or {},
+    )
+    plain_dk = resp['Plaintext']
+    cipher = AESGCM(plain_dk)
+    plaintext = cipher.decrypt(nonce, ciphertext, b'')
+    plain_dk = b'\x00' * len(plain_dk)
+    return plaintext
+```
+
+> NOTA importante: el cliente boto3 KMS debe venir de `shared.aws`
+> (catalogo de portadores). En la version implementada,
+> `encryption.py` importa `from shared.aws import kms` o agrega un
+> wrapper en `shared.aws` que expone `generate_data_key` /
+> `decrypt`. **Update al catalogo de portadores** (rule
+> `lambda-shared-imports.md`) sera parte de este plan.
+
+## `totp.py` — pyotp wrappers
+
+```python
+import pyotp
+
+
+def generate_totp_secret_b32() -> str:
+    """20 bytes random codificados en base32 (160 bits, RFC 6238)."""
+    return pyotp.random_base32()  # 32 chars base32 = 160 bits
+
+
+def build_otpauth_url(
+    *, secret_b32: str, account_email: str, issuer: str = 'the-full-stack.com',
+) -> str:
+    """RFC 6238 URL para QR codes. Compatible Google Authenticator/Authy/1Password."""
+    return pyotp.TOTP(secret_b32).provisioning_uri(
+        name=account_email, issuer_name=issuer)
+
+
+def qr_code_svg(otpauth_url: str) -> str:
+    """SVG inline del QR (sin dependencias extras: usar `qrcode[pil]` o
+    derivar matriz manual). Decision: usar `segno` (~7KB pure-python)."""
+    import segno
+    qr = segno.make(otpauth_url, error='M')
+    buf = io.StringIO()
+    qr.save(buf, kind='svg', xmldecl=False, omitsize=True, scale=4)
+    return buf.getvalue()
+
+
+def verify_totp_code(*, secret_b32: str, code: str, valid_window: int = 1) -> bool:
+    """valid_window=1 acepta el code actual + el anterior + el siguiente
+    (cubre clock drift hasta 30s)."""
+    return pyotp.TOTP(secret_b32).verify(code, valid_window=valid_window)
+
+
+class TotpError(ApplicationError): ...
+```
+
+Decision: la libreria `segno` se agrega como dep ADICIONAL a
+`shared.auth` (es trivial, 0 deps externas). Alternativa: pre-generar
+el SVG en el frontend desde el `otpauth_url` con `qrcode-svg` JS.
+Preferimos backend para no depender del frontend.
+
+## `webauthn.py` — fido2 wrappers
+
+```python
+from fido2.webauthn import (
+    AttestationConveyancePreference, AuthenticatorSelectionCriteria,
+    AuthenticatorAttachment, ResidentKeyRequirement,
+    PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity,
+    UserVerificationRequirement, PublicKeyCredentialDescriptor,
+    PublicKeyCredentialType,
+)
+from fido2.server import Fido2Server
+
+
+class WebauthnError(ApplicationError): ...
+class WebauthnVerifyError(WebauthnError): ...
+
+
+def _make_server(*, rp_id: str, rp_name: str, expected_origins: list[str]) -> Fido2Server:
+    return Fido2Server(
+        PublicKeyCredentialRpEntity(id=rp_id, name=rp_name),
+        verify_origin=lambda origin: origin in expected_origins,
+    )
+
+
+def build_register_options(
+    *, rp_id: str, rp_name: str, expected_origins: list[str],
+    user_id: bytes, user_name: str, user_display_name: str,
+    existing_credentials: list[bytes],
+) -> tuple[dict, bytes]:
+    """Retorna (options_dict_b64, state) — state se guarda en DDB."""
+    server = _make_server(rp_id=rp_id, rp_name=rp_name,
+                          expected_origins=expected_origins)
+    user = PublicKeyCredentialUserEntity(
+        id=user_id, name=user_name, display_name=user_display_name)
+    auth_selection = AuthenticatorSelectionCriteria(
+        authenticator_attachment=None,  # platform o cross-platform
+        resident_key=ResidentKeyRequirement.PREFERRED,
+        user_verification=UserVerificationRequirement.PREFERRED,
+    )
+    exclude = [
+        PublicKeyCredentialDescriptor(type=PublicKeyCredentialType.PUBLIC_KEY,
+                                       id=cred_id)
+        for cred_id in existing_credentials
+    ]
+    options, state = server.register_begin(
+        user=user, credentials=exclude,
+        user_verification=UserVerificationRequirement.PREFERRED,
+        authenticator_attachment=None,
+    )
+    return options, state  # state = bytes, se persiste en DDB
+
+
+def verify_registration(
+    *, rp_id: str, rp_name: str, expected_origins: list[str],
+    state: bytes, response: dict,
+) -> dict:
+    """Retorna {credential_id, public_key, sign_count, transports, ...}."""
+    server = _make_server(rp_id=rp_id, rp_name=rp_name,
+                          expected_origins=expected_origins)
+    auth_data = server.register_complete(state, response)
+    return {
+        'credential_id': auth_data.credential_data.credential_id,
+        'public_key': auth_data.credential_data.public_key,
+        'sign_count': auth_data.counter,
+        'aaguid': auth_data.credential_data.aaguid,
+        'attestation_format': response.get('fmt', 'none'),
+    }
+
+
+def build_login_options(
+    *, rp_id: str, rp_name: str, expected_origins: list[str],
+    allowed_credentials: list[bytes],
+) -> tuple[dict, bytes]:
+    server = _make_server(rp_id=rp_id, rp_name=rp_name,
+                          expected_origins=expected_origins)
+    creds = [
+        PublicKeyCredentialDescriptor(type=PublicKeyCredentialType.PUBLIC_KEY,
+                                       id=cred_id)
+        for cred_id in allowed_credentials
+    ]
+    options, state = server.authenticate_begin(
+        credentials=creds,
+        user_verification=UserVerificationRequirement.REQUIRED,
+    )
+    return options, state
+
+
+def verify_authentication(
+    *, rp_id: str, rp_name: str, expected_origins: list[str],
+    state: bytes, response: dict, stored_credentials: list[dict],
+) -> dict:
+    """stored_credentials = [{'credential_id': bytes, 'public_key': bytes,
+       'sign_count': int}]. Retorna {credential_id, new_sign_count}."""
+    server = _make_server(rp_id=rp_id, rp_name=rp_name,
+                          expected_origins=expected_origins)
+    creds = [
+        AttestedCredentialData(
+            aaguid=b'\x00' * 16,
+            credential_id=c['credential_id'],
+            public_key=PublicKey.from_bytes(c['public_key']),
+        ) for c in stored_credentials
+    ]
+    auth_data = server.authenticate_complete(state, creds, response)
+    return {
+        'credential_id': auth_data.credential_id,
+        'new_sign_count': auth_data.counter,
+    }
+```
+
+## `recovery_codes.py`
+
+```python
+RECOVERY_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
+RECOVERY_CODE_LENGTH = 10
+RECOVERY_CODE_COUNT = 10
+
+
+def generate_recovery_codes() -> list[str]:
+    """10 codes de 10 chars sin O/0/I/1/L. CSPRNG."""
+    return [
+        ''.join(secrets.choice(RECOVERY_CODE_ALPHABET)
+                for _ in range(RECOVERY_CODE_LENGTH))
+        for _ in range(RECOVERY_CODE_COUNT)
+    ]
+
+
+def hash_recovery_code(code: str) -> bytes:
+    """SHA-256 — codes son 10 chars (espacio 30^10 ~ 5.9x10^14)."""
+    return hashlib.sha256(code.encode('utf-8')).digest()
+
+
+def compare_recovery_code(*, code: str, stored_hash: bytes) -> bool:
+    return secrets.compare_digest(hash_recovery_code(code), stored_hash)
+```
+
+## Tests unit
+
+Path: `serverless/lambda/shared/tests/unit/shared/auth/`.
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_totp_secret_b32_length.py` | secret > 16 chars, todos en alfabeto base32 |
+| `test_totp_otpauth_url_format.py` | URL matchea `otpauth://totp/...` con issuer y email |
+| `test_totp_verify_correct.py` | code generado por pyotp.TOTP(secret).now() -> True |
+| `test_totp_verify_wrong.py` | code aleatorio -> False |
+| `test_totp_verify_drift_acceptable.py` | code de hace 30s -> True (valid_window=1) |
+| `test_totp_verify_drift_too_old.py` | code de hace 90s -> False |
+| `test_qr_svg_renders.py` | output contiene `<svg`, `</svg>`, sin errores |
+| `test_webauthn_register_options.py` | options dict tiene `challenge`, `rp.id`, `user.id` |
+| `test_webauthn_register_verify_ok.py` | con fixture de fido2 stubs -> verifica + retorna credential_id |
+| `test_webauthn_login_options.py` | retorna allowCredentials con stored IDs |
+| `test_webauthn_login_verify_ok.py` | assertion valida -> new_sign_count > old |
+| `test_webauthn_login_verify_sign_count_clone.py` | new <= old -> raises WebauthnVerifyError |
+| `test_recovery_codes_generate_10.py` | exactly 10 codes, todos length=10, en alfabeto |
+| `test_recovery_codes_hash_compare.py` | round-trip |
+| `test_envelope_encrypt_decrypt_roundtrip.py` | (con KMS local-stack o moto) round-trip exitoso |
+| `test_envelope_decrypt_with_wrong_context_fails.py` | mismatch encryption_context -> KMS levanta error |
+| `test_envelope_decrypt_corrupted_ciphertext.py` | flipear 1 byte del ciphertext -> AESGCM levanta InvalidTag |
+
+## Update al catalogo de portadores
+
+En `.claude/rules/lambda-shared-imports.md` agregar (al cierre del
+plan):
+
+| Paquete externo | Portador shared | Como se importa |
+|-----------------|-----------------|------------------|
+| `pyotp` | `shared.auth` | `from shared.auth import generate_totp_secret_b32, verify_totp_code, build_otpauth_url, qr_code_svg` |
+| `python-fido2` | `shared.auth` | `from shared.auth import build_register_options, verify_registration, build_login_options, verify_authentication` |
+| `cryptography` (AESGCM) | `shared.auth` | `from shared.auth import encrypt_envelope, decrypt_envelope` |
+| `segno` (QR svg) | `shared.auth` | re-exportada via `qr_code_svg` solamente |
+| `boto3.client('kms')` | `shared.aws` | wrapper `kms_generate_data_key`, `kms_decrypt` agregados a `shared.aws/__init__.py` |

--- a/docs/specs/02-auth-mfa/04-infraestructura.md
+++ b/docs/specs/02-auth-mfa/04-infraestructura.md
@@ -1,0 +1,207 @@
+# 04. Infraestructura — DynamoDB webauthn-challenges + IAM KMS update
+
+## Resumen
+
+| Recurso | Archivo | Que es |
+|---------|---------|--------|
+| DynamoDB `portfolio-webauthn-challenges-${stage}` | `resources/dynamodb/webauthn-challenges.yaml` | Challenges efimeros (TTL 5 min) |
+| KMS key existente `alias/portfolio-lambdas` | (sin cambios) | Para envelope encryption del TOTP secret |
+| IAM update Lambda `auth` | (via manifest) | Agregar permisos `kms:GenerateDataKey` + `kms:Decrypt` + DDB nuevo + tablas Neon nuevas |
+
+NO se crean SSM nuevos. NO se crea SQS nueva. La cola
+`auth-email-queue` del plan 01 ya alcanza para los emails MFA
+(setup-totp-confirmation, recovery-codes-issued, mfa-disabled-alert).
+
+NO se crea Lambda nuevo: todo va al Lambda `auth` existente.
+
+## 1. DynamoDB — `portfolio-webauthn-challenges-${stage}`
+
+`serverless/lambda/resources/dynamodb/webauthn-challenges.yaml`:
+
+```yaml
+kind: dynamodb-table
+name: portfolio-webauthn-challenges-${stage}
+billing_mode: PAY_PER_REQUEST
+hash_key:
+  name: challenge_id
+  type: S
+range_key: null
+stream: null
+ttl_attribute: expires_at
+encryption: true
+publishes_ssm:
+  name: /portfolio/${stage}/dynamodb/webauthn-challenges/name
+  arn: /portfolio/${stage}/dynamodb/webauthn-challenges/arn
+tags:
+  Project: portfolio
+  Module: auth-mfa
+  ManagedBy: devtools
+```
+
+**Schema de item**:
+
+```jsonc
+{
+  "challenge_id": "01H9X..uuidv7",     // PK
+  "user_id": "01H9V..uuidv7",
+  "kind": "register",                   // 'register' | 'login'
+  "state_b64": "...",                   // fido2 state (bytes -> b64)
+  "created_at": 1717000000,
+  "expires_at": 1717000300              // TTL attribute, +5min
+}
+```
+
+**Operaciones**:
+- `PutItem` al construir options (register/login).
+- `GetItem` + `DeleteItem` (transactional) al verificar.
+
+## 2. IAM update — Lambda `auth` manifest
+
+`serverless/lambda/services/auth/manifest.yaml` — agregar a `uses`:
+
+```yaml
+uses:
+  # ... existente del plan 01
+  tables:
+    # ... existentes
+    webauthn-challenges: read-write       # NUEVO
+  kms:
+    - alias: portfolio-lambdas
+      actions: [GenerateDataKey, Decrypt]  # NUEVO
+```
+
+El provisioner del repo (segun el snapshot que tengo) ya genera IAM
+scoped por table_name del `tables` block. Para `kms`, hay que verificar
+si el manifest del repo lo soporta:
+
+- Si SI: declarar como arriba.
+- Si NO: agregar IAM inline policy patch en
+  `devtools/serverless/provisioner.py` (cambio fuera de scope estricto
+  del plan auth — proponer como T-aparte).
+
+**Decision**: revisar `provisioner.py`. Si no soporta `kms` declarativo,
+implementarlo en este plan (1 commit operativo). Es una extension del
+shape del manifest, no cambia el contrato existente.
+
+## 3. Update al SSM (catalogo de secretos)
+
+NO se crean SSM nuevos. El `jwt-secret` del plan 01 alcanza.
+
+Opcional: si decidimos en el futuro tener una KMS key dedicada SOLO
+para envelope encryption de TOTP (separada de la del SSM SecureString),
+se crearia con un YAML similar a:
+
+```yaml
+# OPCIONAL — futuro
+kind: kms-key
+alias: portfolio-totp-envelope
+description: KMS key para envelope encryption del TOTP secret
+key_spec: SYMMETRIC_DEFAULT
+key_usage: ENCRYPT_DECRYPT
+rotation: true     # rotacion automatica anual
+publishes_ssm:
+  arn: /portfolio/${stage}/kms/totp-envelope/arn
+```
+
+Decision: reusar `alias/portfolio-lambdas` por simplicidad (zero costo
+adicional). Si se quiere separar, es un commit independiente y futuro.
+
+## 4. Env vars nuevas (manifest)
+
+```yaml
+env:
+  default:
+    # ... existentes
+    KMS_TOTP_KEY_ID: alias/portfolio-lambdas   # NUEVO — para envelope encryption
+    WEBAUTHN_RP_NAME: 'The Full Stack Portfolio'
+  dev:
+    WEBAUTHN_RP_ID: portfolio.dev.the-full-stack.com
+    WEBAUTHN_ALLOWED_ORIGINS: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com,http://localhost:9970'
+  stage:
+    WEBAUTHN_RP_ID: portfolio.stage.the-full-stack.com
+    WEBAUTHN_ALLOWED_ORIGINS: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com'
+  prod:
+    WEBAUTHN_RP_ID: the-full-stack.com
+    WEBAUTHN_ALLOWED_ORIGINS: 'https://the-full-stack.com,https://www.the-full-stack.com,https://portfolio.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com'
+```
+
+Notar: el `WEBAUTHN_RP_ID` es **distinto** entre dev/stage/prod porque
+WebAuthn no puede tener un RP_ID que no sea sufijo del origin. Por eso
+en prod usamos el apex `the-full-stack.com` (cubre todos los subdomains),
+pero en dev/stage usamos `portfolio.dev.the-full-stack.com` /
+`portfolio.stage.the-full-stack.com`. **Implicancia**: passkeys
+registrados en dev NO funcionan en prod (y viceversa) — es esperado y
+correcto.
+
+## 5. Rate-limit rules nuevas
+
+```bash
+# mfa.setup-totp: 3/h/IP (raro setear, no debe brute force)
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#mfa.setup-totp' --limit=3 --window=3600 --aws-profile=tfs-dev
+
+# mfa.confirm-totp: 5/min/user_id (no IP) — proteger contra brute force del code TOTP
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#mfa.confirm-totp' --limit=5 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+
+# mfa.recovery-codes-consume: 3/min/user_id (no IP)
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#mfa.recovery-codes-consume' --limit=3 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+
+# webauthn.register-options: 10/min/IP
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#webauthn.register-options' --limit=10 --window=60 --aws-profile=tfs-dev
+
+# webauthn.login-options: 20/min/IP (mas alto, mas legitimo)
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#webauthn.login-options' --limit=20 --window=60 --aws-profile=tfs-dev
+
+# webauthn.login-verify: 10/min/IP
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#webauthn.login-verify' --limit=10 --window=60 --aws-profile=tfs-dev
+
+# login.verify-totp: 5/min/user_id
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#login.verify-totp' --limit=5 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+
+# login.verify-password: 5/min/user_id + 30/min/IP (doble check)
+serverless rate-limit set --stage=dev \
+  --endpoint='/auth#login.verify-password' --limit=5 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+```
+
+Decision: `--key=user_id` requiere que el sistema de rate-limit del
+repo soporte keys customizadas (no solo IP). Si NO lo soporta hoy,
+implementar el soporte como parte de este plan (extension de
+`shared.rate_limit`).
+
+## 6. CI auto-detect
+
+`change_detector.py` auto-detecta:
+- Cambios en `shared/auth/` -> redeploy auth.
+- Cambios en `shared/db/models/auth/` -> redeploy auth + db (db por la
+  migration).
+- Cambios en `services/auth/` -> redeploy auth.
+
+Sin cambios en `deploy-backend.yml`.
+
+## 7. Orden de provisioning
+
+```bash
+# 1. Aplicar migration 00000003
+serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev
+
+# 2. Crear DDB nueva
+serverless provision-infra --stage=dev --aws-profile=tfs-dev
+
+# 3. Actualizar manifest (IAM kms) y redeploy auth
+serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
+
+# 4. Seed rate-limit rules nuevas (8 reglas)
+# ... ver bloque arriba
+
+# 5. (Opcional) Setear el primer passkey y TOTP para Pablo en dev como smoke test manual
+```

--- a/docs/specs/02-auth-mfa/04-infraestructura.md
+++ b/docs/specs/02-auth-mfa/04-infraestructura.md
@@ -5,8 +5,8 @@
 | Recurso | Archivo | Que es |
 |---------|---------|--------|
 | DynamoDB `portfolio-webauthn-challenges-${stage}` | `resources/dynamodb/webauthn-challenges.yaml` | Challenges efimeros (TTL 5 min) |
-| KMS key existente `alias/portfolio-lambdas` | (sin cambios) | Para envelope encryption del TOTP secret |
-| IAM update Lambda `auth` | (via manifest) | Agregar permisos `kms:GenerateDataKey` + `kms:Decrypt` + DDB nuevo + tablas Neon nuevas |
+| KMS key existente `alias/portfolio-lambdas` | (sin cambios) | Para cifrar el TOTP secret via `kms:Encrypt` (CMK directa, decision 1) |
+| IAM update Lambda `auth` | (via manifest) | Agregar permisos `kms:Encrypt` + `kms:Decrypt` + DDB nuevo + tablas Neon nuevas |
 
 NO se crean SSM nuevos. NO se crea SQS nueva. La cola
 `auth-email-queue` del plan 01 ya alcanza para los emails MFA
@@ -52,6 +52,7 @@ tags:
 ```
 
 **Operaciones**:
+
 - `PutItem` al construir options (register/login).
 - `GetItem` + `DeleteItem` (transactional) al verificar.
 
@@ -67,40 +68,47 @@ uses:
     webauthn-challenges: read-write       # NUEVO
   kms:
     - alias: portfolio-lambdas
-      actions: [GenerateDataKey, Decrypt]  # NUEVO
+      actions: [Encrypt, Decrypt]         # NUEVO — CMK directa (NO GenerateDataKey)
 ```
 
-El provisioner del repo (segun el snapshot que tengo) ya genera IAM
-scoped por table_name del `tables` block. Para `kms`, hay que verificar
-si el manifest del repo lo soporta:
+**Spike-first obligatorio (decision 12 del README)**: ANTES de redactar
+el codigo de PR 4, ejecutar `python devtools/run.py serverless
+deploy --lambda=auth --stage=dev --dry-run --aws-profile=tfs-dev` con
+un `manifest.yaml` que ya declare el bloque `uses.kms`. Tres
+escenarios:
 
-- Si SI: declarar como arriba.
-- Si NO: agregar IAM inline policy patch en
-  `devtools/serverless/provisioner.py` (cambio fuera de scope estricto
-  del plan auth — proponer como T-aparte).
+1. **Provisioner soporta `uses.kms` declarativo**: declarar como
+   arriba, sin cambios en devtools. PR 4 trae solo el cambio al
+   manifest.
+2. **Provisioner NO soporta `uses.kms`, refactor < 200 lineas + tests
+   chicos**: hacerlo dentro de PR 4 (commit 4.2). Es la opcion mas
+   probable segun la arquitectura actual del provisioner.
+3. **Provisioner requiere refactor mayor (>200 lineas, tests
+   estructurales)**: sacar a un plan devtools-aparte. PR 4 se
+   reemplaza por inline policy declarada en el shape ya soportado
+   (`uses.iam_extra_policies` o equivalente actual). Anotar la
+   decision en el body de PR 4 + crear issue del plan devtools.
 
-**Decision**: revisar `provisioner.py`. Si no soporta `kms` declarativo,
-implementarlo en este plan (1 commit operativo). Es una extension del
-shape del manifest, no cambia el contrato existente.
+El spike toma 30 minutos. Su resultado decide cual de los 3 caminos.
 
 ## 3. Update al SSM (catalogo de secretos)
 
 NO se crean SSM nuevos. El `jwt-secret` del plan 01 alcanza.
 
-Opcional: si decidimos en el futuro tener una KMS key dedicada SOLO
-para envelope encryption de TOTP (separada de la del SSM SecureString),
+Opcional: si en el futuro se decide tener una KMS key dedicada SOLO
+para cifrar el TOTP secret (separada de la del SSM SecureString),
 se crearia con un YAML similar a:
 
 ```yaml
 # OPCIONAL — futuro
 kind: kms-key
-alias: portfolio-totp-envelope
-description: KMS key para envelope encryption del TOTP secret
+alias: portfolio-totp
+description: KMS key dedicada para cifrar el TOTP secret (CMK directa)
 key_spec: SYMMETRIC_DEFAULT
 key_usage: ENCRYPT_DECRYPT
 rotation: true     # rotacion automatica anual
 publishes_ssm:
-  arn: /portfolio/${stage}/kms/totp-envelope/arn
+  arn: /portfolio/${stage}/kms/totp/arn
 ```
 
 Decision: reusar `alias/portfolio-lambdas` por simplicidad (zero costo
@@ -112,7 +120,7 @@ adicional). Si se quiere separar, es un commit independiente y futuro.
 env:
   default:
     # ... existentes
-    KMS_TOTP_KEY_ID: alias/portfolio-lambdas   # NUEVO — para envelope encryption
+    KMS_TOTP_KEY_ID: alias/portfolio-lambdas   # NUEVO — para kms:Encrypt CMK directa del TOTP secret
     WEBAUTHN_RP_NAME: 'The Full Stack Portfolio'
   dev:
     WEBAUTHN_RP_ID: portfolio.dev.the-full-stack.com
@@ -135,20 +143,29 @@ correcto.
 
 ## 5. Rate-limit rules nuevas
 
+**Decision 13 del README**: TODAS las reglas de rate-limit usan
+`IP` como key. NO `user_id`. Razones:
+
+- `shared.rate_limit` actual SOLO soporta keys por IP (sliding
+  window weighted, ver skill `serverless-rate-limit`). Soporte para
+  custom keys es un plan devtools separado, fuera de scope.
+- Rate-limit por `user_id` antes de password-validate filtra info
+  (un atacante mide el rate-limit para enumerar emails validos).
+  Rate-limit por IP no tiene este problema.
+
 ```bash
 # mfa.setup-totp: 3/h/IP (raro setear, no debe brute force)
 serverless rate-limit set --stage=dev \
   --endpoint='/auth#mfa.setup-totp' --limit=3 --window=3600 --aws-profile=tfs-dev
 
-# mfa.confirm-totp: 5/min/user_id (no IP) — proteger contra brute force del code TOTP
+# mfa.confirm-totp: 10/min/IP (brute force del code TOTP ya esta cubierto
+# por las 3 intentos de AC-3 — el rate-limit es defense in depth)
 serverless rate-limit set --stage=dev \
-  --endpoint='/auth#mfa.confirm-totp' --limit=5 --window=60 \
-  --key=user_id --aws-profile=tfs-dev
+  --endpoint='/auth#mfa.confirm-totp' --limit=10 --window=60 --aws-profile=tfs-dev
 
-# mfa.recovery-codes-consume: 3/min/user_id (no IP)
+# mfa.recovery-codes-consume: 5/min/IP
 serverless rate-limit set --stage=dev \
-  --endpoint='/auth#mfa.recovery-codes-consume' --limit=3 --window=60 \
-  --key=user_id --aws-profile=tfs-dev
+  --endpoint='/auth#mfa.recovery-codes-consume' --limit=5 --window=60 --aws-profile=tfs-dev
 
 # webauthn.register-options: 10/min/IP
 serverless rate-limit set --stage=dev \
@@ -162,21 +179,22 @@ serverless rate-limit set --stage=dev \
 serverless rate-limit set --stage=dev \
   --endpoint='/auth#webauthn.login-verify' --limit=10 --window=60 --aws-profile=tfs-dev
 
-# login.verify-totp: 5/min/user_id
+# login.verify-totp: 10/min/IP (defense in depth — el temp JWT step=2 ya
+# requiere haber pasado password; aqui solo limitamos brute force adicional)
 serverless rate-limit set --stage=dev \
-  --endpoint='/auth#login.verify-totp' --limit=5 --window=60 \
-  --key=user_id --aws-profile=tfs-dev
+  --endpoint='/auth#login.verify-totp' --limit=10 --window=60 --aws-profile=tfs-dev
 
-# login.verify-password: 5/min/user_id + 30/min/IP (doble check)
+# login.verify-password: 30/min/IP. La proteccion principal contra brute
+# force por user es el lock-out de cuenta (failed_attempts) del plan 01,
+# que SI usa user_id (es un contador en auth_users, no rate-limit).
 serverless rate-limit set --stage=dev \
-  --endpoint='/auth#login.verify-password' --limit=5 --window=60 \
-  --key=user_id --aws-profile=tfs-dev
+  --endpoint='/auth#login.verify-password' --limit=30 --window=60 --aws-profile=tfs-dev
 ```
 
-Decision: `--key=user_id` requiere que el sistema de rate-limit del
-repo soporte keys customizadas (no solo IP). Si NO lo soporta hoy,
-implementar el soporte como parte de este plan (extension de
-`shared.rate_limit`).
+**Compensacion** (la perdida del rate-limit por user_id): el contador
+`auth_users.failed_attempts` del plan 01 sigue siendo el mecanismo
+principal de proteccion por user (lock-out tras N intentos fallidos).
+El rate-limit por IP es defense in depth, no la primera linea.
 
 ## 6. CI auto-detect
 

--- a/docs/specs/02-auth-mfa/05-lambda-auth-extensions.md
+++ b/docs/specs/02-auth-mfa/05-lambda-auth-extensions.md
@@ -1,0 +1,358 @@
+# 05. Lambda `auth` — extensiones MFA + WebAuthn
+
+## Nuevas operations y actions
+
+```text
+operation 'mfa' (8 actions):
+- setup-totp                POST  -> genera secret + QR
+- confirm-totp              POST  -> verifica primer code -> activa
+- setup-email-code          POST  -> marca email_code como metodo
+- set-preferred             POST  -> cambia preferred entre activos
+- disable                   POST  -> deshabilita un metodo (no si es unico)
+- list                      GET   -> lista metodos activos del user
+- recovery-codes-generate   POST  -> emite 10 codes (muestra UNA vez)
+- recovery-codes-consume    POST  -> consume 1 code (bypass MFA)
+
+operation 'webauthn' (6 actions):
+- register-options          POST  -> retorna challenge + options
+- register-verify           POST  -> valida attestation + guarda credential
+- login-options             POST  -> retorna challenge + allowCredentials
+- login-verify              POST  -> valida assertion + emite JWT
+- list-credentials          GET   -> lista credentials del user
+- delete-credential         POST  -> elimina un credential
+
+operation 'login' (extensiones):
+- verify-password           POST  -> NUEVA  paso 2a tras start con password
+- verify-totp               POST  -> NUEVA  paso 3 si MFA configurado
+- ...existing del plan 01
+
+operation 'verify' (sin cambios respecto al plan 01)
+operation 'session' (sin cambios)
+```
+
+## Estructura de carpetas (delta)
+
+```text
+serverless/lambda/services/auth/core/
+- controllers/
+  - mfa/
+    - __init__.py
+    - setup_totp.py            (SetupTotp(BaseController))
+    - confirm_totp.py
+    - setup_email_code.py
+    - set_preferred.py
+    - disable.py
+    - list.py                  (List)
+    - recovery_codes_generate.py
+    - recovery_codes_consume.py
+  - webauthn/
+    - __init__.py
+    - register_options.py
+    - register_verify.py
+    - login_options.py
+    - login_verify.py
+    - list_credentials.py
+    - delete_credential.py
+  - login/                     (extension)
+    - verify_password.py       (NUEVO)
+    - verify_totp.py           (NUEVO)
+- services/
+  - totp_service.py            (NUEVO)
+  - webauthn_service.py        (NUEVO)
+  - recovery_codes_service.py  (NUEVO)
+  - challenge_service.py       (NUEVO  CRUD DDB webauthn-challenges)
+  - mfa_method_service.py      (NUEVO  CRUD auth_mfa_methods)
+  - (existentes del plan 01)
+- models/
+  - mfa.py                     (NUEVO  Pydantic in schemas)
+  - webauthn.py                (NUEVO)
+```
+
+## Patron de un controller MFA — ejemplo `mfa.setup-totp`
+
+```python
+"""mfa.setup-totp  genera secret + QR.
+
+Requiere: access JWT valido (header Authorization).
+Retorna: {secret_b32, otpauth_url, qr_code_svg}. NO persiste todavia
+un row confirmado  guarda con confirmed_at=NULL.
+"""
+
+from shared.lambda_kit import BaseController
+from shared.auth import (
+    build_otpauth_url,
+    encrypt_envelope,
+    generate_totp_secret_b32,
+    qr_code_svg,
+)
+from shared.observability import logger, metrics
+
+from ...services.audit_service import AuditService
+from ...services.auth_service import require_active_user
+from ...services.mfa_method_service import MfaMethodService
+from ...settings.config import app_config
+
+
+class SetupTotp(BaseController):
+    def preload(self):
+        return {'is_valid': True, 'data': {}, 'code': 0}
+
+    def validate(self):
+        user = require_active_user(
+            self.data['_meta'].get('authorization'),
+            config=app_config,
+        )
+        from shared.rate_limit import check_or_raise
+        check_or_raise(
+            ip=self.data['_meta']['ip'],
+            endpoint='/auth#mfa.setup-totp',
+            key_override=str(user.id),
+        )
+        self.context = {'user': user}
+        return {'is_valid': True, 'data': {}, 'code': 0}
+
+    def execute(self):
+        user = self.context['user']
+        mfa_svc = MfaMethodService(app_config)
+        audit = AuditService(app_config)
+
+        secret_b32 = generate_totp_secret_b32()
+        envelope = encrypt_envelope(
+            plaintext=secret_b32.encode('utf-8'),
+            kms_key_id=app_config.kms_totp_key_id,
+            encryption_context={
+                'user_id': str(user.id),
+                'purpose': 'totp',
+            },
+        )
+        mfa_svc.upsert_pending_totp(
+            user_id=user.id,
+            ciphertext=envelope['ciphertext'],
+            nonce=envelope['nonce'],
+            data_key_ciphertext=envelope['data_key_ciphertext'],
+        )
+
+        otpauth_url = build_otpauth_url(
+            secret_b32=secret_b32,
+            account_email=user.email,
+            issuer='the-full-stack.com',
+        )
+        svg = qr_code_svg(otpauth_url)
+
+        audit.log(event='mfa.setup-totp', success=True, user_id=user.id,
+                  ip=self.data['_meta']['ip'])
+        metrics.add_metric(name='MfaSetupTotp', unit='Count', value=1)
+
+        return {
+            'is_valid': True, 'code': 0,
+            'data': {
+                'secret_b32': secret_b32,   # mostrar UNA vez; NUNCA logear
+                'otpauth_url': otpauth_url,
+                'qr_code_svg': svg,
+            },
+        }
+```
+
+## Patron de `webauthn.register-options`
+
+```python
+class RegisterOptions(BaseController):
+    def execute(self):
+        user = self.context['user']
+        webauthn_svc = WebauthnService(app_config)
+        challenge_svc = ChallengeService(app_config)
+
+        existing = webauthn_svc.list_credential_ids(user_id=user.id)
+        options, state = webauthn_svc.build_register_options(
+            user_id=user.id, user_name=user.email,
+            user_display_name=user.email, existing_credentials=existing,
+        )
+
+        challenge_id = new_uuidv7()
+        challenge_svc.put_challenge(
+            challenge_id=str(challenge_id),
+            user_id=str(user.id),
+            kind='register',
+            state=state,
+            ttl_seconds=300,
+        )
+
+        return {
+            'is_valid': True, 'code': 0,
+            'data': {
+                'challenge_id': str(challenge_id),
+                'options': _options_to_b64_dict(options),
+            },
+        }
+```
+
+El cliente recibe `challenge_id` + `options`. Llama
+`navigator.credentials.create({publicKey: options})` y luego POSTea el
+attestation_response al endpoint `register-verify` junto con
+`challenge_id`. El verify:
+
+1. `GetItem` por `challenge_id` -> obtiene state.
+2. Llama `webauthn_svc.verify_registration(state, response)`.
+3. `DeleteItem` del challenge.
+4. INSERT en `auth_webauthn_credentials`.
+5. Retorna `{credential_id, nickname}`.
+
+## Login con MFA — diagrama de flujo
+
+```text
+POST /auth operation=login action=start
+  body: {email, cf_turnstile, password?}
+                 |
+                 v
+   email no existe?
+     si  ->  404 + suggest_register
+     no  ->  user activo? (locked -> 423 ACCOUNT_LOCKED)
+              |
+              v
+       password en body?
+         no  ->  busca methods (magic-link + email-code + totp + webauthn)
+                 emite temp JWT step=1
+                 envia magic-link / code via SQS
+                 (igual que plan 01)
+         si  ->  valida con argon2.verify
+                 fail -> 401 INVALID_PASSWORD + incrementa failed_attempts
+                 ok   -> user tiene MFA?
+                          no  -> emite access+refresh (login terminado)
+                          si  -> emite temp JWT step=2
+                                 methods = [totp, webauthn]
+                                 (continuar con verify-totp / webauthn.login-verify
+                                  / mfa.recovery-codes-consume)
+                                 |
+                                 v
+                 emite access+refresh
+                 marca last_used_at en el method usado
+```
+
+## Que toca cada nuevo service
+
+| Service | Responsabilidad |
+|---------|-----------------|
+| `MfaMethodService` | CRUD `auth_mfa_methods`: list, upsert_pending_totp, confirm, set_preferred, disable, get_active_methods |
+| `TotpService` | wrapper de `shared.auth.totp` + decrypt del secret en cada verify |
+| `WebauthnService` | wrapper de `shared.auth.webauthn` + DB ops (`auth_webauthn_credentials`) |
+| `ChallengeService` | CRUD DDB `webauthn-challenges`: put, get_and_consume (transactional Get+Delete) |
+| `RecoveryCodesService` | gen + hash + persist (INSERT 10 rows) + consume_one_with_lock |
+
+## EventModel  registrar las 14 actions nuevas + 2 de login
+
+```python
+# core/models/event.py  extension
+EVENT_MODEL = build_event_model({
+    'register': {...},   # del plan 01
+    'login': {
+        'start': LoginStartIn,
+        'verify-magic-link': LoginVerifyMagicLinkIn,
+        'verify-code': LoginVerifyCodeIn,
+        'verify-password': LoginVerifyPasswordIn,    # NUEVO
+        'verify-totp': LoginVerifyTotpIn,            # NUEVO
+    },
+    'verify': {...},     # del plan 01
+    'session': {...},    # del plan 01
+    'mfa': {
+        'setup-totp': MfaSetupTotpIn,
+        'confirm-totp': MfaConfirmTotpIn,
+        'setup-email-code': MfaSetupEmailCodeIn,
+        'set-preferred': MfaSetPreferredIn,
+        'disable': MfaDisableIn,
+        'list': MfaListIn,
+        'recovery-codes-generate': MfaRecoveryCodesGenerateIn,
+        'recovery-codes-consume': MfaRecoveryCodesConsumeIn,
+    },
+    'webauthn': {
+        'register-options': WebauthnRegisterOptionsIn,
+        'register-verify': WebauthnRegisterVerifyIn,
+        'login-options': WebauthnLoginOptionsIn,
+        'login-verify': WebauthnLoginVerifyIn,
+        'list-credentials': WebauthnListCredentialsIn,
+        'delete-credential': WebauthnDeleteCredentialIn,
+    },
+})
+```
+
+## Pydantic schemas — ejemplos
+
+```python
+# models/mfa.py
+class MfaConfirmTotpIn(BaseModel):
+    code: str = Field(min_length=6, max_length=6, pattern=r'^\d{6}$')
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+class MfaRecoveryCodesConsumeIn(BaseModel):
+    temp_token: str = Field(min_length=20)
+    code: str = Field(min_length=10, max_length=10,
+                       pattern=r'^[A-HJ-NP-Z2-9]{10}$')
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+# models/webauthn.py
+class WebauthnRegisterVerifyIn(BaseModel):
+    challenge_id: UUID
+    response: dict       # raw fido2 client response
+    nickname: str | None = Field(default=None, max_length=64)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+# models/login.py  extension
+class LoginVerifyPasswordIn(BaseModel):
+    temp_token: str = Field(min_length=20)
+    password: str = Field(min_length=12, max_length=256)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+```
+
+## Manejo de errores
+
+| Codigo | Significado |
+|--------|-------------|
+| `MFA_NOT_CONFIGURED` | El user no tiene metodos MFA y intenta `set-preferred` o similar |
+| `INVALID_TOTP_CODE` | code TOTP no matchea el secret |
+| `MUST_KEEP_ONE_METHOD` | el `disable` dejaria al user sin metodos MFA |
+| `MUST_KEEP_ONE_CREDENTIAL` | el `webauthn.delete-credential` dejaria al user con 0 passkeys habiendo otros metodos dependientes |
+| `RECOVERY_CODE_CONSUMED` | code ya usado |
+| `RECOVERY_CODE_INVALID` | code no matchea (incremento de attempts) |
+| `WEBAUTHN_CHALLENGE_NOT_FOUND` | challenge_id no esta en DDB o expiro |
+| `WEBAUTHN_CLONE_DETECTED` | sign_count <= stored |
+| `WEBAUTHN_RP_ID_MISMATCH` | origin del request no coincide con WEBAUTHN_ALLOWED_ORIGINS |
+| `INVALID_PASSWORD` | password no matchea (login.verify-password) |
+
+## Auth helper — `require_active_user`
+
+Nuevo helper en `core/services/auth_service.py`:
+
+```python
+def require_active_user(
+    authorization_header: str | None,
+    *,
+    config: AppConfig,
+) -> AuthUser:
+    """Extrae access JWT del header 'Bearer <X>', valida + verifica
+    blacklist + carga user de Neon. Levanta ApplicationError si falla."""
+    if not authorization_header or not authorization_header.startswith('Bearer '):
+        raise ApplicationError('MISSING_AUTHORIZATION', code=4010)
+    raw = authorization_header.removeprefix('Bearer ')
+
+    claims = verify_jwt(raw, secret=config.jwt_secret, expected_typ='access')
+    if BlacklistService(config).is_revoked(jti=claims.jti):
+        raise JwtRevokedError('TOKEN_BLACKLISTED', code=4011)
+
+    with db_session() as session:
+        user = session.get(AuthUser, claims.sub)
+        if user is None or user.status != AuthUserStatus.ACTIVE:
+            raise ApplicationError('USER_NOT_ACTIVE', code=4012)
+    return user
+```
+
+El `Authorization` header viaja en `data['_meta']['authorization']` —
+se inyecta en `http_handler` desde el evento API GW (el repo ya
+inyecta `_meta`; verificar si el header `Authorization` ya esta en
+extract_request; si no, agregar la inyeccion como pequeno commit en
+`shared.lambda_kit.http_dispatch`).

--- a/docs/specs/02-auth-mfa/05-lambda-auth-extensions.md
+++ b/docs/specs/02-auth-mfa/05-lambda-auth-extensions.md
@@ -71,20 +71,21 @@ serverless/lambda/services/auth/core/
 ## Patron de un controller MFA — ejemplo `mfa.setup-totp`
 
 ```python
-"""mfa.setup-totp  genera secret + QR.
+"""mfa.setup-totp  genera secret + otpauth_url.
 
 Requiere: access JWT valido (header Authorization).
-Retorna: {secret_b32, otpauth_url, qr_code_svg}. NO persiste todavia
-un row confirmado  guarda con confirmed_at=NULL.
+Retorna: {secret_b32, otpauth_url}. El QR lo renderiza el frontend
+desde el otpauth_url (decision 8). NO persiste todavia un row
+confirmado — guarda con confirmed_at=NULL.
+
+El secret se cifra con kms:Encrypt CMK directa
+(EncryptionContext={user_id, purpose:totp}) antes de persistir.
+SIN envelope encryption (decision 1).
 """
 
+from shared.aws import kms_encrypt
+from shared.auth import build_otpauth_url, generate_totp_secret_b32
 from shared.lambda_kit import BaseController
-from shared.auth import (
-    build_otpauth_url,
-    encrypt_envelope,
-    generate_totp_secret_b32,
-    qr_code_svg,
-)
 from shared.observability import logger, metrics
 
 from ...services.audit_service import AuditService
@@ -106,7 +107,6 @@ class SetupTotp(BaseController):
         check_or_raise(
             ip=self.data['_meta']['ip'],
             endpoint='/auth#mfa.setup-totp',
-            key_override=str(user.id),
         )
         self.context = {'user': user}
         return {'is_valid': True, 'data': {}, 'code': 0}
@@ -117,27 +117,21 @@ class SetupTotp(BaseController):
         audit = AuditService(app_config)
 
         secret_b32 = generate_totp_secret_b32()
-        envelope = encrypt_envelope(
+        ciphertext = kms_encrypt(
             plaintext=secret_b32.encode('utf-8'),
-            kms_key_id=app_config.kms_totp_key_id,
+            key_id=app_config.kms_totp_key_id,
             encryption_context={
                 'user_id': str(user.id),
                 'purpose': 'totp',
             },
         )
-        mfa_svc.upsert_pending_totp(
-            user_id=user.id,
-            ciphertext=envelope['ciphertext'],
-            nonce=envelope['nonce'],
-            data_key_ciphertext=envelope['data_key_ciphertext'],
-        )
+        mfa_svc.upsert_pending_totp(user_id=user.id, ciphertext=ciphertext)
 
         otpauth_url = build_otpauth_url(
             secret_b32=secret_b32,
             account_email=user.email,
             issuer='the-full-stack.com',
         )
-        svg = qr_code_svg(otpauth_url)
 
         audit.log(event='mfa.setup-totp', success=True, user_id=user.id,
                   ip=self.data['_meta']['ip'])
@@ -148,9 +142,28 @@ class SetupTotp(BaseController):
             'data': {
                 'secret_b32': secret_b32,   # mostrar UNA vez; NUNCA logear
                 'otpauth_url': otpauth_url,
-                'qr_code_svg': svg,
             },
         }
+```
+
+### Side effect critico de `mfa.confirm-totp` y `webauthn.register-verify`
+
+Cuando confirman el PRIMER metodo MFA del user (transicion
+`total_mfa: 0 -> 1`), el controller revoca la familia de refresh
+tokens activa del user (AC-27 / decision 15). Implementacion en el
+`MfaMethodService.confirm()` y `WebauthnService.persist_credential()`:
+
+```python
+def confirm(self, *, user_id, method_id):
+    with db_session() as session:
+        before = count_active_mfa(session, user_id=user_id)
+        # ... UPDATE confirmed_at=now() ...
+        after = count_active_mfa(session, user_id=user_id)
+    if before == 0 and after == 1:
+        # primera transicion a "tiene MFA": cerrar sesiones previas
+        SessionService(app_config).revoke_all_for_user(user_id=user_id)
+        logger.info('mfa.first_method_confirmed.sessions_revoked',
+                    extra={'user_id': str(user_id)})
 ```
 
 ## Patron de `webauthn.register-options`
@@ -211,17 +224,19 @@ POST /auth operation=login action=start
               v
        password en body?
          no  ->  busca methods (magic-link + email-code + totp + webauthn)
-                 emite temp JWT step=1
+                 emite temp JWT step=1 (claim prev=email-prove)
                  envia magic-link / code via SQS
                  (igual que plan 01)
          si  ->  valida con argon2.verify
                  fail -> 401 INVALID_PASSWORD + incrementa failed_attempts
                  ok   -> user tiene MFA?
                           no  -> emite access+refresh (login terminado)
-                          si  -> emite temp JWT step=2
-                                 methods = [totp, webauthn]
-                                 (continuar con verify-totp / webauthn.login-verify
-                                  / mfa.recovery-codes-consume)
+                          si  -> emite temp JWT step=2 con claim prev=password
+                                 methods = [totp, webauthn]  (NO email-code,
+                                                              decision 10)
+                                 (continuar con login.verify-totp /
+                                  webauthn.login-verify /
+                                  mfa.recovery-codes-consume)
                                  |
                                  v
                  emite access+refresh
@@ -315,8 +330,8 @@ class LoginVerifyPasswordIn(BaseModel):
 |--------|-------------|
 | `MFA_NOT_CONFIGURED` | El user no tiene metodos MFA y intenta `set-preferred` o similar |
 | `INVALID_TOTP_CODE` | code TOTP no matchea el secret |
-| `MUST_KEEP_ONE_METHOD` | el `disable` dejaria al user sin metodos MFA |
-| `MUST_KEEP_ONE_CREDENTIAL` | el `webauthn.delete-credential` dejaria al user con 0 passkeys habiendo otros metodos dependientes |
+| `MUST_KEEP_ONE_MFA_METHOD` | el `disable` o `webauthn.delete-credential` dejaria al user con `total_mfa == 0` (cuenta transversal — AC-5 y AC-17) |
+| `RECOVERY_REQUIRES_STRONG_FACTOR` | temp JWT step=2 con `prev=magic-link` o `prev=email-code` intenta `recovery-codes-consume` (AC-9b, decision 10) |
 | `RECOVERY_CODE_CONSUMED` | code ya usado |
 | `RECOVERY_CODE_INVALID` | code no matchea (incremento de attempts) |
 | `WEBAUTHN_CHALLENGE_NOT_FOUND` | challenge_id no esta en DDB o expiro |

--- a/docs/specs/02-auth-mfa/06-testing.md
+++ b/docs/specs/02-auth-mfa/06-testing.md
@@ -4,10 +4,14 @@
 > docstring Given/When/Then, asserts EXACTOS, 1 archivo = 1 escenario).
 > Aqui los tests nuevos son del scope MFA + WebAuthn + login extension.
 
-## Tests unit `shared.auth` (nuevos)
+## Tests unit `shared.auth` + `shared.aws.kms` (nuevos)
 
 Ya listados en [03-shared-auth-extension.md](03-shared-auth-extension.md):
-17 archivos (TOTP, QR, WebAuthn, recovery codes, envelope encryption).
+
+- 13 archivos en `shared/auth/` (TOTP, WebAuthn, recovery codes).
+  NO incluyen `test_qr_svg_*` ni `test_envelope_*` — el QR es
+  frontend, no hay envelope encryption (decision 1 + 8).
+- 4 archivos en `shared/aws/` (KMS Encrypt/Decrypt con moto).
 
 ## Tests unit `shared/db/repositories/auth_mfa.py`
 
@@ -62,7 +66,7 @@ Ya listados en [03-shared-auth-extension.md](03-shared-auth-extension.md):
 | `test_mfa_confirm_totp_no_pending.py` | — | 404 NO_PENDING_TOTP |
 | `test_mfa_set_preferred_ok.py` | AC-4 | UPDATE OK |
 | `test_mfa_set_preferred_unknown_kind.py` | — | 400 |
-| `test_mfa_disable_keeps_one.py` | AC-5 | 409 MUST_KEEP_ONE_METHOD |
+| `test_mfa_disable_keeps_one.py` | AC-5 | 409 MUST_KEEP_ONE_MFA_METHOD (cuenta transversal: total_mfa-1 == 0) |
 | `test_mfa_disable_with_two.py` | AC-6 | OK |
 | `test_mfa_list_returns_active.py` | — | 200 con metodos del user |
 | `test_mfa_recovery_codes_generate_first.py` | AC-7 | 10 codes en response |
@@ -109,9 +113,12 @@ Ya listados en [03-shared-auth-extension.md](03-shared-auth-extension.md):
 | `test_webauthn_register_full_flow_e2e.py` | register-options -> verify -> list -> delete |
 | `test_webauthn_login_full_flow_e2e.py` | register -> login-options -> login-verify -> JWT |
 | `test_login_with_password_and_mfa_e2e.py` | set-password -> setup-totp -> logout -> login con pass + TOTP |
-| `test_disable_last_method_e2e.py` | disable solo metodo -> 409 |
+| `test_disable_last_method_e2e.py` | AC-5/AC-17 — disable o delete-credential que dejaria total_mfa=0 -> 409 MUST_KEEP_ONE_MFA_METHOD |
 | `test_migration_00000003_up_down_e2e.py` | AC-23 |
-| `test_totp_secret_at_rest_encrypted_e2e.py` | AC-24 — query directa muestra ciphertext, no plain |
+| `test_totp_secret_at_rest_encrypted_e2e.py` | AC-24 — query directa muestra ciphertext (output de kms:Encrypt), no plain |
+| `test_passkey_does_not_migrate_envs_e2e.py` | AC-26 — passkey de dev (RP_ID `portfolio.dev....`) no funciona en prod (RP_ID `the-full-stack.com`) |
+| `test_first_mfa_confirm_revokes_sessions_e2e.py` | AC-27 — al confirmar el primer metodo MFA, refresh tokens previos quedan invalidos |
+| `test_recovery_requires_strong_factor_e2e.py` | AC-9b — temp JWT step=2 con prev=magic-link rechaza recovery-codes-consume -> 403 |
 
 ## Fixtures de WebAuthn
 
@@ -129,10 +136,19 @@ serverless/lambda/services/auth/tests/unit/controllers/webauthn/_fixtures.py
 
 ## Cobertura objetivo
 
-- shared.auth (modulos nuevos): 95%+
-- services/ (lambda auth nuevos): 85%+
-- controllers/ (nuevos): 85%+
-- models/ (nuevos): 100%
+Alineado con `.claude/rules/git-hooks.md` (>= 80% per-file en archivos
+modificados — gate del pre-push):
+
+- shared.auth (modulos nuevos): >= 80% per-file.
+- shared.aws.kms: >= 80% per-file.
+- services/ (lambda auth nuevos): >= 80% per-file.
+- controllers/ (nuevos): >= 80% per-file.
+- models/ (nuevos Pydantic): >= 80% per-file. NO se exige 100% porque
+  los schemas son mayormente declaracion — un par de branches en
+  validators custom pueden no rendir tests utiles.
+
+Tests integration NO cuentan a coverage (corren contra AWS real, no
+en el pipeline de coverage).
 
 ## Comandos
 
@@ -152,8 +168,9 @@ python devtools/run.py serverless tests --type=integration --lambda=auth
 
 - **SIEMPRE** WebAuthn fixtures usan SoftWebauthnDevice de python-fido2;
   no fixtures hardcoded de YubiKey reales (no reproducibles).
-- **SIEMPRE** envelope encryption tests usan moto.mock_aws() para KMS
-  (no AWS real en unit).
+- **SIEMPRE** tests de `kms_encrypt` / `kms_decrypt` usan
+  `moto.mock_aws()` para KMS (no AWS real en unit). Encryption es
+  CMK directa, no envelope (decision 1).
 - **SIEMPRE** TOTP test que verifica el code usa `pyotp.TOTP(secret).now()`
   como source-of-truth, no codes hardcodeados.
 - **NUNCA** test que dependa de un browser real para WebAuthn (E2E con

--- a/docs/specs/02-auth-mfa/06-testing.md
+++ b/docs/specs/02-auth-mfa/06-testing.md
@@ -1,0 +1,160 @@
+# 06. Estrategia de testing — plan 02 MFA + WebAuthn
+
+> Hereda el patron del plan 01 (`tests/unit/` + `tests/integration/`,
+> docstring Given/When/Then, asserts EXACTOS, 1 archivo = 1 escenario).
+> Aqui los tests nuevos son del scope MFA + WebAuthn + login extension.
+
+## Tests unit `shared.auth` (nuevos)
+
+Ya listados en [03-shared-auth-extension.md](03-shared-auth-extension.md):
+17 archivos (TOTP, QR, WebAuthn, recovery codes, envelope encryption).
+
+## Tests unit `shared/db/repositories/auth_mfa.py`
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_list_mfa_methods_returns_active_only.py` | filtra `disabled_at IS NULL` |
+| `test_upsert_totp_pending.py` | INSERT row con confirmed_at=NULL |
+| `test_upsert_totp_re_setup_replaces.py` | si ya existe row TOTP, reusa (UPDATE) |
+| `test_confirm_mfa_sets_timestamp.py` | UPDATE confirmed_at=now() |
+| `test_disable_mfa_sets_disabled_at.py` | UPDATE disabled_at=now() |
+| `test_set_preferred_unsets_others.py` | UPDATE preferred=false en otros, true en kind |
+| `test_insert_recovery_codes_10.py` | INSERT 10 rows en una transaccion |
+| `test_consume_recovery_code_marks_consumed.py` | UPDATE consumed_at=now() en el row matcheado |
+| `test_consume_recovery_code_returns_false_if_consumed.py` | row con consumed_at IS NOT NULL -> False |
+| `test_regenerate_recovery_codes_deletes_old.py` | DELETE viejos + INSERT 10 nuevos |
+| `test_insert_webauthn_credential.py` | INSERT con credential_id UK |
+| `test_update_sign_count.py` | UPDATE solo si new > old (condicional) |
+| `test_delete_webauthn_credential_returns_true_if_found.py` | DELETE + return True |
+| `test_delete_webauthn_credential_returns_false_if_other_user.py` | filtro WHERE user_id |
+
+## Tests unit del Lambda `auth` (nuevos)
+
+### `services/` (~25 archivos)
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_mfa_method_service_get_active.py` | filtra disabled_at IS NULL |
+| `test_mfa_method_service_upsert_totp_encrypts.py` | encrypt_envelope called con kms_key_id correcto |
+| `test_mfa_method_service_confirm_sets_preferred_if_first.py` | si es el unico, preferred=true |
+| `test_totp_service_decrypt_and_verify_ok.py` | decrypt_envelope + verify_totp_code -> True |
+| `test_totp_service_decrypt_and_verify_wrong_code.py` | False |
+| `test_totp_service_kms_decrypt_fails.py` | KMS raises -> service levanta `EnvelopeEncryptionError` |
+| `test_webauthn_service_build_options_includes_existing.py` | exclude_credentials del user incluido |
+| `test_webauthn_service_verify_register_persists.py` | INSERT row + retorna credential_id |
+| `test_webauthn_service_verify_login_sign_count_progresses.py` | UPDATE sign_count si new > old |
+| `test_webauthn_service_verify_login_clone_detected.py` | new <= old -> levanta WebauthnVerifyError |
+| `test_challenge_service_put_with_ttl.py` | PutItem con expires_at = now+300 |
+| `test_challenge_service_get_and_consume_atomic.py` | GetItem + DeleteItem; si race -> ConditionalCheckFailed |
+| `test_challenge_service_expired_returns_none.py` | TTL ya expiro y DDB borro -> GetItem none |
+| `test_recovery_codes_service_generate_persists_hashes.py` | INSERT 10 rows con hashes |
+| `test_recovery_codes_service_consume_atomicity.py` | UPDATE condicional; si race -> False |
+
+### `controllers/` (~30 archivos, 1 por escenario)
+
+| Archivo | AC | Escenario |
+|---------|-----|-----------|
+| `test_mfa_setup_totp_ok.py` | AC-1 | 200 con secret_b32 + otpauth + svg |
+| `test_mfa_setup_totp_no_auth.py` | — | sin Authorization -> 401 |
+| `test_mfa_setup_totp_rate_limited.py` | — | 4ta request -> 429 |
+| `test_mfa_confirm_totp_ok.py` | AC-2 | activa el row |
+| `test_mfa_confirm_totp_wrong_code.py` | AC-3 | 400 + audit log |
+| `test_mfa_confirm_totp_no_pending.py` | — | 404 NO_PENDING_TOTP |
+| `test_mfa_set_preferred_ok.py` | AC-4 | UPDATE OK |
+| `test_mfa_set_preferred_unknown_kind.py` | — | 400 |
+| `test_mfa_disable_keeps_one.py` | AC-5 | 409 MUST_KEEP_ONE_METHOD |
+| `test_mfa_disable_with_two.py` | AC-6 | OK |
+| `test_mfa_list_returns_active.py` | — | 200 con metodos del user |
+| `test_mfa_recovery_codes_generate_first.py` | AC-7 | 10 codes en response |
+| `test_mfa_recovery_codes_regenerate.py` | AC-8 | viejos borrados |
+| `test_mfa_recovery_codes_consume_ok.py` | AC-9 | access+refresh + consumed_at |
+| `test_mfa_recovery_codes_consume_already.py` | AC-10 | 400 RECOVERY_CODE_CONSUMED |
+| `test_webauthn_register_options_ok.py` | AC-11 | DDB challenge persistido |
+| `test_webauthn_register_verify_ok.py` | AC-12 | INSERT credential + DELETE challenge |
+| `test_webauthn_register_verify_challenge_expired.py` | — | 400 WEBAUTHN_CHALLENGE_NOT_FOUND |
+| `test_webauthn_register_verify_attestation_invalid.py` | — | 400 WEBAUTHN_REGISTRATION_FAILED |
+| `test_webauthn_login_options_ok.py` | AC-13 | allowCredentials populated |
+| `test_webauthn_login_options_no_credentials.py` | — | 404 NO_WEBAUTHN_CREDENTIALS |
+| `test_webauthn_login_verify_ok.py` | AC-14 | sign_count++, access+refresh |
+| `test_webauthn_login_verify_clone.py` | AC-15 | 401 + disabled |
+| `test_webauthn_list_credentials_ok.py` | AC-16 | ordenado por last_used_at DESC |
+| `test_webauthn_delete_credential_ok.py` | — | DELETE + 204 |
+| `test_webauthn_delete_credential_must_keep_one.py` | AC-17 | 409 |
+| `test_webauthn_delete_credential_other_user.py` | AC-25 | 404 (no 403) |
+| `test_login_start_with_password_ok.py` | AC-18 | temp JWT step=2 |
+| `test_login_start_with_password_wrong.py` | AC-21 | 401 + failed_attempts++ |
+| `test_login_start_with_password_no_mfa.py` | AC-20 | access+refresh directo |
+| `test_login_verify_totp_ok.py` | AC-19 | access+refresh |
+| `test_login_verify_totp_wrong.py` | — | 401 INVALID_TOTP_CODE |
+| `test_login_verify_password_brute_force_locks.py` | — | 10 fails -> status=locked |
+
+### `models/` (~10 archivos)
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_mfa_confirm_totp_in_pattern_6_digits.py` | code != 6 digits -> ValidationError |
+| `test_mfa_recovery_codes_consume_in_pattern.py` | code con O/0/I/1/L -> ValidationError |
+| `test_webauthn_register_verify_in_response_dict.py` | response no dict -> ValidationError |
+| `test_login_verify_password_in_min_length.py` | password < 12 -> ValidationError |
+| `test_login_verify_totp_in_temp_token.py` | sin temp_token -> ValidationError |
+| `test_mfa_set_preferred_in_kind_enum.py` | kind no en enum -> ValidationError |
+| `test_webauthn_delete_credential_in_uuid.py` | credential_id no UUID -> ValidationError |
+
+## Tests integration
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_mfa_setup_totp_full_flow_e2e.py` | setup -> confirm -> login con TOTP (todo verde) |
+| `test_mfa_recovery_codes_full_flow_e2e.py` | setup MFA -> generate recovery -> bypass MFA en login |
+| `test_webauthn_register_full_flow_e2e.py` | register-options -> verify -> list -> delete |
+| `test_webauthn_login_full_flow_e2e.py` | register -> login-options -> login-verify -> JWT |
+| `test_login_with_password_and_mfa_e2e.py` | set-password -> setup-totp -> logout -> login con pass + TOTP |
+| `test_disable_last_method_e2e.py` | disable solo metodo -> 409 |
+| `test_migration_00000003_up_down_e2e.py` | AC-23 |
+| `test_totp_secret_at_rest_encrypted_e2e.py` | AC-24 — query directa muestra ciphertext, no plain |
+
+## Fixtures de WebAuthn
+
+Los tests de WebAuthn requieren fixtures realistas del flujo del browser
+(navigator.credentials.create / get). python-fido2 trae helpers para
+generar fixtures con SoftWebauthnDevice. Crear:
+
+```text
+serverless/lambda/services/auth/tests/unit/controllers/webauthn/_fixtures.py
+- _make_soft_authenticator()  -> dispositivo WebAuthn simulado
+- _make_registration_response(user_id, challenge, rp_id, origin) -> dict
+- _make_authentication_response(stored_credential, challenge, ...) -> dict
+- _make_clone_response(...)  -> response con sign_count viejo
+```
+
+## Cobertura objetivo
+
+- shared.auth (modulos nuevos): 95%+
+- services/ (lambda auth nuevos): 85%+
+- controllers/ (nuevos): 85%+
+- models/ (nuevos): 100%
+
+## Comandos
+
+```bash
+# unit
+python devtools/run.py serverless tests --type=unit --lambda=auth
+python devtools/run.py serverless tests --type=unit --shared
+
+# coverage
+python devtools/run.py serverless tests --type=coverage --lambda=auth
+
+# integration (requiere recursos AWS dev)
+python devtools/run.py serverless tests --type=integration --lambda=auth
+```
+
+## Reglas duras de testing (heredadas + nuevas)
+
+- **SIEMPRE** WebAuthn fixtures usan SoftWebauthnDevice de python-fido2;
+  no fixtures hardcoded de YubiKey reales (no reproducibles).
+- **SIEMPRE** envelope encryption tests usan moto.mock_aws() para KMS
+  (no AWS real en unit).
+- **SIEMPRE** TOTP test que verifica el code usa `pyotp.TOTP(secret).now()`
+  como source-of-truth, no codes hardcodeados.
+- **NUNCA** test que dependa de un browser real para WebAuthn (E2E con
+  Playwright queda para plan futuro de frontend).

--- a/docs/specs/02-auth-mfa/07-archivos-afectados.md
+++ b/docs/specs/02-auth-mfa/07-archivos-afectados.md
@@ -1,0 +1,166 @@
+# 07. Archivos Afectados — plan 02
+
+## Crear
+
+### Migration + modelos Neon
+
+- `serverless/lambda/shared/db/alembic/versions/00000003_auth_mfa.py`
+  — migration con 3 tablas (`auth_mfa_methods`,
+  `auth_mfa_recovery_codes`, `auth_webauthn_credentials`) + enum
+  `auth_mfa_kind`.
+  - Verificar: en branch Neon de prueba aplicar up + down + up
+    idempotente.
+- `serverless/lambda/shared/db/models/auth/mfa_method.py`
+- `serverless/lambda/shared/db/models/auth/recovery_code.py`
+- `serverless/lambda/shared/db/models/auth/webauthn_credential.py`
+- `serverless/lambda/shared/db/models/auth/enums.py` — agregar
+  `AuthMfaKind` al archivo existente del plan 01.
+- `serverless/lambda/shared/db/models/auth/__init__.py` — re-export
+  los nuevos.
+- `serverless/lambda/shared/db/repositories/auth_mfa.py` — helpers
+  para los 3 dominios + tests (~14 archivos).
+  - Verificar: `serverless tests --type=unit --shared`.
+
+### Shared.auth extension
+
+- `serverless/lambda/shared/auth/totp.py`
+- `serverless/lambda/shared/auth/webauthn.py`
+- `serverless/lambda/shared/auth/recovery_codes.py`
+- `serverless/lambda/shared/auth/encryption.py`
+- `serverless/lambda/shared/auth/__init__.py` — agregar re-exports.
+- `serverless/lambda/shared/auth/pyproject.toml` — agregar pyotp,
+  python-fido2, cryptography, segno.
+- `serverless/lambda/shared/auth/uv.lock` — regenerar con `uv lock`.
+- `serverless/lambda/shared/aws/__init__.py` — agregar wrapper
+  `kms_generate_data_key` y `kms_decrypt` (re-exports nuevos para
+  shared.auth.encryption los consuma).
+- `serverless/lambda/shared/aws/pyproject.toml` — agregar boto3
+  ya esta declarado.
+- `serverless/lambda/shared/tests/unit/shared/auth/` — 17 archivos
+  nuevos (listados en seccion 03).
+  - Verificar: `serverless lint-deps --shared` +
+    `serverless tests --type=unit --shared`.
+
+### Infra (resources/)
+
+- `serverless/lambda/resources/dynamodb/webauthn-challenges.yaml` —
+  PK `challenge_id`, TTL `expires_at`.
+  - Verificar:
+    `serverless validate-catalog --stage=dev`
+    `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
+
+### Lambda `auth` extension
+
+- `serverless/lambda/services/auth/manifest.yaml` — MODIFICAR
+  agregando:
+  - `uses.tables.webauthn-challenges: read-write`
+  - `uses.kms` con `alias/portfolio-lambdas` + actions
+    `GenerateDataKey`, `Decrypt`
+  - env vars `KMS_TOTP_KEY_ID`, `WEBAUTHN_RP_ID`,
+    `WEBAUTHN_RP_NAME`, `WEBAUTHN_ALLOWED_ORIGINS`
+- `serverless/lambda/services/auth/core/settings/config.py` —
+  MODIFICAR agregando properties (`kms_totp_key_id`,
+  `webauthn_rp_id`, `webauthn_rp_name`, `webauthn_allowed_origins`,
+  `webauthn_challenges_table`).
+- `serverless/lambda/services/auth/core/settings/operations.py` —
+  MODIFICAR agregando `mfa` y `webauthn` (+ actions nuevas de
+  `login`).
+- `serverless/lambda/services/auth/core/models/event.py` — MODIFICAR
+  agregando las nuevas operations al `build_event_model()`.
+- `serverless/lambda/services/auth/core/models/mfa.py` — Pydantic
+  schemas (8 actions).
+- `serverless/lambda/services/auth/core/models/webauthn.py` — Pydantic
+  schemas (6 actions).
+- `serverless/lambda/services/auth/core/models/login.py` — MODIFICAR
+  agregando `LoginVerifyPasswordIn`, `LoginVerifyTotpIn`.
+
+- `serverless/lambda/services/auth/core/controllers/mfa/__init__.py`
+- `serverless/lambda/services/auth/core/controllers/mfa/{setup_totp,confirm_totp,setup_email_code,set_preferred,disable,list,recovery_codes_generate,recovery_codes_consume}.py`
+- `serverless/lambda/services/auth/core/controllers/webauthn/__init__.py`
+- `serverless/lambda/services/auth/core/controllers/webauthn/{register_options,register_verify,login_options,login_verify,list_credentials,delete_credential}.py`
+- `serverless/lambda/services/auth/core/controllers/login/{verify_password,verify_totp}.py` — NUEVOS
+
+- `serverless/lambda/services/auth/core/services/{mfa_method,totp,webauthn,recovery_codes,challenge,auth}_service.py` — NUEVOS (6 services nuevos).
+
+- `serverless/lambda/services/auth/events/mfa-*.json` (8 archivos).
+- `serverless/lambda/services/auth/events/webauthn-*.json` (6 archivos).
+- `serverless/lambda/services/auth/events/login-verify-password.json`,
+  `login-verify-totp.json`.
+
+- `serverless/lambda/services/auth/tests/unit/services/test_*.py` (~25 nuevos).
+- `serverless/lambda/services/auth/tests/unit/controllers/test_mfa_*.py` (~15).
+- `serverless/lambda/services/auth/tests/unit/controllers/test_webauthn_*.py` (~10).
+- `serverless/lambda/services/auth/tests/unit/controllers/test_login_*.py` (~5 nuevos).
+- `serverless/lambda/services/auth/tests/unit/models/test_mfa_*.py` (~5).
+- `serverless/lambda/services/auth/tests/unit/models/test_webauthn_*.py` (~5).
+- `serverless/lambda/services/auth/tests/unit/controllers/webauthn/_fixtures.py` — helpers SoftWebauthnDevice.
+- `serverless/lambda/services/auth/tests/integration/test_mfa_*.py` y `test_webauthn_*.py` (~7 archivos).
+
+  - Verificar:
+    `serverless lint-deps --lambda=auth`
+    `serverless tests --type=unit --lambda=auth`
+    `serverless tests --type=coverage --lambda=auth` (>= 85%)
+
+### Documentacion permanente
+
+- `.claude/docs/auth-system/04-mfa.md` — NUEVO (TOTP setup, recovery
+  codes, login con MFA).
+- `.claude/docs/auth-system/05-webauthn.md` — NUEVO (Passkeys, RP_ID,
+  sign_count, clone detection).
+- `.claude/rules/auth-system.md` — MODIFICAR agregando seccion MFA +
+  WebAuthn.
+- `.claude/rules/lambda-shared-imports.md` — MODIFICAR el catalogo de
+  portadores (agregar pyotp, python-fido2, cryptography, segno).
+- `.claude/skills/auth-system/SKILL.md` — MODIFICAR el frontmatter
+  para incluir keywords MFA + WebAuthn (`mfa`, `totp`, `passkey`,
+  `webauthn`, `2fa`, `autenticacion en dos pasos`, `factor doble`).
+
+## Modificar
+
+- `docs/diagrams/db-er.mmd` — agregar las 3 tablas nuevas
+  (`auth_mfa_methods`, `auth_mfa_recovery_codes`,
+  `auth_webauthn_credentials`) + relacion FK a `auth_users`.
+- `docs/specs/02-auth-mfa/` — esta carpeta del plan (efimera, se
+  elimina en commit final).
+- `serverless/lambda/services/auth/manifest.yaml` — listado arriba
+  como modificar.
+- `serverless/lambda/services/auth/core/settings/{config,operations}.py`
+  — modificacion incremental.
+- `serverless/lambda/services/auth/core/models/event.py` —
+  modificacion incremental.
+- `serverless/lambda/services/auth/core/models/login.py` — agregar
+  schemas nuevos.
+
+- `devtools/serverless/provisioner.py` — POSIBLEMENTE modificar si
+  el manifest no soporta `uses.kms` declarativo (verificar primero;
+  si soporta, no se toca). Es un cambio menor (~50 lineas).
+
+## Eliminar
+
+- `docs/specs/02-auth-mfa/` — al cerrar el plan (ultimo commit).
+
+## NO se toca
+
+- Frontend Astro.
+- Lambdas `cv`, `contact_form`, `contact_worker`, `tracking_pixel`,
+  `tracking_worker`, `stream_processor`, `auth_email_worker`, `db`.
+- Shared subpackages `core`, `db`, `http`, `observability`,
+  `rate_limit`, `cache`, `dynamodb`, `lambda_kit` (excepto los
+  delta indicados arriba en `shared.aws` y `shared.auth`).
+- `.github/workflows/*.yml`.
+
+## Resumen contable
+
+| Categoria | Crear | Modificar | Eliminar | Total |
+|-----------|-------|-----------|----------|-------|
+| Migration Alembic | 1 | 0 | 0 | 1 |
+| Modelos SQLAlchemy + repositories | 4 + ~14 tests | 1 | 0 | ~19 |
+| `shared.auth/` (impl + tests + pyproject) | ~25 | 2 | 0 | 27 |
+| `shared.aws/` (wrappers KMS) | 0 | 2 | 0 | 2 |
+| Infra resources | 1 | 0 | 0 | 1 |
+| Lambda `auth` (controllers + services + models + events + tests) | ~85 | 5 | 0 | 90 |
+| Documentacion permanente (.claude/) | 2 | 3 | 0 | 5 |
+| Plan efimero (`docs/specs/02-...`) | 12 | 0 | -12 | 0 |
+| Diagrama ER | 0 | 1 | 0 | 1 |
+| Devtools provisioner (eventual) | 0 | 1 | 0 | 1 |
+| **Total neto** |  |  |  | **~147 archivos nuevos** |

--- a/docs/specs/02-auth-mfa/07-archivos-afectados.md
+++ b/docs/specs/02-auth-mfa/07-archivos-afectados.md
@@ -21,23 +21,30 @@
   para los 3 dominios + tests (~14 archivos).
   - Verificar: `serverless tests --type=unit --shared`.
 
-### Shared.auth extension
+### Shared.auth extension (TOTP + WebAuthn + recovery codes)
 
-- `serverless/lambda/shared/auth/totp.py`
-- `serverless/lambda/shared/auth/webauthn.py`
-- `serverless/lambda/shared/auth/recovery_codes.py`
-- `serverless/lambda/shared/auth/encryption.py`
+- `serverless/lambda/shared/auth/totp.py` — pyotp wrappers (sin QR).
+- `serverless/lambda/shared/auth/webauthn.py` — fido2 wrappers (post-spike).
+- `serverless/lambda/shared/auth/recovery_codes.py`.
 - `serverless/lambda/shared/auth/__init__.py` — agregar re-exports.
-- `serverless/lambda/shared/auth/pyproject.toml` — agregar pyotp,
-  python-fido2, cryptography, segno.
+- `serverless/lambda/shared/auth/pyproject.toml` — agregar SOLO pyotp +
+  python-fido2. NO `cryptography`, NO `segno` (decision 1 + 8 del README).
 - `serverless/lambda/shared/auth/uv.lock` — regenerar con `uv lock`.
-- `serverless/lambda/shared/aws/__init__.py` — agregar wrapper
-  `kms_generate_data_key` y `kms_decrypt` (re-exports nuevos para
-  shared.auth.encryption los consuma).
-- `serverless/lambda/shared/aws/pyproject.toml` — agregar boto3
-  ya esta declarado.
-- `serverless/lambda/shared/tests/unit/shared/auth/` — 17 archivos
-  nuevos (listados en seccion 03).
+- `serverless/lambda/shared/tests/unit/shared/auth/` — 13 archivos
+  nuevos (listados en seccion 03; menos que la version inicial — sin
+  envelope encryption ni QR SVG).
+
+### Shared.aws (KMS wrappers — CMK directa)
+
+- `serverless/lambda/shared/aws/kms.py` — `kms_encrypt` +
+  `kms_decrypt` (KMS Encrypt/Decrypt directos, sin
+  GenerateDataKey).
+- `serverless/lambda/shared/aws/__init__.py` — agregar re-exports.
+- `serverless/lambda/shared/aws/pyproject.toml` — sin cambios (boto3
+  ya esta declarado).
+- `serverless/lambda/shared/tests/unit/shared/aws/test_kms_*.py` — 4
+  tests con moto (listados en seccion 03).
+
   - Verificar: `serverless lint-deps --shared` +
     `serverless tests --type=unit --shared`.
 
@@ -55,7 +62,7 @@
   agregando:
   - `uses.tables.webauthn-challenges: read-write`
   - `uses.kms` con `alias/portfolio-lambdas` + actions
-    `GenerateDataKey`, `Decrypt`
+    `Encrypt`, `Decrypt` (CMK directa, decision 1)
   - env vars `KMS_TOTP_KEY_ID`, `WEBAUTHN_RP_ID`,
     `WEBAUTHN_RP_NAME`, `WEBAUTHN_ALLOWED_ORIGINS`
 - `serverless/lambda/services/auth/core/settings/config.py` —
@@ -110,7 +117,8 @@
 - `.claude/rules/auth-system.md` — MODIFICAR agregando seccion MFA +
   WebAuthn.
 - `.claude/rules/lambda-shared-imports.md` — MODIFICAR el catalogo de
-  portadores (agregar pyotp, python-fido2, cryptography, segno).
+  portadores (agregar pyotp, python-fido2, boto3.kms). NO se agrega
+  `cryptography` ni `segno` (decision 1 + 8).
 - `.claude/skills/auth-system/SKILL.md` — MODIFICAR el frontmatter
   para incluir keywords MFA + WebAuthn (`mfa`, `totp`, `passkey`,
   `webauthn`, `2fa`, `autenticacion en dos pasos`, `factor doble`).
@@ -155,12 +163,12 @@
 |-----------|-------|-----------|----------|-------|
 | Migration Alembic | 1 | 0 | 0 | 1 |
 | Modelos SQLAlchemy + repositories | 4 + ~14 tests | 1 | 0 | ~19 |
-| `shared.auth/` (impl + tests + pyproject) | ~25 | 2 | 0 | 27 |
-| `shared.aws/` (wrappers KMS) | 0 | 2 | 0 | 2 |
+| `shared.auth/` (impl + tests + pyproject) | 16 (3 modulos + 13 tests) | 2 | 0 | 18 |
+| `shared.aws/` (impl + tests KMS) | 5 (1 modulo + 4 tests) | 1 | 0 | 6 |
 | Infra resources | 1 | 0 | 0 | 1 |
 | Lambda `auth` (controllers + services + models + events + tests) | ~85 | 5 | 0 | 90 |
 | Documentacion permanente (.claude/) | 2 | 3 | 0 | 5 |
 | Plan efimero (`docs/specs/02-...`) | 12 | 0 | -12 | 0 |
 | Diagrama ER | 0 | 1 | 0 | 1 |
-| Devtools provisioner (eventual) | 0 | 1 | 0 | 1 |
-| **Total neto** |  |  |  | **~147 archivos nuevos** |
+| Devtools provisioner (post-spike, condicional) | 0 | 0 o 1 | 0 | 0 o 1 |
+| **Total neto** | | | | **~140 archivos** (vs ~147 inicial — sin `encryption.py` ni `segno`) |

--- a/docs/specs/02-auth-mfa/08-descomposicion-paralelizacion.md
+++ b/docs/specs/02-auth-mfa/08-descomposicion-paralelizacion.md
@@ -1,0 +1,262 @@
+# 08. Descomposicion para Paralelizacion — plan 02
+
+> Plan **Large** (~147 archivos). 11 tareas atomicas. Las tareas T9,
+> T10 (mfa, webauthn) son paralelizables entre si. Login extension
+> (T11) viene al final porque toca codigo del plan 01.
+
+## Grafo de dependencias
+
+```text
+T1 plan + claude docs                          (raiz)
+  |
+  +--> T2 shared.auth extension                (raiz tras T1)
+  |     (totp, webauthn, recovery, encryption)
+  |     |
+  |     +--> tests shared.auth                 (parte de T2)
+  |
+  +--> T3 shared.aws KMS wrappers              (raiz tras T1, indep T2)
+  |
+  +--> T4 schema Neon + modelos + repository    (raiz tras T1)
+  |
+  +--> T5 resources (webauthn-challenges DDB)   (raiz tras T1)
+  |
+  +--> T6 manifest update + provisioner kms     (raiz tras T1; afecta T7+)
+  |
+  +--> T7 lambda auth: services nuevos         (depende de T2..T6)
+  |     (mfa_method, totp, webauthn, recovery, challenge, auth-helper)
+  |
+  +--> T8 lambda auth: EventModel + operations registry + models Pydantic
+  |     (depende de T7)
+  |
+  +--> T9 controllers/mfa/                     (depende de T8)
+  |     |  (paralelo con T10)
+  |     +--> 8 controllers + tests
+  |
+  +--> T10 controllers/webauthn/               (depende de T8)
+  |     |  (paralelo con T9)
+  |     +--> 6 controllers + tests
+  |
+  +--> T11 login extension (verify-password, verify-totp + login.start delta)
+  |     (depende de T7 + T9; ya que reutiliza TotpService y MfaMethodService)
+  |     |
+  |     +--> 2 controllers nuevos + 1 modificado (login/start.py)
+  |
+  +--> T12 verificacion E2E + ER + limpieza spec  (seccion 11)
+```
+
+## Tareas
+
+### T1: Plan + claude docs
+
+- **Archivos**:
+  - `docs/specs/02-auth-mfa/*.md` (12).
+  - `.claude/docs/auth-system/04-mfa.md`
+  - `.claude/docs/auth-system/05-webauthn.md`
+  - `.claude/rules/auth-system.md` (modificar).
+  - `.claude/rules/lambda-shared-imports.md` (modificar — catalogo).
+  - `.claude/skills/auth-system/SKILL.md` (modificar — keywords).
+- **AC**: ninguna.
+- **Depende de**: ninguna.
+- **Paralelizable con**: ninguna.
+- **Verify**:
+  - markdownlint
+  - Validacion skill segun `.claude/rules/claude-config-testing.md`.
+- **Done**: spec + docs/claude + skill commiteados.
+
+### T2: shared.auth extension
+
+- **Archivos**:
+  - `shared/auth/{totp,webauthn,recovery_codes,encryption}.py`
+  - `shared/auth/__init__.py` (modificar)
+  - `shared/auth/pyproject.toml` (modificar — agregar deps)
+  - `shared/auth/uv.lock` (regenerar)
+  - `shared/tests/unit/shared/auth/test_*` (17 nuevos)
+- **AC**: AC-24 (encryption at rest).
+- **Depende de**: T1.
+- **Paralelizable con**: T3, T4, T5, T6.
+- **Verify**:
+  `serverless lint-deps --shared`
+  `serverless tests --type=unit --shared`
+- **Done**: 17 tests verdes, coverage >= 95% en modulos nuevos.
+
+### T3: shared.aws KMS wrappers
+
+- **Archivos**:
+  - `shared/aws/__init__.py` (modificar — re-exports kms_generate_data_key, kms_decrypt)
+  - `shared/aws/kms.py` (NUEVO — wrappers boto3)
+  - `shared/aws/pyproject.toml` (sin cambios — boto3 ya esta)
+  - `shared/tests/unit/shared/aws/test_kms_*.py` (4 tests con moto)
+- **AC**: soporta AC-24 indirectamente.
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T4, T5, T6.
+- **Verify**: `serverless tests --type=unit --shared`.
+- **Done**: 4 tests verdes; T2 puede importar de aqui (depende de la
+  publicacion de shared.aws.kms_* re-exports).
+
+> Nota: T2 (`shared.auth.encryption.py`) importa de `shared.aws.kms_*`.
+> Por orden topologico: T3 antes que T2. Si se trabajan en paralelo,
+> T2 puede stub `shared.aws.kms_*` con `# type: ignore[attr-defined]`
+> hasta que T3 merge. Recomendado: completar T3 antes de T2.
+
+### T4: Schema Neon + repositories
+
+- **Archivos**:
+  - `shared/db/alembic/versions/00000003_auth_mfa.py`
+  - `shared/db/models/auth/{mfa_method,recovery_code,webauthn_credential}.py`
+  - `shared/db/models/auth/enums.py` (modificar — agregar `AuthMfaKind`)
+  - `shared/db/models/auth/__init__.py` (modificar)
+  - `shared/db/repositories/auth_mfa.py`
+  - `shared/tests/unit/shared/db/repositories/test_auth_mfa_*.py` (14)
+- **AC**: AC-23.
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T3, T5, T6.
+- **Verify**:
+  Branch Neon de prueba upgrade + downgrade + upgrade idempotente
+  `serverless tests --type=unit --shared`
+- **Done**: migration up/down OK, 14 tests verdes.
+
+### T5: Resources
+
+- **Archivos**:
+  - `serverless/lambda/resources/dynamodb/webauthn-challenges.yaml`
+- **AC**: soporta AC-11..14.
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T3, T4, T6.
+- **Verify**:
+  `serverless validate-catalog --stage=dev`
+  `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
+- **Done**: tabla creada en AWS dev.
+
+### T6: Manifest update + provisioner KMS (si aplica)
+
+- **Archivos**:
+  - `serverless/lambda/services/auth/manifest.yaml` (modificar)
+  - `devtools/serverless/provisioner.py` (modificar SOLO si no soporta
+    `uses.kms` declarativo)
+  - tests del provisioner si se toca.
+- **AC**: soporta AC-1, AC-12 (necesita IAM correcto).
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T3, T4, T5.
+- **Verify**: `serverless deploy --lambda=auth --stage=dev --dry-run`.
+- **Done**: manifest actualizado + provisioner soporta `uses.kms`.
+
+### T7: Services del lambda auth
+
+- **Archivos**:
+  - `services/auth/core/services/{mfa_method,totp,webauthn,recovery_codes,challenge,auth}_service.py`
+  - tests unit ~25.
+- **AC**: transversal.
+- **Depende de**: T2, T3, T4, T5, T6 (cierre transitivo necesario).
+- **Paralelizable con**: ninguna en su capa.
+- **Verify**: `serverless tests --type=unit --lambda=auth`.
+- **Done**: 6 services + 25 tests verdes.
+
+### T8: EventModel + operations + models Pydantic
+
+- **Archivos**:
+  - `core/settings/operations.py` (modificar)
+  - `core/models/event.py` (modificar)
+  - `core/models/mfa.py` (NUEVO)
+  - `core/models/webauthn.py` (NUEVO)
+  - `core/models/login.py` (modificar — schemas nuevos)
+  - tests models ~10.
+- **AC**: soporta validacion.
+- **Depende de**: T7 (services existen).
+- **Paralelizable con**: ninguna en su capa.
+- **Verify**: `serverless tests --type=unit --lambda=auth`.
+- **Done**: 10 tests models verdes; el lambda compila con
+  EVENT_MODEL extendido.
+
+### T9: Controllers mfa/ (paralelo con T10)
+
+- **Archivos**:
+  - `core/controllers/mfa/{setup_totp,confirm_totp,setup_email_code,set_preferred,disable,list,recovery_codes_generate,recovery_codes_consume}.py`
+  - `events/mfa-*.json` (8)
+  - tests controllers/test_mfa_*.py (~15)
+- **AC**: AC-1..AC-10.
+- **Depende de**: T7, T8.
+- **Paralelizable con**: T10.
+- **Verify**: `serverless tests --type=unit --lambda=auth`.
+- **Done**: 8 controllers + 15 tests verdes.
+
+### T10: Controllers webauthn/ (paralelo con T9)
+
+- **Archivos**:
+  - `core/controllers/webauthn/{register_options,register_verify,login_options,login_verify,list_credentials,delete_credential}.py`
+  - `events/webauthn-*.json` (6)
+  - tests controllers/webauthn/_fixtures.py
+  - tests controllers/test_webauthn_*.py (~10)
+- **AC**: AC-11..AC-17, AC-25.
+- **Depende de**: T7, T8.
+- **Paralelizable con**: T9.
+- **Verify**: idem.
+- **Done**: 6 controllers + 10 tests verdes.
+
+### T11: Login extension (verify-password + verify-totp + login.start delta)
+
+- **Archivos**:
+  - `core/controllers/login/{verify_password,verify_totp}.py` (NUEVOS)
+  - `core/controllers/login/start.py` (modificar — agregar deteccion
+    de password en body + methods MFA en response)
+  - tests/unit/controllers/test_login_verify_*.py (~5)
+  - tests/unit/controllers/test_login_start_with_password_*.py (~3)
+- **AC**: AC-18..AC-22.
+- **Depende de**: T7, T9 (necesita TotpService + MfaMethodService).
+- **Paralelizable con**: T10.
+- **Verify**: idem.
+- **Done**: 2 controllers nuevos + 1 modificado + 8 tests verdes.
+
+### T12: Verificacion E2E + ER + limpieza spec (= seccion 11)
+
+- **Archivos**:
+  - `services/auth/tests/integration/test_mfa_*.py` y
+    `test_webauthn_*.py` (7)
+  - `docs/diagrams/db-er.mmd` (modificar)
+  - `docs/specs/02-auth-mfa/` (eliminar)
+- **AC**: TODOS.
+- **Depende de**: T2..T11.
+- **Paralelizable con**: ninguna.
+- **Verify**: ver [11-verificacion-e2e.md](11-verificacion-e2e.md).
+- **Done**: bateria verde.
+
+## Tabla de paralelismo
+
+| Tarea | Depende de | Paralelizable con |
+|-------|------------|--------------------|
+| T1 plan + docs/claude | — | — |
+| T2 shared.auth ext | T1 (T3) | T4, T5, T6 |
+| T3 shared.aws KMS | T1 | T2, T4, T5, T6 |
+| T4 schema Neon + repos | T1 | T2, T3, T5, T6 |
+| T5 resources DDB | T1 | T2, T3, T4, T6 |
+| T6 manifest + provisioner | T1 | T2, T3, T4, T5 |
+| T7 services auth | T2..T6 | — |
+| T8 EventModel + models | T7 | — |
+| T9 controllers mfa | T8 | T10 |
+| T10 controllers webauthn | T8 | T9 |
+| T11 login extension | T7, T9 | T10 |
+| T12 E2E + ER + cleanup | T2..T11 | — |
+
+## Maximo paralelismo util
+
+- Tras T1: lanzar **T2 + T3 + T4 + T5 + T6** en 5 worktrees
+  concurrentes (raices, archivos disjuntos). Limite practico
+  recomendado.
+- Tras T7 + T8: lanzar **T9 + T10** en 2 worktrees concurrentes.
+- Tras T9: lanzar T11 (depende de T9 por TotpService usage).
+
+3-5 worktrees concurrentes. Dentro del limite.
+
+## Anti-patrones evitados
+
+- T2 (`shared.auth.encryption`) importa de `shared.aws.kms_*` (T3).
+  Para evitar circular trabajo, T3 termina antes (es chico: ~80 lineas
+  + 4 tests). Si los 2 se hacen en paralelo y T2 stubea, requiere
+  rebase antes del merge.
+- T6 (manifest + provisioner) toca un archivo central (`provisioner.py`).
+  Hacerse antes del PR de T7 evita conflictos.
+- T9 y T10 son worktree-safe (carpetas disjuntas `controllers/mfa/` vs
+  `controllers/webauthn/`). NO modifican `event.py` (lo hace T8 ya en
+  scaffold).
+- T11 modifica `login/start.py` (existente desde plan 01). NO se
+  puede paralelizar con otro worktree que tambien quiera tocar ese
+  archivo. T11 es el unico que lo toca en este plan.

--- a/docs/specs/02-auth-mfa/08-descomposicion-paralelizacion.md
+++ b/docs/specs/02-auth-mfa/08-descomposicion-paralelizacion.md
@@ -82,8 +82,8 @@ T1 plan + claude docs                          (raiz)
 ### T3: shared.aws KMS wrappers
 
 - **Archivos**:
-  - `shared/aws/__init__.py` (modificar — re-exports kms_generate_data_key, kms_decrypt)
-  - `shared/aws/kms.py` (NUEVO — wrappers boto3)
+  - `shared/aws/__init__.py` (modificar — re-exports kms_encrypt, kms_decrypt)
+  - `shared/aws/kms.py` (NUEVO — wrappers boto3 Encrypt/Decrypt, CMK directa)
   - `shared/aws/pyproject.toml` (sin cambios — boto3 ya esta)
   - `shared/tests/unit/shared/aws/test_kms_*.py` (4 tests con moto)
 - **AC**: soporta AC-24 indirectamente.
@@ -93,10 +93,11 @@ T1 plan + claude docs                          (raiz)
 - **Done**: 4 tests verdes; T2 puede importar de aqui (depende de la
   publicacion de shared.aws.kms_* re-exports).
 
-> Nota: T2 (`shared.auth.encryption.py`) importa de `shared.aws.kms_*`.
-> Por orden topologico: T3 antes que T2. Si se trabajan en paralelo,
-> T2 puede stub `shared.aws.kms_*` con `# type: ignore[attr-defined]`
-> hasta que T3 merge. Recomendado: completar T3 antes de T2.
+> Nota: T2 (`shared.auth`) NO importa directamente KMS — los
+> controllers del Lambda son los que llaman a `shared.aws.kms_*`.
+> shared.auth solo conoce TOTP secret en plaintext, sin cifrado. Por
+> eso T2 y T3 son totalmente independientes y se pueden paralelizar
+> en worktrees separados sin coordinacion.
 
 ### T4: Schema Neon + repositories
 

--- a/docs/specs/02-auth-mfa/09-commits.md
+++ b/docs/specs/02-auth-mfa/09-commits.md
@@ -1,0 +1,275 @@
+# 09. Commits — plan 02
+
+> Rama base: `feature/auth-mfa-N-<x>` desde `dev` (plan 01 ya mergeado).
+> Multiples PRs incrementales a `dev`. Conventional Commits espanol.
+
+## Modelo de PRs
+
+7 PRs en total. Cada uno deja el repo verde y deployable.
+
+### Ramas
+
+```text
+dev (post plan 01 mergeado)
+ ├── feature/auth-mfa-1-spec-and-docs              (T1)
+ ├── feature/auth-mfa-2-shared-auth-ext-and-kms    (T2 + T3)
+ ├── feature/auth-mfa-3-schema-and-repos           (T4)
+ ├── feature/auth-mfa-4-infra-and-manifest         (T5 + T6)
+ ├── feature/auth-mfa-5-services                   (T7 + T8)
+ ├── feature/auth-mfa-6-controllers-mfa-webauthn   (T9 + T10)  PARALELO
+ ├── feature/auth-mfa-7-login-extension            (T11)
+ └── feature/auth-mfa-8-verificacion-e2e           (T12)
+```
+
+## PR 1 — `docs(specs+claude): plan 02-auth-mfa + docs/auth-system MFA + WebAuthn`
+
+#### Commit 1.1 — `docs(specs): plan 02-auth-mfa`
+
+- Agrega `docs/specs/02-auth-mfa/` (12 archivos).
+- **Verificacion**: markdownlint OK.
+
+#### Commit 1.2 — `docs(claude): docs/auth-system/04-mfa.md + 05-webauthn.md + rule update + skill keywords`
+
+- Agrega `.claude/docs/auth-system/04-mfa.md`, `05-webauthn.md`.
+- Modifica `.claude/rules/auth-system.md` agregando secciones.
+- Modifica `.claude/rules/lambda-shared-imports.md` (catalogo
+  portadores: pyotp, python-fido2, cryptography, segno).
+- Modifica `.claude/skills/auth-system/SKILL.md` agregando keywords.
+- **Verificacion**:
+  - markdownlint
+  - 5 prompts ES via `claude -p` (validacion skill).
+- **AC**: ninguna (meta).
+
+> Merge PR 1.
+
+---
+
+## PR 2 — `feat(shared): auth.totp + auth.webauthn + auth.recovery_codes + auth.encryption + aws.kms wrappers`
+
+#### Commit 2.1 — `feat(shared/aws): wrappers kms generate_data_key + decrypt`
+
+- Agrega `shared/aws/kms.py` + 4 tests (con moto).
+- Modifica `shared/aws/__init__.py` re-exports.
+- **Verificacion**: `serverless tests --type=unit --shared`.
+
+#### Commit 2.2 — `feat(shared/auth): envelope encryption + totp + webauthn + recovery codes`
+
+- Agrega `shared/auth/{encryption,totp,webauthn,recovery_codes}.py`.
+- Modifica `shared/auth/__init__.py`, `pyproject.toml`, `uv.lock`.
+- Agrega 17 tests en `shared/tests/unit/shared/auth/`.
+- **Verificacion**:
+  - `serverless lint-deps --shared`
+  - `serverless tests --type=coverage --shared` (>= 95%)
+
+> Merge PR 2.
+
+---
+
+## PR 3 — `feat(db): schema auth_mfa + auth_webauthn + repositories`
+
+#### Commit 3.1 — `feat(db/models): mfa_method + recovery_code + webauthn_credential`
+
+- Agrega modelos + actualiza `enums.py` con `AuthMfaKind`.
+- Modifica `models/auth/__init__.py`.
+- **Verificacion**: `python -m compileall -q`.
+
+#### Commit 3.2 — `feat(db/alembic): migration 00000003_auth_mfa`
+
+- Agrega migration.
+- **Verificacion** (branch Neon de prueba):
+  - upgrade head -> down -1 -> upgrade head idempotente.
+
+#### Commit 3.3 — `feat(db/repositories): auth_mfa helpers + 14 tests unit`
+
+- Agrega `repositories/auth_mfa.py` + tests.
+- **Verificacion**: `serverless tests --type=unit --shared`.
+- **AC**: AC-23 indirectamente.
+
+#### Commit 3.4 — `chore(db): aplica migration 00000003 en dev`
+
+- Operativo: `serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev`.
+- Verificacion: `current.json` muestra revision `00000003`.
+
+> Merge PR 3.
+
+---
+
+## PR 4 — `feat(infra): webauthn-challenges DDB + manifest auth kms + provisioner`
+
+#### Commit 4.1 — `feat(resources/dynamodb): webauthn-challenges`
+
+- Agrega `resources/dynamodb/webauthn-challenges.yaml`.
+- **Verificacion**: `serverless validate-catalog`.
+
+#### Commit 4.2 — `feat(provisioner): soporte uses.kms en manifest` (SI APLICA)
+
+- Modifica `devtools/serverless/provisioner.py` si el shape `uses.kms`
+  no esta hoy. Agrega tests del provisioner.
+- **Verificacion**: tests + smoke `serverless deploy --dry-run`.
+
+#### Commit 4.3 — `feat(services/auth): manifest update con kms + webauthn env vars`
+
+- Modifica `services/auth/manifest.yaml`.
+- **Verificacion**: `serverless deploy --lambda=auth --stage=dev --dry-run --aws-profile=tfs-dev`.
+
+#### Commit 4.4 — `chore(infra): provision dev (webauthn-challenges + iam kms)`
+
+- Operativo:
+  `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
+  `serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev`
+- Verificacion: `serverless status --lambda=auth --stage=dev`.
+
+> Merge PR 4.
+
+---
+
+## PR 5 — `feat(auth): services internos + AppConfig + EventModel extension`
+
+#### Commit 5.1 — `feat(auth/config): AppConfig con kms_totp_key_id + webauthn_*`
+
+- Modifica `core/settings/config.py`.
+- **Verificacion**: `serverless tests --type=unit --lambda=auth`.
+
+#### Commit 5.2 — `feat(auth/services): mfa_method + totp + webauthn + recovery_codes + challenge + auth helper`
+
+- Agrega 6 services + ~25 tests.
+- **Verificacion**: `serverless tests --type=coverage --lambda=auth` (>= 85%).
+
+#### Commit 5.3 — `feat(auth/models): mfa.py + webauthn.py + login.py extension`
+
+- Agrega modelos Pydantic + ~10 tests.
+- Modifica `event.py` y `operations.py`.
+- **Verificacion**: idem.
+
+> Merge PR 5.
+
+---
+
+## PR 6 — `feat(auth): controllers mfa + webauthn (worktrees paralelos)`
+
+Worktrees T9 + T10. Mergear los 2 en un solo PR para reducir overhead.
+
+#### Commit 6.1 — `feat(auth/mfa): controllers setup-totp/confirm-totp/setup-email-code/set-preferred/disable/list`
+
+- Agrega 6 controllers de mfa basicos + 6 events + ~10 tests.
+- **AC**: AC-1..AC-6.
+- **Verificacion**: `serverless tests --type=unit --lambda=auth`.
+
+#### Commit 6.2 — `feat(auth/mfa): controllers recovery-codes-generate + recovery-codes-consume`
+
+- Agrega 2 controllers + 2 events + ~5 tests.
+- **AC**: AC-7..AC-10.
+
+#### Commit 6.3 — `feat(auth/webauthn): controllers register-options + register-verify`
+
+- Agrega 2 controllers + 2 events + 5 tests + `_fixtures.py`.
+- **AC**: AC-11, AC-12.
+
+#### Commit 6.4 — `feat(auth/webauthn): controllers login-options + login-verify`
+
+- Agrega 2 controllers + 2 events + ~5 tests.
+- **AC**: AC-13, AC-14, AC-15.
+
+#### Commit 6.5 — `feat(auth/webauthn): list-credentials + delete-credential`
+
+- Agrega 2 controllers + 2 events + 3 tests.
+- **AC**: AC-16, AC-17, AC-25.
+
+> Merge PR 6.
+
+---
+
+## PR 7 — `feat(auth): login extension con password + verify-totp`
+
+#### Commit 7.1 — `feat(auth/login): verify-password controller`
+
+- Agrega `controllers/login/verify_password.py` + event + ~3 tests.
+- **AC**: AC-18, AC-21.
+
+#### Commit 7.2 — `feat(auth/login): verify-totp controller`
+
+- Agrega `controllers/login/verify_totp.py` + event + ~2 tests.
+- **AC**: AC-19.
+
+#### Commit 7.3 — `feat(auth/login): start delta con password opcional + deteccion MFA`
+
+- Modifica `controllers/login/start.py` agregando logica de
+  password (si presente -> validar) + listar methods MFA + emitir
+  temp JWT step=2 si MFA configurado.
+- **Verificacion incremental**:
+  - tests unit del controller existente NO regresionan.
+  - tests nuevos `test_login_start_with_password_*.py` (~3) verdes.
+- **AC**: AC-20.
+
+#### Commit 7.4 — `chore(rate-limit): seed reglas MFA + WebAuthn + login.verify-* en dev/stage/prod`
+
+- Operativo. 8 reglas nuevas listadas en seccion 04.
+- Verificacion: `serverless rate-limit list --stage=dev`.
+
+#### Commit 7.5 — `chore(deploy): auth lambda -> dev`
+
+- Operativo.
+- Comando: `serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev`.
+
+> Merge PR 7.
+
+---
+
+## PR 8 — `chore(specs): verificacion E2E + cierre del plan 02-auth-mfa`
+
+#### Commit 8.1 — `test(auth): integration tests MFA + WebAuthn + login con password`
+
+- Agrega 7 archivos en `tests/integration/`.
+- **Verificacion**:
+  `serverless tests --type=integration --lambda=auth`
+  (con AWS dev + Neon dev disponibles).
+
+#### Commit 8.2 — `docs(diagrams): actualiza db-er.mmd con cluster auth_mfa_*`
+
+- Modifica `docs/diagrams/db-er.mmd`.
+
+#### Commit 8.3 — `chore(specs): elimina la carpeta efimera del plan 02`
+
+- `git rm -r docs/specs/02-auth-mfa/`.
+- **Verificacion**:
+  - Bateria completa de [11-verificacion-e2e.md](11-verificacion-e2e.md) verde.
+
+> Merge PR 8 a `dev`. Promociones a `stage` y `main` siguen
+> `.claude/rules/git-workflow.md`.
+
+## Resumen de la secuencia
+
+```text
+PR 1  spec + docs/claude                       (sin codigo)
+PR 2  shared.auth ext + shared.aws kms         transversal
+PR 3  schema + repos                           AC-23
+PR 4  infra (DDB + manifest + kms)             AC-12 (IAM)
+PR 5  services internos del lambda             transversal
+PR 6  controllers mfa + webauthn (paralelos)   AC-1..17, AC-25
+PR 7  login extension (pass + TOTP) + deploy   AC-18..22
+PR 8  E2E + ER + cleanup spec                  AC-24, AC-23
+```
+
+## Body de PR — template
+
+```markdown
+## Problema
+
+- (subscope que cubre este PR del plan 02)
+
+## Solucion
+
+- (paralelo a Problema)
+
+## Como probar
+
+```bash
+# (bateria especifica del PR)
+```
+
+## TODO
+
+- (vacio o follow-ups)
+```
+
+NUNCA atribucion de IA.

--- a/docs/specs/02-auth-mfa/09-commits.md
+++ b/docs/specs/02-auth-mfa/09-commits.md
@@ -5,7 +5,8 @@
 
 ## Modelo de PRs
 
-7 PRs en total. Cada uno deja el repo verde y deployable.
+**8 PRs en total**. Cada uno deja el repo verde y deployable. Mapeo
+1:1 con las fases del README + tareas del 08-descomposicion.
 
 ### Ramas
 
@@ -32,9 +33,13 @@ dev (post plan 01 mergeado)
 
 - Agrega `.claude/docs/auth-system/04-mfa.md`, `05-webauthn.md`.
 - Modifica `.claude/rules/auth-system.md` agregando secciones.
-- Modifica `.claude/rules/lambda-shared-imports.md` (catalogo
-  portadores: pyotp, python-fido2, cryptography, segno).
-- Modifica `.claude/skills/auth-system/SKILL.md` agregando keywords.
+- Modifica `.claude/skills/auth-system/SKILL.md` agregando keywords
+  (`mfa`, `totp`, `passkey`, `webauthn`, `2fa`, etc.).
+- **NO modifica `.claude/rules/lambda-shared-imports.md`** — el
+  catalogo se actualiza en Commit 2.3 (PR 2), una vez que el codigo
+  publicado de `shared.auth` + `shared.aws.kms` ya existe (evita la
+  ventana de incoherencia donde el catalogo cita paquetes que aun
+  no estan en `pyproject.toml`).
 - **Verificacion**:
   - markdownlint
   - 5 prompts ES via `claude -p` (validacion skill).
@@ -44,22 +49,39 @@ dev (post plan 01 mergeado)
 
 ---
 
-## PR 2 — `feat(shared): auth.totp + auth.webauthn + auth.recovery_codes + auth.encryption + aws.kms wrappers`
+## PR 2 — `feat(shared): aws.kms (CMK directa) + auth.totp + auth.webauthn + auth.recovery_codes + catalogo de portadores`
 
-#### Commit 2.1 — `feat(shared/aws): wrappers kms generate_data_key + decrypt`
+#### Commit 2.1 — `feat(shared/aws): wrappers kms_encrypt + kms_decrypt (CMK directa)`
 
-- Agrega `shared/aws/kms.py` + 4 tests (con moto).
+- Agrega `shared/aws/kms.py` con `kms_encrypt` / `kms_decrypt`
+  (Encrypt/Decrypt directos, NO GenerateDataKey).
 - Modifica `shared/aws/__init__.py` re-exports.
+- Agrega 4 tests con moto en `shared/tests/unit/shared/aws/test_kms_*.py`.
 - **Verificacion**: `serverless tests --type=unit --shared`.
 
-#### Commit 2.2 — `feat(shared/auth): envelope encryption + totp + webauthn + recovery codes`
+#### Commit 2.2 — `feat(shared/auth): totp + webauthn (post-spike) + recovery codes`
 
-- Agrega `shared/auth/{encryption,totp,webauthn,recovery_codes}.py`.
-- Modifica `shared/auth/__init__.py`, `pyproject.toml`, `uv.lock`.
-- Agrega 17 tests en `shared/tests/unit/shared/auth/`.
+- **Pre-commit**: spike de 30 min validando python-fido2 API actual
+  (ver decision 4 + nota en 03-shared-auth-extension.md). Ajustar
+  el codigo del webauthn.py si la firma difiere.
+- Agrega `shared/auth/{totp,webauthn,recovery_codes}.py`. NO
+  `encryption.py` (decision 1 — KMS CMK directa hace el cifrado).
+- Modifica `shared/auth/__init__.py`, `pyproject.toml` (agregar
+  SOLO pyotp + python-fido2, sin cryptography ni segno), `uv.lock`.
+- Agrega 13 tests en `shared/tests/unit/shared/auth/`.
 - **Verificacion**:
   - `serverless lint-deps --shared`
-  - `serverless tests --type=coverage --shared` (>= 95%)
+  - `serverless tests --type=coverage --shared` (>= 80% per-file).
+
+#### Commit 2.3 — `docs(claude): catalogo de portadores con pyotp + python-fido2 + boto3.kms`
+
+- Modifica `.claude/rules/lambda-shared-imports.md` agregando los 3
+  paquetes nuevos al catalogo. Hace este commit en PR 2 (NO en PR 1)
+  para que el catalogo refleje SIEMPRE el codigo publicado, sin
+  ventana de incoherencia.
+- **Verificacion**:
+  - markdownlint
+  - skill validation (`.claude/rules/claude-config-testing.md`)
 
 > Merge PR 2.
 
@@ -240,14 +262,14 @@ Worktrees T9 + T10. Mergear los 2 en un solo PR para reducir overhead.
 ## Resumen de la secuencia
 
 ```text
-PR 1  spec + docs/claude                       (sin codigo)
-PR 2  shared.auth ext + shared.aws kms         transversal
+PR 1  spec + docs/claude (sin catalogo aun)    (sin codigo)
+PR 2  shared.aws.kms + shared.auth ext + catalogo  transversal
 PR 3  schema + repos                           AC-23
-PR 4  infra (DDB + manifest + kms)             AC-12 (IAM)
+PR 4  infra (DDB + manifest + spike provisioner)  AC-12 (IAM)
 PR 5  services internos del lambda             transversal
 PR 6  controllers mfa + webauthn (paralelos)   AC-1..17, AC-25
-PR 7  login extension (pass + TOTP) + deploy   AC-18..22
-PR 8  E2E + ER + cleanup spec                  AC-24, AC-23
+PR 7  login ext (pass + TOTP) + rate-limit IP + deploy  AC-18..22
+PR 8  E2E + ER + cleanup spec                  AC-23, AC-24, AC-26, AC-27
 ```
 
 ## Body de PR — template

--- a/docs/specs/02-auth-mfa/10-paralelizacion-worktrees.md
+++ b/docs/specs/02-auth-mfa/10-paralelizacion-worktrees.md
@@ -1,0 +1,156 @@
+# 10. Paralelizacion con git worktrees — plan 02
+
+## Base secuencial
+
+```text
+PR 1  T1 plan + docs/claude            <-- BASE 1
+PR 2  T2 shared.auth + T3 shared.aws   <-- BASE 2 (transversal)
+PR 3  T4 schema + repos                <-- BASE 3
+PR 4  T5 infra + T6 manifest+provis    <-- BASE 4
+PR 5  T7 services + T8 EventModel      <-- BASE 5
+```
+
+BASE 1..5 secuencial. Cada PR mergeado antes de empezar el siguiente.
+
+## Fase paralela: worktrees tras PR 5 mergeado
+
+Tras PR 5 mergeado en `dev`, el repo tiene services + EventModel
+listos. Los controllers no existen aun. Se abre ventana de
+paralelizacion:
+
+| Worktree | Tarea | Archivos nuevos | Modificados | Colision? |
+|----------|-------|-----------------|-------------|-----------|
+| WT-A | T9 controllers mfa | `controllers/mfa/*` + tests + events | ninguno | no |
+| WT-B | T10 controllers webauthn | `controllers/webauthn/*` + tests + events | ninguno | no |
+| WT-C | T11 login extension | `controllers/login/{verify_password,verify_totp}.py` + tests | `controllers/login/start.py` | si — con T9 si T9 toca login/start (no lo toca, OK) |
+
+WT-A y WT-B son 100% disjuntos. WT-C modifica `login/start.py` que
+es un archivo del plan 01. NO se solapa con WT-A ni WT-B porque T9
+solo toca `controllers/mfa/` y T10 solo `controllers/webauthn/`.
+
+### Tabla de colisiones
+
+| Archivo | T9 | T10 | T11 | Status |
+|---------|-----|------|------|--------|
+| `controllers/mfa/*` | WRITE | — | — | exclusivo T9 |
+| `controllers/webauthn/*` | — | WRITE | — | exclusivo T10 |
+| `controllers/login/verify_password.py` | — | — | WRITE | exclusivo T11 |
+| `controllers/login/verify_totp.py` | — | — | WRITE | exclusivo T11 |
+| `controllers/login/start.py` | — | — | WRITE | exclusivo T11 |
+| `events/mfa-*.json` | WRITE | — | — | exclusivo T9 |
+| `events/webauthn-*.json` | — | WRITE | — | exclusivo T10 |
+| `events/login-verify-*.json` | — | — | WRITE | exclusivo T11 |
+| `tests/unit/controllers/test_mfa_*.py` | WRITE | — | — | exclusivo T9 |
+| `tests/unit/controllers/test_webauthn_*.py` | — | WRITE | — | exclusivo T10 |
+| `tests/unit/controllers/test_login_*.py` | — | — | WRITE (nuevos) | exclusivo T11 |
+| `tests/unit/controllers/webauthn/_fixtures.py` | — | WRITE | — | exclusivo T10 |
+| `core/models/event.py` | — | — | — | sin cambios (ya hecho en T8/PR 5) |
+| `core/models/{mfa,webauthn,login}.py` | — | — | — | sin cambios (ya hecho en T8/PR 5) |
+
+Sin colisiones. 3 worktrees concurrentes.
+
+## Fase secuencial final
+
+```text
+T11 paralelizado con T9 + T10 (PR 6 + PR 7 puede mergearse en orden).
+
+Tras los 3 worktrees mergeados:
+- PR 7.4  rate-limit seed                 (operativo)
+- PR 7.5  deploy auth -> dev              (operativo)
+- PR 8    integration tests + ER + cleanup (verificacion E2E)
+```
+
+## Como lanzar un worktree
+
+Mismo patron que plan 01. Ejemplo para WT-B (webauthn):
+
+```bash
+# Asumiendo dev al dia con PR 5 mergeado
+git checkout dev
+git pull origin dev
+
+git worktree add ../portfolio-wt-webauthn-controllers feature/auth-mfa-6-webauthn
+cd ../portfolio-wt-webauthn-controllers
+git checkout -b feature/auth-mfa-6-webauthn
+
+# Instalar deps
+pnpm install
+cd serverless/lambda/services/auth && uv sync
+
+# Implementar T10
+#  - controllers/webauthn/register_options.py
+#  - controllers/webauthn/register_verify.py
+#  - controllers/webauthn/login_options.py
+#  - controllers/webauthn/login_verify.py
+#  - controllers/webauthn/list_credentials.py
+#  - controllers/webauthn/delete_credential.py
+#  - tests/unit/controllers/webauthn/_fixtures.py
+#  - tests/unit/controllers/test_webauthn_*.py
+#  - events/webauthn-*.json
+
+# Verificar
+serverless tests --type=unit --lambda=auth
+serverless run --stage=local --lambda=auth --event=events/webauthn-register-options.json
+
+# Commit + push
+git add -A
+git commit -m "feat(auth/webauthn): controllers register-options + register-verify + login-options + login-verify + list + delete"
+git push -u origin feature/auth-mfa-6-webauthn
+gh pr create --base dev --title "feat(auth): webauthn controllers" --body "..."
+```
+
+### Con subagentes en paralelo
+
+3 instancias de `Agent` con `isolation: "worktree"`. Cada una con
+prompt apuntando al archivo de la tarea correspondiente:
+
+```text
+Agent A (T9 mfa): "Implementar segun docs/specs/02-auth-mfa/05-...md
+  controller mfa.* + docs/specs/02-auth-mfa/08-...md tarea T9"
+Agent B (T10 webauthn): "... seccion webauthn + tarea T10"
+Agent C (T11 login extension): "... login + tarea T11"
+```
+
+## Que NO se paraleliza
+
+- T1, T2, T3, T4, T5, T6, T7, T8: dependencias estrictas.
+- `event.py`, `operations.py`: editados SOLO en T8 (PR 5). Cada
+  worktree asume el EventModel ya extendido.
+- T6 (`provisioner.py`): central; se hace antes de T7.
+- T12 (seccion 11): cierre.
+
+## Anti-patrones evitados
+
+| Anti-patron | Como lo evitamos |
+|-------------|------------------|
+| WT-C y WT-A editan login/start.py | WT-A no toca login/* — solo controllers/mfa/* |
+| WT-B y WT-A editan event.py | event.py se cierra en T8/PR 5, NO en los worktrees |
+| WT-B y WT-C editan models/login.py | models/login.py se cierra en T8/PR 5 |
+| Mas de 5 worktrees | Maximo 3 (T9, T10, T11) |
+
+## Resumen visual
+
+```text
+PR 1 spec+docs/claude            ─┐
+PR 2 shared.auth + aws.kms       ─┤
+PR 3 schema + repos              ─┤   BASE secuencial
+PR 4 infra + manifest            ─┤
+PR 5 services + EventModel       ─┘
+                                  │
+       ┌──────────────┬───────────┼───────────┐
+       │              │           │           │
+     WT-A           WT-B        WT-C
+   mfa            webauthn    login-ext
+   controllers   controllers
+       │              │           │
+       └──────────────┼───────────┘
+                      │
+              PR 6 (T9 mfa + T10 webauthn)
+              PR 7 (T11 login + rate-limit + deploy)
+                      │
+                      v
+              PR 8 verificacion E2E + cleanup (SEC. 11)
+```
+
+Maximo paralelismo util: **3 worktrees concurrentes** (T9, T10, T11)
+durante la fase de controllers. Resto secuencial.

--- a/docs/specs/02-auth-mfa/11-verificacion-e2e.md
+++ b/docs/specs/02-auth-mfa/11-verificacion-e2e.md
@@ -1,0 +1,279 @@
+# 11. Verificacion E2E iterativa — plan 02
+
+> Ultima fase. Gate del PR 8.
+
+## Parte A — refactor de tests
+
+| Archivo | Accion |
+|---------|--------|
+| `services/auth/tests/integration/test_mfa_*.py` (3) | CREAR |
+| `services/auth/tests/integration/test_webauthn_*.py` (2) | CREAR |
+| `services/auth/tests/integration/test_login_with_password_and_mfa_e2e.py` | CREAR |
+| `services/auth/tests/integration/test_migration_00000003_up_down_e2e.py` | CREAR |
+| `services/auth/tests/integration/test_totp_secret_at_rest_encrypted_e2e.py` | CREAR |
+| `services/auth/tests/unit/...` | sin cambios (creados en PRs 5-7) |
+| `services/auth/tests/unit/controllers/login/test_login_start_*.py` (plan 01) | revisar — algunos pueden necesitar adaptarse al nuevo body con `password` opcional |
+| `docs/diagrams/db-er.mmd` | MODIFICAR |
+| `docs/specs/02-auth-mfa/` | ELIMINAR |
+
+### Barrido global
+
+```bash
+# Tests del plan 01 con `password` en body — verificar que NO romperon
+rg -l "password" serverless/lambda/services/auth/tests/unit/controllers/login/
+
+# Codigo eliminado (no aplica — este plan no elimina nada)
+rg -l "deprecated_totp|legacy_mfa" serverless/
+
+# TODOs/FIXMEs del scope
+rg -l "TODO.*mfa|FIXME.*webauthn|TODO.*passkey" serverless/lambda/services/auth/
+```
+
+## Parte B — bateria de comandos reales
+
+### Bloque 1 — sintaxis + lint
+
+```bash
+python -m compileall -q \
+  serverless/lambda/shared/auth \
+  serverless/lambda/shared/aws \
+  serverless/lambda/shared/db/models/auth \
+  serverless/lambda/shared/db/repositories \
+  serverless/lambda/services/auth
+
+python devtools/run.py serverless lint --lambda=auth
+python devtools/run.py serverless lint --shared
+
+python devtools/run.py serverless lint-deps --lambda=auth
+python devtools/run.py serverless lint-deps --shared
+# Esperado: shared.auth ahora declara pyotp+fido2+cryptography+segno
+# Lambda auth NO duplica (D-3 OK)
+```
+
+### Bloque 2 — tests unit + coverage
+
+```bash
+python devtools/run.py serverless tests --type=unit --shared
+python devtools/run.py serverless tests --type=unit --lambda=auth
+python devtools/run.py serverless tests --type=coverage --lambda=auth
+# Verificar coverage per-file >= 85% en controllers/{mfa,webauthn,login}/
+# y >= 95% en shared/auth/{totp,webauthn,recovery_codes,encryption}.py
+```
+
+### Bloque 3 — run local (RIE) por endpoint nuevo
+
+```bash
+# mfa.setup-totp requires un access JWT valido en _meta.authorization
+# El event JSON debe traer un JWT generado en setup local
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/mfa-setup-totp.json
+# Esperado: 200 con secret_b32 + otpauth_url + qr_code_svg
+
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/mfa-confirm-totp.json
+# Esperado: 204 (o 400 si el code del event esta vencido)
+
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/webauthn-register-options.json
+# Esperado: 200 con challenge_id + options.publicKey.{challenge, rp.id, user.id}
+
+python devtools/run.py serverless run --stage=local --lambda=auth \
+  --event=events/login-verify-password.json
+# Esperado: 200 con temp_token (step=2) o access+refresh si no MFA
+```
+
+### Bloque 4 — migration en branch Neon
+
+```bash
+neon branches create --name verify-mfa-plan --parent main
+BRANCH_URL="$(neon connection-string verify-mfa-plan)"
+
+# Aplicar 00000002 y 00000003 sequentially
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/migrate.json
+
+# Verificar tablas auth_mfa_*
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/tables.json | \
+  grep -E "auth_(mfa_methods|mfa_recovery_codes|webauthn_credentials)"
+
+# down -1 (vuelve a 00000002)
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/downgrade.json
+
+# up de nuevo (idempotencia)
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/migrate.json
+
+neon branches delete verify-mfa-plan
+```
+
+AC verificada: **AC-23**.
+
+### Bloque 5 — integration tests con AWS dev
+
+```bash
+# Asegurar deploys actualizados
+serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
+
+# Migration aplicada en dev
+serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev
+serverless run --stage=dev --lambda=db --event=events/current.json --aws-profile=tfs-dev
+# Esperado: revision 00000003
+
+# Integration tests
+python devtools/run.py serverless tests --type=integration --lambda=auth
+```
+
+### Bloque 6 — smoke E2E HTTP en dev
+
+```bash
+API="https://api.portfolio.dev.the-full-stack.com/auth"
+TURNSTILE_BYPASS="$(grep -m1 '^TURNSTILE_BYPASS_SECRET=' docker/env/server/.dev | cut -d= -f2-)"
+
+# 1. Crear user y obtener access JWT (asumiendo flow del plan 01 ya
+#    expuesto en dev)
+EMAIL="mfa-smoke-$(date +%s)@example.com"
+
+# Skip toda la fase de register/verify (se asume flow del plan 01
+# funcional). Para el smoke, usar el endpoint
+# (futuro) /auth#admin.create-test-user que NO existe.
+# Alternativa: completar el flow manualmente via curl.
+
+# Aqui se asume que se tiene un ACCESS_TOKEN valido en variable
+ACCESS="<access-token-obtenido-del-flow-de-plan-01>"
+
+# 2. mfa.setup-totp
+curl -sS -X POST "$API" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"mfa","action":"setup-totp","data":{}}' | jq .
+# Esperado: data.secret_b32 (string base32), data.otpauth_url, data.qr_code_svg
+# AC-1 verificada
+
+# 3. mfa.confirm-totp con code generado por pyotp
+SECRET="<secret_b32 obtenido>"
+CODE=$(python -c "import pyotp; print(pyotp.TOTP('$SECRET').now())")
+curl -sS -X POST "$API" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d "{\"operation\":\"mfa\",\"action\":\"confirm-totp\",\"data\":{\"code\":\"$CODE\"}}"
+# Esperado: 204
+# AC-2 verificada
+
+# 4. mfa.recovery-codes-generate
+curl -sS -X POST "$API" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"mfa","action":"recovery-codes-generate","data":{}}' | jq .data
+# Esperado: data.codes -> array de 10 strings 10 chars cada uno
+# AC-7 verificada
+
+# 5. Verificar at-rest encryption del TOTP secret
+# (consulta directa a Neon — la lambda no lo expone)
+psql "<DATABASE_URL del branch dev>" \
+  -c "SELECT user_id, encode(totp_secret_ciphertext, 'hex') FROM auth_mfa_methods WHERE kind='totp' LIMIT 1;"
+# Esperado: ciphertext en hex, NO el secret_b32 plain
+# AC-24 verificada
+```
+
+### Bloque 7 — verificacion del PR 8 (cierre)
+
+```bash
+# 1. spec eliminada
+test ! -d docs/specs/02-auth-mfa && echo "OK" || echo "FAIL"
+
+# 2. ER actualizado
+grep -q "auth_mfa_methods" docs/diagrams/db-er.mmd && echo "ER OK"
+grep -q "auth_webauthn_credentials" docs/diagrams/db-er.mmd && echo "ER OK"
+
+# 3. Skill auth-system tiene keywords MFA
+grep -q "totp\|webauthn\|passkey\|mfa" .claude/skills/auth-system/SKILL.md && echo "skill OK"
+
+# 4. Validacion skill
+claude --permission-mode bypassPermissions \
+  --disallowedTools "WebSearch" "WebFetch" \
+  --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
+  --output-format json \
+  -p "como funciona webauthn passkeys en el portfolio" 2>&1 | tail -10
+# Esperado: num_turns > 1
+```
+
+## Parte C — bucle de correccion
+
+```text
+ejecutar bloque N
+   |
+   v
+{paso?}--si--> bloque N+1
+   |
+   no
+   |
+   v
+diagnosticar (logs CloudWatch + tail de tests + queries DB)
+   |
+   v
+corregir codigo / test / config
+   |
+   v
+re-ejecutar el bloque que fallo
+   |
+   +-----------> volver
+```
+
+### Errores tipicos
+
+| Sintoma | Diagnostico | Correccion |
+|---------|-------------|------------|
+| `KMS not authorized to GenerateDataKey` | IAM role del lambda sin `kms:GenerateDataKey` | Verificar `manifest.yaml.uses.kms` esta declarado + provisioner aplica policy |
+| `Webauthn challenge expired` aun en < 5min | DDB TTL aplico antes — clock drift | Aumentar TTL a 600s en el commit del scaffold (o ver clock skew Lambda) |
+| `Webauthn rp_id mismatch` | `WEBAUTHN_RP_ID` no matchea el `origin` del header | Ajustar env var por stage (apex en prod, subdomain en dev/stage) |
+| `pyotp.TOTP(secret).verify(code) returns False` aun con code correcto | Clock drift entre client y server > 30s | `valid_window=1` en `verify_totp_code` (ya esta por default) |
+| `Recovery code consumed_at race` | 2 requests concurrentes del mismo code | Usar UPDATE ... WHERE consumed_at IS NULL RETURNING * (atomic) |
+| `pyotp ImportError` en lambda | uv lock desactualizado | `cd serverless/lambda/services/auth && uv sync` |
+| `lint-deps reporta python-fido2 duplicada` | Lambda declara fido2 ademas de shared.auth | Retirar del pyproject.toml del lambda |
+| Migration falla por `auth_users not exists` | branch Neon no tiene plan 01 aplicado | Aplicar 00000002 primero |
+| `aws ssm GetParameter access denied` para webauthn-challenges name | provisioner no agrego el SSM path al IAM | Verificar `uses.tables.webauthn-challenges` en el manifest |
+
+## Regla de cierre
+
+NO se marca completa mientras:
+
+- Algun bloque falle,
+- Algun test rojo,
+- Coverage per-file < 85% en controllers nuevos,
+- < 95% en `shared/auth/{totp,webauthn,recovery_codes,encryption}.py`,
+- La carpeta `docs/specs/02-auth-mfa/` siga viva.
+
+Iterar hasta verde. Solo entonces:
+
+```bash
+git add -A
+git commit -m "chore(specs): elimina la carpeta efimera del plan 02-auth-mfa"
+git push -u origin feature/auth-mfa-8-verificacion-e2e
+gh pr create --base dev --title "chore(specs): verificacion E2E + cierre del plan 02-auth-mfa" --body "..."
+```
+
+## Promocion dev -> stage -> main
+
+Tras PR 8 mergeado:
+
+```bash
+gh pr create --base stage --head dev --title "chore: promover plan-02-auth-mfa a stage"
+gh pr merge --merge
+gh pr create --base main --head stage --title "chore: promover plan-02-auth-mfa a main"
+gh pr merge --merge
+```
+
+CI auto-deploya `auth` con el nuevo codigo + aplica migration en
+stage/prod automaticamente (deploy-backend.yml).
+
+## Pendientes que el PR 8 NO cubre
+
+- UI Astro de MFA setup (QR scanner mobile-friendly, WebAuthn JS API
+  invoke, recovery codes download).
+- Email worker plantillas adicionales (`mfa-confirmed-alert`,
+  `mfa-disabled-alert`, `passkey-added-alert`).
+- Quedan para planes futuros o se agregan inline al plan 03.
+
+Estos pendientes se documentan en el `## TODO` del PR 8.

--- a/docs/specs/02-auth-mfa/11-verificacion-e2e.md
+++ b/docs/specs/02-auth-mfa/11-verificacion-e2e.md
@@ -10,7 +10,10 @@
 | `services/auth/tests/integration/test_webauthn_*.py` (2) | CREAR |
 | `services/auth/tests/integration/test_login_with_password_and_mfa_e2e.py` | CREAR |
 | `services/auth/tests/integration/test_migration_00000003_up_down_e2e.py` | CREAR |
-| `services/auth/tests/integration/test_totp_secret_at_rest_encrypted_e2e.py` | CREAR |
+| `services/auth/tests/integration/test_totp_secret_at_rest_encrypted_e2e.py` | CREAR — AC-24 (verifica kms:Encrypt output, sin nonce ni data_key) |
+| `services/auth/tests/integration/test_passkey_does_not_migrate_envs_e2e.py` | CREAR — AC-26 |
+| `services/auth/tests/integration/test_first_mfa_confirm_revokes_sessions_e2e.py` | CREAR — AC-27 |
+| `services/auth/tests/integration/test_recovery_requires_strong_factor_e2e.py` | CREAR — AC-9b |
 | `services/auth/tests/unit/...` | sin cambios (creados en PRs 5-7) |
 | `services/auth/tests/unit/controllers/login/test_login_start_*.py` (plan 01) | revisar — algunos pueden necesitar adaptarse al nuevo body con `password` opcional |
 | `docs/diagrams/db-er.mmd` | MODIFICAR |
@@ -46,8 +49,9 @@ python devtools/run.py serverless lint --shared
 
 python devtools/run.py serverless lint-deps --lambda=auth
 python devtools/run.py serverless lint-deps --shared
-# Esperado: shared.auth ahora declara pyotp+fido2+cryptography+segno
-# Lambda auth NO duplica (D-3 OK)
+# Esperado: shared.auth ahora declara pyotp+python-fido2 (NO cryptography,
+# NO segno — decision 1 + 8); shared.aws declara boto3 (ya existia).
+# Lambda auth NO duplica (D-3 OK).
 ```
 
 ### Bloque 2 — tests unit + coverage
@@ -67,7 +71,8 @@ python devtools/run.py serverless tests --type=coverage --lambda=auth
 # El event JSON debe traer un JWT generado en setup local
 python devtools/run.py serverless run --stage=local --lambda=auth \
   --event=events/mfa-setup-totp.json
-# Esperado: 200 con secret_b32 + otpauth_url + qr_code_svg
+# Esperado: 200 con secret_b32 + otpauth_url (sin qr_code_svg — el QR
+# lo renderiza el frontend, decision 8)
 
 python devtools/run.py serverless run --stage=local --lambda=auth \
   --event=events/mfa-confirm-totp.json
@@ -148,7 +153,8 @@ curl -sS -X POST "$API" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ACCESS" \
   -d '{"operation":"mfa","action":"setup-totp","data":{}}' | jq .
-# Esperado: data.secret_b32 (string base32), data.otpauth_url, data.qr_code_svg
+# Esperado: data.secret_b32 (string base32), data.otpauth_url. Sin
+# data.qr_code_svg — el frontend renderiza el QR.
 # AC-1 verificada
 
 # 3. mfa.confirm-totp con code generado por pyotp
@@ -172,9 +178,32 @@ curl -sS -X POST "$API" \
 # 5. Verificar at-rest encryption del TOTP secret
 # (consulta directa a Neon — la lambda no lo expone)
 psql "<DATABASE_URL del branch dev>" \
-  -c "SELECT user_id, encode(totp_secret_ciphertext, 'hex') FROM auth_mfa_methods WHERE kind='totp' LIMIT 1;"
-# Esperado: ciphertext en hex, NO el secret_b32 plain
+  -c "SELECT user_id, encode(totp_secret_ciphertext, 'hex'),
+             totp_secret_ciphertext IS NOT NULL AS has_ct
+      FROM auth_mfa_methods WHERE kind='totp' LIMIT 1;"
+# Esperado: ciphertext en hex (output de kms:Encrypt con CMK directa),
+# NO el secret_b32 plain. NO existen columnas totp_secret_nonce ni
+# totp_data_key_ciphertext (decision 1).
 # AC-24 verificada
+
+# 6. Verificar que passkeys no migran entre envs (AC-26)
+# Smoke manual: registrar passkey en dev (RP_ID portfolio.dev.the-full-stack.com),
+# luego intentar login en prod (RP_ID the-full-stack.com).
+# Esperado: webauthn.login-options en prod devuelve allowCredentials=[]
+# para el mismo user_id, porque los credentials del user en prod
+# tienen RP_ID distinto y no matchean.
+# El test integration `test_passkey_does_not_migrate_envs_e2e.py`
+# automatiza esto con dos SoftWebauthnDevice configurados con RP_ID
+# distinto.
+
+# 7. Verificar revocacion de sessions tras primer MFA (AC-27)
+# Flow:
+#   a) login.start con password (no MFA) -> access+refresh
+#   b) mfa.setup-totp -> mfa.confirm-totp con primer code
+#   c) /session/refresh con el refresh anterior
+# Esperado: 401 TOKEN_FAMILY_REVOKED
+# El test integration `test_first_mfa_confirm_revokes_sessions_e2e.py`
+# automatiza esto.
 ```
 
 ### Bloque 7 — verificacion del PR 8 (cierre)
@@ -225,7 +254,8 @@ re-ejecutar el bloque que fallo
 
 | Sintoma | Diagnostico | Correccion |
 |---------|-------------|------------|
-| `KMS not authorized to GenerateDataKey` | IAM role del lambda sin `kms:GenerateDataKey` | Verificar `manifest.yaml.uses.kms` esta declarado + provisioner aplica policy |
+| `KMS not authorized to Encrypt` / `Decrypt` | IAM role del lambda sin `kms:Encrypt` o `kms:Decrypt` | Verificar `manifest.yaml.uses.kms` declara ambas actions + provisioner aplica policy (decision 1 — CMK directa, NO envelope) |
+| `InvalidCiphertextException` en `kms:Decrypt` | `EncryptionContext` no matchea el del encrypt (suele ser `user_id` distinto si se cachea mal) | Verificar que el `user_id` en `data['_meta']` coincide con el del row `auth_mfa_methods` |
 | `Webauthn challenge expired` aun en < 5min | DDB TTL aplico antes — clock drift | Aumentar TTL a 600s en el commit del scaffold (o ver clock skew Lambda) |
 | `Webauthn rp_id mismatch` | `WEBAUTHN_RP_ID` no matchea el `origin` del header | Ajustar env var por stage (apex en prod, subdomain en dev/stage) |
 | `pyotp.TOTP(secret).verify(code) returns False` aun con code correcto | Clock drift entre client y server > 30s | `valid_window=1` en `verify_totp_code` (ya esta por default) |
@@ -241,8 +271,8 @@ NO se marca completa mientras:
 
 - Algun bloque falle,
 - Algun test rojo,
-- Coverage per-file < 85% en controllers nuevos,
-- < 95% en `shared/auth/{totp,webauthn,recovery_codes,encryption}.py`,
+- Coverage per-file < 80% en archivos modificados (alineado con
+  `.claude/rules/git-hooks.md` y `.claude/rules/verify-before-done.md`),
 - La carpeta `docs/specs/02-auth-mfa/` siga viva.
 
 Iterar hasta verde. Solo entonces:

--- a/docs/specs/02-auth-mfa/README.md
+++ b/docs/specs/02-auth-mfa/README.md
@@ -1,0 +1,188 @@
+# Plan 02: Auth MFA — TOTP + email-code-as-MFA + WebAuthn / Passkeys
+
+> **Orden en la serie auth**: este es el **2 de 3** planes secuenciales.
+>
+> ```text
+> 01 — auth-infra-basics       (DEPENDENCIA: shared.auth + schema + lambda auth basico)
+> 02 — auth-mfa                <-- ESTE PLAN (TOTP + email-MFA + WebAuthn)
+> 03 — auth-users-management   (Lambda `users` con profile/status/admin)
+> ```
+>
+> **Dependencia dura**: requiere el plan 01 completamente mergeado a `dev`
+> (idealmente a `main`). Este plan extiende el Lambda `auth` con las
+> operations `mfa` y `webauthn`, agrega 3 tablas Neon
+> (`auth_mfa_methods`, `auth_webauthn_credentials`, `auth_webauthn_challenges`)
+> y suma `pyotp` + `fido2` al subpackage `shared.auth`.
+
+## Que entrega este plan
+
+- **Schema Neon (migration 00000003)**:
+  - `auth_mfa_methods`: enum `mfa_kind` (totp|email_code), preferred,
+    user_id FK, secret encrypted (solo TOTP), recovery_codes_hash JSONB,
+    confirmed_at, last_used_at, disabled_at.
+  - `auth_webauthn_credentials`: credential_id (BYTEA UK), public_key
+    BYTEA, sign_count INT, transports JSONB, attestation_format, aaguid,
+    user_id FK, nickname, created_at, last_used_at.
+  - `auth_webauthn_challenges`: tabla efimera de challenges (TTL via
+    DELETE despues de 5 min). En realidad: usar DynamoDB con TTL en
+    vez de tabla Neon — decision en seccion 1.
+- **Shared subpackage `shared.auth` (extension)**: agrega `pyotp`
+  + `fido2`. Modulos nuevos: `totp.py`, `webauthn.py`,
+  `recovery_codes.py`. Sigue siendo UN solo portador.
+- **DynamoDB nueva**: `portfolio-webauthn-challenges-${stage}` (PK
+  `challenge_id`, TTL `expires_at` = 5 min). Challenges WebAuthn son
+  por naturaleza efimeros y MUCHOS por segundo en uso.
+- **Lambda `auth` extension** — nuevas operations:
+  - `mfa.setup-totp` (genera secret + QR code) — requiere temp JWT del
+    flujo `setup-mfa`.
+  - `mfa.confirm-totp` (verifica primer codigo TOTP -> guarda secret).
+  - `mfa.setup-email-code` (marca email-code como metodo activo).
+  - `mfa.set-preferred` (cambia preferido entre los metodos activos).
+  - `mfa.disable` (deshabilita un metodo; al menos uno debe quedar).
+  - `mfa.recovery-codes-generate` (10 codes de 10 chars; muestra UNA vez).
+  - `mfa.recovery-codes-consume` (consume 1 code -> levanta MFA bypass).
+  - `webauthn.register-options` (challenge para crear credential).
+  - `webauthn.register-verify` (valida attestation + guarda credential).
+  - `webauthn.login-options` (challenge para login).
+  - `webauthn.login-verify` (valida assertion + emite access+refresh).
+  - `webauthn.list-credentials` (devuelve credentials del user).
+  - `webauthn.delete-credential` (borra credential por id).
+- **Login con MFA**: extiende `login.start` para devolver
+  `methods` ampliado (`magic-link`, `email-code`, `totp`, `password`,
+  `webauthn`) basado en `auth_mfa_methods`, `auth_credentials`,
+  `auth_webauthn_credentials`. Cuando user tiene password seteada,
+  `login.start` con `password=<X>` opcional valida y pide MFA si
+  configurado. Nueva action: `login.verify-totp`, `login.verify-password`.
+
+## Que NO entrega este plan
+
+- Lambda `users` (profile, status, admin) -> **plan 03**.
+- Frontend Astro de MFA setup (QR scanner, WebAuthn JS, recovery
+  codes UI) -> plan futuro.
+- SMS/Twilio como MFA — fuera de scope.
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| Problema, solucion, AC numerados | [01-contexto-y-decision.md](01-contexto-y-decision.md) |
+| Schema Neon extension (3 tablas nuevas) | [02-schema-neon-mfa.md](02-schema-neon-mfa.md) |
+| Shared.auth extension (TOTP + WebAuthn + recovery codes) | [03-shared-auth-extension.md](03-shared-auth-extension.md) |
+| Infraestructura: DynamoDB challenges + SSM nuevos | [04-infraestructura.md](04-infraestructura.md) |
+| Arquitectura del Lambda auth: nuevas operations mfa + webauthn | [05-lambda-auth-extensions.md](05-lambda-auth-extensions.md) |
+| Testing (unit + integration + WebAuthn fixtures) | [06-testing.md](06-testing.md) |
+| Archivos afectados con verificacion por archivo | [07-archivos-afectados.md](07-archivos-afectados.md) |
+| Descomposicion en tareas atomicas | [08-descomposicion-paralelizacion.md](08-descomposicion-paralelizacion.md) |
+| Commits incrementales | [09-commits.md](09-commits.md) |
+| Paralelizacion con git worktrees | [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md) |
+| Verificacion E2E iterativa | [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Estado por fase
+
+| Fase | Descripcion | Estado |
+|------|-------------|--------|
+| 0 | Plan 01 mergeado a `dev` (prerequisito) | pending (depende de 01) |
+| 1 | Plan escrito + carpeta `docs/specs/02-auth-mfa/` commiteada | pending |
+| 2 | Schema Neon `auth_mfa_methods` + `auth_webauthn_credentials` (migration 00000003) | pending |
+| 3 | `shared.auth` extension (pyotp + fido2 + totp/webauthn/recovery_codes) | pending |
+| 4 | DynamoDB `webauthn-challenges` + SSM `webauthn-encryption-key` | pending |
+| 5 | Lambda `auth` operation `mfa` (setup-totp, confirm-totp, setup-email-code, set-preferred, disable) | pending |
+| 6 | Lambda `auth` operation `mfa` (recovery-codes-generate, recovery-codes-consume) | pending |
+| 7 | Lambda `auth` operation `webauthn` (register-options, register-verify) | pending |
+| 8 | Lambda `auth` operation `webauthn` (login-options, login-verify, list, delete) | pending |
+| 9 | Extension de `login.start` para detectar metodos MFA del user + nuevos `login.verify-*` (password, totp) | pending |
+| 10 | Rate-limit rules nuevas + integracion + audit log events nuevos | pending |
+| 11 | Verificacion E2E + actualizacion ER + limpieza spec | pending |
+
+## Decisiones no-reabribles
+
+1. **WebAuthn challenges en DynamoDB, NO en Neon**: los challenges
+   son efimeros (5 min TTL), 1 por intento de register/login, en uso
+   activo pueden ser muchos por usuario. TTL nativo + lookup O(1)
+   justifican DDB. La tabla `auth_webauthn_challenges` propuesta
+   originalmente se descarta.
+2. **TOTP secret cifrado at-rest con KMS DataKey**: el secret de
+   TOTP es un secreto sensible (permite generar codes validos). Se
+   cifra con AWS KMS GenerateDataKey + AES-256-GCM antes de guardarlo
+   en `auth_mfa_methods.totp_secret_ciphertext`. La envelope encryption
+   key se identifica por `data_key_ciphertext` (almacenado al lado).
+3. **Recovery codes: 10 codes de 10 chars Crockford, mostrados UNA vez**:
+   se muestran al setear MFA exitoso por primera vez. Hash SHA-256 en
+   DB (`auth_mfa_recovery_codes` tabla nueva o JSONB en
+   `auth_mfa_methods.recovery_codes_hash`). Decision: tabla aparte
+   `auth_mfa_recovery_codes` (id, user_id FK, code_hash UK, consumed_at
+   NULL) para auditoria individual por code consumido.
+4. **fido2 lib**: `python-fido2>=1.1,<2.0` (Yubico). Soporta WebAuthn
+   L2 + L3 partial. Implementa validacion de attestation (`none`,
+   `direct`, `indirect`, `packed`, `tpm`, `android-key`).
+5. **WebAuthn RP_ID y origin**: `RP_ID = 'the-full-stack.com'`
+   (matchea el apex + todos los subdomains). `expected_origin` lista
+   de los 6 hostnames de prod + sus equivalentes dev/stage. En el cold
+   start, leer de env var `WEBAUTHN_ALLOWED_ORIGINS`.
+6. **User verification (UV)**: requerir UV=`preferred` en register,
+   `required` en login (ie biometric/PIN confirm). Trade-off: algunos
+   YubiKeys no tienen UV; preferimos seguridad sobre cobertura
+   universal.
+7. **TOTP issuer label**: `the-full-stack.com:<email>` para que el QR
+   muestre nombre del sitio + email en Google/Authy. RFC 6238 standard.
+8. **Login con password opcional**: `login.start` acepta `password`
+   opcional en el body. Si password presente: valida ANTES de devolver
+   los methods. Si match: emite temp JWT con flow=`login-mfa` step=2
+   y devuelve la lista de MFA methods. Si MFA no configurado: emite
+   access+refresh directo (skip MFA). Si MFA configurado: el cliente
+   llama a `login.verify-totp` o `webauthn.login-verify`.
+9. **Bypass MFA con recovery code**: action
+   `mfa.recovery-codes-consume` acepta temp JWT del flujo login (con
+   step=2 post-password) + el code. Si match: emite access+refresh y
+   marca el code como consumed. NO se puede recovery-code-consume sin
+   haber pasado password primero (defense in depth).
+10. **Migration 00000003 forward-only en prod**: el downgrade tira
+    `auth_webauthn_credentials` que puede tener data real de usuarios.
+    El `downgrade()` se implementa (para branches de prueba) pero NO
+    se corre en `prod` nunca.
+
+## Reglas criticas (siempre activas)
+
+- **SIEMPRE** TOTP secret se cifra con envelope encryption (KMS
+  DataKey + AES-256-GCM) antes de persistir en Neon. NUNCA en plain
+  text.
+- **SIEMPRE** las recovery codes se muestran UNA sola vez (response
+  de `recovery-codes-generate`). El frontend debe guardarlas. El
+  backend SOLO guarda el hash SHA-256.
+- **SIEMPRE** WebAuthn challenge se valida contra DDB con TTL antes de
+  consumir. Single-use: tras verificar exitosa, DELETE del row.
+- **SIEMPRE** sign_count se valida monotonicamente creciente. Si
+  llega un sign_count <= sotrado -> rechazar (token cloning detection).
+- **SIEMPRE** el flujo de MFA setup requiere el user ya autenticado
+  (access JWT valido).
+- **NUNCA** logear el TOTP secret, ni el plaintext del DataKey, ni el
+  contenido de la cookie/credential WebAuthn.
+- **NUNCA** permitir disable de TODOS los metodos MFA: si el user
+  tiene `mfa.disable` para su unico metodo, devolver
+  `409 MUST_KEEP_ONE_METHOD`.
+
+## Matriz de verificacion (rapida)
+
+| Capa | Comando |
+|------|---------|
+| Sintaxis Python | `python -m compileall -q serverless/lambda/services/auth serverless/lambda/shared/auth` |
+| Imports shared-only | `python devtools/run.py serverless lint-deps --lambda=auth` |
+| Tests unit `shared.auth` (incluye TOTP + WebAuthn + recovery) | `python devtools/run.py serverless tests --type=unit --shared` |
+| Tests unit `auth` (incluye operations mfa + webauthn) | `python devtools/run.py serverless tests --type=unit --lambda=auth` |
+| Migration up (dev) | `python devtools/run.py serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev` |
+| Run local TOTP setup | `python devtools/run.py serverless run --stage=local --lambda=auth --event=events/mfa-setup-totp.json` |
+| Deploy dev | `python devtools/run.py serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev` |
+| Smoke E2E | ver [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Bibliografia interna
+
+- Plan 01 (precursor): docs/specs/01-auth-infra-basics/ — al cierre
+  estara eliminado del repo; referencia historica en `git log`.
+- `.claude/docs/auth-system/` — documentacion permanente creada por
+  el plan 01. Este plan agrega capitulos sobre MFA.
+- `.claude/rules/lambda-controller.md`, `.claude/rules/lambda-shared-imports.md`,
+  `.claude/rules/neon-management.md`, `.claude/rules/serverless-secrets.md`.
+- python-fido2: https://github.com/Yubico/python-fido2 (NO fetch
+  desde aqui — solo referencia).
+- WebAuthn spec L2: https://www.w3.org/TR/webauthn-2/ (idem).
+- pyotp: RFC 6238 / 4226.

--- a/docs/specs/02-auth-mfa/README.md
+++ b/docs/specs/02-auth-mfa/README.md
@@ -16,19 +16,21 @@
 
 ## Que entrega este plan
 
-- **Schema Neon (migration 00000003)**:
+- **Schema Neon (migration 00000003)** — 3 tablas nuevas:
   - `auth_mfa_methods`: enum `mfa_kind` (totp|email_code), preferred,
-    user_id FK, secret encrypted (solo TOTP), recovery_codes_hash JSONB,
-    confirmed_at, last_used_at, disabled_at.
+    user_id FK, `totp_secret_ciphertext` (BYTEA, KMS-encrypted via CMK
+    directa — NO envelope), confirmed_at, last_used_at, disabled_at.
+  - `auth_mfa_recovery_codes`: tabla aparte con `user_id`, `code_hash`
+    UK, `consumed_at`. Auditoria individual por code.
   - `auth_webauthn_credentials`: credential_id (BYTEA UK), public_key
     BYTEA, sign_count INT, transports JSONB, attestation_format, aaguid,
-    user_id FK, nickname, created_at, last_used_at.
-  - `auth_webauthn_challenges`: tabla efimera de challenges (TTL via
-    DELETE despues de 5 min). En realidad: usar DynamoDB con TTL en
-    vez de tabla Neon — decision en seccion 1.
+    user_id FK, nickname, created_at, last_used_at, disabled_at.
 - **Shared subpackage `shared.auth` (extension)**: agrega `pyotp`
-  + `fido2`. Modulos nuevos: `totp.py`, `webauthn.py`,
-  `recovery_codes.py`. Sigue siendo UN solo portador.
+  + `python-fido2`. Modulos nuevos: `totp.py`, `webauthn.py`,
+  `recovery_codes.py`. NO `encryption.py` (envelope encryption se
+  descarto a favor de KMS CMK directa — el secret TOTP de 20 bytes
+  entra en el limite de 4KB de `kms:Encrypt`). Sigue siendo UN solo
+  portador.
 - **DynamoDB nueva**: `portfolio-webauthn-challenges-${stage}` (PK
   `challenge_id`, TTL `expires_at` = 5 min). Challenges WebAuthn son
   por naturaleza efimeros y MUCHOS por segundo en uso.
@@ -79,20 +81,20 @@
 
 ## Estado por fase
 
-| Fase | Descripcion | Estado |
-|------|-------------|--------|
-| 0 | Plan 01 mergeado a `dev` (prerequisito) | pending (depende de 01) |
-| 1 | Plan escrito + carpeta `docs/specs/02-auth-mfa/` commiteada | pending |
-| 2 | Schema Neon `auth_mfa_methods` + `auth_webauthn_credentials` (migration 00000003) | pending |
-| 3 | `shared.auth` extension (pyotp + fido2 + totp/webauthn/recovery_codes) | pending |
-| 4 | DynamoDB `webauthn-challenges` + SSM `webauthn-encryption-key` | pending |
-| 5 | Lambda `auth` operation `mfa` (setup-totp, confirm-totp, setup-email-code, set-preferred, disable) | pending |
-| 6 | Lambda `auth` operation `mfa` (recovery-codes-generate, recovery-codes-consume) | pending |
-| 7 | Lambda `auth` operation `webauthn` (register-options, register-verify) | pending |
-| 8 | Lambda `auth` operation `webauthn` (login-options, login-verify, list, delete) | pending |
-| 9 | Extension de `login.start` para detectar metodos MFA del user + nuevos `login.verify-*` (password, totp) | pending |
-| 10 | Rate-limit rules nuevas + integracion + audit log events nuevos | pending |
-| 11 | Verificacion E2E + actualizacion ER + limpieza spec | pending |
+Mapeo 1:1 con las 12 tareas (T1..T12) de [08-descomposicion-paralelizacion.md](08-descomposicion-paralelizacion.md)
+y los 8 PRs de [09-commits.md](09-commits.md).
+
+| Fase | Tarea | PR | Descripcion |
+|------|-------|----|-------------|
+| 0 | — | — | Plan 01 mergeado a `dev` (prerequisito) |
+| 1 | T1 | PR 1 | Plan + docs/claude permanentes (NO catalogo de portadores aun) |
+| 2 | T2 + T3 | PR 2 | `shared.auth` ext (pyotp + fido2 + recovery_codes) + `shared.aws` KMS wrappers + catalogo |
+| 3 | T4 | PR 3 | Schema Neon (migration 00000003) + modelos + repositories |
+| 4 | T5 + T6 | PR 4 | DynamoDB `webauthn-challenges` + manifest update (IAM kms) |
+| 5 | T7 + T8 | PR 5 | Lambda `auth`: services internos + EventModel + Pydantic models |
+| 6 | T9 + T10 | PR 6 | Controllers `mfa.*` + `webauthn.*` (worktrees paralelos) |
+| 7 | T11 | PR 7 | Login extension: verify-password + verify-totp + login.start delta + rate-limit + deploy dev |
+| 8 | T12 | PR 8 | Verificacion E2E + integration tests + ER + cleanup carpeta spec |
 
 ## Decisiones no-reabribles
 
@@ -101,65 +103,125 @@
    activo pueden ser muchos por usuario. TTL nativo + lookup O(1)
    justifican DDB. La tabla `auth_webauthn_challenges` propuesta
    originalmente se descarta.
-2. **TOTP secret cifrado at-rest con KMS DataKey**: el secret de
-   TOTP es un secreto sensible (permite generar codes validos). Se
-   cifra con AWS KMS GenerateDataKey + AES-256-GCM antes de guardarlo
-   en `auth_mfa_methods.totp_secret_ciphertext`. La envelope encryption
-   key se identifica por `data_key_ciphertext` (almacenado al lado).
+2. **TOTP secret cifrado at-rest con KMS CMK directa (sin envelope)**:
+   el secret TOTP de 20 bytes entra holgado en el limite de 4 KB de
+   `kms:Encrypt`. Llamamos `kms:Encrypt` con la CMK
+   `alias/portfolio-lambdas` + `EncryptionContext={user_id, purpose:totp}`
+   y guardamos UNICAMENTE `totp_secret_ciphertext` (BYTEA) en
+   `auth_mfa_methods`. Sin envelope encryption, sin DataKey por user,
+   sin `nonce`/`data_key_ciphertext`. Trade-off: cada
+   `verify-totp` llama a `kms:Decrypt` (cacheable in-memory dentro
+   del Lambda con TTL 5 min para no martillar KMS). Razon del cambio:
+   envelope encryption con DataKey-por-user no aporta seguridad
+   adicional sobre CMK directa con encryption-context (el CMK sigue
+   siendo el unico punto de compromiso) y agrega ~30% mas de codigo
+   + 2 columnas + latencia adicional.
 3. **Recovery codes: 10 codes de 10 chars Crockford, mostrados UNA vez**:
    se muestran al setear MFA exitoso por primera vez. Hash SHA-256 en
-   DB (`auth_mfa_recovery_codes` tabla nueva o JSONB en
-   `auth_mfa_methods.recovery_codes_hash`). Decision: tabla aparte
-   `auth_mfa_recovery_codes` (id, user_id FK, code_hash UK, consumed_at
-   NULL) para auditoria individual por code consumido.
+   DB en tabla aparte `auth_mfa_recovery_codes` (`id`, `user_id` FK,
+   `code_hash` UK, `consumed_at` NULL) para auditoria individual por
+   code consumido. NUNCA en JSONB de `auth_mfa_methods`.
 4. **fido2 lib**: `python-fido2>=1.1,<2.0` (Yubico). Soporta WebAuthn
    L2 + L3 partial. Implementa validacion de attestation (`none`,
-   `direct`, `indirect`, `packed`, `tpm`, `android-key`).
-5. **WebAuthn RP_ID y origin**: `RP_ID = 'the-full-stack.com'`
-   (matchea el apex + todos los subdomains). `expected_origin` lista
-   de los 6 hostnames de prod + sus equivalentes dev/stage. En el cold
-   start, leer de env var `WEBAUTHN_ALLOWED_ORIGINS`.
+   `direct`, `indirect`, `packed`, `tpm`, `android-key`). **Spike
+   obligatorio en T2** (commit 2.2 — antes de redactar el codigo
+   final): validar firma actual de `Fido2Server.register_begin` /
+   `register_complete` / `authenticate_begin` / `authenticate_complete`
+   (state es `dict` JSON-serializable, no `bytes`). Si la firma
+   difiere, ajustar `shared.auth.webauthn` y `ChallengeService`.
+5. **WebAuthn RP_ID por env (passkeys no migran)**: en `prod`
+   `RP_ID=the-full-stack.com` (apex cubre los 6 subdomains). En `dev`
+   `RP_ID=portfolio.dev.the-full-stack.com`. En `stage` idem con
+   `stage`. **Consecuencia explicita**: un passkey registrado en
+   `dev` NO funciona en `prod` (RP_ID es sufijo del origin, distinto
+   por env). Se acepta como diseno — un passkey por env. Los tests
+   E2E lo cubren en AC-26.
 6. **User verification (UV)**: requerir UV=`preferred` en register,
    `required` en login (ie biometric/PIN confirm). Trade-off: algunos
    YubiKeys no tienen UV; preferimos seguridad sobre cobertura
    universal.
 7. **TOTP issuer label**: `the-full-stack.com:<email>` para que el QR
    muestre nombre del sitio + email en Google/Authy. RFC 6238 standard.
-8. **Login con password opcional**: `login.start` acepta `password`
+8. **QR del TOTP lo renderiza el frontend (NO el backend)**: el
+   Lambda devuelve solo `secret_b32` + `otpauth_url`; el cliente
+   renderiza el QR con `qrcode` JS (~5KB gzipped). Razon: evita una
+   dep mas en `shared.auth` (`segno`), reduce ~3-5 KB por response,
+   y mantiene el Lambda mas chico (mejor cold start). El AC-1 refleja
+   el contrato actual.
+9. **Login con password opcional**: `login.start` acepta `password`
    opcional en el body. Si password presente: valida ANTES de devolver
    los methods. Si match: emite temp JWT con flow=`login-mfa` step=2
    y devuelve la lista de MFA methods. Si MFA no configurado: emite
    access+refresh directo (skip MFA). Si MFA configurado: el cliente
    llama a `login.verify-totp` o `webauthn.login-verify`.
-9. **Bypass MFA con recovery code**: action
-   `mfa.recovery-codes-consume` acepta temp JWT del flujo login (con
-   step=2 post-password) + el code. Si match: emite access+refresh y
-   marca el code como consumed. NO se puede recovery-code-consume sin
-   haber pasado password primero (defense in depth).
-10. **Migration 00000003 forward-only en prod**: el downgrade tira
+10. **Bypass MFA con recovery code SOLO post-password o post-webauthn**:
+    `mfa.recovery-codes-consume` exige temp JWT step=2 con claim
+    `prev=password` o `prev=webauthn`. NUNCA acepta step=2 con
+    `prev=magic-link` o `prev=email-code` (ambos son verificables con
+    acceso al email — permitir recovery-bypass desde ahi anularia
+    el segundo factor). Defense in depth.
+11. **Migration 00000003 forward-only en prod**: el downgrade tira
     `auth_webauthn_credentials` que puede tener data real de usuarios.
     El `downgrade()` se implementa (para branches de prueba) pero NO
     se corre en `prod` nunca.
+12. **`provisioner.py` para `uses.kms`: spike-first**: si el manifest
+    actual NO soporta el bloque `uses.kms` declarativo, T6 se hace
+    DENTRO de este plan (1 commit chico). Si el cambio requiere
+    refactor mayor del provisioner (>200 lineas, tests propios),
+    se saca a un plan devtools-aparte y T6 se reemplaza por una
+    inline policy declarada en el shape ya soportado. **Antes de
+    PR 4** se decide cual de los dos. La decision queda anotada en
+    el body del PR 4.
+13. **`shared.rate_limit` custom keys (`user_id` en vez de IP)**:
+    se saca de este plan. Si hoy `shared.rate_limit` SOLO soporta
+    rate-limit por IP, todas las reglas MFA usan IP. Soporte para
+    custom keys es un plan separado. **Consecuencia**: AC del rate
+    limit usan IP, no user_id (ver seccion 04 actualizada). Evita
+    enumeration de emails via timing del rate-limit.
+14. **Clone detection (sign_count regresion) -> disable obligatorio**:
+    AC-15 sin "opcional". Al detectar `new <= stored`, el credential
+    se marca `disabled_at=now()` y se loggea
+    `webauthn.login.clone_detected`. La reactivacion solo por endpoint
+    admin (futuro plan 03 / users-management).
+15. **Sesiones activas tras setup TOTP/WebAuthn**: cuando el user
+    habilita su PRIMER metodo MFA confirmado, se revoca la familia de
+    refresh tokens activa del user (igual que `session.logout-all`).
+    El frontend recibe `401` en el proximo refresh y obliga a re-login
+    con MFA. Se documenta como AC-27. Razon: cerrar la ventana donde
+    un atacante con refresh previo seguiria operando sin pasar MFA.
 
 ## Reglas criticas (siempre activas)
 
-- **SIEMPRE** TOTP secret se cifra con envelope encryption (KMS
-  DataKey + AES-256-GCM) antes de persistir en Neon. NUNCA en plain
-  text.
+- **SIEMPRE** TOTP secret se cifra con `kms:Encrypt` (CMK directa
+  `alias/portfolio-lambdas` + `EncryptionContext={user_id, purpose:totp}`)
+  antes de persistir. NUNCA en plain text. NUNCA envelope encryption
+  con DataKey-por-user.
 - **SIEMPRE** las recovery codes se muestran UNA sola vez (response
   de `recovery-codes-generate`). El frontend debe guardarlas. El
   backend SOLO guarda el hash SHA-256.
 - **SIEMPRE** WebAuthn challenge se valida contra DDB con TTL antes de
   consumir. Single-use: tras verificar exitosa, DELETE del row.
 - **SIEMPRE** sign_count se valida monotonicamente creciente. Si
-  llega un sign_count <= sotrado -> rechazar (token cloning detection).
+  llega un sign_count <= stored -> rechazar Y marcar el credential
+  `disabled_at=now()` (clone detection, decision 14).
 - **SIEMPRE** el flujo de MFA setup requiere el user ya autenticado
   (access JWT valido).
-- **NUNCA** logear el TOTP secret, ni el plaintext del DataKey, ni el
-  contenido de la cookie/credential WebAuthn.
-- **NUNCA** permitir disable de TODOS los metodos MFA: si el user
-  tiene `mfa.disable` para su unico metodo, devolver
-  `409 MUST_KEEP_ONE_METHOD`.
+- **SIEMPRE** tras confirmar el PRIMER metodo MFA, revocar la familia
+  de refresh tokens activa del user (decision 15 / AC-27).
+- **SIEMPRE** `mfa.recovery-codes-consume` exige temp JWT con
+  `prev=password` o `prev=webauthn`. NUNCA `prev=magic-link` ni
+  `prev=email-code` (decision 10).
+- **SIEMPRE** rate-limit de auth se aplica por IP (decision 13);
+  custom keys por `user_id` quedan fuera de scope.
+- **NUNCA** logear el TOTP secret (ni `secret_b32` plaintext ni el
+  resultado de `kms:Decrypt`), ni el contenido de la cookie/credential
+  WebAuthn.
+- **NUNCA** permitir disable de TODOS los metodos MFA del user. Si
+  `mfa.disable` o `webauthn.delete-credential` dejaria al user con 0
+  metodos MFA totales (suma de `auth_mfa_methods` activos +
+  `auth_webauthn_credentials` activos), devolver
+  `409 MUST_KEEP_ONE_MFA_METHOD`. La cuenta se hace sobre TODOS los
+  metodos del user, no por tipo.
 
 ## Matriz de verificacion (rapida)
 

--- a/docs/specs/03-auth-users-management/01-contexto-y-decision.md
+++ b/docs/specs/03-auth-users-management/01-contexto-y-decision.md
@@ -168,7 +168,10 @@ borrado).
   (a) anonimiza `email = 'deleted-<id>@invalid.local'`,
   (b) marca `deleted_at=now()`,
   (c) borra `auth_credentials`, `auth_mfa_methods`,
-      `auth_mfa_recovery_codes`, `auth_webauthn_credentials` (cascade),
+      `auth_mfa_recovery_codes`, `auth_webauthn_credentials`,
+      `auth_email_codes`, `auth_magic_links` con DELETE explicitos
+      dentro de la misma transaccion del UPDATE (NO via FK cascade
+      — el UPDATE de `deleted_at` no dispara la cascade),
   (d) blacklistea TODOS los JWT activos del user
       (DELETE `auth_user_sessions` + INSERT en `jwt-blacklist` DDB),
   (e) devuelve `204`.
@@ -205,8 +208,23 @@ borrado).
   primeros 50 users ordenados por created_at DESC + cursor `next`.
 
 - **AC-13**: Given admin, When llama `admin.list-users` con
-  `{page_size: 20, cursor: '<X>'}`, Then devuelve siguiente pagina con
-  paginacion correcta.
+  `{page_size: 20, cursor: '<last_id_uuid_str>'}`, Then devuelve
+  exactamente esta forma:
+
+  ```jsonc
+  {
+    "users": [ {"id": "...", "email": "...", "status": "active",
+                "created_at": "...", "display_name": "..."}, ... ],
+    "next_cursor": "<uuid_str>|null",  // null si no hay mas paginas
+    "page_size": 20,
+    "total_returned": 20               // count exacto de items en `users`
+  }
+  ```
+
+  Backend filtra `WHERE id > cursor ORDER BY id ASC LIMIT page_size`.
+  `next_cursor = users[-1].id` si `total_returned == page_size`, sino
+  `null`. Si el cliente pasa un `cursor` no decodificable (no es UUID
+  valido), 400 `INVALID_CURSOR`.
 
 - **AC-14**: Given admin, When llama `admin.get-user` con
   `{user_id}`, Then devuelve detalle: profile + status + sessions

--- a/docs/specs/03-auth-users-management/01-contexto-y-decision.md
+++ b/docs/specs/03-auth-users-management/01-contexto-y-decision.md
@@ -219,9 +219,13 @@ borrado).
   action='disable', metadata={reason}, ip, created_at)` + devuelve 204.
 
 - **AC-16**: Given user disabled, When intenta `auth.login.start`,
-  Then `auth.login.start` (logica del plan 01) devuelve `403
-  ACCOUNT_DISABLED`. (Re-validacion del comportamiento del plan 01,
-  con el nuevo path.)
+  Then `auth.login.start` (logica del plan 01) devuelve HTTP `403`
+  con `{error: 'ACCOUNT_DISABLED'}`. Si en cambio tiene un access
+  JWT vivo de antes del disable y llama `/users` o `auth.session.*`,
+  `require_active_user` tambien devuelve `403 ACCOUNT_DISABLED` (no
+  401 — el JWT es valido pero el user esta bloqueado). 401 queda
+  reservado para token invalido/ausente. (Re-validacion del
+  comportamiento del plan 01, con el nuevo path.)
 
 - **AC-17**: Given admin, When llama `admin.enable-user` con
   `{user_id}`, Then UPDATE `auth_users.status='active'`, audit row,
@@ -281,3 +285,10 @@ borrado).
 - **AC-28**: Given un user soft-deleted, When admin llama
   `admin.get-user`, Then devuelve el row con `deleted_at` poblado +
   email anonimizado (`deleted-<id>@invalid.local`).
+
+- **AC-29**: Given un user activo cuyo `email` esta en
+  `/portfolio/${stage}/admin-emails` SSM (es admin), When intenta
+  `profile.delete-account`, Then devuelve `409
+  CANNOT_DELETE_ADMIN_ACCOUNT` con mensaje pidiendo que el email se
+  remueva de la whitelist antes (defensa contra "ultimo admin se
+  borra a si mismo").

--- a/docs/specs/03-auth-users-management/01-contexto-y-decision.md
+++ b/docs/specs/03-auth-users-management/01-contexto-y-decision.md
@@ -1,0 +1,283 @@
+# 01. Contexto y decision
+
+## 1. Contexto / Problema
+
+Tras planes 01 + 02 el portfolio tiene:
+
+- Schema Neon `auth_users`, `auth_credentials`, `auth_email_codes`,
+  `auth_magic_links`, `auth_audit_log`, `auth_mfa_methods`,
+  `auth_mfa_recovery_codes`, `auth_webauthn_credentials`.
+- Lambda `auth` con 5 operations (`register`, `login`, `verify`,
+  `session`, `mfa`, `webauthn`).
+- Cola SQS + worker `auth_email_worker` con 5 plantillas.
+
+El usuario en la peticion original pidio explicitamente **2
+Lambdas**: `auth` (autenticacion) + un segundo Lambda para **gestion
+de usuarios**: "creacion, status, login, logout, register". Los planes
+01 + 02 entregaron toda la parte de autenticacion (creacion via
+register, login/logout via session) en el Lambda `auth`. El Lambda
+restante, `users`, cubre el **CRUD del perfil + status + admin**.
+
+Sin este plan:
+
+- Un user activo NO puede actualizar su display_name, locale,
+  marketing_consent.
+- NO hay endpoint admin para Pablo: list/disable/delete users.
+- NO hay tracking de sesiones activas (multi-device) — el plan 01 da
+  refresh_token con `family_id` pero no expone una API para verlos.
+- NO hay self-service delete-account (GDPR).
+
+Este plan completa el inventario solicitado.
+
+### Hallazgos de exploracion
+
+- El patron lambda-controller del repo permite agregar un Lambda
+  nuevo en la misma API Gateway sin tocar otros Lambdas. `change_detector.py`
+  lo recoge automaticamente.
+- El `auth_users.profile_id` FK a `cv_profiles` del plan 01 queda
+  intacto; este plan no lo modifica. Solo agrega columnas de
+  preferencias.
+- El `auth_audit_log` del plan 01 ya soporta cualquier event string;
+  podemos agregar `users.*` events sin migration.
+- SSM con `SecureString` + KMS para la lista de admin-emails es el
+  mismo patron que `jwt-secret`.
+- `auth_email_worker` puede agregar plantillas sin redeploy del
+  lambda `auth` (los kinds son strings que llegan en el mensaje SQS).
+
+## 2. Solucion Propuesta
+
+Lambda `users` nuevo, HTTP POST `/users`. Codigo siguiendo el mismo
+formato que `auth` (handler delgado, http_handler, controllers, services).
+
+3 operations:
+
+- `profile`: CRUD del perfil del propio user (self).
+- `status`: visibilidad del estado + sesiones activas.
+- `admin`: scope para Pablo (whitelist por SSM).
+
+Schema delta:
+- Agregar columnas a `auth_users`: `display_name`, `locale`, `timezone`,
+  `marketing_consent`, `privacy_policy_version`, `deleted_at`.
+- Agregar enum `email-change` al type `auth_link_kind` existente
+  (reuso de `auth_magic_links` table para change-email flow).
+- Nuevas tablas: `auth_user_sessions`, `auth_user_admin_actions`,
+  `auth_user_consent_log`.
+
+Cero cambio en el Lambda `auth`. Solo el schema y un nuevo Lambda.
+
+### Decisiones clave
+
+**Decision 1: Lambda `users` separado** — confirmado en el dialogo
+original. Beneficios: aislamiento de dominios, IAM least privilege
+(users NO necesita KMS para TOTP), deploy independiente, separation
+of concerns. Costo: 1 lambda extra (gratis en AWS free tier hasta 1M
+invocaciones/mes).
+
+**Decision 2: admin via SSM whitelist** — `/portfolio/${stage}/admin-emails`
+como `SecureString` (lista coma-separada). Lambda `users` lee en cold
+start con TTL 5 min. Para rotar admin: editar SSM. NO se cambia codigo.
+
+Alternativa rechazada: columna `auth_users.role` enum. Mas
+"correcto" pero requiere migration por cada cambio de rol. Para un
+portfolio con 1 admin (Pablo) la whitelist es overkill suficiente.
+
+Cuando aplique (futuro), si hay >5 admins, migrar a tabla
+`auth_user_roles` con FK.
+
+**Decision 3: sesiones tracking via `auth_user_sessions`** —
+cuando el lambda `auth` emite refresh_token, INSERT en
+`auth_user_sessions` con `family_id`, `device_info` (extraido de
+user_agent: browser + os), `ip`, `created_at`, `last_active_at`. Cada
+refresh: UPDATE `last_active_at`. Logout: DELETE row. Force-logout
+admin: DELETE row + blacklist family.
+
+Implica modificacion al lambda `auth`: tras `session.refresh` y
+`register.verify-magic-link` / `login.verify-*`, INSERT (o UPDATE) en
+esta tabla. **Riesgo**: agrega complejidad al lambda `auth` despues de
+estar "cerrado". Mitigacion: este plan toca SOLO los archivos de
+`services/sessions_persistence.py` (nuevo helper) e inyecta su
+llamada en 4 puntos especificos del lambda `auth`. Cambios minimos,
+test cobertura adicional.
+
+**Decision 4: change-email reusa `auth_magic_links`** — agregar
+`email-change` al enum `auth_link_kind`. La migration de plan 01
+debe permitir ALTER TYPE para agregar valores. Migration 00000004
+incluye:
+
+```sql
+ALTER TYPE auth_link_kind ADD VALUE IF NOT EXISTS 'email-change';
+```
+
+(PostgreSQL 18 soporta esto sin recrear el tipo.)
+
+**Decision 5: soft-delete del user con re-uso de email** — `auth_users`
+tiene constraint `UNIQUE(email) WHERE deleted_at IS NULL` (partial
+index). Esto permite que un email se libere al soft-delete y se pueda
+re-registrar. Caso edge: si un atacante registra el email de un user
+deleted, hay anonymity break — mitigacion: el flow de re-register
+trata al email como inexistente (mantiene la consistencia).
+
+**Decision 6: paginacion cursor-based para list-users** — usar UUIDv7
+del `auth_users.id` (cronologico nativo). Cursor opaco `last_id`
+opcional en request; backend hace `WHERE id > last_id ORDER BY id ASC
+LIMIT page_size`. Para portfolios con <1k users es overkill pero
+escalable.
+
+**Decision 7: hard-delete cascade preservando audit** — `admin.delete-user`
+elimina las filas relacionadas en `auth_credentials`,
+`auth_mfa_methods`, `auth_mfa_recovery_codes`,
+`auth_webauthn_credentials`, `auth_email_codes`, `auth_magic_links`,
+`auth_user_sessions`. NO borra `auth_audit_log` (FK SET NULL en
+`user_id`). Preserva `auth_user_admin_actions` rows como audit
+admin con `target_user_id` reference (eventualmente NULL si target
+borrado).
+
+## 3. Criterios de Aceptacion
+
+### Profile
+
+- **AC-1**: Given user activo con access JWT, When llama
+  `POST /users operation=profile action=get`, Then devuelve `{id, email,
+  display_name, locale, timezone, marketing_consent, status, created_at,
+  email_verified_at, mfa_configured: bool}`. NO devuelve password_hash,
+  TOTP secret ni info sensible.
+
+- **AC-2**: Given user activo, When llama `profile.update` con
+  `{display_name, locale, timezone, marketing_consent}`, Then UPDATE
+  los campos enviados (parcial) y devuelve el row actualizado.
+
+- **AC-3**: Given user activo cambia `marketing_consent` de false a
+  true, Then ademas de UPDATE en `auth_users`, INSERT en
+  `auth_user_consent_log(user_id, field='marketing_consent', old_value=false,
+  new_value=true, ip, user_agent, created_at)`.
+
+- **AC-4**: Given user activo llama `profile.change-email` con
+  `{new_email, password?}`, When new_email NO esta en uso, Then:
+  (a) si user tiene password seteada, valida con argon2;
+  (b) genera magic-link `auth_magic_links` kind=`email-change` con
+      `user_id` actual + nuevo email en metadata,
+  (c) publica mensaje SQS para enviar magic-link al `new_email`,
+  (d) devuelve `200 {request_id, expires_in: 900}`.
+
+- **AC-5**: Given el magic-link `email-change` clickeado, When es
+  valido y no expirado, Then UPDATE `auth_users.email = new_email`,
+  marca link consumed, audit log `profile.change-email.confirmed`.
+
+- **AC-6**: Given user activo, When llama `profile.delete-account`
+  con `{confirm: 'DELETE-MY-ACCOUNT'}` (sentinel string), Then:
+  (a) anonimiza `email = 'deleted-<id>@invalid.local'`,
+  (b) marca `deleted_at=now()`,
+  (c) borra `auth_credentials`, `auth_mfa_methods`,
+      `auth_mfa_recovery_codes`, `auth_webauthn_credentials` (cascade),
+  (d) blacklistea TODOS los JWT activos del user
+      (DELETE `auth_user_sessions` + INSERT en `jwt-blacklist` DDB),
+  (e) devuelve `204`.
+
+### Status
+
+- **AC-7**: Given user activo, When llama `status.get`, Then devuelve
+  `{status, mfa_configured: bool, mfa_methods: [...], webauthn_count: int,
+  recovery_codes_remaining: int, failed_attempts: int, locked_until:
+  iso8601|null}`.
+
+- **AC-8**: Given user activo con N sesiones activas, When llama
+  `status.list-sessions`, Then devuelve
+  `[{session_id, device_info, ip, country, created_at, last_active_at,
+  current: bool}, ...]` ordenado por last_active_at DESC. `current:true`
+  para la session del access JWT en curso.
+
+- **AC-9**: Given user activo con session_id != current, When llama
+  `status.revoke-session` con `{session_id}`, Then DELETE row +
+  blacklistea la family completa + devuelve 204.
+
+- **AC-10**: Given user intenta `status.revoke-session` con su
+  session_id actual, Then devuelve `400 CANNOT_REVOKE_CURRENT_SESSION`
+  (debe usar `auth.session.logout`).
+
+### Admin
+
+- **AC-11**: Given un NO-admin con access JWT, When llama
+  `admin.list-users`, Then devuelve `404 NOT_FOUND` (NO 403, evita
+  enumeration).
+
+- **AC-12**: Given admin (email en whitelist SSM) con access JWT,
+  When llama `admin.list-users` (sin params), Then devuelve los
+  primeros 50 users ordenados por created_at DESC + cursor `next`.
+
+- **AC-13**: Given admin, When llama `admin.list-users` con
+  `{page_size: 20, cursor: '<X>'}`, Then devuelve siguiente pagina con
+  paginacion correcta.
+
+- **AC-14**: Given admin, When llama `admin.get-user` con
+  `{user_id}`, Then devuelve detalle: profile + status + sessions
+  count + audit log mas reciente (top 10). NO password hash, NO TOTP
+  secret.
+
+- **AC-15**: Given admin, When llama `admin.disable-user` con
+  `{user_id, reason}`, Then UPDATE `auth_users.status='disabled'` +
+  INSERT `auth_user_admin_actions(admin_user_id, target_user_id,
+  action='disable', metadata={reason}, ip, created_at)` + devuelve 204.
+
+- **AC-16**: Given user disabled, When intenta `auth.login.start`,
+  Then `auth.login.start` (logica del plan 01) devuelve `403
+  ACCOUNT_DISABLED`. (Re-validacion del comportamiento del plan 01,
+  con el nuevo path.)
+
+- **AC-17**: Given admin, When llama `admin.enable-user` con
+  `{user_id}`, Then UPDATE `auth_users.status='active'`, audit row,
+  devuelve 204.
+
+- **AC-18**: Given admin, When llama `admin.force-logout` con
+  `{user_id, reason?}`, Then: DELETE todas las `auth_user_sessions`
+  del target + blacklistea TODAS las families activas + audit row +
+  devuelve 204.
+
+- **AC-19**: Given admin, When llama `admin.delete-user` con
+  `{user_id, confirm: 'HARD-DELETE-USER-<user_id>'}` (sentinel
+  obligatorio), Then borra TODAS las filas del target en cascada
+  (mantiene `auth_audit_log` con `user_id` SET NULL), audit row
+  `admin.delete-user`, devuelve 204.
+
+- **AC-20**: Given admin, When llama `admin.list-admin-actions` con
+  `{from_date, to_date}`, Then devuelve historico paginado de las
+  admin actions (incluyendo metadata, IP, admin_user_id, target_user_id).
+
+- **AC-21**: Given admin sin sus emails en SSM (admin-emails vacio o
+  no contiene el suyo), When llama cualquier `admin.*`, Then 404
+  NOT_FOUND (whitelist vacia = sin admins).
+
+### Sessions tracking (integracion con auth)
+
+- **AC-22**: Given un user completa `register.verify-magic-link` o
+  `login.verify-*` exitosa, Then el lambda `auth` (via nuevo helper)
+  INSERT `auth_user_sessions(user_id, family_id, device_info, ip,
+  user_agent, country, created_at, last_active_at)`.
+
+- **AC-23**: Given un user usa `session.refresh`, Then el lambda
+  `auth` UPDATE `auth_user_sessions.last_active_at = now()` y
+  `family_id = <nuevo>` (rotation). El row se mantiene; cambia el
+  family_id.
+
+- **AC-24**: Given un user usa `session.logout`, Then DELETE el row
+  de `auth_user_sessions` con el family_id correspondiente.
+
+### Migration
+
+- **AC-25**: Given la migration `00000004_auth_users_extension.py`
+  aplicada en branch Neon de prueba, When se ejecuta `downgrade -1` y
+  luego `upgrade head`, Then schema vuelve al de plan 02 y se recrean
+  las columnas + tablas sin error.
+
+### Seguridad / GDPR
+
+- **AC-26**: Given un user es soft-deleted, When intenta `auth.login.start`
+  con su email original, Then devuelve `404 EMAIL_NOT_FOUND` (se
+  comporta como inexistente).
+
+- **AC-27**: Given un email previamente soft-deleted, When otro user
+  intenta `auth.register.start` con el mismo email, Then exitoso (el
+  email esta libre por el partial unique index).
+
+- **AC-28**: Given un user soft-deleted, When admin llama
+  `admin.get-user`, Then devuelve el row con `deleted_at` poblado +
+  email anonimizado (`deleted-<id>@invalid.local`).

--- a/docs/specs/03-auth-users-management/02-schema-neon-users.md
+++ b/docs/specs/03-auth-users-management/02-schema-neon-users.md
@@ -1,0 +1,286 @@
+# 02. Schema Neon — extension `auth_users` + tablas de gestion
+
+## Delta del schema
+
+```text
+auth_users  (extension)
+─────────────────────
+ + display_name varchar(64)
+ + locale varchar(8)  default 'en'  CHECK locale IN ('en', 'es')
+ + timezone varchar(64)  default 'UTC'
+ + marketing_consent boolean default false
+ + privacy_policy_version varchar(16) NULL
+ + deleted_at timestamptz NULL
+ (existentes del plan 01)
+
+auth_user_sessions
+──────────────────
+ id           uuid PK uuidv7()
+ user_id      uuid FK auth_users.id ON DELETE CASCADE
+ family_id    uuid UNIQUE  -- 1 row por refresh family
+ device_info  jsonb        -- {browser, os, device_type}
+ ip           inet
+ country      char(2) NULL
+ user_agent   text
+ created_at   timestamptz
+ last_active_at timestamptz
+
+auth_user_admin_actions
+────────────────────────
+ id              uuid PK
+ admin_user_id   uuid FK auth_users.id ON DELETE SET NULL
+ target_user_id  uuid FK auth_users.id ON DELETE SET NULL
+ action          varchar(64)   -- 'disable'|'enable'|'force-logout'|'delete'|...
+ metadata        jsonb NULL    -- {reason, ip_target, etc.}
+ ip              inet
+ user_agent      text NULL
+ created_at      timestamptz
+
+auth_user_consent_log
+─────────────────────
+ id          uuid PK
+ user_id     uuid FK auth_users.id ON DELETE CASCADE
+ field       varchar(32)        -- 'marketing_consent'|'privacy_policy'
+ old_value   text
+ new_value   text
+ ip          inet
+ user_agent  text NULL
+ created_at  timestamptz
+```
+
+## Migration 00000004
+
+```python
+"""auth_users_extension
+
+Revision ID: 00000004
+Revises: 00000003
+Create Date: 2026-05-27
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '00000004'
+down_revision = '00000003'
+
+
+def upgrade() -> None:
+    # 1. Extender auth_users con columnas nuevas
+    op.add_column('auth_users',
+        sa.Column('display_name', sa.String(64), nullable=True))
+    op.add_column('auth_users',
+        sa.Column('locale', sa.String(8), nullable=False, server_default='en'))
+    op.add_column('auth_users',
+        sa.Column('timezone', sa.String(64), nullable=False, server_default='UTC'))
+    op.add_column('auth_users',
+        sa.Column('marketing_consent', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+    op.add_column('auth_users',
+        sa.Column('privacy_policy_version', sa.String(16), nullable=True))
+    op.add_column('auth_users',
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True))
+
+    # 2. CHECK locale + partial unique index para soporte de soft-delete
+    op.create_check_constraint(
+        'ck_auth_users_locale', 'auth_users',
+        "locale IN ('en', 'es')",
+    )
+    # Drop el UNIQUE viejo de email (era full)
+    op.drop_constraint('auth_users_email_key', 'auth_users', type_='unique')
+    # Reemplazar con partial unique index
+    op.create_index(
+        'ux_auth_users_email_active', 'auth_users', ['email'],
+        unique=True, postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+    op.create_index(
+        'ix_auth_users_deleted_at', 'auth_users', ['deleted_at'],
+    )
+
+    # 3. ALTER TYPE auth_link_kind ADD VALUE 'email-change'
+    op.execute("ALTER TYPE auth_link_kind ADD VALUE IF NOT EXISTS 'email-change'")
+
+    # 4. auth_user_sessions
+    op.create_table(
+        'auth_user_sessions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('family_id', postgresql.UUID(as_uuid=True), nullable=False, unique=True),
+        sa.Column('device_info', postgresql.JSONB(), nullable=True),
+        sa.Column('ip', postgresql.INET(), nullable=True),
+        sa.Column('country', sa.CHAR(2), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.Column('last_active_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'], ondelete='CASCADE'),
+    )
+    op.create_index('ix_auth_user_sessions_user_active',
+                    'auth_user_sessions', ['user_id', 'last_active_at'])
+
+    # 5. auth_user_admin_actions
+    op.create_table(
+        'auth_user_admin_actions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('admin_user_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('target_user_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('action', sa.String(64), nullable=False),
+        sa.Column('metadata', postgresql.JSONB(), nullable=True),
+        sa.Column('ip', postgresql.INET(), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['admin_user_id'], ['auth_users.id'],
+                                ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['target_user_id'], ['auth_users.id'],
+                                ondelete='SET NULL'),
+    )
+    op.create_index('ix_auth_admin_actions_target_ts',
+                    'auth_user_admin_actions',
+                    ['target_user_id', 'created_at'])
+
+    # 6. auth_user_consent_log
+    op.create_table(
+        'auth_user_consent_log',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('uuidv7()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('field', sa.String(32), nullable=False),
+        sa.Column('old_value', sa.Text(), nullable=True),
+        sa.Column('new_value', sa.Text(), nullable=True),
+        sa.Column('ip', postgresql.INET(), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['auth_users.id'],
+                                ondelete='CASCADE'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('auth_user_consent_log')
+    op.drop_table('auth_user_admin_actions')
+    op.drop_table('auth_user_sessions')
+
+    # NO se puede DROP VALUE de un enum en PG. Para downgrade limpio
+    # habria que recrear el tipo (destructivo). En este plan asumimos
+    # downgrade en branch Neon de prueba; en prod NO se hace downgrade.
+    # Aqui dejamos el value en el enum (forward-only en prod).
+    pass
+
+    op.drop_index('ix_auth_users_deleted_at', 'auth_users')
+    op.drop_index('ux_auth_users_email_active', 'auth_users')
+    op.create_unique_constraint('auth_users_email_key', 'auth_users', ['email'])
+
+    op.drop_constraint('ck_auth_users_locale', 'auth_users', type_='check')
+
+    op.drop_column('auth_users', 'deleted_at')
+    op.drop_column('auth_users', 'privacy_policy_version')
+    op.drop_column('auth_users', 'marketing_consent')
+    op.drop_column('auth_users', 'timezone')
+    op.drop_column('auth_users', 'locale')
+    op.drop_column('auth_users', 'display_name')
+```
+
+> **Importante**: `ALTER TYPE ADD VALUE` no se puede revertir en
+> PostgreSQL sin recrear el tipo. El `downgrade()` deja `email-change`
+> en el enum. En prod NO se corre downgrade; en branches de prueba es
+> aceptable.
+
+## Modelos SQLAlchemy (delta)
+
+```text
+serverless/lambda/shared/db/models/auth/
+├── user.py             # MODIFICAR — agregar columnas nuevas
+├── enums.py            # MODIFICAR — agregar 'email-change' a AuthLinkKind
+├── user_session.py     # NUEVO — AuthUserSession
+├── admin_action.py     # NUEVO — AuthUserAdminAction
+└── consent_log.py      # NUEVO — AuthUserConsentLog
+```
+
+`user.py` (delta):
+
+```python
+class AuthUser(UUIDPKMixin, TimestampMixin, Base):
+    # ... existentes del plan 01
+
+    # NUEVOS del plan 03
+    display_name: Mapped[str | None] = mapped_column(String(64))
+    locale: Mapped[str] = mapped_column(String(8), default='en', nullable=False)
+    timezone: Mapped[str] = mapped_column(String(64), default='UTC', nullable=False)
+    marketing_consent: Mapped[bool] = mapped_column(default=False, nullable=False)
+    privacy_policy_version: Mapped[str | None] = mapped_column(String(16))
+    deleted_at: Mapped[datetime | None]
+
+    __table_args__ = (
+        # ... existentes
+        CheckConstraint("locale IN ('en', 'es')", name='ck_auth_users_locale'),
+        Index('ux_auth_users_email_active', 'email', unique=True,
+              postgresql_where=sa.text('deleted_at IS NULL')),
+        Index('ix_auth_users_deleted_at', 'deleted_at'),
+    )
+```
+
+`user_session.py`:
+
+```python
+class AuthUserSession(UUIDPKMixin, Base):
+    __tablename__ = 'auth_user_sessions'
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey('auth_users.id', ondelete='CASCADE'), nullable=False)
+    family_id: Mapped[UUID] = mapped_column(unique=True, nullable=False)
+    device_info: Mapped[dict | None] = mapped_column(JSONB)
+    ip: Mapped[str | None] = mapped_column(INET)
+    country: Mapped[str | None] = mapped_column(CHAR(2))
+    user_agent: Mapped[str | None]
+    created_at: Mapped[datetime] = mapped_column(
+        server_default=sa.text('now()'), nullable=False)
+    last_active_at: Mapped[datetime] = mapped_column(
+        server_default=sa.text('now()'), nullable=False)
+```
+
+## Repository extensions
+
+`shared/db/repositories/auth_users.py` (NUEVO archivo, separa lo del
+plan 01 que estaba en `auth.py`):
+
+```python
+def get_user_by_id(session, *, user_id) -> AuthUser | None: ...
+def update_profile(session, *, user_id, **fields) -> AuthUser: ...
+def soft_delete_user(session, *, user_id, anonymized_email) -> None: ...
+def hard_delete_user(session, *, user_id) -> None: ...
+def list_users_paginated(session, *, cursor, page_size, status_filter) -> list[AuthUser]: ...
+def disable_user(session, *, user_id) -> None: ...
+def enable_user(session, *, user_id) -> None: ...
+
+def insert_user_session(session, *, user_id, family_id, device_info, ip, country, user_agent) -> AuthUserSession: ...
+def update_session_activity(session, *, family_id) -> bool: ...
+def rotate_session_family_id(session, *, old_family_id, new_family_id) -> bool: ...
+def list_user_sessions(session, *, user_id) -> list[AuthUserSession]: ...
+def revoke_session(session, *, user_id, session_id) -> bool: ...
+def revoke_all_user_sessions(session, *, user_id) -> list[UUID]: ...  # retorna family_ids para blacklist
+
+def insert_admin_action(session, *, admin_user_id, target_user_id, action, metadata, ip) -> None: ...
+def list_admin_actions(session, *, from_date, to_date, page_size) -> list[AuthUserAdminAction]: ...
+
+def insert_consent_log(session, *, user_id, field, old_value, new_value, ip, user_agent) -> None: ...
+```
+
+## Indices justificacion
+
+| Indice | Justificacion |
+|--------|---------------|
+| `ux_auth_users_email_active` (partial unique) | Permite re-uso de email tras soft-delete (AC-27) |
+| `ix_auth_users_deleted_at` | Filtro `WHERE deleted_at IS NULL` en queries de list |
+| `ix_auth_user_sessions_user_active` | List sessions del user |
+| `auth_user_sessions.family_id` UNIQUE | Lookup por family_id en rotation/revoke |
+| `ix_auth_admin_actions_target_ts` | Audit historico de un target user |
+
+## Update al ER permanente
+
+Al cerrar plan 03: actualizar `docs/diagrams/db-er.mmd` con:
+- columnas nuevas de `auth_users`
+- 3 tablas nuevas + relaciones FK

--- a/docs/specs/03-auth-users-management/02-schema-neon-users.md
+++ b/docs/specs/03-auth-users-management/02-schema-neon-users.md
@@ -97,7 +97,16 @@ def upgrade() -> None:
     )
 
     # 3. ALTER TYPE auth_link_kind ADD VALUE 'email-change'
-    op.execute("ALTER TYPE auth_link_kind ADD VALUE IF NOT EXISTS 'email-change'")
+    #
+    # CRITICAL: ALTER TYPE ... ADD VALUE NO se puede ejecutar dentro
+    # de un bloque transaccional en PostgreSQL (PG18 mantiene la
+    # limitacion para enums con datos existentes). Alembic envuelve
+    # upgrade() en transaction por default, asi que hay que usar el
+    # autocommit_block del context.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE auth_link_kind ADD VALUE IF NOT EXISTS 'email-change'"
+        )
 
     # 4. auth_user_sessions
     op.create_table(
@@ -184,10 +193,27 @@ def downgrade() -> None:
     op.drop_column('auth_users', 'display_name')
 ```
 
-> **Importante**: `ALTER TYPE ADD VALUE` no se puede revertir en
-> PostgreSQL sin recrear el tipo. El `downgrade()` deja `email-change`
-> en el enum. En prod NO se corre downgrade; en branches de prueba es
-> aceptable.
+> **Importante (1)**: `ALTER TYPE ADD VALUE` no se puede ejecutar
+> dentro de una transaction (limitacion de PG, no removida en PG18).
+> Por eso el `upgrade()` envuelve el `op.execute` en
+> `op.get_context().autocommit_block()`. El `alembic.ini` del repo
+> NO necesita `transactional_ddl=false` global — el bloque
+> autocommit es local a esa instruccion.
+>
+> **Importante (2)**: `ALTER TYPE ADD VALUE` no se puede revertir en
+> PostgreSQL sin recrear el tipo. El `downgrade()` deja
+> `email-change` en el enum. En prod NO se corre downgrade; en
+> branches de prueba es aceptable.
+>
+> **Importante (3) — sobre AC-25 (idempotencia up/down/up)**: tras
+> `downgrade -1` el enum conserva `email-change`. El segundo
+> `upgrade head` re-ejecuta `ADD VALUE IF NOT EXISTS` (no-op) y
+> recrea las 3 tablas + columnas. El resultado es idempotente en
+> schema y datos, pero el catalogo del enum queda con el valor
+> extra. Documentar este detalle en el test
+> `test_migration_00000004_up_down_e2e.py`: la asercion final NO
+> debe exigir que el enum vuelva al set original, solo que las
+> columnas/tablas se recreen correctamente.
 
 ## Modelos SQLAlchemy (delta)
 
@@ -204,7 +230,12 @@ serverless/lambda/shared/db/models/auth/
 
 ```python
 class AuthUser(UUIDPKMixin, TimestampMixin, Base):
-    # ... existentes del plan 01
+    # MODIFICAR — quitar `unique=True` de la columna email; el unique
+    # ahora es PARTIAL (solo WHERE deleted_at IS NULL) y se declara
+    # como Index en __table_args__. Si se deja `unique=True` aqui,
+    # SQLAlchemy `Base.metadata.create_all()` recrea la constraint
+    # full y rompe AC-27 (re-uso de email tras soft-delete).
+    email: Mapped[str] = mapped_column(CITEXT(), nullable=False)
 
     # NUEVOS del plan 03
     display_name: Mapped[str | None] = mapped_column(String(64))
@@ -215,13 +246,24 @@ class AuthUser(UUIDPKMixin, TimestampMixin, Base):
     deleted_at: Mapped[datetime | None]
 
     __table_args__ = (
-        # ... existentes
+        # ... existentes (mantener ix_auth_users_status y los del plan 01,
+        #     PERO RETIRAR cualquier `UniqueConstraint('email')` viejo)
         CheckConstraint("locale IN ('en', 'es')", name='ck_auth_users_locale'),
         Index('ux_auth_users_email_active', 'email', unique=True,
               postgresql_where=sa.text('deleted_at IS NULL')),
         Index('ix_auth_users_deleted_at', 'deleted_at'),
     )
 ```
+
+> **Drift modelo/DB**: el modelo del plan 01 declara
+> `email: Mapped[str] = mapped_column(CITEXT(), unique=True, ...)`.
+> La migration 00000004 hace `op.drop_constraint('auth_users_email_key')`
+> y crea el partial unique como `Index` separado, pero **si el modelo
+> SQLAlchemy del plan 01 no se modifica para retirar `unique=True`**,
+> queda drift: cualquier `create_all()` (tests integration, branches
+> Neon nuevos) recreara la constraint full y rompera AC-27. El
+> commit `feat(db/models): auth_users extension` debe incluir esta
+> modificacion del modelo del plan 01 ademas de las columnas nuevas.
 
 `user_session.py`:
 

--- a/docs/specs/03-auth-users-management/03-shared-and-admin.md
+++ b/docs/specs/03-auth-users-management/03-shared-and-admin.md
@@ -1,0 +1,183 @@
+# 03. Shared.auth extension + admin whitelist
+
+## Que se agrega al subpackage `shared.auth`
+
+```text
+serverless/lambda/shared/auth/
+├── ... (archivos del plan 01 y 02)
+└── admin.py              # NUEVO — load_admin_emails + is_admin + require_admin
+```
+
+NO se agregan deps externas en este plan. `admin.py` usa solo
+`shared.aws.get_secret_by_name` (existente).
+
+## `admin.py`
+
+```python
+"""shared.auth.admin — admin whitelist via SSM.
+
+SSM path: /portfolio/${stage}/admin-emails (SecureString + KMS).
+Valor: 'pacg1991@gmail.com,otro@admin.com' (lista coma-separada).
+
+El handler `require_admin` se cachea con TTL 5 min para evitar
+hit a SSM en cada request.
+"""
+
+from functools import lru_cache
+from time import time
+
+from shared.aws import get_secret_by_name
+from shared.core import ApplicationError
+
+
+class AdminAuthzError(ApplicationError): ...
+
+
+_CACHE: dict = {'emails': frozenset(), 'expires_at': 0.0}
+
+
+def load_admin_emails(*, ssm_path: str | None = None, ttl: int = 300) -> frozenset[str]:
+    """Carga la lista de admin emails desde SSM con cache TTL."""
+    now = time()
+    if _CACHE['expires_at'] > now and _CACHE['emails']:
+        return _CACHE['emails']
+
+    raw = get_secret_by_name('admin-emails', local_env='ADMIN_EMAILS')
+    if not raw:
+        emails = frozenset()
+    else:
+        emails = frozenset(
+            email.strip().lower()
+            for email in raw.split(',')
+            if email.strip()
+        )
+
+    _CACHE['emails'] = emails
+    _CACHE['expires_at'] = now + ttl
+    return emails
+
+
+def is_admin(email: str, *, ttl: int = 300) -> bool:
+    """True si email esta en la whitelist SSM."""
+    return email.lower().strip() in load_admin_emails(ttl=ttl)
+
+
+def require_admin(email: str) -> None:
+    """Levanta AdminAuthzError si email no es admin."""
+    if not is_admin(email):
+        # Mensaje generico para evitar enumeration
+        raise AdminAuthzError('NOT_FOUND', code=4040)
+```
+
+NOTA: la excepcion tiene mensaje generico (`NOT_FOUND`) en vez de
+`FORBIDDEN` — esto es deliberado segun AC-11 y la regla critica del
+plan ("NO-admin recibe 404 NOT_FOUND").
+
+## Update `__init__.py` de `shared.auth`
+
+```python
+from .admin import (
+    AdminAuthzError,
+    is_admin,
+    load_admin_emails,
+    require_admin,
+)
+
+__all__ = [
+    # ... existentes de plan 01 + 02
+    'AdminAuthzError',
+    'is_admin',
+    'load_admin_emails',
+    'require_admin',
+]
+```
+
+## Tests unit
+
+`shared/tests/unit/shared/auth/test_admin_*.py`:
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_admin_load_emails_parses_comma_separated.py` | 'a@x,b@y' -> {a@x, b@y} |
+| `test_admin_load_emails_lowercases.py` | 'A@X.com' -> {a@x.com} |
+| `test_admin_load_emails_strips_whitespace.py` | ' a@x , b@y ' -> {a@x, b@y} |
+| `test_admin_load_emails_empty_returns_frozenset.py` | '' -> frozenset() |
+| `test_admin_load_emails_caches.py` | 2nd call dentro de TTL no llama SSM |
+| `test_admin_load_emails_refreshes_after_ttl.py` | tras TTL=0 vuelve a llamar |
+| `test_admin_is_admin_true.py` | email en lista -> True |
+| `test_admin_is_admin_false.py` | email no en lista -> False |
+| `test_admin_is_admin_case_insensitive.py` | 'X@Y.com' matchea 'x@y.com' |
+| `test_admin_require_admin_ok.py` | no levanta para admin |
+| `test_admin_require_admin_raises_with_404.py` | levanta AdminAuthzError code=4040 |
+
+## SSM — `/portfolio/${stage}/admin-emails`
+
+`serverless/lambda/resources/secrets/admin-emails.yaml`:
+
+```yaml
+short_name: admin-emails
+description: Comma-separated list of admin user emails (whitelist)
+type: SecureString
+kms_key: alias/portfolio-lambdas
+ssm_path: /portfolio/${stage}/admin-emails
+source_env_var: ADMIN_EMAILS                # docker/env/server/.{stage}
+local_env_var: ADMIN_EMAILS
+rotation_interval_days: 365                  # raro cambiar
+consumers:
+  - lambda: users
+```
+
+**Valor inicial**: `pacg1991@gmail.com` (email del owner, segun memoria
+del proyecto). Configurar en `docker/env/server/.{stage}`:
+
+```text
+ADMIN_EMAILS=pacg1991@gmail.com
+```
+
+Sincronizar:
+
+```bash
+serverless sync-secrets --stage=dev --aws-profile=tfs-dev
+serverless sync-secrets --stage=stage --aws-profile=tfs-dev
+serverless sync-secrets --stage=prod --aws-profile=tfs-dev
+```
+
+## Helper en el Lambda `users`
+
+`services/users/core/services/admin_service.py`:
+
+```python
+from shared.auth import require_admin
+from shared.lambda_kit import BaseController
+
+from ..settings.config import app_config
+from .audit_admin_service import AuditAdminService
+
+
+def require_admin_user(user, *, ip, audit_action='admin.access') -> None:
+    """Valida que `user.email` este en SSM admin-emails. Si NO,
+    levanta 404 (oculta la existencia del endpoint).
+
+    Tambien escribe un audit log antes de devolver, para registrar
+    incluso los attempts fallidos (defensa contra brute force admin).
+    """
+    audit = AuditAdminService(app_config)
+    try:
+        require_admin(user.email)
+    except Exception:
+        audit.log_attempt(admin_user_id=user.id, action=audit_action,
+                          success=False, ip=ip)
+        raise
+    audit.log_attempt(admin_user_id=user.id, action=audit_action,
+                      success=True, ip=ip)
+```
+
+Cada controller admin lo llama al inicio del `validate()`.
+
+## Update al catalogo de portadores
+
+NO se agregan paquetes externos. `shared.auth.admin` solo usa
+`shared.aws.get_secret_by_name` (catalogo ya tiene boto3 via
+shared.aws). Update minimo al catalogo: registrar
+`load_admin_emails`, `is_admin`, `require_admin` en la tabla de
+re-exports de `shared.auth` si decidimos exponerlos.

--- a/docs/specs/03-auth-users-management/04-infraestructura.md
+++ b/docs/specs/03-auth-users-management/04-infraestructura.md
@@ -158,6 +158,16 @@ modifica** 1 archivo:
   - `controllers/webauthn/login_verify.py` (post-emision)
   - `controllers/mfa/recovery_codes_consume.py` (post-emision)
 
+> **Sobre `family_id`**: el refresh JWT del plan 01 ya lleva
+> `family_id` en sus claims (uuidv7), generado en
+> `register.verify-*` / `login.verify-*` y rotado en
+> `session.refresh`. El helper `session_tracking_service` lo recibe
+> como argumento; **no necesita inferirlo**. En cada controller del
+> lambda `auth`, tras emitir los tokens, el codigo ya tiene en
+> memoria el `family_id` viejo (de los claims del refresh entrante,
+> solo aplica a `session.refresh`) y el `family_id` nuevo
+> (recien generado). Ambos se pasan al helper.
+
 `session_tracking_service.py`:
 
 ```python
@@ -255,19 +265,27 @@ CI matrix se arma automaticamente.
 
 ## 7. Orden de provisioning
 
+El **orden es estricto**: `auth` (con sessions tracking) debe estar
+deployado ANTES que `users` se exponga, porque
+`status.list-sessions` lee de `auth_user_sessions` y esa tabla solo
+empieza a poblarse tras el deploy de `auth` con el helper inyectado.
+
 ```bash
-# 1. Aplicar migration 00000004
+# 1. Aplicar migration 00000004 (crea auth_user_sessions, etc.)
 serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev
 
 # 2. SSM admin-emails
 serverless provision-infra --stage=dev --aws-profile=tfs-dev
 serverless sync-secrets --stage=dev --aws-profile=tfs-dev
 
-# 3. Deploy auth (con sessions tracking) + auth_email_worker (3 plantillas nuevas)
+# 3. Deploy auth (con sessions tracking) PRIMERO
+#    A partir de aqui, cada nueva sesion (register/login/refresh)
+#    inserta o actualiza la row en auth_user_sessions.
 serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
 serverless deploy --lambda=auth_email_worker --stage=dev --aws-profile=tfs-dev
 
-# 4. Deploy users
+# 4. Deploy users (lee auth_user_sessions ya poblado por el lambda
+#    auth desde el paso 3)
 serverless deploy --lambda=users --stage=dev --aws-profile=tfs-dev
 
 # 5. Seed rate-limit rules
@@ -275,3 +293,21 @@ serverless deploy --lambda=users --stage=dev --aws-profile=tfs-dev
 
 # 6. Smoke E2E (ver verificacion-e2e.md)
 ```
+
+> **Sesiones pre-deploy quedan invisibles**: refresh tokens emitidos
+> ANTES del deploy de `auth` con session tracking NO tienen row en
+> `auth_user_sessions`. Para esos users, `status.list-sessions`
+> devuelve vacio hasta que hagan `session.refresh` (que rota family
+> y entra al INSERT/UPDATE del helper) o re-login. Es comportamiento
+> esperado, no un bug. Documentar en el frontend cuando exista:
+> "si la lista de sesiones aparece vacia, hacer logout+login para
+> reactivar el tracking".
+>
+> **Dependencia del integration test multi-device** (AC-8): el test
+> `test_status_list_sessions_multi_device_e2e.py` (06-testing)
+> requiere que T10 (sessions tracking en auth) ya este deployado
+> en dev. La descomposicion en 08 hace WT-C (T9) y WT-D (T10)
+> paralelos en codigo, pero **el integration test del paso de E2E
+> en `users` depende del deploy de `auth` post-T10**. Reflejar en
+> PR 9 (verificacion E2E): correr integration tests SOLO tras
+> mergear PR 8.

--- a/docs/specs/03-auth-users-management/04-infraestructura.md
+++ b/docs/specs/03-auth-users-management/04-infraestructura.md
@@ -1,0 +1,277 @@
+# 04. Infraestructura — Lambda `users` + SSM admin-emails + email-worker plantillas
+
+## Resumen
+
+| Recurso | Archivo | Que es |
+|---------|---------|--------|
+| SSM `/portfolio/${stage}/admin-emails` | `resources/secrets/admin-emails.yaml` | Whitelist de emails admin |
+| Lambda `users` manifest | `services/users/manifest.yaml` | Nuevo Lambda HTTP `POST /users` |
+| Email worker — 3 plantillas nuevas | `services/auth_email_worker/core/templates/{es,en}/{email-changed,account-disabled,account-deleted}.{txt,html}` | + 3 nuevos `kinds` en el worker |
+
+NO se crean tablas DDB nuevas (sessions tracking vive en Neon). NO
+se crean SQS nuevas. NO se modifica API Gateway directamente — el
+provisioner del repo agrega la ruta `/users` automaticamente desde el
+manifest del Lambda.
+
+## 1. Lambda `users` (manifest)
+
+`serverless/lambda/services/users/manifest.yaml`:
+
+```yaml
+name: users
+trigger:
+  type: http
+  method: POST
+  path: /users
+runtime: python3.13
+handler: core.handler.lambda_handler
+memory: 384
+timeout: 15
+snap_start: true
+uses:
+  queues:
+    - name: portfolio-auth-email-${stage}     # publica emails de change-email, account-disabled, etc.
+      access: producer
+  tables:
+    cache: read-write
+    rate-limit-rules: read-write
+    rate-limit-buckets: read-write
+    jwt-blacklist: read-write                  # para revoke-session / force-logout
+  secrets:
+    - neon-url
+    - jwt-secret
+    - admin-emails                              # NUEVO
+    - ses-from-address
+  sends-email: false
+env:
+  default:
+    LOG_LEVEL: INFO
+    POWERTOOLS_SERVICE_NAME: users
+    POWERTOOLS_METRICS_NAMESPACE: Portfolio/Users
+    JWT_ISSUER: portfolio-auth
+    JWT_AUDIENCE: portfolio
+  dev:
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com,http://localhost:9970'
+  stage:
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com'
+  prod:
+    LOG_LEVEL: WARNING
+    CORS_ALLOWED_ORIGINS: 'https://the-full-stack.com,https://www.the-full-stack.com,https://portfolio.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com'
+```
+
+NO usa Turnstile (el endpoint requiere access JWT, ya autenticado).
+NO publica magic-links a SQS para los emails de admin
+(`account-disabled`, `account-deleted` no son interactivos —
+son notifications). Si lo son, el worker los procesa igual.
+
+## 2. SSM admin-emails
+
+`serverless/lambda/resources/secrets/admin-emails.yaml`:
+
+```yaml
+short_name: admin-emails
+description: Lista coma-separada de emails admin (whitelist)
+type: SecureString
+kms_key: alias/portfolio-lambdas
+ssm_path: /portfolio/${stage}/admin-emails
+source_env_var: ADMIN_EMAILS
+local_env_var: ADMIN_EMAILS
+rotation_interval_days: 365
+consumers:
+  - lambda: users
+```
+
+Configurar antes del primer deploy:
+
+```bash
+# 1. Agregar a docker/env/server/.{dev,stage,prod} (NO commitear)
+#    ADMIN_EMAILS=pacg1991@gmail.com
+
+# 2. Sincronizar a SSM
+serverless sync-secrets --stage=dev --aws-profile=tfs-dev
+# repetir stage + prod
+
+# 3. Verificar
+serverless secrets-status --stage=dev
+# admin-emails: SKIP (hash match)
+```
+
+## 3. Auth_email_worker — plantillas nuevas
+
+Agregar al `auth_email_worker` 3 plantillas + 3 controllers:
+
+```text
+serverless/lambda/services/auth_email_worker/core/
+├── controllers/email/
+│   ├── email_changed.py            # NUEVO
+│   ├── account_disabled.py          # NUEVO
+│   └── account_deleted.py           # NUEVO
+└── templates/
+    ├── es/
+    │   ├── email-changed.txt
+    │   ├── email-changed.html
+    │   ├── account-disabled.txt
+    │   ├── account-disabled.html
+    │   ├── account-deleted.txt
+    │   └── account-deleted.html
+    └── en/   (mismas 6 plantillas)
+```
+
+Modificar `core/settings/operations.py` del worker agregando los
+nuevos kinds. Cero impacto en el deploy de `auth`.
+
+Schema del mensaje SQS para los nuevos kinds:
+
+```jsonc
+{
+  "kind": "email-changed",
+  "to": "old@example.com",
+  "user_id": "01H9V...",
+  "niche": "fintech",
+  "subject_id": "auth.profile.email-changed.subject",
+  "data": {
+    "old_email": "old@example.com",
+    "new_email": "new@example.com",
+    "changed_at": "2026-05-27T10:00:00Z",
+    "revoke_url": "https://api.portfolio.dev.the-full-stack.com/auth?operation=verify&action=revoke-email-change&token=<X>"
+  }
+}
+```
+
+(El `revoke_url` permite undo del cambio si se hizo sin permiso — flow
+opcional, no obligatorio en este plan.)
+
+## 4. Cambios al Lambda `auth` (minimos para sessions tracking)
+
+El plan 03 NO crea un PR aparte sobre el lambda `auth`, pero **si
+modifica** 1 archivo:
+
+- `services/auth/core/services/session_tracking_service.py` (NUEVO)
+- 4 puntos de invocacion (inyectados en):
+  - `controllers/register/verify_magic_link.py` (post-emision de
+    access+refresh)
+  - `controllers/register/verify_code.py`
+  - `controllers/login/verify_magic_link.py`, `verify_code.py`,
+    `verify_password.py`, `verify_totp.py`
+  - `controllers/session/refresh.py` (rotation: UPDATE family_id)
+  - `controllers/session/logout.py` (DELETE row)
+  - `controllers/webauthn/login_verify.py` (post-emision)
+  - `controllers/mfa/recovery_codes_consume.py` (post-emision)
+
+`session_tracking_service.py`:
+
+```python
+"""Track sessions activas en `auth_user_sessions`.
+
+Llamado tras CADA emision de refresh JWT (creacion o rotation).
+"""
+
+from shared.db import db_session
+from shared.db.repositories.auth_users import (
+    insert_user_session,
+    rotate_session_family_id,
+    revoke_session as repo_revoke_session,
+)
+
+
+class SessionTrackingService:
+    def on_session_created(self, *, user_id, family_id, ip, country,
+                            user_agent) -> None:
+        with db_session() as session:
+            insert_user_session(
+                session,
+                user_id=user_id, family_id=family_id,
+                device_info=_parse_device_info(user_agent),
+                ip=ip, country=country, user_agent=user_agent,
+            )
+
+    def on_session_rotated(self, *, old_family_id, new_family_id) -> None:
+        with db_session() as session:
+            rotate_session_family_id(
+                session,
+                old_family_id=old_family_id, new_family_id=new_family_id,
+            )
+
+    def on_session_revoked(self, *, family_id) -> bool:
+        with db_session() as session:
+            return repo_revoke_session(session, family_id=family_id)
+```
+
+`_parse_device_info(user_agent)` retorna `{browser, browser_version,
+os, device_type}` con una lib liviana (ua-parser-light) o regex
+custom. Para minimizar deps, regex custom inicial — agregar lib si
+necesario.
+
+## 5. Rate-limit rules nuevas (para `/users`)
+
+```bash
+# profile.get: 30/min/user_id (lectura)
+serverless rate-limit set --stage=dev \
+  --endpoint='/users#profile.get' --limit=30 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+
+# profile.update: 10/min/user_id (escritura)
+serverless rate-limit set --stage=dev \
+  --endpoint='/users#profile.update' --limit=10 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+
+# profile.change-email: 3/h/user_id (sensible)
+serverless rate-limit set --stage=dev \
+  --endpoint='/users#profile.change-email' --limit=3 --window=3600 \
+  --key=user_id --aws-profile=tfs-dev
+
+# profile.delete-account: 2/h/user_id (super sensible)
+serverless rate-limit set --stage=dev \
+  --endpoint='/users#profile.delete-account' --limit=2 --window=3600 \
+  --key=user_id --aws-profile=tfs-dev
+
+# status.* : 60/min/user_id
+serverless rate-limit set --stage=dev \
+  --endpoint='/users#status' --limit=60 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+
+# admin.list-users: 30/min/user_id (admin)
+# admin.* otros: 60/min/user_id
+serverless rate-limit set --stage=dev \
+  --endpoint='/users#admin' --limit=60 --window=60 \
+  --key=user_id --aws-profile=tfs-dev
+```
+
+Repetir para `stage` y `prod`.
+
+## 6. CI auto-detect
+
+`change_detector.py` auto-detecta:
+- `services/users/` -> redeploy `users`
+- `shared/auth/admin.py` -> redeploy `users` (y posiblemente auth si
+  decidimos importar `admin.py` desde auth — no necesario en este
+  plan)
+- `shared/db/models/auth/` (modelos nuevos) -> redeploy auth + users +
+  db (migration)
+- `services/auth/` (sessions tracking inyectado en 8 archivos) ->
+  redeploy `auth`
+
+CI matrix se arma automaticamente.
+
+## 7. Orden de provisioning
+
+```bash
+# 1. Aplicar migration 00000004
+serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev
+
+# 2. SSM admin-emails
+serverless provision-infra --stage=dev --aws-profile=tfs-dev
+serverless sync-secrets --stage=dev --aws-profile=tfs-dev
+
+# 3. Deploy auth (con sessions tracking) + auth_email_worker (3 plantillas nuevas)
+serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
+serverless deploy --lambda=auth_email_worker --stage=dev --aws-profile=tfs-dev
+
+# 4. Deploy users
+serverless deploy --lambda=users --stage=dev --aws-profile=tfs-dev
+
+# 5. Seed rate-limit rules
+# ... ver bloque rate-limit arriba
+
+# 6. Smoke E2E (ver verificacion-e2e.md)
+```

--- a/docs/specs/03-auth-users-management/04-infraestructura.md
+++ b/docs/specs/03-auth-users-management/04-infraestructura.md
@@ -42,6 +42,11 @@ uses:
     - jwt-secret
     - admin-emails                              # NUEVO
     - ses-from-address
+  # publish-only: el Lambda `users` NUNCA invoca SES directamente.
+  # Solo publica mensajes a la cola `auth-email-queue`; el
+  # `auth_email_worker` consume y manda el email. Por eso
+  # `sends-email: false` (no necesita IAM ses:SendEmail) pese a que
+  # operativamente algunas actions terminan disparando un email.
   sends-email: false
 env:
   default:
@@ -143,20 +148,25 @@ opcional, no obligatorio en este plan.)
 
 ## 4. Cambios al Lambda `auth` (minimos para sessions tracking)
 
-El plan 03 NO crea un PR aparte sobre el lambda `auth`, pero **si
-modifica** 1 archivo:
+El plan 03 SI toca el lambda `auth`: agrega **1 archivo nuevo** y
+modifica **10 controllers existentes** con una inyeccion minima
+(2-3 lineas para llamar al helper).
 
 - `services/auth/core/services/session_tracking_service.py` (NUEVO)
-- 4 puntos de invocacion (inyectados en):
+- 10 controllers modificados (post-emision de tokens):
   - `controllers/register/verify_magic_link.py` (post-emision de
-    access+refresh)
-  - `controllers/register/verify_code.py`
-  - `controllers/login/verify_magic_link.py`, `verify_code.py`,
-    `verify_password.py`, `verify_totp.py`
-  - `controllers/session/refresh.py` (rotation: UPDATE family_id)
-  - `controllers/session/logout.py` (DELETE row)
-  - `controllers/webauthn/login_verify.py` (post-emision)
-  - `controllers/mfa/recovery_codes_consume.py` (post-emision)
+    access+refresh — `on_session_created`)
+  - `controllers/register/verify_code.py` (`on_session_created`)
+  - `controllers/login/verify_magic_link.py` (`on_session_created`)
+  - `controllers/login/verify_code.py` (`on_session_created`)
+  - `controllers/login/verify_password.py` (`on_session_created`)
+  - `controllers/login/verify_totp.py` (`on_session_created`)
+  - `controllers/webauthn/login_verify.py` (`on_session_created`)
+  - `controllers/mfa/recovery_codes_consume.py` (`on_session_created`)
+  - `controllers/session/refresh.py` (rotation: `on_session_rotated`
+    con old_family_id + new_family_id)
+  - `controllers/session/logout.py` (`on_session_revoked` tras
+    blacklist family DDB)
 
 > **Sobre `family_id`**: el refresh JWT del plan 01 ya lleva
 > `family_id` en sus claims (uuidv7), generado en
@@ -213,6 +223,13 @@ custom. Para minimizar deps, regex custom inicial — agregar lib si
 necesario.
 
 ## 5. Rate-limit rules nuevas (para `/users`)
+
+> `shared.rate_limit` ya soporta `--key=user_id` desde el plan 02
+> (introducido para `mfa.confirm-totp`, `mfa.recovery-codes-consume`,
+> etc.). El bucket key se computa con `user_id` extraido del access
+> JWT, no de la IP. Si el controller no tiene access JWT, el helper
+> hace fallback a IP automaticamente (defensa contra requests
+> anonimos que igual quieren rate-limitearse).
 
 ```bash
 # profile.get: 30/min/user_id (lectura)

--- a/docs/specs/03-auth-users-management/05-lambda-users-arquitectura.md
+++ b/docs/specs/03-auth-users-management/05-lambda-users-arquitectura.md
@@ -1,0 +1,355 @@
+# 05. Lambda `users` — arquitectura
+
+## Operations + actions
+
+```text
+operation 'profile':
+- get               POST  -> retorna profile del propio user
+- update            POST  -> actualiza display_name/locale/timezone/marketing_consent
+- change-email      POST  -> inicia flow magic-link al new_email
+- delete-account    POST  -> self-service GDPR soft-delete
+
+operation 'status':
+- get               POST  -> status + MFA info
+- list-sessions     POST  -> lista sesiones activas
+- revoke-session    POST  -> cierra una session (no la actual)
+
+operation 'admin':  (whitelist via SSM)
+- list-users        POST  -> paginado
+- get-user          POST  -> detalle por user_id
+- disable-user      POST  -> marca status=disabled
+- enable-user       POST  -> marca status=active
+- force-logout      POST  -> revoca todas las sessions del target
+- delete-user       POST  -> hard-delete con cascade (sentinel obligatorio)
+- list-admin-actions POST -> historico de admin actions
+```
+
+Total: 14 actions (4 + 3 + 7).
+
+## Estructura de carpetas
+
+```text
+serverless/lambda/services/users/
+├── manifest.yaml
+├── pyproject.toml             # PEP 621; deps minimas (todo via shared)
+├── uv.lock
+├── .gitignore                 # build/ + build.zip
+├── core/
+│   ├── handler.py             # http_handler con EVENT_MODEL
+│   ├── settings/
+│   │   ├── config.py          # AppConfig
+│   │   └── operations.py      # OPERATIONS = {profile, status, admin}
+│   ├── models/
+│   │   ├── event.py
+│   │   ├── profile.py
+│   │   ├── status.py
+│   │   └── admin.py
+│   ├── controllers/
+│   │   ├── __init__.py
+│   │   ├── profile/
+│   │   │   ├── get.py
+│   │   │   ├── update.py
+│   │   │   ├── change_email.py
+│   │   │   └── delete_account.py
+│   │   ├── status/
+│   │   │   ├── get.py
+│   │   │   ├── list_sessions.py
+│   │   │   └── revoke_session.py
+│   │   └── admin/
+│   │       ├── list_users.py
+│   │       ├── get_user.py
+│   │       ├── disable_user.py
+│   │       ├── enable_user.py
+│   │       ├── force_logout.py
+│   │       ├── delete_user.py
+│   │       └── list_admin_actions.py
+│   ├── services/
+│   │   ├── profile_service.py
+│   │   ├── session_service.py
+│   │   ├── admin_service.py            # require_admin_user helper
+│   │   ├── audit_admin_service.py      # writes a auth_user_admin_actions
+│   │   ├── consent_service.py          # writes a auth_user_consent_log
+│   │   ├── blacklist_service.py        # reusa el shape del de auth lambda
+│   │   ├── jwt_service.py              # verify_access (reusa shared.auth)
+│   │   ├── email_dispatch_service.py   # publica SQS (change-email magic-link, etc.)
+│   │   ├── audit_service.py            # writes a auth_audit_log generico
+│   │   └── rate_limit_service.py
+│   └── utils/
+│       └── (vacio; kit en shared.lambda_kit)
+├── events/                    # JSONs de prueba
+└── tests/
+    ├── unit/
+    └── integration/
+```
+
+## Patron de controller — ejemplo `profile.update`
+
+```python
+"""profile.update — actualiza campos del propio user.
+
+Requiere: access JWT valido.
+Acepta parcial: cualquier subset de {display_name, locale,
+timezone, marketing_consent, privacy_policy_version}.
+Si marketing_consent cambia -> INSERT en auth_user_consent_log.
+"""
+
+from shared.lambda_kit import BaseController
+from shared.observability import logger, metrics
+
+from ...services.audit_service import AuditService
+from ...services.consent_service import ConsentService
+from ...services.jwt_service import require_active_user
+from ...services.profile_service import ProfileService
+from ...services.rate_limit_service import RateLimitService
+from ...settings.config import app_config
+
+
+class Update(BaseController):
+    def preload(self):
+        return {'is_valid': True, 'data': {}, 'code': 0}
+
+    def validate(self):
+        user = require_active_user(
+            self.data['_meta'].get('authorization'),
+            config=app_config,
+        )
+        RateLimitService(app_config).check_or_raise(
+            ip=self.data['_meta']['ip'],
+            endpoint='/users#profile.update',
+            key_override=str(user.id),
+        )
+        self.context = {'user': user}
+        return {'is_valid': True, 'data': {}, 'code': 0}
+
+    def execute(self):
+        user = self.context['user']
+        meta = self.data['_meta']
+        profile_svc = ProfileService(app_config)
+        consent_svc = ConsentService(app_config)
+        audit = AuditService(app_config)
+
+        updates = {
+            k: v for k, v in self.data.items()
+            if k in {'display_name', 'locale', 'timezone',
+                     'marketing_consent', 'privacy_policy_version'}
+            and v is not None
+        }
+
+        old_marketing = user.marketing_consent
+        new_marketing = updates.get('marketing_consent')
+
+        updated_user = profile_svc.update(user_id=user.id, **updates)
+
+        if new_marketing is not None and new_marketing != old_marketing:
+            consent_svc.log(
+                user_id=user.id, field='marketing_consent',
+                old_value=str(old_marketing),
+                new_value=str(new_marketing),
+                ip=meta['ip'], user_agent=meta['user_agent'],
+            )
+
+        audit.log(event='profile.update', success=True, user_id=user.id,
+                  ip=meta['ip'], metadata={'fields': list(updates.keys())})
+        metrics.add_metric(name='ProfileUpdate', unit='Count', value=1)
+
+        return {
+            'is_valid': True, 'code': 0,
+            'data': {
+                'id': str(updated_user.id),
+                'email': updated_user.email,
+                'display_name': updated_user.display_name,
+                'locale': updated_user.locale,
+                'timezone': updated_user.timezone,
+                'marketing_consent': updated_user.marketing_consent,
+            },
+        }
+```
+
+## Patron admin — ejemplo `admin.disable-user`
+
+```python
+class DisableUser(BaseController):
+    def validate(self):
+        actor = require_active_user(
+            self.data['_meta'].get('authorization'),
+            config=app_config,
+        )
+        # require_admin_user levanta 404 (no 403) si no es admin
+        from ...services.admin_service import require_admin_user
+        require_admin_user(actor, ip=self.data['_meta']['ip'],
+                            audit_action='admin.disable-user.attempt')
+        self.context = {'actor': actor}
+        return {'is_valid': True, 'data': {}, 'code': 0}
+
+    def execute(self):
+        actor = self.context['actor']
+        meta = self.data['_meta']
+        target_id = UUID(self.data['user_id'])
+        reason = self.data.get('reason', 'admin discretion')
+
+        profile_svc = ProfileService(app_config)
+        admin_audit = AuditAdminService(app_config)
+
+        target = profile_svc.get_by_id(user_id=target_id)
+        if target is None or target.deleted_at is not None:
+            return {'is_valid': False, 'code': 4040,
+                    'data': {'error': 'NOT_FOUND'}}
+
+        if target.id == actor.id:
+            return {'is_valid': False, 'code': 4000,
+                    'data': {'error': 'CANNOT_DISABLE_SELF'}}
+
+        profile_svc.disable_user(user_id=target.id)
+
+        # Audit PRE-hoc — ya se intento, el DB cambio
+        admin_audit.log(
+            admin_user_id=actor.id, target_user_id=target.id,
+            action='disable', metadata={'reason': reason},
+            ip=meta['ip'], user_agent=meta['user_agent'],
+        )
+
+        return {
+            'is_valid': True, 'code': 0,
+            'data': {'message': 'OK', 'status': 204},
+        }
+```
+
+## Modelos Pydantic — ejemplos
+
+`models/profile.py`:
+
+```python
+class ProfileGetIn(BaseModel):
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+class ProfileUpdateIn(BaseModel):
+    display_name: str | None = Field(default=None, max_length=64)
+    locale: Literal['es', 'en'] | None = None
+    timezone: str | None = Field(default=None, max_length=64)
+    marketing_consent: bool | None = None
+    privacy_policy_version: str | None = Field(default=None, max_length=16)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+class ProfileChangeEmailIn(BaseModel):
+    new_email: EmailStr
+    password: str | None = Field(default=None, min_length=12, max_length=256)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+class ProfileDeleteAccountIn(BaseModel):
+    confirm: Literal['DELETE-MY-ACCOUNT']
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+```
+
+`models/admin.py`:
+
+```python
+class AdminListUsersIn(BaseModel):
+    cursor: UUID | None = None
+    page_size: int = Field(default=50, ge=1, le=200)
+    status_filter: Literal['pending', 'active', 'disabled', 'locked'] | None = None
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+class AdminDisableUserIn(BaseModel):
+    user_id: UUID
+    reason: str | None = Field(default=None, max_length=256)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+
+class AdminDeleteUserIn(BaseModel):
+    user_id: UUID
+    confirm: str = Field(min_length=20)  # debe matchear `HARD-DELETE-USER-<uuid>`
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = {'populate_by_name': True}
+
+    @field_validator('confirm')
+    @classmethod
+    def confirm_matches_user_id(cls, v, info):
+        user_id = info.data.get('user_id')
+        if user_id and v != f'HARD-DELETE-USER-{user_id}':
+            raise ValueError('Confirm sentinel must match user_id')
+        return v
+```
+
+## EventModel
+
+```python
+EVENT_MODEL = build_event_model({
+    'profile': {
+        'get': ProfileGetIn,
+        'update': ProfileUpdateIn,
+        'change-email': ProfileChangeEmailIn,
+        'delete-account': ProfileDeleteAccountIn,
+    },
+    'status': {
+        'get': StatusGetIn,
+        'list-sessions': StatusListSessionsIn,
+        'revoke-session': StatusRevokeSessionIn,
+    },
+    'admin': {
+        'list-users': AdminListUsersIn,
+        'get-user': AdminGetUserIn,
+        'disable-user': AdminDisableUserIn,
+        'enable-user': AdminEnableUserIn,
+        'force-logout': AdminForceLogoutIn,
+        'delete-user': AdminDeleteUserIn,
+        'list-admin-actions': AdminListAdminActionsIn,
+    },
+})
+```
+
+## Que toca cada service
+
+| Service | Responsabilidad |
+|---------|-----------------|
+| `ProfileService` | CRUD `auth_users`: get_by_id, update, change_email, soft_delete, hard_delete, disable, enable |
+| `SessionService` | CRUD `auth_user_sessions`: list_for_user, revoke, revoke_all_for_user |
+| `AdminService` | `require_admin_user` helper |
+| `AuditAdminService` | INSERT `auth_user_admin_actions` |
+| `ConsentService` | INSERT `auth_user_consent_log` |
+| `BlacklistService` | reusa del lambda auth (DDB ops) |
+| `JwtService` | verify_access (lectura), `require_active_user` |
+| `EmailDispatchService` | publica a `auth-email-queue` (kind: `email-changed`, `account-disabled`, `account-deleted`) |
+| `AuditService` | INSERT `auth_audit_log` generico |
+| `RateLimitService` | wrapper de `shared.rate_limit.check_or_raise` |
+
+## Errores
+
+| Codigo | Significado |
+|--------|-------------|
+| `NOT_FOUND` | user_id no existe O caller no es admin (deliberado) |
+| `CANNOT_DISABLE_SELF` | admin intentando deshabilitarse a si mismo |
+| `CANNOT_DELETE_SELF` | admin intentando hard-deletarse a si mismo |
+| `EMAIL_ALREADY_IN_USE` | el `change-email` apunta a un email ya activo |
+| `INVALID_PASSWORD` | el `change-email` exige password (si user tiene) — no matchea |
+| `CANNOT_REVOKE_CURRENT_SESSION` | (AC-10) usar `auth.session.logout` en su lugar |
+| `USER_NOT_DISABLED` | `enable-user` aplicado a alguien no disabled |
+| `INVALID_CONFIRM_SENTINEL` | `delete-account` con sentinel no exacto |
+
+## Que toca cada controller — matriz resumen
+
+| Controller | Neon R/W | DDB R/W | SQS publish | JWT/Auth |
+|------------|----------|---------|-------------|----------|
+| profile.get | R auth_users + auth_mfa_methods + auth_webauthn_credentials | — | 0 | require_active_user |
+| profile.update | RW auth_users + W consent_log | — | 0 | require_active_user |
+| profile.change-email | R auth_users + W auth_magic_links | — | 1 (magic-link) | require_active_user |
+| profile.delete-account | RW auth_users (soft) + cascade DELETE | RW blacklist (todas las sessions) | 1 (notify) | require_active_user |
+| status.get | R auth_users + mfa + webauthn | — | 0 | require_active_user |
+| status.list-sessions | R auth_user_sessions | — | 0 | require_active_user |
+| status.revoke-session | RW auth_user_sessions | RW blacklist (family_id) | 0 | require_active_user |
+| admin.list-users | R auth_users paginado | — | 0 | require_admin_user |
+| admin.get-user | R auth_users + relations + audit_log | — | 0 | require_admin_user |
+| admin.disable-user | RW auth_users + W admin_actions | — | 1 (notify target) | require_admin_user |
+| admin.enable-user | RW auth_users + W admin_actions | — | 0 | require_admin_user |
+| admin.force-logout | DELETE auth_user_sessions + W admin_actions | RW blacklist | 0 | require_admin_user |
+| admin.delete-user | cascade DELETE + W admin_actions | RW blacklist | 1 (notify) | require_admin_user |
+| admin.list-admin-actions | R admin_actions paginado | — | 0 | require_admin_user |

--- a/docs/specs/03-auth-users-management/05-lambda-users-arquitectura.md
+++ b/docs/specs/03-auth-users-management/05-lambda-users-arquitectura.md
@@ -396,7 +396,7 @@ EVENT_MODEL = build_event_model({
 | profile.get | R auth_users + auth_mfa_methods + auth_webauthn_credentials | — | 0 | require_active_user |
 | profile.update | RW auth_users + W consent_log | — | 0 | require_active_user |
 | profile.change-email | R auth_users + W auth_magic_links | — | 1 (magic-link) | require_active_user |
-| profile.delete-account | RW auth_users (soft) + cascade DELETE | RW blacklist (todas las sessions) | 1 (notify) | require_active_user |
+| profile.delete-account | UPDATE auth_users (soft) + DELETE explicitos en credentials/mfa/recovery/webauthn/email_codes/magic_links/user_sessions | RW blacklist (todas las families) | 1 (notify) | require_active_user |
 | status.get | R auth_users + mfa + webauthn | — | 0 | require_active_user |
 | status.list-sessions | R auth_user_sessions | — | 0 | require_active_user |
 | status.revoke-session | RW auth_user_sessions | RW blacklist (family_id) | 0 | require_active_user |

--- a/docs/specs/03-auth-users-management/05-lambda-users-arquitectura.md
+++ b/docs/specs/03-auth-users-management/05-lambda-users-arquitectura.md
@@ -271,13 +271,17 @@ class AdminDeleteUserIn(BaseModel):
     meta: _Meta = Field(default_factory=_Meta, alias='_meta')
     model_config = {'populate_by_name': True}
 
-    @field_validator('confirm')
-    @classmethod
-    def confirm_matches_user_id(cls, v, info):
-        user_id = info.data.get('user_id')
-        if user_id and v != f'HARD-DELETE-USER-{user_id}':
+    # IMPORTANTE: usamos model_validator(mode='after') en vez de
+    # field_validator porque field_validator NO garantiza el orden
+    # de validacion en Pydantic v2 — `info.data.get('user_id')`
+    # podria estar vacio si confirm se valida primero. Con
+    # mode='after' los dos campos ya pasaron por su validacion
+    # individual y estan poblados en `self`.
+    @model_validator(mode='after')
+    def confirm_matches_user_id(self) -> 'AdminDeleteUserIn':
+        if self.confirm != f'HARD-DELETE-USER-{self.user_id}':
             raise ValueError('Confirm sentinel must match user_id')
-        return v
+        return self
 ```
 
 ## EventModel
@@ -311,8 +315,58 @@ EVENT_MODEL = build_event_model({
 
 | Service | Responsabilidad |
 |---------|-----------------|
-| `ProfileService` | CRUD `auth_users`: get_by_id, update, change_email, soft_delete, hard_delete, disable, enable |
+| `ProfileService` | CRUD `auth_users`: get_by_id, update, change_email, soft_delete (ver nota abajo), hard_delete, disable, enable |
 | `SessionService` | CRUD `auth_user_sessions`: list_for_user, revoke, revoke_all_for_user |
+
+> **`ProfileService.soft_delete` — borrado explicito, NO FK cascade**.
+> El `soft_delete` NO borra la fila de `auth_users` (solo setea
+> `deleted_at` + anonimiza `email`). Por lo tanto los FK
+> `ON DELETE CASCADE` declarados en `auth_credentials`,
+> `auth_mfa_methods`, `auth_mfa_recovery_codes`,
+> `auth_webauthn_credentials`, `auth_user_sessions`, etc. **NO se
+> disparan** (las cascades reaccionan a DELETE, no a UPDATE). El
+> service debe ejecutar los DELETE manuales en una sola transaccion
+> SQLAlchemy, en este orden:
+>
+> ```python
+> def soft_delete(self, *, user_id: UUID, ip: str | None,
+>                 user_agent: str | None) -> list[UUID]:
+>     """Soft-delete del user + DELETE explicito de credentials/mfa.
+>     Retorna la lista de family_ids cuyas sesiones se borraron, para
+>     que el controller las blacklisteen en DDB."""
+>     with db_session() as session:
+>         # 1. DELETE explicito en cascada (auth_users.id NO se borra)
+>         session.execute(delete(AuthCredential).where(
+>             AuthCredential.user_id == user_id))
+>         session.execute(delete(AuthMfaMethod).where(
+>             AuthMfaMethod.user_id == user_id))
+>         session.execute(delete(AuthMfaRecoveryCode).where(
+>             AuthMfaRecoveryCode.user_id == user_id))
+>         session.execute(delete(AuthWebauthnCredential).where(
+>             AuthWebauthnCredential.user_id == user_id))
+>         session.execute(delete(AuthEmailCode).where(
+>             AuthEmailCode.user_id == user_id))
+>         session.execute(delete(AuthMagicLink).where(
+>             AuthMagicLink.user_id == user_id))
+>         # 2. Recolectar y borrar sessions activas (para blacklist
+>         #    posterior por el controller)
+>         families = session.execute(
+>             select(AuthUserSession.family_id).where(
+>                 AuthUserSession.user_id == user_id)
+>         ).scalars().all()
+>         session.execute(delete(AuthUserSession).where(
+>             AuthUserSession.user_id == user_id))
+>         # 3. Soft-delete del user (UPDATE — NO DELETE)
+>         user = session.get(AuthUser, user_id)
+>         user.deleted_at = func.now()
+>         user.email = f'deleted-{user.id}@invalid.local'
+>         session.commit()
+>         return families
+> ```
+>
+> En contraste, `ProfileService.hard_delete` (admin only) **si**
+> hace `DELETE FROM auth_users WHERE id=?` y las FK cascades operan
+> normalmente.
 | `AdminService` | `require_admin_user` helper |
 | `AuditAdminService` | INSERT `auth_user_admin_actions` |
 | `ConsentService` | INSERT `auth_user_consent_log` |

--- a/docs/specs/03-auth-users-management/06-testing.md
+++ b/docs/specs/03-auth-users-management/06-testing.md
@@ -153,5 +153,16 @@ python devtools/run.py serverless tests --type=integration --lambda=auth
   (c) JWT blacklisted en DDB,
   (d) auth_audit_log preservado.
 - **SIEMPRE** mock SSM `admin-emails` con admin email del test fixture.
+- **SIEMPRE** los tests que toquen `shared.auth.admin.is_admin` /
+  `load_admin_emails` (directa o transitivamente) deben **resetear
+  el cache module-level** antes y despues. Patron recomendado:
+  fixture `autouse=True` en `shared/tests/unit/shared/auth/conftest.py`
+  que llame a `shared.auth.admin._CACHE.update({'emails':
+  frozenset(), 'expires_at': 0.0})`. Sin esto, el orden de tests
+  cambia el resultado (cache hit de un test anterior con emails
+  mockeados distintos).
+- **SIEMPRE** test de `delete-account` con AC-29 verifica: si el
+  user esta en `admin-emails`, recibe `409 CANNOT_DELETE_ADMIN_ACCOUNT`
+  y NO se borra nada.
 - **NUNCA** test de admin contra un user real del repo (usar fixtures
   con uuidv7 nuevos).

--- a/docs/specs/03-auth-users-management/06-testing.md
+++ b/docs/specs/03-auth-users-management/06-testing.md
@@ -1,0 +1,157 @@
+# 06. Estrategia de testing — plan 03
+
+> Hereda el patron de los planes 01 y 02. Tests nuevos enfocados en
+> profile / status / admin authz.
+
+## Tests unit `shared.auth.admin` (en shared/tests/)
+
+Listados en [03-shared-and-admin.md](03-shared-and-admin.md): 11
+archivos.
+
+## Tests unit `shared/db/repositories/auth_users.py`
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_update_profile_partial.py` | UPDATE solo campos presentes |
+| `test_soft_delete_anonymizes_email.py` | email -> deleted-<id>@invalid.local |
+| `test_partial_unique_email_allows_reuse.py` | tras soft-delete, INSERT con mismo email OK |
+| `test_hard_delete_cascades.py` | DELETE auth_users -> cascada en credenciales/mfa/etc. |
+| `test_list_users_paginated_by_cursor.py` | cursor=last_id retorna siguientes 50 |
+| `test_list_users_status_filter.py` | filtro disabled retorna solo esos |
+| `test_insert_user_session.py` | INSERT con family_id UK |
+| `test_update_session_activity.py` | UPDATE last_active_at |
+| `test_rotate_session_family_id.py` | UPDATE family_id viejo -> nuevo |
+| `test_revoke_all_user_sessions_returns_families.py` | DELETE + retorna list[family_id] |
+| `test_insert_admin_action.py` | INSERT row con metadata jsonb |
+| `test_list_admin_actions_paginated.py` | range from/to + ordering |
+| `test_insert_consent_log.py` | INSERT con old/new value |
+
+## Tests unit del Lambda `users`
+
+### `services/` (~30 archivos)
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_profile_service_get_by_id.py` | retorna user con relations |
+| `test_profile_service_update_partial.py` | parcial OK |
+| `test_profile_service_change_email_new_email_available.py` | INSERT magic_link |
+| `test_profile_service_change_email_taken.py` | levanta EmailAlreadyInUseError |
+| `test_profile_service_soft_delete_anonymizes.py` | email anonimo + cascade |
+| `test_profile_service_disable_active.py` | UPDATE status=disabled |
+| `test_profile_service_enable_disabled.py` | UPDATE status=active |
+| `test_profile_service_enable_active_no_op.py` | no cambia si ya active |
+| `test_session_service_list_with_current_flag.py` | marca current=true para el access JWT |
+| `test_session_service_revoke_blacklists_family.py` | DELETE + DDB PutItem family blacklist |
+| `test_admin_service_require_admin_ok.py` | admin email pasa |
+| `test_admin_service_require_admin_not_admin_raises_404.py` | NOT_FOUND code=4040 |
+| `test_audit_admin_service_log.py` | INSERT row con metadata correcto |
+| `test_consent_service_log.py` | INSERT row |
+| `test_blacklist_service_blacklist_family.py` | Query GSI by_family_id + PutItem en cada jti |
+| `test_jwt_service_require_active_user_ok.py` | access JWT valido + user active -> retorna user |
+| `test_jwt_service_require_active_user_disabled.py` | user disabled -> ApplicationError |
+| `test_jwt_service_require_active_user_deleted.py` | user deleted -> ApplicationError |
+| `test_email_dispatch_service_publish_email_changed.py` | SQS SendMessage con kind=email-changed |
+| `test_email_dispatch_service_publish_account_disabled.py` | idem |
+
+### `controllers/` (~25 archivos)
+
+| Archivo | AC | Escenario |
+|---------|-----|-----------|
+| `test_profile_get_ok.py` | AC-1 | retorna profile completo |
+| `test_profile_get_no_auth.py` | — | 401 sin Authorization |
+| `test_profile_update_partial_ok.py` | AC-2 | UPDATE solo display_name |
+| `test_profile_update_full_ok.py` | AC-2 | UPDATE todos los campos |
+| `test_profile_update_invalid_locale.py` | — | 400 ValidationError |
+| `test_profile_update_marketing_consent_logs.py` | AC-3 | INSERT consent_log |
+| `test_profile_update_marketing_consent_same_no_log.py` | — | sin INSERT (no cambio) |
+| `test_profile_change_email_ok.py` | AC-4 | magic_link + SQS |
+| `test_profile_change_email_already_in_use.py` | — | 409 |
+| `test_profile_change_email_wrong_password.py` | — | 401 INVALID_PASSWORD |
+| `test_profile_delete_account_ok.py` | AC-6 | soft-delete + cascade + blacklist |
+| `test_profile_delete_account_wrong_confirm.py` | — | 400 INVALID_CONFIRM_SENTINEL |
+| `test_status_get_ok.py` | AC-7 | retorna info correcta |
+| `test_status_list_sessions_ok.py` | AC-8 | ordenado last_active_at DESC, current marcado |
+| `test_status_revoke_session_ok.py` | AC-9 | DELETE + blacklist |
+| `test_status_revoke_session_current_fails.py` | AC-10 | CANNOT_REVOKE_CURRENT_SESSION |
+| `test_admin_list_users_not_admin_404.py` | AC-11 | NOT_FOUND |
+| `test_admin_list_users_admin_ok.py` | AC-12 | 50 users + cursor |
+| `test_admin_list_users_paginated.py` | AC-13 | cursor + page_size respetados |
+| `test_admin_get_user_ok.py` | AC-14 | detalle con relations |
+| `test_admin_disable_user_ok.py` | AC-15 | UPDATE + admin_action row |
+| `test_admin_disable_self_fails.py` | — | CANNOT_DISABLE_SELF |
+| `test_admin_enable_user_ok.py` | AC-17 | UPDATE + audit |
+| `test_admin_force_logout_ok.py` | AC-18 | DELETE all sessions + blacklist families |
+| `test_admin_delete_user_ok.py` | AC-19 | cascade + audit |
+| `test_admin_delete_user_wrong_sentinel.py` | — | INVALID_CONFIRM_SENTINEL |
+| `test_admin_delete_self_fails.py` | — | CANNOT_DELETE_SELF |
+| `test_admin_list_admin_actions_ok.py` | AC-20 | range + pagination |
+| `test_admin_empty_whitelist_returns_404.py` | AC-21 | si admin-emails='' SSM, 404 |
+
+### `models/` (~10 archivos)
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_profile_update_in_locale_enum.py` | locale no en {es,en} -> ValidationError |
+| `test_profile_update_in_display_name_max_64.py` | > 64 chars -> ValidationError |
+| `test_profile_change_email_in_email_format.py` | not email -> ValidationError |
+| `test_profile_delete_account_in_sentinel_exact.py` | confirm != exact -> ValidationError |
+| `test_admin_disable_user_in_uuid.py` | user_id no UUID -> ValidationError |
+| `test_admin_delete_user_in_sentinel_matches_user_id.py` | confirm no matchea -> ValidationError |
+| `test_admin_list_users_in_page_size_max.py` | > 200 -> ValidationError |
+
+## Tests integration
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_profile_update_full_flow_e2e.py` | register + update + verify update reflected |
+| `test_profile_change_email_full_flow_e2e.py` | inicia + click magic-link + login con nuevo email OK |
+| `test_profile_delete_account_full_flow_e2e.py` | delete + verify login imposible |
+| `test_status_list_sessions_multi_device_e2e.py` | login desde 2 "dispositivos" (2 calls a auth) + status.list muestra 2 |
+| `test_admin_disable_then_login_e2e.py` | admin disables + target intenta login -> 403 (AC-16) |
+| `test_admin_force_logout_e2e.py` | admin force_logout + target con access JWT viejo -> 401 |
+| `test_admin_delete_user_cascade_e2e.py` | admin delete + verify cascada en credenciales/mfa |
+| `test_email_reuse_after_soft_delete_e2e.py` | AC-27: soft-delete + re-register con mismo email |
+| `test_migration_00000004_up_down_e2e.py` | AC-25 |
+
+## Tests integration tambien al lambda `auth` (sessions tracking)
+
+| Archivo (en `services/auth/tests/integration/`) | Escenario |
+|---------|-----------|
+| `test_session_tracking_create_on_login_e2e.py` | tras login.verify-code -> auth_user_sessions row creado |
+| `test_session_tracking_rotates_on_refresh_e2e.py` | session.refresh -> family_id rota en row |
+| `test_session_tracking_deletes_on_logout_e2e.py` | session.logout -> row deleted |
+| `test_session_tracking_persists_across_refresh_e2e.py` | 5 refresh -> 1 solo row (same family) |
+
+## Cobertura objetivo
+
+- Lambda `users`: >= 85% per-file en `core/{services,controllers,models}/`.
+- shared.auth.admin: 100% (modulo chico).
+- shared/db/repositories/auth_users.py: 90%+.
+
+## Comandos
+
+```bash
+# unit
+python devtools/run.py serverless tests --type=unit --lambda=users
+python devtools/run.py serverless tests --type=unit --shared
+
+# coverage
+python devtools/run.py serverless tests --type=coverage --lambda=users
+
+# integration (con AWS dev + Neon dev)
+python devtools/run.py serverless tests --type=integration --lambda=users
+python devtools/run.py serverless tests --type=integration --lambda=auth
+```
+
+## Reglas duras
+
+- **SIEMPRE** test admin authz incluye un caso "no admin" -> 404
+  (no 403).
+- **SIEMPRE** test de `delete-account` verifica:
+  (a) email anonimizado,
+  (b) credentials/mfa borrados,
+  (c) JWT blacklisted en DDB,
+  (d) auth_audit_log preservado.
+- **SIEMPRE** mock SSM `admin-emails` con admin email del test fixture.
+- **NUNCA** test de admin contra un user real del repo (usar fixtures
+  con uuidv7 nuevos).

--- a/docs/specs/03-auth-users-management/06-testing.md
+++ b/docs/specs/03-auth-users-management/06-testing.md
@@ -36,7 +36,7 @@ archivos.
 | `test_profile_service_update_partial.py` | parcial OK |
 | `test_profile_service_change_email_new_email_available.py` | INSERT magic_link |
 | `test_profile_service_change_email_taken.py` | levanta EmailAlreadyInUseError |
-| `test_profile_service_soft_delete_anonymizes.py` | email anonimo + cascade |
+| `test_profile_service_soft_delete_anonymizes.py` | email anonimo + DELETE explicitos en credentials/mfa/sessions |
 | `test_profile_service_disable_active.py` | UPDATE status=disabled |
 | `test_profile_service_enable_disabled.py` | UPDATE status=active |
 | `test_profile_service_enable_active_no_op.py` | no cambia si ya active |
@@ -67,7 +67,7 @@ archivos.
 | `test_profile_change_email_ok.py` | AC-4 | magic_link + SQS |
 | `test_profile_change_email_already_in_use.py` | — | 409 |
 | `test_profile_change_email_wrong_password.py` | — | 401 INVALID_PASSWORD |
-| `test_profile_delete_account_ok.py` | AC-6 | soft-delete + cascade + blacklist |
+| `test_profile_delete_account_ok.py` | AC-6 | soft-delete (UPDATE + DELETE explicitos en credentials/mfa/recovery/webauthn/email_codes/magic_links) + blacklist DDB |
 | `test_profile_delete_account_wrong_confirm.py` | — | 400 INVALID_CONFIRM_SENTINEL |
 | `test_status_get_ok.py` | AC-7 | retorna info correcta |
 | `test_status_list_sessions_ok.py` | AC-8 | ordenado last_active_at DESC, current marcado |

--- a/docs/specs/03-auth-users-management/07-archivos-afectados.md
+++ b/docs/specs/03-auth-users-management/07-archivos-afectados.md
@@ -85,17 +85,18 @@
 
 - `services/auth/core/services/session_tracking_service.py` — NUEVO
   helper.
-- 8 archivos donde se inyecta el helper:
-  - `controllers/register/verify_magic_link.py`
-  - `controllers/register/verify_code.py`
-  - `controllers/login/verify_magic_link.py`
-  - `controllers/login/verify_code.py`
-  - `controllers/login/verify_password.py`
-  - `controllers/login/verify_totp.py`
-  - `controllers/webauthn/login_verify.py`
-  - `controllers/mfa/recovery_codes_consume.py`
-  - `controllers/session/refresh.py` (rotation)
-  - `controllers/session/logout.py` (DELETE)
+- 10 controllers modificados con inyeccion minima del helper
+  (2-3 lineas en `execute()`):
+  - `controllers/register/verify_magic_link.py` (on_session_created)
+  - `controllers/register/verify_code.py` (on_session_created)
+  - `controllers/login/verify_magic_link.py` (on_session_created)
+  - `controllers/login/verify_code.py` (on_session_created)
+  - `controllers/login/verify_password.py` (on_session_created)
+  - `controllers/login/verify_totp.py` (on_session_created)
+  - `controllers/webauthn/login_verify.py` (on_session_created)
+  - `controllers/mfa/recovery_codes_consume.py` (on_session_created)
+  - `controllers/session/refresh.py` (on_session_rotated, rotation)
+  - `controllers/session/logout.py` (on_session_revoked, DELETE)
 - tests adicionales `services/auth/tests/integration/test_session_tracking_*.py` (4).
 
 ### En el shared.db
@@ -124,15 +125,32 @@
 
 ## Resumen contable
 
+Recuento item-por-item (todos los archivos del plan, separando
+`Crear` / `Modificar` / `Eliminar` por subcategoria):
+
 | Categoria | Crear | Modificar | Eliminar | Total |
 |-----------|-------|-----------|----------|-------|
-| Migration + modelos + repos | 4 + ~13 tests | 3 | 0 | ~20 |
-| `shared.auth.admin` (impl + tests) | 12 | 1 | 0 | 13 |
-| Infra resources | 1 | 0 | 0 | 1 |
-| auth_email_worker extension | 3 + 12 templates + 3 tests | 2 | 0 | 20 |
-| Lambda `users` (controllers + services + models + events + tests) | ~85 | 0 | 0 | 85 |
-| Lambda `auth` (sessions tracking inyectado) | 1 + 4 tests | 8 | 0 | 13 |
-| Documentacion permanente (.claude/) | 3 | 2 | 0 | 5 |
+| Migration alembic + 3 modelos nuevos + 1 repo + 13 tests repos | 18 | 3 (user.py + enums.py + auth/__init__.py) | 0 | 21 |
+| `shared.auth.admin` (admin.py + 11 tests) | 12 | 1 (`shared/auth/__init__.py`) | 0 | 13 |
+| Infra resources (admin-emails.yaml) | 1 | 0 | 0 | 1 |
+| auth_email_worker extension (3 controllers + 12 templates + 3 tests) | 18 | 2 (operations.py + email.py) | 0 | 20 |
+| Lambda `users` scaffold (manifest+pyproject+uv.lock+.gitignore) | 4 | 0 | 0 | 4 |
+| Lambda `users` core (handler + 2 settings + 4 models + 14 controllers + 10 services) | 31 | 0 | 0 | 31 |
+| Lambda `users` events JSON (1 por action) | 14 | 0 | 0 | 14 |
+| Lambda `users` tests unit (services ~30 + controllers ~25 + models ~10 + helpers) | ~70 | 0 | 0 | ~70 |
+| Lambda `users` tests integration | 9 | 0 | 0 | 9 |
+| Lambda `auth` sessions tracking (1 helper + tests integration) | 5 (1 service + 4 tests) | 8 (4 verify-* + refresh + logout + webauthn.login_verify + mfa.recovery_codes_consume) | 0 | 13 |
+| Documentacion permanente (.claude/) (3 docs nuevos + rule + skill) | 3 | 2 | 0 | 5 |
 | Plan efimero (`docs/specs/03-...`) | 12 | 0 | -12 | 0 |
 | Diagrama ER | 0 | 1 | 0 | 1 |
-| **Total neto** |  |  |  | **~158 archivos nuevos** |
+| __Total neto__ | __~197__ | __~17__ | __-12__ | __~202 archivos tocados__ |
+
+> __Nota__: las cifras de tests unit (`~70` para users, `13` para
+> repos shared, `11` para admin) son aproximadas — la enumeracion
+> exacta vive en [06-testing.md](06-testing.md). El total real puede
+> variar +/- 5% segun se desagreguen casos parametrizados o se
+> consoliden helpers compartidos en `tests/unit/_helpers.py`.
+>
+> __Conteo viejo__ decia "~158 archivos nuevos" — subestimaba el
+> Lambda `users` (85 vs ~128 reales) y omitia desagregar
+> modelos/repos. El numero correcto es __~202__.

--- a/docs/specs/03-auth-users-management/07-archivos-afectados.md
+++ b/docs/specs/03-auth-users-management/07-archivos-afectados.md
@@ -1,0 +1,138 @@
+# 07. Archivos Afectados — plan 03
+
+## Crear
+
+### Migration + modelos
+
+- `serverless/lambda/shared/db/alembic/versions/00000004_auth_users_extension.py`
+- `serverless/lambda/shared/db/models/auth/user_session.py`
+- `serverless/lambda/shared/db/models/auth/admin_action.py`
+- `serverless/lambda/shared/db/models/auth/consent_log.py`
+- `serverless/lambda/shared/db/repositories/auth_users.py` — separa
+  helpers del plan 01 + agrega 15+ nuevos.
+- tests `shared/tests/unit/shared/db/repositories/test_auth_users_*.py` (~13).
+  - Verificar: `serverless tests --type=unit --shared`, branch Neon
+    de prueba para AC-25.
+
+### shared.auth.admin
+
+- `serverless/lambda/shared/auth/admin.py`
+- `serverless/lambda/shared/auth/__init__.py` (modificar — agregar
+  exports).
+- tests `shared/tests/unit/shared/auth/test_admin_*.py` (11).
+
+### Infra
+
+- `serverless/lambda/resources/secrets/admin-emails.yaml`.
+
+### auth_email_worker — extension
+
+- `services/auth_email_worker/core/controllers/email/email_changed.py`
+- `services/auth_email_worker/core/controllers/email/account_disabled.py`
+- `services/auth_email_worker/core/controllers/email/account_deleted.py`
+- `services/auth_email_worker/core/templates/{es,en}/email-changed.{txt,html}` (4 archivos)
+- `services/auth_email_worker/core/templates/{es,en}/account-disabled.{txt,html}` (4)
+- `services/auth_email_worker/core/templates/{es,en}/account-deleted.{txt,html}` (4)
+- `services/auth_email_worker/core/settings/operations.py` — MODIFICAR
+  agregando los 3 nuevos kinds.
+- `services/auth_email_worker/core/models/email.py` — MODIFICAR
+  agregando schemas Pydantic para los 3 nuevos kinds.
+- tests `services/auth_email_worker/tests/unit/test_worker_handles_email_changed.py` y los otros 2 (3 archivos).
+  - Verificar: `serverless tests --type=unit --lambda=auth_email_worker`.
+
+### Lambda `users` (NUEVO)
+
+- `services/users/manifest.yaml`
+- `services/users/pyproject.toml`
+- `services/users/uv.lock`
+- `services/users/.gitignore`
+- `services/users/core/handler.py`
+- `services/users/core/settings/{config,operations}.py`
+- `services/users/core/models/{event,profile,status,admin}.py`
+- `services/users/core/controllers/profile/{get,update,change_email,delete_account}.py`
+- `services/users/core/controllers/status/{get,list_sessions,revoke_session}.py`
+- `services/users/core/controllers/admin/{list_users,get_user,disable_user,enable_user,force_logout,delete_user,list_admin_actions}.py`
+- `services/users/core/services/{profile,session,admin,audit_admin,consent,blacklist,jwt,email_dispatch,audit,rate_limit}_service.py`
+- `services/users/events/*.json` (14 archivos, uno por action).
+- `services/users/tests/unit/...` (~75 archivos).
+- `services/users/tests/integration/...` (~9 archivos).
+  - Verificar:
+    `serverless lint-deps --lambda=users`
+    `serverless tests --type=unit --lambda=users`
+    `serverless tests --type=coverage --lambda=users` (>= 85%)
+
+### Documentacion permanente
+
+- `.claude/docs/auth-system/06-users.md` (profile, status).
+- `.claude/docs/auth-system/07-admin.md` (whitelist, admin actions,
+  audit).
+- `.claude/docs/auth-system/08-sessions.md` (tracking via
+  auth_user_sessions, multi-device).
+- `.claude/rules/auth-system.md` — MODIFICAR agregando secciones
+  users + admin.
+- `.claude/skills/auth-system/SKILL.md` — MODIFICAR keywords para
+  incluir `profile`, `status`, `admin`, `perfil`, `gestion de usuarios`,
+  `sesiones activas`, `panel admin`.
+
+## Modificar
+
+- `docs/diagrams/db-er.mmd` — agregar columnas nuevas en `auth_users`
+  + 3 tablas nuevas + relaciones.
+- `docs/specs/03-auth-users-management/` — esta carpeta (efimera, se
+  elimina al cerrar).
+
+### En el Lambda `auth` (sessions tracking)
+
+- `services/auth/core/services/session_tracking_service.py` — NUEVO
+  helper.
+- 8 archivos donde se inyecta el helper:
+  - `controllers/register/verify_magic_link.py`
+  - `controllers/register/verify_code.py`
+  - `controllers/login/verify_magic_link.py`
+  - `controllers/login/verify_code.py`
+  - `controllers/login/verify_password.py`
+  - `controllers/login/verify_totp.py`
+  - `controllers/webauthn/login_verify.py`
+  - `controllers/mfa/recovery_codes_consume.py`
+  - `controllers/session/refresh.py` (rotation)
+  - `controllers/session/logout.py` (DELETE)
+- tests adicionales `services/auth/tests/integration/test_session_tracking_*.py` (4).
+
+### En el shared.db
+
+- `shared/db/models/auth/user.py` — MODIFICAR agregando columnas
+  nuevas + indices.
+- `shared/db/models/auth/enums.py` — MODIFICAR agregando
+  `email-change` a `AuthLinkKind`.
+- `shared/db/models/auth/__init__.py` — MODIFICAR re-exports.
+- `shared/db/repositories/auth.py` (existente) — sin cambios; los
+  nuevos helpers viven en `auth_users.py`.
+
+## Eliminar
+
+- `docs/specs/03-auth-users-management/` — al cerrar (ultimo commit).
+
+## NO se toca
+
+- Frontend Astro.
+- Lambdas `cv`, `contact_form`, `contact_worker`, `tracking_pixel`,
+  `tracking_worker`, `stream_processor`, `db`.
+- Shared subpackages `core`, `aws`, `http`, `observability`,
+  `rate_limit`, `cache`, `dynamodb`, `lambda_kit` (sin cambios en este
+  plan).
+- `.github/workflows/*.yml`.
+
+## Resumen contable
+
+| Categoria | Crear | Modificar | Eliminar | Total |
+|-----------|-------|-----------|----------|-------|
+| Migration + modelos + repos | 4 + ~13 tests | 3 | 0 | ~20 |
+| `shared.auth.admin` (impl + tests) | 12 | 1 | 0 | 13 |
+| Infra resources | 1 | 0 | 0 | 1 |
+| auth_email_worker extension | 3 + 12 templates + 3 tests | 2 | 0 | 20 |
+| Lambda `users` (controllers + services + models + events + tests) | ~85 | 0 | 0 | 85 |
+| Lambda `auth` (sessions tracking inyectado) | 1 + 4 tests | 8 | 0 | 13 |
+| Documentacion permanente (.claude/) | 3 | 2 | 0 | 5 |
+| Plan efimero (`docs/specs/03-...`) | 12 | 0 | -12 | 0 |
+| Diagrama ER | 0 | 1 | 0 | 1 |
+| **Total neto** |  |  |  | **~158 archivos nuevos** |

--- a/docs/specs/03-auth-users-management/08-descomposicion-paralelizacion.md
+++ b/docs/specs/03-auth-users-management/08-descomposicion-paralelizacion.md
@@ -1,0 +1,249 @@
+# 08. Descomposicion para Paralelizacion — plan 03
+
+> Plan **Large** (~158 archivos). 12 tareas atomicas.
+
+## Grafo de dependencias
+
+```text
+T1 plan + claude docs                          (raiz)
+  |
+  +--> T2 shared.auth.admin                    (raiz tras T1)
+  |
+  +--> T3 schema Neon (migration + modelos + repos)   (raiz tras T1)
+  |
+  +--> T4 infra (SSM admin-emails + sync)       (raiz tras T1)
+  |
+  +--> T5 auth_email_worker extension          (raiz tras T1; indep)
+  |     (3 controllers + 12 plantillas)
+  |
+  +--> T6 lambda users scaffold + services      (depende T2 + T3 + T4)
+  |     (manifest + AppConfig + handler + EventModel + services internos)
+  |
+  +--> T7 controllers profile/                 (depende T6)
+  |     (paralelo con T8, T9)
+  |
+  +--> T8 controllers status/                  (depende T6)
+  |     (paralelo con T7, T9)
+  |
+  +--> T9 controllers admin/                   (depende T6 + T2)
+  |     (paralelo con T7, T8)
+  |
+  +--> T10 sessions tracking en lambda auth     (depende T3; modifica auth)
+  |     (paralelo con T7-T9 si el merge se ordena bien)
+  |
+  +--> T11 rate-limit seed + deploys           (depende T7..T10)
+  |
+  +--> T12 verificacion E2E + ER + cleanup     (seccion 11; final)
+```
+
+## Tareas
+
+### T1: Plan + claude docs
+
+- **Archivos**:
+  - `docs/specs/03-auth-users-management/*.md` (12).
+  - `.claude/docs/auth-system/{06-users,07-admin,08-sessions}.md`
+  - `.claude/rules/auth-system.md` (modificar).
+  - `.claude/skills/auth-system/SKILL.md` (modificar keywords).
+- **AC**: ninguna.
+- **Depende de**: ninguna.
+- **Paralelizable con**: ninguna.
+- **Verify**: markdownlint + skill validation (`claude -p`).
+- **Done**: spec + docs/claude commiteados.
+
+### T2: shared.auth.admin
+
+- **Archivos**:
+  - `shared/auth/admin.py`
+  - `shared/auth/__init__.py` (modificar)
+  - `shared/tests/unit/shared/auth/test_admin_*.py` (11)
+- **AC**: soporta AC-11, AC-12, AC-21.
+- **Depende de**: T1.
+- **Paralelizable con**: T3, T4, T5.
+- **Verify**:
+  `serverless lint-deps --shared`
+  `serverless tests --type=unit --shared`
+- **Done**: 11 tests verdes, coverage 100% en `admin.py`.
+
+### T3: Schema Neon + modelos + repositories
+
+- **Archivos**:
+  - `shared/db/alembic/versions/00000004_auth_users_extension.py`
+  - `shared/db/models/auth/{user_session,admin_action,consent_log}.py`
+  - `shared/db/models/auth/user.py` (modificar)
+  - `shared/db/models/auth/enums.py` (modificar — agregar `email-change`)
+  - `shared/db/models/auth/__init__.py` (modificar)
+  - `shared/db/repositories/auth_users.py` (NUEVO, 15+ helpers)
+  - tests (~13)
+- **AC**: AC-22..AC-25.
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T4, T5.
+- **Verify**:
+  - Branch Neon de prueba: up -> down -> up idempotente.
+  - `serverless tests --type=unit --shared`
+- **Done**: migration aplica + reverte, 13 tests verdes.
+
+### T4: Infra (SSM admin-emails)
+
+- **Archivos**:
+  - `resources/secrets/admin-emails.yaml`
+- **AC**: soporta AC-11, AC-21.
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T3, T5.
+- **Verify**:
+  `serverless validate-catalog --stage=dev`
+  `serverless provision-infra --stage=dev --aws-profile=tfs-dev` (crea
+    el SSM)
+  `serverless sync-secrets --stage=dev --aws-profile=tfs-dev` (publica
+    `ADMIN_EMAILS=pacg1991@gmail.com`)
+- **Done**: SSM existe + valor sincronizado.
+
+### T5: auth_email_worker extension
+
+- **Archivos**:
+  - `services/auth_email_worker/core/controllers/email/{email_changed,account_disabled,account_deleted}.py`
+  - 12 templates en es/ y en/
+  - `core/settings/operations.py` (modificar)
+  - `core/models/email.py` (modificar)
+  - 3 tests
+- **AC**: ninguna directa (soporta plan funcional).
+- **Depende de**: T1.
+- **Paralelizable con**: T2, T3, T4.
+- **Verify**:
+  `serverless tests --type=unit --lambda=auth_email_worker`
+  `serverless run --stage=local --lambda=auth_email_worker --event=events/email-changed.json`
+- **Done**: 3 controllers + 12 templates + 3 tests verdes.
+
+### T6: Lambda `users` scaffold + services
+
+- **Archivos**:
+  - `services/users/{manifest.yaml, pyproject.toml, uv.lock, .gitignore}`
+  - `core/handler.py`
+  - `core/settings/{config,operations}.py`
+  - `core/models/event.py`
+  - `core/services/{profile,session,admin,audit_admin,consent,blacklist,jwt,email_dispatch,audit,rate_limit}_service.py`
+  - `core/models/{profile,status,admin}.py`
+  - tests services (~25)
+  - tests models (~10)
+- **AC**: transversal.
+- **Depende de**: T2, T3, T4.
+- **Paralelizable con**: T5.
+- **Verify**:
+  `serverless lint-deps --lambda=users`
+  `serverless tests --type=unit --lambda=users` (35 tests verdes)
+- **Done**: scaffold + services + models verdes.
+
+### T7: Controllers profile/ (paralelo con T8, T9)
+
+- **Archivos**:
+  - `core/controllers/profile/{get,update,change_email,delete_account}.py`
+  - 4 events JSON
+  - ~10 tests controllers
+- **AC**: AC-1..AC-6, AC-26.
+- **Depende de**: T6.
+- **Paralelizable con**: T8, T9.
+- **Verify**: `serverless tests --type=unit --lambda=users`.
+- **Done**: 4 controllers + 10 tests verdes.
+
+### T8: Controllers status/ (paralelo con T7, T9)
+
+- **Archivos**:
+  - `core/controllers/status/{get,list_sessions,revoke_session}.py`
+  - 3 events JSON
+  - ~4 tests
+- **AC**: AC-7..AC-10.
+- **Depende de**: T6.
+- **Paralelizable con**: T7, T9.
+- **Verify**: idem.
+- **Done**: 3 controllers + 4 tests.
+
+### T9: Controllers admin/ (paralelo con T7, T8)
+
+- **Archivos**:
+  - `core/controllers/admin/{list_users,get_user,disable_user,enable_user,force_logout,delete_user,list_admin_actions}.py`
+  - 7 events JSON
+  - ~13 tests
+- **AC**: AC-11..AC-21, AC-28.
+- **Depende de**: T2 (require_admin), T6.
+- **Paralelizable con**: T7, T8.
+- **Verify**: idem.
+- **Done**: 7 controllers + 13 tests verdes.
+
+### T10: Sessions tracking en lambda auth
+
+- **Archivos**:
+  - `services/auth/core/services/session_tracking_service.py` (NUEVO)
+  - 8 modificaciones (4 verify-* + refresh + logout + 2 mas)
+  - 4 tests integration nuevos en `services/auth/tests/integration/`
+- **AC**: AC-22..AC-24.
+- **Depende de**: T3 (auth_user_sessions table).
+- **Paralelizable con**: T7, T8, T9 (toca lambda DISTINTO — auth, no
+  users).
+- **Verify**:
+  `serverless tests --type=unit --lambda=auth` (los unit tests del
+  auth no deben regresionar)
+  `serverless tests --type=integration --lambda=auth` (con AWS dev).
+- **Done**: 4 integration tests verdes + 8 archivos integran helper
+  sin romper tests del plan 01/02.
+
+### T11: Rate-limit seed + deploys
+
+- **Archivos**: ninguno (operativo) o pequenos ajustes manifest si
+  surgen.
+- **AC**: transversal.
+- **Depende de**: T6..T10.
+- **Paralelizable con**: ninguna.
+- **Verify**:
+  6 reglas seedeadas en dev/stage/prod.
+  Deploys exitosos: auth_email_worker, auth, users.
+- **Done**: seeds aplicados + deploys verdes.
+
+### T12: Verificacion E2E + ER + limpieza spec (= seccion 11)
+
+- **Archivos**:
+  - tests integration de users (~9 archivos)
+  - `docs/diagrams/db-er.mmd` (modificar)
+  - `docs/specs/03-auth-users-management/` (eliminar)
+- **AC**: TODOS.
+- **Depende de**: T2..T11.
+- **Paralelizable con**: ninguna.
+- **Verify**: ver [11-verificacion-e2e.md](11-verificacion-e2e.md).
+- **Done**: bateria verde.
+
+## Tabla de paralelismo
+
+| Tarea | Depende de | Paralelizable con |
+|-------|------------|--------------------|
+| T1 plan + claude docs | — | — |
+| T2 shared.auth.admin | T1 | T3, T4, T5 |
+| T3 schema + repos | T1 | T2, T4, T5 |
+| T4 SSM admin-emails | T1 | T2, T3, T5 |
+| T5 auth_email_worker ext | T1 | T2, T3, T4 |
+| T6 users scaffold + services | T2, T3, T4 | T5 |
+| T7 controllers profile | T6 | T8, T9, T10 |
+| T8 controllers status | T6 | T7, T9, T10 |
+| T9 controllers admin | T2, T6 | T7, T8, T10 |
+| T10 sessions tracking en auth | T3 | T7, T8, T9 |
+| T11 rate-limit + deploys | T6..T10 | — |
+| T12 E2E + ER + cleanup | T2..T11 | — |
+
+## Maximo paralelismo util
+
+- Tras T1: **4 worktrees concurrentes** (T2, T3, T4, T5).
+- Tras T6: **4 worktrees concurrentes** (T7, T8, T9, T10).
+
+8 worktrees totales a lo largo del plan, max 4 simultaneos. Dentro
+del limite de 5-7 recomendado.
+
+## Anti-patrones evitados
+
+- T7, T8, T9 son worktree-safe entre si (cada uno su subcarpeta
+  `controllers/<op>/` + su `models/<op>.py` ya cerrado en T6).
+- T10 toca el lambda `auth` (distinto al `users`). NO se solapa con
+  T7-T9.
+- T6 (scaffold) cierra `core/models/event.py`, `core/settings/operations.py`,
+  `core/models/{profile,status,admin}.py` desde el inicio. Los worktrees
+  T7/T8/T9 NO los modifican (cero conflicto).
+- T3 (schema) bloquea T6 (lambda users) y T10 (sessions tracking en
+  auth). T2 (shared.auth.admin) bloquea T6 (depende del `require_admin`)
+  y T9 (depende del `require_admin_user`).

--- a/docs/specs/03-auth-users-management/09-commits.md
+++ b/docs/specs/03-auth-users-management/09-commits.md
@@ -13,8 +13,10 @@ dev (post planes 01 + 02)
  ├── feature/auth-users-mgmt-4-infra                   (T4)
  ├── feature/auth-users-mgmt-5-email-worker-ext        (T5)
  ├── feature/auth-users-mgmt-6-users-scaffold          (T6)
- ├── feature/auth-users-mgmt-7-controllers-paralel     (T7 + T8 + T9 worktrees)
- ├── feature/auth-users-mgmt-8-sessions-tracking-auth  (T10)
+ ├── feature/auth-users-mgmt-7a-profile-controllers    (T7 — WT-A)
+ ├── feature/auth-users-mgmt-7b-status-controllers     (T8 — WT-B)
+ ├── feature/auth-users-mgmt-7c-admin-controllers      (T9 — WT-C)
+ ├── feature/auth-users-mgmt-8-sessions-tracking-auth  (T10 — WT-D)
  └── feature/auth-users-mgmt-9-verificacion-e2e        (T11 + T12)
 ```
 
@@ -149,28 +151,60 @@ dev (post planes 01 + 02)
 
 ---
 
-## PR 7 — `feat(users): controllers profile + status + admin (worktrees paralelos)`
+## PR 7a — `feat(users/profile): controllers profile (4 actions)`
 
-3 worktrees: T7 (profile) + T8 (status) + T9 (admin). Mergear en un
-solo PR para reducir overhead.
+Rama: `feature/auth-users-mgmt-7a-profile-controllers` (worktree
+WT-A). Disjunto de PR 7b y PR 7c — mergear en cualquier orden.
 
-### Commit 7.1 — `feat(users/profile): 4 controllers + 10 tests`
+### Commit 7a.1 — `feat(users/profile): 4 controllers + 10 tests`
 
-- Agrega controllers + events + tests.
-- **AC**: AC-1..AC-6, AC-26.
+- Agrega `controllers/profile/{get,update,change_email,delete_account}.py`.
+- Agrega 4 events JSON + 10 tests.
+- **AC**: AC-1..AC-6, AC-26, AC-29 (guard self-delete admin).
 - **Verificacion**: `serverless tests --type=unit --lambda=users`.
 
-### Commit 7.2 — `feat(users/status): 3 controllers + 4 tests`
+> Merge PR 7a a `dev`.
 
-- Idem.
+---
+
+## PR 7b — `feat(users/status): controllers status (3 actions)`
+
+Rama: `feature/auth-users-mgmt-7b-status-controllers` (worktree
+WT-B). Disjunto de PR 7a y PR 7c.
+
+### Commit 7b.1 — `feat(users/status): 3 controllers + 4 tests`
+
+- Agrega `controllers/status/{get,list_sessions,revoke_session}.py`.
+- Agrega 3 events JSON + 4 tests.
 - **AC**: AC-7..AC-10.
+- **Verificacion**: `serverless tests --type=unit --lambda=users`.
 
-### Commit 7.3 — `feat(users/admin): 7 controllers + 13 tests`
+> Merge PR 7b a `dev`.
 
-- Idem.
+---
+
+## PR 7c — `feat(users/admin): controllers admin (7 actions)`
+
+Rama: `feature/auth-users-mgmt-7c-admin-controllers` (worktree
+WT-C). Disjunto de PR 7a y PR 7b.
+
+### Commit 7c.1 — `feat(users/admin): 7 controllers + 13 tests`
+
+- Agrega
+  `controllers/admin/{list_users,get_user,disable_user,enable_user,force_logout,delete_user,list_admin_actions}.py`.
+- Agrega 7 events JSON + 13 tests.
 - **AC**: AC-11..AC-21, AC-28.
+- **Verificacion**: `serverless tests --type=unit --lambda=users`.
 
-> Merge PR 7.
+> Merge PR 7c a `dev`.
+>
+> **Por que 3 PRs en vez de 1**: cumple
+> [git-workflow.md](../../../.claude/rules/git-workflow.md) ("PRs
+> pequenos y atomicos"). Los 3 worktrees son disjuntos en su zona
+> de write (subcarpetas `controllers/<op>/` + events `<op>-*.json` +
+> tests por op) — `event.py` y `models/{profile,status,admin}.py`
+> ya estan cerrados en PR 6. El review humano de 4-7 controllers
+> por PR es manejable, en cambio uno solo de 14 es ruido.
 
 ---
 
@@ -244,7 +278,9 @@ PR 3  schema + repos                           AC-25
 PR 4  SSM admin-emails                         infra
 PR 5  auth_email_worker plantillas             notifications
 PR 6  users scaffold + services + models       transversal
-PR 7  controllers profile + status + admin     AC-1..21, AC-26..28
+PR 7a controllers profile                      AC-1..6, AC-26, AC-29
+PR 7b controllers status                       AC-7..10
+PR 7c controllers admin                        AC-11..21, AC-28
 PR 8  sessions tracking en auth                AC-22..24
 PR 9  deploy + integration + ER + cleanup      consolida
 ```

--- a/docs/specs/03-auth-users-management/09-commits.md
+++ b/docs/specs/03-auth-users-management/09-commits.md
@@ -20,7 +20,11 @@ dev (post planes 01 + 02)
  └── feature/auth-users-mgmt-9-verificacion-e2e        (T11 + T12)
 ```
 
-## PR 1 — `docs(specs+claude): plan 03-auth-users-management + claude docs/auth-system users + admin + sessions`
+## PR 1 — `docs(specs): plan 03-auth-users-management + claude docs auth-system extension`
+
+Titulo del PR usa scope `docs(specs)` (scope valido segun
+`.claude/rules/git-workflow.md`). Los dos commits del PR llevan
+scopes distintos para mantener trazabilidad por carpeta tocada.
 
 ### Commit 1.1 — `docs(specs): plan 03-auth-users-management`
 
@@ -29,7 +33,7 @@ dev (post planes 01 + 02)
 
 ### Commit 1.2 — `docs(claude): auth-system 06-users + 07-admin + 08-sessions + rule + skill keywords`
 
-- Agrega 3 docs nuevos.
+- Agrega 3 docs nuevos en `.claude/docs/auth-system/`.
 - Modifica `.claude/rules/auth-system.md`.
 - Modifica `.claude/skills/auth-system/SKILL.md` (keywords).
 - **Verificacion**:
@@ -193,7 +197,11 @@ WT-C). Disjunto de PR 7a y PR 7b.
 - Agrega
   `controllers/admin/{list_users,get_user,disable_user,enable_user,force_logout,delete_user,list_admin_actions}.py`.
 - Agrega 7 events JSON + 13 tests.
-- **AC**: AC-11..AC-21, AC-28.
+- **AC**: AC-11..AC-21, AC-28 (AC-28 lo cubre `admin.get-user`:
+  cuando el target esta soft-deleted, devuelve el row con
+  `deleted_at` poblado + email anonimizado — verificado por
+  `test_admin_get_user_ok.py` + `test_admin_get_user_soft_deleted.py`
+  del listado de 06-testing).
 - **Verificacion**: `serverless tests --type=unit --lambda=users`.
 
 > Merge PR 7c a `dev`.

--- a/docs/specs/03-auth-users-management/09-commits.md
+++ b/docs/specs/03-auth-users-management/09-commits.md
@@ -1,0 +1,255 @@
+# 09. Commits — plan 03
+
+> Rama base: `feature/auth-users-management-N-<x>` desde `dev` (planes
+> 01 + 02 ya mergeados). Multiples PRs incrementales.
+
+## Ramas
+
+```text
+dev (post planes 01 + 02)
+ ├── feature/auth-users-mgmt-1-spec-and-docs           (T1)
+ ├── feature/auth-users-mgmt-2-shared-admin            (T2)
+ ├── feature/auth-users-mgmt-3-schema-and-repos        (T3)
+ ├── feature/auth-users-mgmt-4-infra                   (T4)
+ ├── feature/auth-users-mgmt-5-email-worker-ext        (T5)
+ ├── feature/auth-users-mgmt-6-users-scaffold          (T6)
+ ├── feature/auth-users-mgmt-7-controllers-paralel     (T7 + T8 + T9 worktrees)
+ ├── feature/auth-users-mgmt-8-sessions-tracking-auth  (T10)
+ └── feature/auth-users-mgmt-9-verificacion-e2e        (T11 + T12)
+```
+
+## PR 1 — `docs(specs+claude): plan 03-auth-users-management + claude docs/auth-system users + admin + sessions`
+
+### Commit 1.1 — `docs(specs): plan 03-auth-users-management`
+
+- Agrega `docs/specs/03-auth-users-management/` (12 archivos).
+- **Verificacion**: markdownlint.
+
+### Commit 1.2 — `docs(claude): auth-system 06-users + 07-admin + 08-sessions + rule + skill keywords`
+
+- Agrega 3 docs nuevos.
+- Modifica `.claude/rules/auth-system.md`.
+- Modifica `.claude/skills/auth-system/SKILL.md` (keywords).
+- **Verificacion**:
+  - markdownlint
+  - 5 prompts ES via `claude -p`.
+
+> Merge PR 1.
+
+---
+
+## PR 2 — `feat(shared/auth): admin whitelist via SSM`
+
+### Commit 2.1 — `feat(shared/auth): admin.py + load_admin_emails + is_admin + require_admin`
+
+- Agrega `shared/auth/admin.py`.
+- Modifica `shared/auth/__init__.py`.
+- Agrega 11 tests.
+- **Verificacion**:
+  - `serverless lint-deps --shared`
+  - `serverless tests --type=unit --shared`
+
+> Merge PR 2.
+
+---
+
+## PR 3 — `feat(db): schema auth_users extension + sessions/admin_actions/consent_log + repos`
+
+### Commit 3.1 — `feat(db/models): auth_users extension + 3 tablas nuevas`
+
+- Modifica `models/auth/user.py` (columnas nuevas + indices).
+- Modifica `models/auth/enums.py` (AuthLinkKind: agregar `email-change`).
+- Agrega `models/auth/{user_session,admin_action,consent_log}.py`.
+- Modifica `models/auth/__init__.py`.
+- **Verificacion**: `python -m compileall -q`.
+
+### Commit 3.2 — `feat(db/alembic): migration 00000004_auth_users_extension`
+
+- Agrega migration.
+- **Verificacion**: branch Neon de prueba up -> down -> up
+  idempotente. AC-25.
+
+### Commit 3.3 — `feat(db/repositories): auth_users helpers + sessions + admin_actions + consent`
+
+- Agrega `repositories/auth_users.py` (15+ helpers).
+- Agrega 13 tests.
+- **Verificacion**: `serverless tests --type=unit --shared`.
+
+### Commit 3.4 — `chore(db): aplica migration 00000004 en dev`
+
+- Operativo.
+- Verificacion: `current.json` muestra `00000004`.
+
+> Merge PR 3.
+
+---
+
+## PR 4 — `feat(infra): SSM admin-emails`
+
+### Commit 4.1 — `feat(resources/secrets): admin-emails entry`
+
+- Agrega `resources/secrets/admin-emails.yaml`.
+- **Verificacion**: `serverless validate-catalog`.
+
+### Commit 4.2 — `chore(infra): provision SSM admin-emails + sync valor en dev`
+
+- Operativo:
+  - Agregar `ADMIN_EMAILS=pacg1991@gmail.com` a `docker/env/server/.{dev,stage,prod}`.
+  - `serverless provision-infra --stage=dev --aws-profile=tfs-dev`
+  - `serverless sync-secrets --stage=dev --aws-profile=tfs-dev` (luego stage + prod)
+- **Verificacion**: `serverless secrets-status --stage=dev` reporta
+  `SKIP` en admin-emails.
+
+> Merge PR 4.
+
+---
+
+## PR 5 — `feat(auth_email_worker): 3 plantillas nuevas (email-changed, account-disabled, account-deleted)`
+
+### Commit 5.1 — `feat(auth_email_worker): 3 controllers + 3 schemas + 12 templates`
+
+- Agrega controllers + templates es/en.
+- Modifica operations.py + email.py models.
+- Agrega 3 tests unit.
+- **Verificacion**:
+  `serverless tests --type=unit --lambda=auth_email_worker`
+  `serverless run --stage=local --lambda=auth_email_worker --event=events/email-changed.json` exitoso.
+
+### Commit 5.2 — `chore(deploy): auth_email_worker -> dev`
+
+- Operativo: `serverless deploy --lambda=auth_email_worker --stage=dev --aws-profile=tfs-dev`.
+
+> Merge PR 5.
+
+---
+
+## PR 6 — `feat(users): scaffold lambda + services internos + EventModel`
+
+### Commit 6.1 — `feat(users): scaffold manifest + AppConfig + handler`
+
+- Agrega `services/users/{manifest.yaml, pyproject.toml, uv.lock, .gitignore, core/handler.py, core/settings/{config,operations}.py, core/models/event.py}`.
+- **Verificacion**:
+  `serverless lint-deps --lambda=users`
+  `python -m compileall -q services/users`
+
+### Commit 6.2 — `feat(users/services): 10 services internos + tests`
+
+- Agrega `core/services/*.py` (10).
+- Agrega ~25 tests.
+- **Verificacion**: `serverless tests --type=coverage --lambda=users` (>= 80% en services).
+
+### Commit 6.3 — `feat(users/models): Pydantic schemas + tests`
+
+- Agrega `core/models/{profile,status,admin}.py`.
+- Modifica `event.py` agregando los 14 actions.
+- Agrega ~10 tests models.
+- **Verificacion**: `serverless tests --type=unit --lambda=users`.
+
+> Merge PR 6.
+
+---
+
+## PR 7 — `feat(users): controllers profile + status + admin (worktrees paralelos)`
+
+3 worktrees: T7 (profile) + T8 (status) + T9 (admin). Mergear en un
+solo PR para reducir overhead.
+
+### Commit 7.1 — `feat(users/profile): 4 controllers + 10 tests`
+
+- Agrega controllers + events + tests.
+- **AC**: AC-1..AC-6, AC-26.
+- **Verificacion**: `serverless tests --type=unit --lambda=users`.
+
+### Commit 7.2 — `feat(users/status): 3 controllers + 4 tests`
+
+- Idem.
+- **AC**: AC-7..AC-10.
+
+### Commit 7.3 — `feat(users/admin): 7 controllers + 13 tests`
+
+- Idem.
+- **AC**: AC-11..AC-21, AC-28.
+
+> Merge PR 7.
+
+---
+
+## PR 8 — `feat(auth): sessions tracking integrado en el lambda auth`
+
+### Commit 8.1 — `feat(auth/services): session_tracking_service helper`
+
+- Agrega `services/session_tracking_service.py`.
+- Agrega tests unit del helper.
+- **Verificacion**: `serverless tests --type=unit --lambda=auth` (no
+  regresiones).
+
+### Commit 8.2 — `feat(auth/controllers): inyecta session_tracking en verify-* + refresh + logout`
+
+- Modifica 8 controllers (verify_magic_link x2, verify_code x2,
+  verify_password, verify_totp, webauthn.login_verify, mfa.recovery_codes_consume, session.refresh, session.logout).
+- Cada modificacion es minima: 2-3 lineas para llamar al helper.
+- **Verificacion**:
+  `serverless tests --type=unit --lambda=auth` verde
+  `serverless run --stage=local --lambda=auth --event=events/session-refresh.json` rotation funciona
+
+### Commit 8.3 — `test(auth): integration tests session tracking E2E`
+
+- Agrega 4 integration tests en `services/auth/tests/integration/`.
+- **AC**: AC-22, AC-23, AC-24.
+- **Verificacion**:
+  `serverless tests --type=integration --lambda=auth` (con AWS dev).
+
+### Commit 8.4 — `chore(deploy): auth lambda con session tracking -> dev`
+
+- Operativo: `serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev`.
+
+> Merge PR 8.
+
+---
+
+## PR 9 — `chore: rate-limit seed + deploy users + verificacion E2E + cleanup spec 03`
+
+### Commit 9.1 — `chore(rate-limit): seed reglas users# en dev/stage/prod`
+
+- Operativo. 6 reglas (profile.get, profile.update, profile.change-email,
+  profile.delete-account, status, admin).
+
+### Commit 9.2 — `chore(deploy): users lambda -> dev`
+
+- Operativo: `serverless deploy --lambda=users --stage=dev --aws-profile=tfs-dev`.
+- Verificacion: `serverless status --lambda=users --stage=dev` -> Active.
+
+### Commit 9.3 — `test(users): 9 integration tests E2E`
+
+- Agrega tests integration en `services/users/tests/integration/`.
+- **Verificacion**: `serverless tests --type=integration --lambda=users`.
+
+### Commit 9.4 — `docs(diagrams): actualiza db-er.mmd con auth_user_sessions + admin_actions + consent_log`
+
+- Modifica `docs/diagrams/db-er.mmd`.
+
+### Commit 9.5 — `chore(specs): elimina la carpeta efimera del plan 03`
+
+- `git rm -r docs/specs/03-auth-users-management/`.
+- **Verificacion**: bateria de [11-verificacion-e2e.md](11-verificacion-e2e.md) en verde.
+
+> Merge PR 9 a `dev`. Promociones a `stage` y `main`.
+
+## Resumen de la secuencia
+
+```text
+PR 1  spec + docs/claude                       (sin codigo)
+PR 2  shared.auth.admin                        AC-11, AC-21
+PR 3  schema + repos                           AC-25
+PR 4  SSM admin-emails                         infra
+PR 5  auth_email_worker plantillas             notifications
+PR 6  users scaffold + services + models       transversal
+PR 7  controllers profile + status + admin     AC-1..21, AC-26..28
+PR 8  sessions tracking en auth                AC-22..24
+PR 9  deploy + integration + ER + cleanup      consolida
+```
+
+## PR body template — sin atribucion IA
+
+Cada PR usa `.claude/rules/git-workflow.md`: Problema / Solucion / Como
+probar / TODO.

--- a/docs/specs/03-auth-users-management/10-paralelizacion-worktrees.md
+++ b/docs/specs/03-auth-users-management/10-paralelizacion-worktrees.md
@@ -136,8 +136,10 @@ PR 6 users scaffold + services ─┘
        │           │            │            │ (en lambda auth)
        └───────────┴────────────┴────────────┘
                                 │
-                       PR 7 (T7+T8+T9 mergeados)
-                       PR 8 (T10 mergeado)
+                       PR 7a (T7 mergeado)
+                       PR 7b (T8 mergeado)
+                       PR 7c (T9 mergeado)
+                       PR 8  (T10 mergeado)
                                 │
                                 v
                        PR 9 verificacion E2E + cleanup (SEC. 11)

--- a/docs/specs/03-auth-users-management/10-paralelizacion-worktrees.md
+++ b/docs/specs/03-auth-users-management/10-paralelizacion-worktrees.md
@@ -43,8 +43,19 @@ worktrees concurrentes seguros.
 | `services/auth/tests/integration/test_session_tracking_*.py` | — | — | — | WRITE (4 nuevos) |
 
 `services/users/events/` es la unica zona compartida en cuanto a
-carpeta. Pero los archivos son disjuntos (`profile-*.json` vs
-`status-*.json` vs `admin-*.json`) — File Exclusivity OK.
+carpeta. Pero los archivos son disjuntos por prefijo
+(`profile-*.json` en WT-A vs `status-*.json` en WT-B vs
+`admin-*.json` en WT-C) — File Exclusivity OK.
+
+> **Nota sobre el orden de merge**: si WT-A mergea PRIMERO, los
+> workflows CI de WT-B y WT-C (no mergeados aun) van a tener
+> `events/profile-*.json` ya en `dev` cuando rebaseen. NO es
+> colision (los archivos son disjuntos), pero el integration test
+> de WT-B/WT-C ahora "ve" 4 events de profile que antes no
+> existian. Como los tests de cada worktree filtran por su
+> operation/action, esto es benigno. Si en el futuro algun test
+> hace `glob('events/*.json')` sin filtrar, podria romperse — fix:
+> filtrar por prefijo (`events/status-*.json`).
 
 ## Fase secuencial final
 

--- a/docs/specs/03-auth-users-management/10-paralelizacion-worktrees.md
+++ b/docs/specs/03-auth-users-management/10-paralelizacion-worktrees.md
@@ -1,0 +1,146 @@
+# 10. Paralelizacion con git worktrees — plan 03
+
+## Base secuencial
+
+```text
+PR 1  T1 plan + docs/claude         <-- BASE 1
+PR 2  T2 shared.auth.admin          <-- BASE 2 (require_admin)
+PR 3  T3 schema + repos             <-- BASE 3 (modelos + auth_user_sessions table)
+PR 4  T4 SSM admin-emails           <-- BASE 4
+PR 5  T5 email-worker plantillas    <-- BASE 5 (independiente; mergeable en paralelo a 2-4)
+PR 6  T6 users scaffold + services  <-- BASE 6 (depende de 2+3+4)
+```
+
+BASE 1..6 secuencial. PR 5 puede mergearse paralelo a PR 2-4 si el
+equipo coordina, pero recomendado en orden para review claridad.
+
+## Fase paralela: worktrees tras PR 6 mergeado
+
+| Worktree | Tarea | Archivos | Colision? |
+|----------|-------|----------|-----------|
+| WT-A | T7 controllers profile | `controllers/profile/*` + events + tests | no |
+| WT-B | T8 controllers status | `controllers/status/*` + events + tests | no |
+| WT-C | T9 controllers admin | `controllers/admin/*` + events + tests | no |
+| WT-D | T10 sessions tracking en auth | `services/auth/core/services/session_tracking_service.py` + 8 controllers MODIFICADOS de auth | si — con planes 01/02 si alguien mas toca esos 8 archivos (no aplica) |
+
+WT-A, WT-B, WT-C son disjuntos entre si (subcarpetas distintas en
+`services/users/`). WT-D vive en `services/auth/` (lambda distinto). 4
+worktrees concurrentes seguros.
+
+### Tabla de colisiones
+
+| Archivo | T7 | T8 | T9 | T10 |
+|---------|-----|------|------|------|
+| `services/users/controllers/profile/*` | WRITE | — | — | — |
+| `services/users/controllers/status/*` | — | WRITE | — | — |
+| `services/users/controllers/admin/*` | — | — | WRITE | — |
+| `services/users/events/*` | WRITE (4) | WRITE (3) | WRITE (7) | — |
+| `services/users/tests/unit/controllers/*` | WRITE | WRITE | WRITE | — |
+| `services/users/core/models/event.py` | — | — | — | — (cerrado en T6) |
+| `services/users/core/models/{profile,status,admin}.py` | — | — | — | — (cerrados en T6) |
+| `services/auth/core/services/session_tracking_service.py` | — | — | — | WRITE (nuevo) |
+| `services/auth/core/controllers/{register,login,session,webauthn,mfa}/*.py` (8 archivos) | — | — | — | WRITE (inyeccion minima de 2-3 lineas) |
+| `services/auth/tests/integration/test_session_tracking_*.py` | — | — | — | WRITE (4 nuevos) |
+
+`services/users/events/` es la unica zona compartida en cuanto a
+carpeta. Pero los archivos son disjuntos (`profile-*.json` vs
+`status-*.json` vs `admin-*.json`) — File Exclusivity OK.
+
+## Fase secuencial final
+
+Tras T7+T8+T9+T10 mergeados:
+
+- PR 9 T11 (rate-limit seed + deploy users) — operativo
+- PR 9 T12 (integration tests + ER + cleanup) — seccion 11
+
+## Como lanzar worktree
+
+Mismo patron de planes 01 y 02. Ejemplo WT-D (sessions tracking):
+
+```bash
+git checkout dev
+git pull origin dev
+
+git worktree add ../portfolio-wt-sessions-tracking feature/auth-users-mgmt-8-sessions
+cd ../portfolio-wt-sessions-tracking
+git checkout -b feature/auth-users-mgmt-8-sessions
+
+pnpm install
+cd serverless/lambda/services/auth && uv sync
+
+# Implementar T10:
+# 1. core/services/session_tracking_service.py
+# 2. Modificar 8 controllers para inyectar:
+#    - controllers/register/verify_magic_link.py: tras issue_access+refresh,
+#      llamar session_tracking_service.on_session_created(...)
+#    - controllers/register/verify_code.py: idem
+#    - controllers/login/{verify_magic_link, verify_code, verify_password, verify_totp}.py: idem
+#    - controllers/webauthn/login_verify.py: idem
+#    - controllers/mfa/recovery_codes_consume.py: idem
+#    - controllers/session/refresh.py: on_session_rotated(...) en rotation
+#    - controllers/session/logout.py: on_session_revoked(...) tras blacklist
+# 3. Agregar 4 tests integration
+
+# Verificar
+serverless tests --type=unit --lambda=auth      # no regresiones plan 01/02
+serverless tests --type=integration --lambda=auth  # 4 tests nuevos verdes
+
+# Commit + push + PR
+```
+
+### Con subagentes en paralelo
+
+4 instancias de `Agent` con `isolation: "worktree"`:
+
+```text
+Agent A (T7 profile): "Implementar segun docs/specs/03-.../05-...md
+  controller profile.* + docs/specs/03-.../08-...md tarea T7"
+Agent B (T8 status): "... seccion status + tarea T8"
+Agent C (T9 admin): "... seccion admin + tarea T9"
+Agent D (T10 sessions tracking): "... seccion 'Cambios al Lambda auth'
+  + tarea T10. Notas: NO modificar los servicios existentes, solo
+  inyectar la llamada en 8 controllers."
+```
+
+## Que NO se paraleliza
+
+- T1..T6: secuenciales.
+- T11 (rate-limit + deploys): operativo final.
+- T12 (verificacion E2E): cierre.
+
+## Anti-patrones evitados
+
+- T7, T8, T9 no editan `event.py`, `operations.py`, `models/{profile,status,admin}.py`
+  (todos cerrados en T6 con los 14 actions registrados desde el inicio).
+- WT-A, WT-B, WT-C son completamente disjuntos.
+- T10 toca un lambda DIFERENTE (auth) — NO colisiona con T7/T8/T9.
+- Inyeccion del session tracking en los 8 controllers del lambda auth
+  es minima (2-3 lineas en `execute()` tras emitir tokens). No
+  refactoriza la logica, solo agrega una llamada al helper.
+
+## Resumen visual
+
+```text
+PR 1 spec+docs/claude          ─┐
+PR 2 shared.auth.admin         ─┤
+PR 3 schema + repos            ─┤   BASE secuencial
+PR 4 SSM admin-emails          ─┤
+PR 5 email-worker ext          ─┤
+PR 6 users scaffold + services ─┘
+                                │
+       ┌───────────┬────────────┼────────────┬───────────┐
+       │           │            │            │           │
+     WT-A        WT-B         WT-C         WT-D
+   profile     status       admin       sessions
+   controllers controllers  controllers  tracking
+       │           │            │            │ (en lambda auth)
+       └───────────┴────────────┴────────────┘
+                                │
+                       PR 7 (T7+T8+T9 mergeados)
+                       PR 8 (T10 mergeado)
+                                │
+                                v
+                       PR 9 verificacion E2E + cleanup (SEC. 11)
+```
+
+Maximo paralelismo util: **4 worktrees concurrentes**.

--- a/docs/specs/03-auth-users-management/11-verificacion-e2e.md
+++ b/docs/specs/03-auth-users-management/11-verificacion-e2e.md
@@ -1,0 +1,341 @@
+# 11. Verificacion E2E iterativa — plan 03
+
+> Ultima fase. Gate del PR 9.
+
+## Parte A — refactor de tests
+
+| Archivo | Accion |
+|---------|--------|
+| `services/users/tests/integration/test_*_e2e.py` (9) | CREAR |
+| `services/auth/tests/integration/test_session_tracking_*.py` (4) | CREAR (ya en PR 8) |
+| `services/auth/tests/unit/controllers/login/test_*.py` | revisar — verificar que session tracking inyectado no rompe |
+| `docs/diagrams/db-er.mmd` | MODIFICAR |
+| `docs/specs/03-auth-users-management/` | ELIMINAR |
+| `docs/specs/01-auth-infra-basics/` y `docs/specs/02-auth-mfa/` | (ya eliminados al cerrar planes 01 y 02 respectivamente; verificar) |
+
+### Barrido global
+
+```bash
+# Tests que referencien funciones eliminadas (no aplica — solo agregamos)
+rg -l "deprecated_users|legacy_admin" serverless/
+
+# TODOs/FIXMEs del scope
+rg -l "TODO.*users|FIXME.*admin" serverless/lambda/services/users/
+
+# La spec se elimino
+test ! -d docs/specs/03-auth-users-management && echo OK || echo FAIL
+```
+
+## Parte B — bateria de comandos reales
+
+### Bloque 1 — sintaxis + lint
+
+```bash
+python -m compileall -q \
+  serverless/lambda/shared/auth \
+  serverless/lambda/shared/db/models/auth \
+  serverless/lambda/shared/db/repositories \
+  serverless/lambda/services/users \
+  serverless/lambda/services/auth \
+  serverless/lambda/services/auth_email_worker
+
+python devtools/run.py serverless lint --lambda=users
+python devtools/run.py serverless lint --lambda=auth
+python devtools/run.py serverless lint --lambda=auth_email_worker
+python devtools/run.py serverless lint --shared
+
+python devtools/run.py serverless lint-deps --lambda=users
+python devtools/run.py serverless lint-deps --lambda=auth
+python devtools/run.py serverless lint-deps --lambda=auth_email_worker
+python devtools/run.py serverless lint-deps --shared
+```
+
+### Bloque 2 — tests unit + coverage
+
+```bash
+python devtools/run.py serverless tests --type=unit --shared
+python devtools/run.py serverless tests --type=unit --lambda=users
+python devtools/run.py serverless tests --type=unit --lambda=auth_email_worker
+python devtools/run.py serverless tests --type=unit --lambda=auth   # no regresiones
+python devtools/run.py serverless tests --type=coverage --lambda=users
+# Coverage per-file >= 85% en controllers/{profile,status,admin}/
+# y >= 100% en shared/auth/admin.py
+```
+
+### Bloque 3 — run local (RIE) por endpoint
+
+```bash
+# Profile
+python devtools/run.py serverless run --stage=local --lambda=users \
+  --event=events/profile-get.json
+# Esperado: 200 con profile
+
+python devtools/run.py serverless run --stage=local --lambda=users \
+  --event=events/profile-update.json
+# Esperado: 200
+
+python devtools/run.py serverless run --stage=local --lambda=users \
+  --event=events/profile-change-email.json
+# Esperado: 200 con request_id
+
+python devtools/run.py serverless run --stage=local --lambda=users \
+  --event=events/profile-delete-account.json
+# Esperado: 204
+
+# Status
+python devtools/run.py serverless run --stage=local --lambda=users \
+  --event=events/status-list-sessions.json
+# Esperado: 200 con array
+
+# Admin
+python devtools/run.py serverless run --stage=local --lambda=users \
+  --event=events/admin-list-users.json
+# Esperado: 200 con primeros N + cursor (si caller es admin)
+# o 404 NOT_FOUND si no admin
+
+# Email worker
+python devtools/run.py serverless run --stage=local --lambda=auth_email_worker \
+  --event=events/email-changed.json
+# Esperado: log "email.sent.email-changed"
+```
+
+### Bloque 4 — migration end-to-end
+
+```bash
+neon branches create --name verify-users-plan --parent main
+BRANCH_URL="$(neon connection-string verify-users-plan)"
+
+# Aplicar 00000002 + 00000003 + 00000004 secuencial
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/migrate.json
+
+# Verificar tablas + columnas
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/tables.json | \
+  grep -E "auth_user_(sessions|admin_actions|consent_log)"
+
+psql "$BRANCH_URL" -c "\d auth_users" | grep -E "(display_name|locale|timezone|marketing_consent|deleted_at)"
+
+# Downgrade -1 (vuelve a 00000003)
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/downgrade.json
+
+# Up de nuevo (idempotencia)
+DATABASE_URL="$BRANCH_URL" \
+  serverless run --stage=local --lambda=db --event=events/migrate.json
+
+neon branches delete verify-users-plan
+```
+
+AC verificada: **AC-25**.
+
+### Bloque 5 — integration tests con AWS dev
+
+```bash
+# Asegurar deploys actualizados
+serverless deploy --lambda=auth_email_worker --stage=dev --aws-profile=tfs-dev
+serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
+serverless deploy --lambda=users --stage=dev --aws-profile=tfs-dev
+
+# Migration en dev
+serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev
+serverless run --stage=dev --lambda=db --event=events/current.json --aws-profile=tfs-dev
+# Esperado: revision 00000004
+
+# Tests integration
+python devtools/run.py serverless tests --type=integration --lambda=users
+python devtools/run.py serverless tests --type=integration --lambda=auth
+```
+
+### Bloque 6 — smoke E2E HTTP en dev
+
+```bash
+API_AUTH="https://api.portfolio.dev.the-full-stack.com/auth"
+API_USERS="https://api.portfolio.dev.the-full-stack.com/users"
+TURNSTILE_BYPASS="$(grep -m1 '^TURNSTILE_BYPASS_SECRET=' docker/env/server/.dev | cut -d= -f2-)"
+
+# 1. Crear un user via register + verify (flow del plan 01)
+EMAIL="users-smoke-$(date +%s)@example.com"
+# ... (curl al flow de plan 01 hasta obtener access_token + refresh_token)
+ACCESS="<access-obtenido>"
+
+# 2. profile.get
+curl -sS -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"profile","action":"get","data":{}}' | jq .data
+# Esperado: data.email = $EMAIL, data.status = 'active', data.mfa_configured = false
+
+# 3. profile.update
+curl -sS -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"profile","action":"update","data":{"display_name":"Pablo Smoke","locale":"es","marketing_consent":true}}' | jq .data
+# Esperado: data.display_name = "Pablo Smoke", data.locale = "es"
+# AC-2, AC-3 verificadas
+
+# 4. status.list-sessions (deberia mostrar 1, la actual)
+curl -sS -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"status","action":"list-sessions","data":{}}' | jq '.data | length'
+# Esperado: 1
+# AC-8 verificada
+
+# 5. admin.list-users con un user NO admin -> 404
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"admin","action":"list-users","data":{}}'
+# Esperado: 404 (porque $EMAIL no esta en ADMIN_EMAILS)
+# AC-11 verificada
+
+# 6. profile.delete-account
+curl -sS -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"profile","action":"delete-account","data":{"confirm":"DELETE-MY-ACCOUNT"}}'
+# Esperado: 204 (o {message: OK, status: 204} en el body)
+# AC-6 verificada
+
+# 7. Verificar que el access JWT ya no funciona (blacklisted)
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS" \
+  -d '{"operation":"profile","action":"get","data":{}}'
+# Esperado: 401 TOKEN_BLACKLISTED
+
+# 8. Intentar register con el mismo email -> AC-27 (re-uso permitido)
+curl -sS -X POST "$API_AUTH" \
+  -H "Content-Type: application/json" \
+  -H "X-Turnstile-Bypass-Secret: $TURNSTILE_BYPASS" \
+  -d "{\"operation\":\"register\",\"action\":\"start\",\"data\":{\"email\":\"$EMAIL\",\"cf_turnstile_response\":\"\"}}" | jq .
+# Esperado: 201 (email libre porque el viejo esta soft-deleted)
+```
+
+### Bloque 7 — smoke admin
+
+Requiere admin (email de Pablo en SSM admin-emails):
+
+```bash
+# Login como Pablo (flow del plan 01 + plan 02 con MFA si aplica)
+PABLO_ACCESS="<obtenido>"
+
+# admin.list-users
+curl -sS -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $PABLO_ACCESS" \
+  -d '{"operation":"admin","action":"list-users","data":{"page_size":10}}' | jq '.data | {users: .users | length, next_cursor}'
+# Esperado: users array + next_cursor presente si hay > 10
+# AC-12 verificada
+
+# admin.disable-user (sobre un user creado en bloque anterior)
+TARGET="<user_id-obtenido>"
+curl -sS -X POST "$API_USERS" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $PABLO_ACCESS" \
+  -d "{\"operation\":\"admin\",\"action\":\"disable-user\",\"data\":{\"user_id\":\"$TARGET\",\"reason\":\"smoke test\"}}"
+# Esperado: 204
+# AC-15 verificada
+
+# El target intenta login -> 403 ACCOUNT_DISABLED
+curl -sS -X POST "$API_AUTH" \
+  -H "Content-Type: application/json" \
+  -H "X-Turnstile-Bypass-Secret: $TURNSTILE_BYPASS" \
+  -d "{\"operation\":\"login\",\"action\":\"start\",\"data\":{\"email\":\"<email-del-target>\",\"cf_turnstile_response\":\"\"}}" | jq .
+# Esperado: data.error = ACCOUNT_DISABLED
+# AC-16 verificada
+```
+
+### Bloque 8 — cierre PR 9
+
+```bash
+test ! -d docs/specs/03-auth-users-management && echo "spec eliminada"
+grep -q "auth_user_sessions" docs/diagrams/db-er.mmd && echo "ER OK"
+grep -q "admin\|sessions" .claude/skills/auth-system/SKILL.md && echo "skill OK"
+
+# Skill validation
+claude --permission-mode bypassPermissions \
+  --disallowedTools "WebSearch" "WebFetch" \
+  --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
+  --output-format json \
+  -p "como deshabilitar un usuario en el portfolio" 2>&1 | tail -10
+# Esperado: num_turns > 1
+```
+
+## Parte C — bucle de correccion
+
+```text
+ejecutar bloque N
+   |
+   v
+{paso?}--si--> bloque N+1
+   |
+   no --> diagnosticar -> corregir -> re-ejecutar -> repetir
+```
+
+### Errores tipicos
+
+| Sintoma | Diagnostico | Correccion |
+|---------|-------------|------------|
+| `admin.list-users` siempre 404 incluso siendo admin | SSM admin-emails vacio o desactualizado | `serverless secrets-status --stage=dev` + sync_secrets |
+| `IntegrityError: duplicate key value violates unique constraint ux_auth_users_email_active` | El partial unique no esta como esperado | Verificar migration 00000004 aplicada + el old UNIQUE removido |
+| `profile.delete-account` no anonimiza email | Logica del service incorrecta o cascade falla | Verificar `profile_service.soft_delete` y models cascade='all, delete-orphan' |
+| `status.list-sessions` retorna vacio aun con sessions activas | session_tracking_service no se llama o falla silenciosamente | logs CloudWatch + verify_session_tracking en auth (T10) |
+| `force-logout` no invalida JWT viejo | Blacklist no se persiste o GSI query falla | Test integration del blacklist family detection |
+| Migration 00000004 falla con `cannot add value to enum used by table` | El ALTER TYPE en transaction | Ejecutar el ALTER TYPE fuera de transaction (con autocommit) |
+
+## Regla de cierre
+
+NO se marca completa mientras:
+
+- Algun bloque (1 a 8) falle,
+- Algun test rojo (unit, integration, ni del lambda auth tampoco),
+- Coverage per-file < 85% en `controllers/{profile,status,admin}/`,
+- < 100% en `shared/auth/admin.py`,
+- Spec `docs/specs/03-auth-users-management/` sigue viva.
+
+Iterar hasta verde. Solo entonces:
+
+```bash
+git add -A
+git commit -m "chore(specs): elimina la carpeta efimera del plan 03-auth-users-management"
+git push -u origin feature/auth-users-mgmt-9-verificacion-e2e
+gh pr create --base dev --title "chore(specs): verificacion E2E + cierre del plan 03-auth-users-management" --body "..."
+```
+
+## Promocion dev -> stage -> main
+
+Tras PR 9 mergeado:
+
+```bash
+gh pr create --base stage --head dev --title "chore: promover plan-03-auth-users-management a stage"
+gh pr merge --merge
+gh pr create --base main --head stage --title "chore: promover plan-03-auth-users-management a main"
+gh pr merge --merge
+```
+
+CI auto-deploya `auth`, `auth_email_worker`, `users` con auto-detect.
+La migration 00000004 se aplica via `deploy-backend.yml` `migrate-db`
+step antes del deploy de lambdas.
+
+Verificacion post-prod:
+
+```bash
+# Smoke check prod
+curl -sS -X POST "https://api.portfolio.the-full-stack.com/users" \
+  -H "Content-Type: application/json" \
+  -d '{"operation":"profile","action":"get","data":{}}'
+# Esperado: 401 MISSING_AUTHORIZATION (sin token)
+```
+
+## Pendientes que el PR 9 NO cubre (queda para futuro)
+
+- Frontend Astro: signup/signin/dashboard/settings con UI.
+- Hard-delete programatico de users soft-deleted >30 dias
+  (cron Lambda nuevo, NO en scope).
+- Bulk admin operations (import/export CSV).
+- Email worker plantilla `revoke-email-change` (undo del cambio si
+  fue malicioso) — opcional.
+
+Documentar en `## TODO` del PR 9.

--- a/docs/specs/03-auth-users-management/11-verificacion-e2e.md
+++ b/docs/specs/03-auth-users-management/11-verificacion-e2e.md
@@ -280,7 +280,7 @@ ejecutar bloque N
 |---------|-------------|------------|
 | `admin.list-users` siempre 404 incluso siendo admin | SSM admin-emails vacio o desactualizado | `serverless secrets-status --stage=dev` + sync_secrets |
 | `IntegrityError: duplicate key value violates unique constraint ux_auth_users_email_active` | El partial unique no esta como esperado | Verificar migration 00000004 aplicada + el old UNIQUE removido |
-| `profile.delete-account` no anonimiza email | Logica del service incorrecta o cascade falla | Verificar `profile_service.soft_delete` y models cascade='all, delete-orphan' |
+| `profile.delete-account` no anonimiza email | Logica del service incorrecta | Verificar `profile_service.soft_delete` — recordar que el soft-delete es UPDATE de `auth_users` mas DELETE explicitos en credentials/mfa/sessions; las FK CASCADE NO se disparan (las cascades reaccionan a DELETE, no a UPDATE) |
 | `status.list-sessions` retorna vacio aun con sessions activas | session_tracking_service no se llama o falla silenciosamente | logs CloudWatch + verify_session_tracking en auth (T10) |
 | `force-logout` no invalida JWT viejo | Blacklist no se persiste o GSI query falla | Test integration del blacklist family detection |
 | Migration 00000004 falla con `cannot add value to enum used by table` | El ALTER TYPE en transaction | Ejecutar el ALTER TYPE fuera de transaction (con autocommit) |

--- a/docs/specs/03-auth-users-management/README.md
+++ b/docs/specs/03-auth-users-management/README.md
@@ -133,10 +133,13 @@
    metadata, ip, created_at)`. Inmutable.
 8. **GDPR delete-account**: el `profile.delete-account` (self-service)
    marca `deleted_at`, anonimiza `email` a `deleted-<id>@invalid.local`
-   y borra `auth_credentials`, `auth_mfa_methods`, etc. en cascade.
-   Conserva `auth_audit_log` y `auth_user_admin_actions` para
-   compliance (sin PII personal). En 30 dias, hard-delete
-   programatico via cron Lambda (NO en scope de este plan, planificado).
+   y borra `auth_credentials`, `auth_mfa_methods`, etc. con DELETE
+   explicitos dentro del service (NO via FK cascade — las cascades
+   reaccionan a DELETE, no a UPDATE; ver detalle en
+   `05-lambda-users-arquitectura.md`). Conserva `auth_audit_log` y
+   `auth_user_admin_actions` para compliance (sin PII personal). En
+   30 dias, hard-delete programatico via cron Lambda (NO en scope
+   de este plan, planificado).
 9. **list-users paginado**: cursor-based con `last_id` (uuidv7
    ordenable). page_size default 50, max 200.
 

--- a/docs/specs/03-auth-users-management/README.md
+++ b/docs/specs/03-auth-users-management/README.md
@@ -38,11 +38,14 @@
     list-users (paginado), get-user, disable-user, enable-user,
     force-logout, delete-user (hard delete con cascada audit),
     list-admin-actions.
-- **Integracion con `auth`**: el Lambda `auth` queda intocable. Las
-  acciones admin (`disable-user`) actualizan `auth_users.status =
-  disabled` -> el siguiente login de ese user devuelve `401
-  ACCOUNT_DISABLED` (logica que ya esta en `auth.login.start` desde
-  plan 01).
+- **Integracion con `auth`**: el Lambda `auth` recibe una modificacion
+  minima (1 helper nuevo `session_tracking_service.py` + 8 puntos de
+  inyeccion de 2-3 lineas en `verify-*` / `refresh` / `logout`) para
+  poblar `auth_user_sessions`. Ver PR 8 en
+  [09-commits.md](09-commits.md). Las acciones admin (`disable-user`)
+  actualizan `auth_users.status = disabled` -> el siguiente
+  `auth.login.start` de ese user devuelve `403 ACCOUNT_DISABLED`
+  (logica que ya esta en `auth.login.start` desde plan 01).
 - **Rate-limit**: reglas nuevas para `users#*` (mas relajadas que auth
   porque requieren access JWT).
 - **Audit**: todas las operations admin escriben a
@@ -153,9 +156,11 @@
   tambien `admin.force-logout`.
 - **NUNCA** un admin puede ver el password_hash, TOTP secret o
   recovery codes hash de otro user (solo metadata).
-- **NUNCA** un user puede `delete-account` si tiene roles administrativos
-  asignados (no aplica hoy: si Pablo intenta, hay que asignar admin a
-  otro email primero — guard).
+- **NUNCA** un user puede `delete-account` si su email esta en la
+  whitelist SSM `admin-emails` (AC-29). Hoy aplica directamente a
+  Pablo: para borrar su cuenta, primero hay que sacar el email de la
+  whitelist (rotar SSM) — guard contra "el ultimo admin se borra a
+  si mismo".
 - **NUNCA** retornar `email` de otro user en respuestas no-admin.
 
 ## Matriz de verificacion (rapida)

--- a/docs/specs/03-auth-users-management/README.md
+++ b/docs/specs/03-auth-users-management/README.md
@@ -1,0 +1,182 @@
+# Plan 03: Auth users management — Lambda `users` con profile / status / admin
+
+> **Orden en la serie auth**: este es el **3 de 3** planes secuenciales.
+>
+> ```text
+> 01 — auth-infra-basics       (DEPENDENCIA: shared.auth + schema + lambda auth basico)
+> 02 — auth-mfa                (DEPENDENCIA: MFA / WebAuthn agregados al lambda auth)
+> 03 — auth-users-management   <-- ESTE PLAN (lambda `users` separado)
+> ```
+>
+> **Dependencia dura**: requiere planes 01 + 02 mergeados a `dev`
+> (idealmente `main`). Este plan agrega el segundo Lambda solicitado
+> originalmente por el usuario, `users`, separando la gestion del
+> identity (CRUD del perfil + status + admin) del ciclo de autenticacion
+> (`auth`).
+
+## Que entrega este plan
+
+- **Schema Neon (migration 00000004)**: agrega columnas a `auth_users`
+  (display_name, locale, timezone, marketing_consent, deleted_at) y
+  3 tablas nuevas:
+  - `auth_user_sessions`: tracking de sesiones activas por user
+    (refresh_token family_id + device info + last_active_at). Permite
+    listar y cerrar sesiones individuales.
+  - `auth_user_admin_actions`: audit de acciones administrativas
+    sobre users (disable, force_logout, delete, restore).
+  - `auth_user_consent_log`: log de cambios de marketing_consent +
+    privacy_policy_version para GDPR.
+- **Shared subpackage `shared.auth` (extension menor)**: agrega
+  `is_admin(user)` helper basado en role o lista whitelist en SSM.
+- **Lambda `users` (NUEVO)**: HTTP `POST /users`. 3 operations:
+  - `profile.*`: get, update (display_name, locale, timezone,
+    marketing_consent), change-email (con re-verificacion),
+    delete-account (soft delete).
+  - `status.*`: get (devuelve el self status), list-sessions,
+    revoke-session (logout de un device).
+  - `admin.*`: scope solo para Pablo (whitelist por email):
+    list-users (paginado), get-user, disable-user, enable-user,
+    force-logout, delete-user (hard delete con cascada audit),
+    list-admin-actions.
+- **Integracion con `auth`**: el Lambda `auth` queda intocable. Las
+  acciones admin (`disable-user`) actualizan `auth_users.status =
+  disabled` -> el siguiente login de ese user devuelve `401
+  ACCOUNT_DISABLED` (logica que ya esta en `auth.login.start` desde
+  plan 01).
+- **Rate-limit**: reglas nuevas para `users#*` (mas relajadas que auth
+  porque requieren access JWT).
+- **Audit**: todas las operations admin escriben a
+  `auth_user_admin_actions` ademas del `auth_audit_log` general.
+
+## Que NO entrega este plan
+
+- Frontend Astro (signup / signin / dashboard / settings) -> plan
+  futuro.
+- Email worker plantillas para "tu cuenta fue deshabilitada", "cambio
+  de email confirmado" -> agregar al `auth_email_worker` en este plan
+  (incremental al worker, no es Lambda nuevo).
+- Bulk operations admin (importar lista de users, exportar CSV) ->
+  fuera de scope.
+- 2FA-enforce-per-organization features (no aplica al portfolio).
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| Problema, solucion, AC numerados | [01-contexto-y-decision.md](01-contexto-y-decision.md) |
+| Schema Neon: columnas nuevas en `auth_users` + 3 tablas nuevas | [02-schema-neon-users.md](02-schema-neon-users.md) |
+| Shared / Admin whitelist | [03-shared-and-admin.md](03-shared-and-admin.md) |
+| Infraestructura: SSM admin-emails + email-worker plantillas | [04-infraestructura.md](04-infraestructura.md) |
+| Arquitectura del Lambda `users`: operations profile/status/admin | [05-lambda-users-arquitectura.md](05-lambda-users-arquitectura.md) |
+| Testing (unit + integration + admin authz) | [06-testing.md](06-testing.md) |
+| Archivos afectados con verificacion por archivo | [07-archivos-afectados.md](07-archivos-afectados.md) |
+| Descomposicion en tareas atomicas | [08-descomposicion-paralelizacion.md](08-descomposicion-paralelizacion.md) |
+| Commits incrementales | [09-commits.md](09-commits.md) |
+| Paralelizacion con git worktrees | [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md) |
+| Verificacion E2E iterativa | [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Estado por fase
+
+| Fase | Descripcion | Estado |
+|------|-------------|--------|
+| 0 | Planes 01 + 02 mergeados a `dev` (prerequisito) | pending |
+| 1 | Plan escrito + claude docs | pending |
+| 2 | Schema Neon (migration 00000004 con columnas nuevas + 3 tablas) | pending |
+| 3 | `shared.auth` extension `is_admin` + `require_admin` helper | pending |
+| 4 | SSM `/portfolio/${stage}/admin-emails` (lista de emails admin) | pending |
+| 5 | `auth_email_worker` extension: 3 plantillas nuevas | pending |
+| 6 | Lambda `users` scaffold (manifest + AppConfig + handler + EventModel) | pending |
+| 7 | Operation `profile` (get/update/change-email/delete-account) | pending |
+| 8 | Operation `status` (get/list-sessions/revoke-session) | pending |
+| 9 | Operation `admin` (list-users, get-user, disable, enable, force-logout, delete, list-actions) | pending |
+| 10 | Rate-limit rules + integracion + tests integration | pending |
+| 11 | Verificacion E2E + actualizacion ER + limpieza spec | pending |
+
+## Decisiones no-reabribles
+
+1. **Lambda separada `users`**: el split solicitado en el dialogo
+   original. Mismo API Gateway que `auth` (path `/users`). Mismo
+   patron `operation + action` + http_handler.
+2. **Admin authz por email whitelist en SSM**: `/portfolio/${stage}/admin-emails`
+   (SecureString, lista coma-separada). El handler `require_admin` lee
+   el SSM y compara contra `user.email` del JWT. Alternativa
+   considerada (role enum en `auth_users.role`) rechazada por
+   simplicidad: solo Pablo es admin y queremos rotacion sin tocar DB.
+3. **Soft-delete del user**: `auth_users.deleted_at` timestamp. Login
+   con email de un user soft-deleted devuelve `404 EMAIL_NOT_FOUND`
+   (se comporta como inexistente). El email queda libre para
+   re-registro (con CITEXT unique + WHERE `deleted_at IS NULL`). Hard
+   delete es admin-only.
+4. **Sesiones activas por refresh_token family_id**: cuando el lambda
+   `auth` emite un refresh_token con `family_id=<X>`, INSERT en
+   `auth_user_sessions(user_id, family_id, device_info, ip,
+   last_active_at)`. Cada refresh actualiza `last_active_at`. Logout
+   borra el row (cascade del blacklist family).
+5. **change-email flujo en dos pasos**: el user pide cambio, recibe
+   magic-link al email NUEVO, al confirmar actualiza `auth_users.email`.
+   Nuevo email tabla efimera `auth_user_email_change_requests` (no,
+   simpler: reusar `auth_magic_links` con `kind='email-change'` agregado
+   al enum existente — preferencia).
+6. **Status del user devuelto al frontend**: enum:
+   - `pending`: registro iniciado, email no verificado.
+   - `active`: operativo.
+   - `disabled`: deshabilitado por admin.
+   - `locked`: bloqueo automatico (10 fallos consecutivos / hora).
+   - `deleted`: soft-deleted.
+   El frontend usa esto para decidir que mostrar (mensaje al user).
+7. **Admin actions audit obligatorio**: cada admin operation
+   (`admin.disable-user`, etc.) inserta row en
+   `auth_user_admin_actions(admin_user_id, target_user_id, action,
+   metadata, ip, created_at)`. Inmutable.
+8. **GDPR delete-account**: el `profile.delete-account` (self-service)
+   marca `deleted_at`, anonimiza `email` a `deleted-<id>@invalid.local`
+   y borra `auth_credentials`, `auth_mfa_methods`, etc. en cascade.
+   Conserva `auth_audit_log` y `auth_user_admin_actions` para
+   compliance (sin PII personal). En 30 dias, hard-delete
+   programatico via cron Lambda (NO en scope de este plan, planificado).
+9. **list-users paginado**: cursor-based con `last_id` (uuidv7
+   ordenable). page_size default 50, max 200.
+
+## Reglas criticas (siempre activas)
+
+- **SIEMPRE** `require_admin` valida via SSM admin-emails (no
+  hardcodear el email de Pablo en el codigo).
+- **SIEMPRE** `admin.*` operations escriben a `auth_user_admin_actions`
+  ANTES de la accion destructiva (audit pre-hoc).
+- **SIEMPRE** un user NO admin que intente `admin.*` recibe `404
+  NOT_FOUND` (no `403 FORBIDDEN`) — defensa contra enumeration.
+- **SIEMPRE** `profile.update` solo modifica campos del propio user
+  (validado por `user.id == claims.sub`).
+- **SIEMPRE** `disable-user` no afecta el JWT vivo del target — el
+  proximo `session.refresh` o cualquier operacion verifica
+  `auth_users.status` y deniega. Para invalidacion inmediata, llamar
+  tambien `admin.force-logout`.
+- **NUNCA** un admin puede ver el password_hash, TOTP secret o
+  recovery codes hash de otro user (solo metadata).
+- **NUNCA** un user puede `delete-account` si tiene roles administrativos
+  asignados (no aplica hoy: si Pablo intenta, hay que asignar admin a
+  otro email primero — guard).
+- **NUNCA** retornar `email` de otro user en respuestas no-admin.
+
+## Matriz de verificacion (rapida)
+
+| Capa | Comando |
+|------|---------|
+| Sintaxis | `python -m compileall -q serverless/lambda/services/users` |
+| Imports shared-only | `serverless lint-deps --lambda=users` |
+| Tests unit | `serverless tests --type=unit --lambda=users` |
+| Tests integration | `serverless tests --type=integration --lambda=users` |
+| Migration up dev | `serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev` |
+| Run local | `serverless run --stage=local --lambda=users --event=events/profile-get.json` |
+| Deploy dev | `serverless deploy --lambda=users --stage=dev --aws-profile=tfs-dev` |
+| Smoke E2E | ver [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Bibliografia interna
+
+- Planes 01 + 02 (precursores). Al cierre del plan 03, sus carpetas
+  ya estan eliminadas del repo; referencia via `git log`.
+- `.claude/docs/auth-system/` — documentacion permanente; este plan
+  agrega capitulos sobre users y admin.
+- `.claude/rules/lambda-controller.md`, `lambda-shared-imports.md`,
+  `neon-management.md`, `serverless-secrets.md`,
+  `ci-cd-pipeline.md`.

--- a/docs/specs/analytics-dashboard-api/01-contexto-y-decision.md
+++ b/docs/specs/analytics-dashboard-api/01-contexto-y-decision.md
@@ -1,0 +1,199 @@
+# 01 — Contexto y decision
+
+[< README](README.md) | [Siguiente: 02-arquitectura >](02-arquitectura.md)
+
+## 1. Contexto / Problema
+
+El backend serverless ya persiste data del visitante en Neon
+PostgreSQL — sessions, visits, tracking events y contacts — pero no hay
+forma de **leerla** desde afuera. Hoy solo se puede inspeccionar abriendo
+`psql` contra la connection string del SSM (operacion manual, sin
+agregaciones, sin UI).
+
+Para construir un dashboard de analytics del portfolio (KPIs, series
+temporales, rankings, listados crudos) se necesita una API HTTP que
+exponga la data agregada y paginada. El dashboard se construira despues
+en una iteracion separada; este plan entrega SOLO el backend
+(API + queries + cache + rate-limit).
+
+### Constraints
+
+- **Free tier**: Neon free (0.5 GB + 191.9h compute/mes), DynamoDB
+  On-Demand free tier perpetuo. El costo de la nueva Lambda + sus
+  queries debe quedar dentro del free tier.
+- **Patron del repo**: el backend ya tiene 6 Lambdas Python siguiendo el
+  patron `lambda-controller` (operation + action -> controller +
+  service). El Lambda nuevo SIGUE el mismo patron — no se introduce un
+  framework distinto.
+- **Sin auth real**: el dashboard es de uso unico-usuario (yo) en esta
+  fase. El rate-limit + el hecho de que la URL no este publicada en
+  ningun lado son la unica barrera. La proxima iteracion puede sumar
+  Cloudflare Access encima sin cambiar el backend.
+- **Lectura unicamente**: el Lambda NO escribe a Neon ni a DynamoDB
+  (mas alla del cache + rate-limit buckets). No hay endpoints `POST/PUT`.
+
+### Hallazgos de exploracion (resumen)
+
+- `cv` Lambda es el analogo mas cercano: GET + SQL + JSON. Reusar el
+  patron.
+- `tracking_pixel` Lambda es el analogo para rate-limit + cache.
+- `shared.lambda_kit.http_handler` ya maneja GET + query params:
+  extrae `operation`/`action` del query string, el resto a `data`.
+- `shared.rate_limit.check_or_raise` se llama explicito desde el
+  controller (NO esta dentro de `http_handler`).
+- `shared.cache.cached` es un decorator (TTL + namespace + tags).
+- `shared.db` re-exporta SQLAlchemy + `db_session` context manager.
+- `shared.db.url.resolve_database_url` lee `DATABASE_URL` o `DB_URL` o
+  el path SSM `SSM_NEON_URL_PATH`.
+- `serverless/lambda/resources/dynamodb/rate-limit-rules.yaml` declara
+  la TABLA — las **reglas** se cargan en runtime desde esa tabla. No
+  hay YAML centralizado de reglas; cada Lambda inserta su propia
+  regla al provisionarse, o la insertamos via `serverless run --lambda=db`
+  con un seed.
+- CI/CD `deploy-backend.yml` auto-detecta Lambdas nuevas por path; con
+  agregar la carpeta + manifest, el matrix lo recoge.
+
+## 2. Solucion Propuesta
+
+Crear un Lambda Python `analytics` en
+`serverless/lambda/services/analytics/` con la estructura
+`lambda-controller` estandar:
+
+```
+analytics/
+├── manifest.yaml              # GET /analytics, memory 512, SnapStart, neon-url
+├── pyproject.toml             # deps = [] (cierre transitivo de shared/)
+├── events/                    # eventos de ejemplo para serverless run
+│   ├── overview.json
+│   ├── timeseries.json
+│   ├── ...
+└── core/
+    ├── handler.py             # http_handler con event_model + cors='public'
+    ├── settings/
+    │   ├── config.py          # AppConfig + ErrorCode + LogMetricType
+    │   └── operations.py      # OPERATIONS (analytics, events, sessions, ...)
+    ├── models/                # un Pydantic por dominio
+    │   ├── analytics.py
+    │   ├── events.py
+    │   ├── sessions.py
+    │   ├── visits.py
+    │   ├── geo.py
+    │   ├── devices.py
+    │   ├── funnel.py
+    │   └── contacts.py
+    ├── controllers/
+    │   ├── analytics/{overview,timeseries,top_pages,top_referrers,top_niches,active_now,retention}.py
+    │   ├── events/{distribution,list,heatmap}.py
+    │   ├── sessions/{list,detail}.py
+    │   ├── visits/{list,landing_pages}.py
+    │   ├── geo/by_country.py
+    │   ├── devices/breakdown.py
+    │   ├── funnel/conversion.py
+    │   └── contacts/{list,by_status}.py
+    ├── services/              # logica de negocio + queries SQL
+    │   ├── analytics_service.py
+    │   ├── events_service.py
+    │   ├── sessions_service.py
+    │   ├── visits_service.py
+    │   ├── geo_service.py
+    │   ├── devices_service.py
+    │   ├── funnel_service.py
+    │   └── contacts_service.py
+    └── utils/
+        └── rate_limit_guard.py  # helper para llamar check_or_raise con el endpoint fijo
+```
+
+Cada action es un controller delgado que:
+
+1. Llama a `check_or_raise(ip, endpoint='/analytics', country)` (rate
+   limit + blacklist + country rules).
+2. Llama al service correspondiente con `self.validated_data`.
+3. Empaqueta la respuesta en el shape estandar `{is_valid, data, code}`.
+
+El service hace la query SQL (via `db_session` + SQLAlchemy 2.x), agrega
+si corresponde, y devuelve `dict` serializable. Las queries agregadas
+estan decoradas con `@cached(ttl=60, namespace='analytics:<action>',
+tags=['analytics-aggregate'])`. Los listados crudos NO se cachean.
+
+### Decisiones clave
+
+- **Decision 1: GET con query params (no POST con body)** — el dashboard
+  hace requests idempotentes de lectura; GET es semanticamente correcto
+  y cacheable a futuro a nivel CDN. `http_handler` ya soporta GET
+  extrayendo operation/action/data del query string.
+- **Decision 2: 1 Lambda + multiples operations (no 1 Lambda por dominio)**
+  — el grafo de queries es chico y comparte conexion a Neon. Splittear
+  multiplica cold starts y costos sin beneficio.
+- **Decision 3: Controllers delgados, services gruesos** — la query
+  SQL vive en el service. El controller solo orquesta (rate-limit +
+  service-call + shape). Esto permite testear queries sin levantar
+  todo el evento Lambda.
+- **Decision 4: Cache SOLO en agregadas** — overview, timeseries,
+  rankings, distribuciones, heatmap. Los listados crudos cambian con
+  cada visita nueva (filtros distintos por request); cachearlos
+  desperdicia espacio.
+- **Decision 5: SnapStart habilitado** — el dashboard se usa
+  esporadicamente (no hay invocaciones constantes que mantengan el
+  container warm). El cold start sin SnapStart es ~3-5s; con
+  SnapStart cae a ~800ms. Patron ya probado en `contact_form`.
+- **Decision 6: Default 30d / max 90d** — la tabla
+  `vis_tracking_events` esta particionada por mes; queries sobre
+  ventanas de 30d tocan 1-2 particiones (rapido). 90d toca hasta 4
+  particiones (aceptable). >90d se rechaza con 400.
+- **Decision 7: Reusar `shared.rate_limit` (no WAF)** — patron
+  consolidado del repo, $0/mes vs $7/mes WAF, suficiente para el
+  caso de uso.
+- **Decision 8: `cors_origin='public'`** — el dashboard frontend aun
+  no existe; al exponer CORS publico, se puede testear desde
+  `localhost:3000` o cualquier herramienta sin redeploy. No expone
+  riesgo porque la API ya tiene rate-limit.
+
+## 3. Criterios de Aceptacion (AC)
+
+Numerados, BDD-style. Cada test del plan referencia uno o varios.
+
+- **AC-1**: Given una request `GET /analytics?operation=analytics&action=overview&from=2026-04-27&to=2026-05-27`, When la API procesa, Then responde 200 con `{is_valid: true, code: 0, data: {sessions, visits, events, contacts, unique_visitors, avg_visit_duration_sec, bounce_rate}}`.
+
+- **AC-2**: Given una request sin `from`/`to`, When la API procesa, Then aplica defaults (ultimos 30d) y responde 200 con la misma forma de payload.
+
+- **AC-3**: Given una request con `from`/`to` > 90 dias, When la API procesa, Then responde 400 con `code=1001` y mensaje "rango de fechas excede el maximo permitido (90 dias)".
+
+- **AC-4**: Given una request con `operation` o `action` invalido, When la API procesa, Then responde 400 con `code=1000` y un mensaje que liste los valores validos.
+
+- **AC-5**: Given un cliente que excede 10 req/min desde la misma IP, When la 11va request llega dentro del minuto, Then responde 429 con `code=4290` y header `Retry-After`.
+
+- **AC-6**: Given una IP en la blacklist, When llega una request, Then responde 403 con `code=4030` (sin consumir slot del rate-limit).
+
+- **AC-7**: Given una request a `analytics/timeseries` con `bucket=day` y rango 7d, When la API responde, Then `data.points` tiene 7 elementos con `{timestamp, count, niche?, event_type?}` y `data.bucket == "day"`.
+
+- **AC-8**: Given dos requests identicas a `analytics/overview` con cache miss y luego hit dentro de 60s, When la segunda request llega, Then el response es **identico** y el header `x-cache: HIT` (o equivalente en logs) confirma cache hit.
+
+- **AC-9**: Given una request a `events/list` con `page=2&page_size=50`, When la API responde, Then `data.items` tiene hasta 50 items, `data.page == 2`, `data.page_size == 50`, `data.total >= items.length` y `data.has_more` es boolean.
+
+- **AC-10**: Given una request a `events/list` con `page_size=500` (sobre el max), When la API procesa, Then responde 400 con `code=1002` y mensaje "page_size excede el maximo permitido (200)".
+
+- **AC-11**: Given una request a `sessions/detail?session_id=<X>` con sesion inexistente, When la API responde, Then devuelve 404 con `code=4040` y `data=null`.
+
+- **AC-12**: Given una request a `sessions/detail?session_id=<X>` valida, When la API responde, Then `data` incluye `{session, visits: [...], events_count}` con la session, sus visits (todos), y el total de eventos asociados.
+
+- **AC-13**: Given una request a `geo/by-country` rango 30d, When la API responde, Then `data.items` esta ordenado desc por `sessions`, cada item tiene `{country, sessions, visits, events}`, y `data.total` es la suma de sessions.
+
+- **AC-14**: Given una request a `devices/breakdown` rango 30d, When la API responde, Then `data` tiene tres listas: `device_types`, `browsers`, `os`, cada una ordenada desc por sessions.
+
+- **AC-15**: Given una request a `funnel/conversion` rango 30d, When la API responde, Then `data` tiene `{sessions, visits, contacts, session_to_visit_rate, visit_to_contact_rate, session_to_contact_rate}` con los rates como floats 0.0-1.0.
+
+- **AC-16**: Given una request a `contacts/list?status=new&page=1`, When la API responde, Then `data.items` solo contiene contacts con `status='new'`, paginados normalmente.
+
+- **AC-17**: Given una request a `analytics/active-now`, When la API procesa, Then `data` tiene `{active_sessions, threshold_minutes: 5, as_of: <iso8601>}` con el conteo de sessions cuyo `last_seen_at >= now() - 5min`.
+
+- **AC-18**: Given una request a `analytics/retention` rango 30d, When la API responde, Then `data` tiene `{new_visitors, returning_visitors, total, returning_rate}` calculado sobre `vis_sessions` agrupado por `first_seen_at`.
+
+- **AC-19**: Given un cold start del Lambda con SnapStart habilitado, When llega la primera request, Then el Restore Duration (CloudWatch) es < 1500ms y la respuesta total al cliente < 2000ms.
+
+- **AC-20**: Given el Lambda recien deployado a `dev`, When se corre `serverless lint-deps --lambda=analytics`, Then exit code es 0 (cero imports prohibidos en `core/`, cero deps duplicadas con `shared/`).
+
+- **AC-21**: Given los tests unit + integration del Lambda, When se corre `serverless tests --type=coverage --lambda=analytics`, Then el coverage per-file >= 80% en `core/`.
+
+- **AC-22**: Given el smoke E2E contra dev/stage/prod (curl con todos los endpoints), When todas las requests pasan, Then cada endpoint responde con su shape esperado y los logs CloudWatch no muestran ningun ERROR/WARN.
+
+[< README](README.md) | [Siguiente: 02-arquitectura >](02-arquitectura.md)

--- a/docs/specs/analytics-dashboard-api/02-arquitectura.md
+++ b/docs/specs/analytics-dashboard-api/02-arquitectura.md
@@ -1,0 +1,543 @@
+# 02 — Arquitectura
+
+[< 01-contexto-y-decision](01-contexto-y-decision.md) | [Siguiente: 03-infraestructura >](03-infraestructura.md)
+
+## 1. Flujo end-to-end
+
+```text
+Browser/curl
+  -> https://api.portfolio.{dev|stage|prod}.the-full-stack.com/analytics
+       ?operation=<op>&action=<act>&from=YYYY-MM-DD&to=YYYY-MM-DD&...
+  -> API Gateway REST (custom domain)
+  -> Lambda `analytics` (SnapStart, arm64, py3.13, 512MB)
+       handler.py
+         -> shared.lambda_kit.http_handler(event, event_model, cors='public', 200)
+              -> extract_request(event) -> {operation, action, data, method}
+              -> inject data._meta = {ip, country, user_agent, ...}
+              -> run_controller({operation, action, data}, event_model)
+                   -> import_controller -> OPERATIONS[op][act]
+                   -> Controller(BaseController).execute()
+                        -> rate_limit_guard.guard(ip, country)
+                             -> shared.rate_limit.check_or_raise
+                        -> service.<action>(...validated_data...)
+                             -> @cached(ttl=60)  (solo agregadas)
+                                  -> shared.db.db_session() -> Neon SQL
+                                  -> rows -> dict serializable
+                        -> {is_valid: true, data: {...}, code: 0}
+              -> json_response(payload, status=200, cors='public')
+  -> Browser/curl
+```
+
+## 2. Inventario de operations y actions
+
+15 actions distribuidos en 8 operations:
+
+| Operation | Action | Tipo | Cache | Endpoint shape |
+|-----------|--------|------|-------|----------------|
+| `analytics` | `overview` | agregada | si | KPIs top-level |
+| `analytics` | `timeseries` | agregada | si | serie temporal |
+| `analytics` | `top-pages` | ranking | si | top N pages |
+| `analytics` | `top-referrers` | ranking | si | top referrers + UTM |
+| `analytics` | `top-niches` | ranking | si | top niches |
+| `analytics` | `active-now` | live | NO (ttl=10s) | sessions activas |
+| `analytics` | `retention` | agregada | si | new vs returning |
+| `events` | `distribution` | agregada | si | event_types share |
+| `events` | `list` | listado | NO | eventos crudos paginados |
+| `events` | `heatmap` | agregada | si | dia_semana x hora |
+| `sessions` | `list` | listado | NO | sessions paginadas |
+| `sessions` | `detail` | crudo | NO | 1 session + visits + count events |
+| `visits` | `list` | listado | NO | visits paginadas |
+| `visits` | `landing-pages` | ranking | si | top landing pages |
+| `geo` | `by-country` | agregada | si | sessions por country |
+| `devices` | `breakdown` | agregada | si | device/browser/os share |
+| `funnel` | `conversion` | agregada | si | session->visit->contact |
+| `contacts` | `list` | listado | NO | contacts paginados |
+| `contacts` | `by-status` | agregada | si | distribucion por status |
+
+**Total**: 8 operations, 19 actions, 12 con cache (TTL 60s), 1 con TTL
+corto (10s, active-now), 6 sin cache (listados crudos y detail).
+
+## 3. Layout del Lambda
+
+```
+serverless/lambda/services/analytics/
+├── manifest.yaml
+├── pyproject.toml
+├── README.md                            # corto, link a docs/specs/
+├── events/                              # eventos para `serverless run`
+│   ├── overview.json
+│   ├── timeseries.json
+│   ├── top_pages.json
+│   ├── top_referrers.json
+│   ├── top_niches.json
+│   ├── active_now.json
+│   ├── retention.json
+│   ├── events_distribution.json
+│   ├── events_list.json
+│   ├── events_heatmap.json
+│   ├── sessions_list.json
+│   ├── sessions_detail.json
+│   ├── visits_list.json
+│   ├── visits_landing_pages.json
+│   ├── geo_by_country.json
+│   ├── devices_breakdown.json
+│   ├── funnel_conversion.json
+│   ├── contacts_list.json
+│   └── contacts_by_status.json
+├── core/
+│   ├── __init__.py
+│   ├── handler.py
+│   ├── settings/
+│   │   ├── __init__.py
+│   │   ├── config.py
+│   │   └── operations.py
+│   ├── models/
+│   │   ├── __init__.py
+│   │   ├── _common.py                   # DateRange, Pagination, _Meta
+│   │   ├── analytics.py
+│   │   ├── events.py
+│   │   ├── sessions.py
+│   │   ├── visits.py
+│   │   ├── geo.py
+│   │   ├── devices.py
+│   │   ├── funnel.py
+│   │   └── contacts.py
+│   ├── controllers/
+│   │   ├── __init__.py
+│   │   ├── analytics/
+│   │   │   ├── __init__.py
+│   │   │   ├── overview.py
+│   │   │   ├── timeseries.py
+│   │   │   ├── top_pages.py
+│   │   │   ├── top_referrers.py
+│   │   │   ├── top_niches.py
+│   │   │   ├── active_now.py
+│   │   │   └── retention.py
+│   │   ├── events/
+│   │   │   ├── __init__.py
+│   │   │   ├── distribution.py
+│   │   │   ├── list.py
+│   │   │   └── heatmap.py
+│   │   ├── sessions/
+│   │   │   ├── __init__.py
+│   │   │   ├── list.py
+│   │   │   └── detail.py
+│   │   ├── visits/
+│   │   │   ├── __init__.py
+│   │   │   ├── list.py
+│   │   │   └── landing_pages.py
+│   │   ├── geo/
+│   │   │   ├── __init__.py
+│   │   │   └── by_country.py
+│   │   ├── devices/
+│   │   │   ├── __init__.py
+│   │   │   └── breakdown.py
+│   │   ├── funnel/
+│   │   │   ├── __init__.py
+│   │   │   └── conversion.py
+│   │   └── contacts/
+│   │       ├── __init__.py
+│   │       ├── list.py
+│   │       └── by_status.py
+│   ├── services/
+│   │   ├── __init__.py
+│   │   ├── analytics_service.py
+│   │   ├── events_service.py
+│   │   ├── sessions_service.py
+│   │   ├── visits_service.py
+│   │   ├── geo_service.py
+│   │   ├── devices_service.py
+│   │   ├── funnel_service.py
+│   │   └── contacts_service.py
+│   └── utils/
+│       ├── __init__.py
+│       └── rate_limit_guard.py
+└── tests/
+    ├── conftest.py
+    ├── unit/
+    │   ├── _helpers.py
+    │   ├── models/                      # 1 archivo por escenario por modelo
+    │   ├── services/                    # mock SQLAlchemy session
+    │   ├── controllers/                 # mock service
+    │   └── handler/
+    └── integration/
+        ├── conftest.py                  # NO mocks: Neon test DB
+        ├── _fixtures/
+        └── test_*_e2e.py
+```
+
+## 4. EventModel + OPERATIONS
+
+`core/settings/operations.py`:
+
+```python
+OPERATIONS: dict[str, dict[str, dict[str, str]]] = {
+    'analytics': {
+        'overview':       {'controller_module': 'controllers.analytics.overview',       'class': 'Overview'},
+        'timeseries':     {'controller_module': 'controllers.analytics.timeseries',     'class': 'Timeseries'},
+        'top-pages':      {'controller_module': 'controllers.analytics.top_pages',      'class': 'TopPages'},
+        'top-referrers':  {'controller_module': 'controllers.analytics.top_referrers',  'class': 'TopReferrers'},
+        'top-niches':     {'controller_module': 'controllers.analytics.top_niches',     'class': 'TopNiches'},
+        'active-now':     {'controller_module': 'controllers.analytics.active_now',     'class': 'ActiveNow'},
+        'retention':      {'controller_module': 'controllers.analytics.retention',      'class': 'Retention'},
+    },
+    'events': {
+        'distribution':   {'controller_module': 'controllers.events.distribution', 'class': 'Distribution'},
+        'list':           {'controller_module': 'controllers.events.list',         'class': 'List'},
+        'heatmap':        {'controller_module': 'controllers.events.heatmap',      'class': 'Heatmap'},
+    },
+    'sessions': {
+        'list':           {'controller_module': 'controllers.sessions.list',   'class': 'List'},
+        'detail':         {'controller_module': 'controllers.sessions.detail', 'class': 'Detail'},
+    },
+    'visits': {
+        'list':           {'controller_module': 'controllers.visits.list',           'class': 'List'},
+        'landing-pages':  {'controller_module': 'controllers.visits.landing_pages',  'class': 'LandingPages'},
+    },
+    'geo': {
+        'by-country':     {'controller_module': 'controllers.geo.by_country', 'class': 'ByCountry'},
+    },
+    'devices': {
+        'breakdown':      {'controller_module': 'controllers.devices.breakdown', 'class': 'Breakdown'},
+    },
+    'funnel': {
+        'conversion':     {'controller_module': 'controllers.funnel.conversion', 'class': 'Conversion'},
+    },
+    'contacts': {
+        'list':           {'controller_module': 'controllers.contacts.list',      'class': 'List'},
+        'by-status':      {'controller_module': 'controllers.contacts.by_status', 'class': 'ByStatus'},
+    },
+}
+```
+
+`core/handler.py`:
+
+```python
+from shared.http import http_handler
+from shared.lambda_kit import build_event_model
+from shared.observability import logger, metrics, tracer
+
+from core.settings.operations import OPERATIONS
+
+_EVENT_MODEL = build_event_model(OPERATIONS, allowed_methods=('GET',))
+
+
+@logger.inject_lambda_context(log_event=False, correlation_id_path='requestContext.requestId')
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event: dict, context: object) -> dict:
+    return http_handler(
+        event,
+        event_model=_EVENT_MODEL,
+        cors_origin='public',
+        success_status=200,
+        metric_names={
+            'submitted': 'AnalyticsQuery',
+            'rejected':  'AnalyticsRejected',
+            'error':     'AnalyticsError',
+        },
+    )
+```
+
+## 5. Modelos Pydantic — diseno
+
+### 5.1 Bloques compartidos (`core/models/_common.py`)
+
+```python
+from datetime import date, datetime
+from shared.core import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class _Meta(BaseModel):
+    """Inyectado por http_handler desde headers + requestContext."""
+    model_config = ConfigDict(populate_by_name=True)
+    ip: str | None = Field(default=None, alias='ip')
+    country: str | None = Field(default=None, alias='country')
+    user_agent: str | None = Field(default=None, alias='user_agent')
+
+
+class DateRange(BaseModel):
+    """Validador comun: from/to opcionales, max 90 dias."""
+    date_from: date | None = Field(default=None, alias='from')
+    date_to:   date | None = Field(default=None, alias='to')
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode='after')
+    def _fill_defaults_and_validate_span(self) -> 'DateRange':
+        today = date.today()
+        if self.date_to is None:
+            self.date_to = today
+        if self.date_from is None:
+            from datetime import timedelta
+            self.date_from = self.date_to - timedelta(days=30)
+        if self.date_from > self.date_to:
+            raise ValueError('from > to')
+        span = (self.date_to - self.date_from).days
+        if span > 90:
+            raise ValueError('rango de fechas excede el maximo permitido (90 dias)')
+        return self
+
+
+class Pagination(BaseModel):
+    page:      int = Field(default=1, ge=1)
+    page_size: int = Field(default=50, ge=1, le=200)
+```
+
+### 5.2 Un modelo Pydantic por (operation, action)
+
+Patron:
+
+```python
+# core/models/analytics.py
+from shared.core import BaseModel, ConfigDict, Field
+from ._common import DateRange, _Meta
+
+
+class OverviewInput(DateRange):
+    """GET ?operation=analytics&action=overview&from=&to="""
+    meta: _Meta | None = Field(default=None, alias='_meta')
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TimeseriesInput(DateRange):
+    """?bucket=day|hour, ?niche=optional, ?event_type=optional"""
+    bucket:     str | None  = Field(default='day', pattern=r'^(day|hour|week)$')
+    niche:      str | None  = Field(default=None, max_length=32)
+    event_type: str | None  = Field(default=None, max_length=64)
+    meta:       _Meta | None = Field(default=None, alias='_meta')
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TopPagesInput(DateRange):
+    limit: int = Field(default=10, ge=1, le=50)
+    niche: str | None = Field(default=None, max_length=32)
+    meta:  _Meta | None = Field(default=None, alias='_meta')
+    model_config = ConfigDict(populate_by_name=True)
+
+
+# ... idem TopReferrersInput, TopNichesInput, ActiveNowInput, RetentionInput
+```
+
+Repeticion del patron en `events.py`, `sessions.py`, etc. Validar el
+shape MINIMO necesario por endpoint — no validar campos opcionales que
+se pasen al SQL sin filtrar.
+
+## 6. Controllers — patron uniforme
+
+Todos los controllers heredan de `BaseController` (de `shared.lambda_kit`)
+y tienen este shape:
+
+```python
+# core/controllers/analytics/overview.py
+from typing import Any
+
+from shared.lambda_kit import BaseController
+from shared.observability import logger
+
+from core.models.analytics import OverviewInput
+from core.services.analytics_service import overview as _overview
+from core.utils.rate_limit_guard import guard
+
+
+class Overview(BaseController):
+    event_model = OverviewInput
+
+    def execute(self) -> dict[str, Any]:
+        data: OverviewInput = self.validated_data
+        guard(meta=data.meta, endpoint='/analytics')
+        result = _overview(date_from=data.date_from, date_to=data.date_to)
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': result,
+        }
+```
+
+Reglas:
+
+- 1 archivo = 1 controller = 1 action.
+- Nombre de clase = `action.capitalize().replace('-', '_')` (`top-pages`
+  -> `TopPages`).
+- `event_model` apunta al input Pydantic correspondiente.
+- `execute()` SIEMPRE: (1) rate-limit guard, (2) service call,
+  (3) return shape.
+- NO mete logica de negocio. Si una operacion necesita mas de 1 service
+  call, el orchestrador vive en el service (no en el controller).
+
+## 7. Services — patron uniforme
+
+Los services concentran:
+
+- Query SQL (via `shared.db.db_session` + select/func/Session).
+- Agregaciones / normalizaciones.
+- Decorador `@cached` cuando aplica.
+- Errores normalizados (excepciones a `ServiceError` que el controller
+  mapea a `{is_valid:false, code:5xxx}`).
+
+```python
+# core/services/analytics_service.py
+from datetime import date
+from typing import Any, Final
+
+from shared.cache import cached
+from shared.db import db_session, func, select
+from shared.observability import logger
+from shared.db.models.visitor import Contact, Session, SessionVisit, TrackingEvent
+
+
+_CACHE_TAGS: Final[list[str]] = ['analytics-aggregate']
+
+
+@cached(ttl=60, namespace='analytics:overview', tags=_CACHE_TAGS)
+def overview(*, date_from: date, date_to: date) -> dict[str, Any]:
+    with db_session() as s:
+        # 5 queries en paralelo logico (cada una es 1 round-trip a Neon)
+        sessions_count = s.scalar(
+            select(func.count())
+            .select_from(Session)
+            .where(Session.first_seen_at >= date_from, Session.first_seen_at < date_to)
+        )
+        visits_count = s.scalar(
+            select(func.count())
+            .select_from(SessionVisit)
+            .where(SessionVisit.started_at >= date_from, SessionVisit.started_at < date_to)
+        )
+        events_count = s.scalar(
+            select(func.count())
+            .select_from(TrackingEvent)
+            .where(TrackingEvent.created_at >= date_from, TrackingEvent.created_at < date_to)
+        )
+        contacts_count = s.scalar(
+            select(func.count())
+            .select_from(Contact)
+            .where(Contact.created_at >= date_from, Contact.created_at < date_to)
+        )
+        unique_visitors = s.scalar(
+            select(func.count(func.distinct(SessionVisit.session_id)))
+            .where(SessionVisit.started_at >= date_from, SessionVisit.started_at < date_to)
+        )
+        avg_visit_duration = s.scalar(
+            select(func.coalesce(func.avg(
+                func.extract('epoch', SessionVisit.ended_at - SessionVisit.started_at)
+            ), 0))
+            .where(SessionVisit.ended_at.is_not(None),
+                   SessionVisit.started_at >= date_from,
+                   SessionVisit.started_at < date_to)
+        )
+        # bounce rate: visits con event_count == 1 / total visits
+        bounce_visits = s.scalar(
+            select(func.count())
+            .select_from(SessionVisit)
+            .where(SessionVisit.event_count == 1,
+                   SessionVisit.started_at >= date_from,
+                   SessionVisit.started_at < date_to)
+        )
+    bounce_rate = (bounce_visits / visits_count) if visits_count else 0.0
+    return {
+        'sessions': int(sessions_count or 0),
+        'visits':   int(visits_count or 0),
+        'events':   int(events_count or 0),
+        'contacts': int(contacts_count or 0),
+        'unique_visitors': int(unique_visitors or 0),
+        'avg_visit_duration_sec': float(avg_visit_duration or 0),
+        'bounce_rate': float(bounce_rate),
+        'from': date_from.isoformat(),
+        'to':   date_to.isoformat(),
+    }
+```
+
+> El SQL detallado de cada service esta en
+> [04-queries-sql.md](04-queries-sql.md).
+
+## 8. Rate-limit guard
+
+`core/utils/rate_limit_guard.py`:
+
+```python
+from typing import Final
+
+from shared.rate_limit import check_or_raise
+from shared.observability import logger
+
+from core.models._common import _Meta
+
+
+_ENDPOINT: Final[str] = '/analytics'
+
+
+def guard(*, meta: _Meta | None, endpoint: str = _ENDPOINT) -> None:
+    """Llama a check_or_raise con la metadata extraida del request.
+
+    Levanta RateLimitExceededError / IPBlacklistedError / CountryBlockedError
+    que `http_handler` mapea a 429/403 con codes 4290/4030/4031.
+    """
+    ip = (meta.ip if meta else None) or 'unknown'
+    country = meta.country if meta else None
+    check_or_raise(
+        ip=ip,
+        endpoint=endpoint,
+        country=country,
+        turnstile_validated=False,  # GET no usa Turnstile
+    )
+```
+
+La regla `/analytics` se inserta en la tabla `rate-limit-rules` al
+provisionar el Lambda — ver [03-infraestructura.md](03-infraestructura.md).
+
+## 9. Error handling
+
+`core/settings/config.py` define enums:
+
+```python
+from enum import IntEnum, StrEnum
+
+
+class ErrorCode(IntEnum):
+    OK                 = 0
+    VALIDATION         = 1000
+    DATE_RANGE         = 1001
+    PAGE_SIZE          = 1002
+    INVALID_PARAM      = 1003
+    NOT_FOUND          = 4040
+    BLACKLISTED        = 4030
+    COUNTRY_BLOCKED    = 4031
+    RATE_LIMITED       = 4290
+    EXTERNAL           = 5100
+    INTERNAL           = 6000
+
+
+class LogMetricType(StrEnum):
+    QUERY_OK       = 'AnalyticsQueryOk'
+    QUERY_REJECTED = 'AnalyticsQueryRejected'
+    QUERY_ERROR    = 'AnalyticsQueryError'
+    CACHE_HIT      = 'AnalyticsCacheHit'
+    CACHE_MISS     = 'AnalyticsCacheMiss'
+```
+
+Mapeo errores -> HTTP status (lo hace `http_handler` desde el code):
+
+| code | status | excepcion / contexto |
+|------|--------|----------------------|
+| 0 | 200 | OK |
+| 1000-1099 | 400 | Pydantic ValidationError / param invalido |
+| 4030 | 403 | IPBlacklistedError |
+| 4031 | 403 | CountryBlockedError |
+| 4040 | 404 | sessions/detail con session_id inexistente |
+| 4290 | 429 | RateLimitExceededError |
+| 5100 | 503 | error transitorio DB (timeout, connection) |
+| 6000 | 500 | error interno no clasificado |
+
+## 10. Cold start path
+
+- Modulo-scope: `import shared.lambda_kit`, `import shared.http`,
+  `OPERATIONS`, `build_event_model(OPERATIONS)` se ejecutan una sola
+  vez por container.
+- `db_session` -> `get_engine()` se inicializa LAZY en la primera query
+  (no en cold start) para que el Restore de SnapStart no necesite una
+  conexion Neon activa. La conexion se establece en el primer handler
+  invoke.
+- SnapStart hook (`runtime_hooks.py`): NO precalentar la conexion a DB
+  — Neon scale-to-zero la cerraria; en cambio precalentar
+  `OPERATIONS`, `build_event_model`, importar todos los controllers.
+
+[< 01-contexto-y-decision](01-contexto-y-decision.md) | [Siguiente: 03-infraestructura >](03-infraestructura.md)

--- a/docs/specs/analytics-dashboard-api/03-infraestructura.md
+++ b/docs/specs/analytics-dashboard-api/03-infraestructura.md
@@ -71,7 +71,7 @@ Notas:
   endpoint; no la inserta (la insertamos via seed con la Lambda `db`).
 - `tables.cache: read-write` -> `@cached` decorator necesita ambos.
 - `secrets: [neon-url]` -> devtools inyecta env var
-  `SSM_NEON_URL_PATH=/portfolio/<stage>/secrets/neon-url`. La Lambda lee
+  `SSM_NEON_URL_PATH=/portfolio/<stage>/neon-url`. La Lambda lee
   el secret en runtime via `shared.db.url.resolve_database_url()`.
 
 ## 2. `pyproject.toml`
@@ -215,7 +215,7 @@ manifest. Resultado esperado para `analytics`:
 | `dynamodb:GetItem`, `Query`, `PutItem`, `UpdateItem`, `DeleteItem` | `arn:.../portfolio-cache-<stage>` | `tables.cache: read-write` |
 | `dynamodb:GetItem`, `Query` | `arn:.../portfolio-rate-limit-rules-<stage>` | `tables.rate-limit-rules: read` |
 | `dynamodb:GetItem`, `Query`, `PutItem`, `UpdateItem`, `DeleteItem` | `arn:.../portfolio-rate-limit-buckets-<stage>` | `tables.rate-limit-buckets: read-write` |
-| `ssm:GetParameter` | `arn:.../portfolio/<stage>/secrets/neon-url` | `secrets: [neon-url]` |
+| `ssm:GetParameter` | `arn:.../portfolio/<stage>/neon-url` | `secrets: [neon-url]` |
 | `kms:Decrypt` | `arn:.../alias/portfolio-lambdas` | implicito (SSM SecureString) |
 | `logs:CreateLogGroup`, `CreateLogStream`, `PutLogEvents` | log group del Lambda | base |
 | `xray:PutTraceSegments`, `PutTelemetryRecords` | * | tracer |

--- a/docs/specs/analytics-dashboard-api/03-infraestructura.md
+++ b/docs/specs/analytics-dashboard-api/03-infraestructura.md
@@ -1,0 +1,314 @@
+# 03 — Infraestructura
+
+[< 02-arquitectura](02-arquitectura.md) | [Siguiente: 04-queries-sql >](04-queries-sql.md)
+
+## 1. `manifest.yaml`
+
+`serverless/lambda/services/analytics/manifest.yaml`:
+
+```yaml
+name: analytics
+description: Dashboard read-only API (sessions, visits, events, contacts).
+
+trigger:
+  type: http
+  method: GET
+  path: /analytics
+
+runtime: python3.13
+architecture: arm64
+handler: core.handler.lambda_handler
+
+memory: 512
+timeout: 30
+
+# SnapStart Python (publica Snap por version)
+snap_start: PublishedVersions
+
+uses:
+  tables:
+    cache:               read-write
+    rate-limit-rules:    read
+    rate-limit-buckets:  read-write
+  secrets:
+    - neon-url
+
+env:
+  default:
+    LOG_LEVEL:                       INFO
+    POWERTOOLS_SERVICE_NAME:         analytics
+    POWERTOOLS_METRICS_NAMESPACE:    Portfolio/Analytics
+    CORS_ALLOWED_ORIGINS:            '*'
+    RATE_LIMIT_ENDPOINT:             '/analytics'
+    ANALYTICS_DATE_DEFAULT_DAYS:     '30'
+    ANALYTICS_DATE_MAX_DAYS:         '90'
+    ANALYTICS_PAGE_SIZE_DEFAULT:     '50'
+    ANALYTICS_PAGE_SIZE_MAX:         '200'
+    ANALYTICS_CACHE_TTL_AGGREGATE:   '60'
+    ANALYTICS_CACHE_TTL_LIVE:        '10'
+
+  stage:
+    dev:
+      LOG_LEVEL: INFO
+    stage:
+      LOG_LEVEL: INFO
+    prod:
+      LOG_LEVEL: WARNING
+```
+
+Notas:
+
+- `snap_start: PublishedVersions` activa SnapStart Python. devtools
+  publica una version nueva en cada deploy y enlaza el alias `live`
+  a esa version (mismo patron que `contact_form`).
+- `architecture: arm64` -> Graviton2 (-20% costo, +19% perf vs x86_64).
+- `memory: 512` MB: la query agregada mas pesada (`heatmap`) toca <100
+  filas en Neon; el bottleneck es CPU JSON-serialize. 512MB da
+  ~~0.5 vCPU asignado.
+- `timeout: 30` s con margen — queries normales < 1s, listados con
+  filtros raros < 5s. 30s es la cuota maxima del API Gateway REST.
+- `tables.rate-limit-rules: read` -> el Lambda solo LEE la regla del
+  endpoint; no la inserta (la insertamos via seed con la Lambda `db`).
+- `tables.cache: read-write` -> `@cached` decorator necesita ambos.
+- `secrets: [neon-url]` -> devtools inyecta env var
+  `SSM_NEON_URL_PATH=/portfolio/<stage>/secrets/neon-url`. La Lambda lee
+  el secret en runtime via `shared.db.url.resolve_database_url()`.
+
+## 2. `pyproject.toml`
+
+`serverless/lambda/services/analytics/pyproject.toml`:
+
+```toml
+[project]
+name = "analytics"
+version = "0.1.0"
+description = "Dashboard read-only API for the portfolio backend."
+requires-python = ">=3.13,<3.14"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3,<9",
+    "pytest-cov>=5.0,<6",
+    "pytest-mock>=3.14,<4",
+    "hypothesis>=6.103,<7",
+]
+```
+
+Reglas:
+
+- `dependencies = []` (regla D-3): TODA dep externa la aporta el cierre
+  transitivo de `shared/`. `serverless lint-deps --lambda=analytics`
+  debe dar exit 0.
+- Grupo `dev` solo con framework de testing — NO infra de runtime.
+
+## 3. Eventos de ejemplo (`events/`)
+
+Un JSON por action para `serverless run --event=events/<X>.json`. Shape:
+
+```json
+{
+  "httpMethod": "GET",
+  "path": "/analytics",
+  "queryStringParameters": {
+    "operation": "analytics",
+    "action": "overview",
+    "from": "2026-04-27",
+    "to": "2026-05-27"
+  },
+  "headers": {
+    "x-forwarded-for": "203.0.113.42",
+    "cloudfront-viewer-country": "AR",
+    "user-agent": "curl/8.0"
+  },
+  "requestContext": {
+    "requestId": "test-overview-001",
+    "identity": {"sourceIp": "203.0.113.42"}
+  },
+  "body": null,
+  "isBase64Encoded": false
+}
+```
+
+19 eventos en total (uno por action). En el plan se crean con un script
+helper en `tests/conftest.py` para no replicar a mano.
+
+## 4. API Gateway
+
+`serverless/lambda/resources/api_gateway/portfolio-api.yaml` NO se
+modifica. El `provisioner` de devtools agrega automaticamente el metodo
+`GET /analytics` al leer `trigger.method` + `trigger.path` del manifest.
+
+CORS pre-flight: API GW REST no necesita OPTIONS si `cors_origin` se
+maneja en el response del Lambda. **Excepcion**: si en el futuro el
+dashboard llama desde un browser con headers custom (Authorization),
+hay que agregar OPTIONS handler. Por ahora SOLO `Content-Type:
+application/json` -> no necesita preflight.
+
+## 5. Rate-limit rule
+
+La regla `/analytics` se inserta en la tabla `rate-limit-rules` via la
+Lambda `db` con un command nuevo `seed-rate-limit-rules`. Esto evita
+hacer `aws dynamodb put-item` a mano.
+
+### 5.1 Schema de la rule
+
+Item DynamoDB en `portfolio-rate-limit-rules-<stage>`:
+
+```json
+{
+  "rule_key": "/analytics",
+  "kind": "ip",
+  "algorithm": "sliding-window-weighted",
+  "limit": 10,
+  "window_seconds": 60,
+  "weight_unverified": 1.0,
+  "weight_verified": 0.1,
+  "enabled": true,
+  "description": "Dashboard API: 10 req/min/IP (sin auth, lectura)",
+  "created_at": "2026-05-27T00:00:00Z",
+  "updated_at": "2026-05-27T00:00:00Z"
+}
+```
+
+### 5.2 Seed via Lambda `db`
+
+Nuevo event: `serverless/lambda/services/db/events/seed_rate_limit_analytics.json`:
+
+```json
+{
+  "command": "seed-rate-limit-rule",
+  "args": {
+    "rule_key": "/analytics",
+    "kind": "ip",
+    "limit": 10,
+    "window_seconds": 60,
+    "algorithm": "sliding-window-weighted",
+    "description": "Dashboard API: 10 req/min/IP"
+  }
+}
+```
+
+Si la Lambda `db` aun no tiene el command `seed-rate-limit-rule`,
+agregarlo en el commit de infraestructura (es ~30 LOC: parsear args,
+`PutItem` con `ConditionExpression='attribute_not_exists(rule_key) OR
+enabled = :true'`, devolver `{created|updated, rule_key}`).
+
+Aplicar a cada stage:
+
+```bash
+python devtools/run.py serverless run --stage=dev --lambda=db \
+  --event=events/seed_rate_limit_analytics.json --aws-profile=tfs-dev
+python devtools/run.py serverless run --stage=stage --lambda=db \
+  --event=events/seed_rate_limit_analytics.json --aws-profile=tfs-dev
+python devtools/run.py serverless run --stage=prod --lambda=db \
+  --event=events/seed_rate_limit_analytics.json --aws-profile=tfs-dev
+```
+
+## 6. IAM scope del rol
+
+devtools genera el rol IAM del Lambda a partir del bloque `uses` del
+manifest. Resultado esperado para `analytics`:
+
+| Permiso | Recurso | Origen |
+|---------|---------|--------|
+| `dynamodb:GetItem`, `Query`, `PutItem`, `UpdateItem`, `DeleteItem` | `arn:.../portfolio-cache-<stage>` | `tables.cache: read-write` |
+| `dynamodb:GetItem`, `Query` | `arn:.../portfolio-rate-limit-rules-<stage>` | `tables.rate-limit-rules: read` |
+| `dynamodb:GetItem`, `Query`, `PutItem`, `UpdateItem`, `DeleteItem` | `arn:.../portfolio-rate-limit-buckets-<stage>` | `tables.rate-limit-buckets: read-write` |
+| `ssm:GetParameter` | `arn:.../portfolio/<stage>/secrets/neon-url` | `secrets: [neon-url]` |
+| `kms:Decrypt` | `arn:.../alias/portfolio-lambdas` | implicito (SSM SecureString) |
+| `logs:CreateLogGroup`, `CreateLogStream`, `PutLogEvents` | log group del Lambda | base |
+| `xray:PutTraceSegments`, `PutTelemetryRecords` | * | tracer |
+| `cloudwatch:PutMetricData` | * | metrics |
+
+Verificacion post-deploy: `aws iam get-role-policy --role-name
+portfolio-analytics-<stage>-role --policy-name inline`.
+
+## 7. SnapStart — runtime hook
+
+`core/runtime_hooks.py` (opcional; si devtools soporta hooks vendoriza
+automaticamente, ver patron `contact_form`):
+
+```python
+"""Hooks SnapStart: precalentar el grafo de imports y la validacion del
+EventModel, sin tocar conexiones externas (Neon scale-to-zero las cerraria)."""
+
+from typing import Any
+
+from shared.lambda_kit import build_event_model
+from shared.observability import logger
+
+from core.settings.operations import OPERATIONS
+
+
+def before_checkpoint(*_args: Any, **_kwargs: Any) -> None:
+    """Se ejecuta una sola vez antes del snapshot SnapStart."""
+    logger.info('SnapStart before_checkpoint: preloading event model')
+    build_event_model(OPERATIONS, allowed_methods=('GET',))
+    # NO abrir engine SQLAlchemy aqui — el restore tendria conexion DB stale.
+
+
+def after_restore(*_args: Any, **_kwargs: Any) -> None:
+    """Se ejecuta tras cada restore (nueva ejecucion)."""
+    logger.info('SnapStart after_restore: container ready')
+```
+
+Registro de hooks: devtools lo hace via env var
+`AWS_LAMBDA_EXEC_WRAPPER` o (mas comun en Python) via
+`runtime_hooks.py` discovery convencional. Ver
+`contact_form/core/runtime_hooks.py` como referencia.
+
+## 8. CloudWatch — logs y metricas
+
+- Log group: `/aws/lambda/portfolio-analytics-<stage>` retention 7d
+  (default del backend).
+- Metric namespace: `Portfolio/Analytics`. Metricas custom:
+  - `AnalyticsQueryOk` (Count) — request exitosa
+  - `AnalyticsQueryRejected` (Count) — request 4xx
+  - `AnalyticsQueryError` (Count) — request 5xx
+  - `AnalyticsCacheHit` / `AnalyticsCacheMiss` (Count, por action)
+  - `AnalyticsColdStart` (Count, capture_cold_start_metric=True)
+  - `AnalyticsRestoreDurationMs` (Milliseconds, SnapStart)
+- Dimensions sugeridas: `Operation`, `Action`, `Stage`. Asi el dashboard
+  futuro puede filtrar por endpoint.
+
+NO se crean CloudWatch Alarms en este plan (politica del repo: $0/mes
+sin alarms). Se agregaran cuando el dashboard sea critico.
+
+## 9. CI/CD impacto
+
+`.github/workflows/deploy-backend.yml` ya auto-detecta Lambdas nuevos al
+escanear `serverless/lambda/services/*/manifest.yaml`. No hace falta
+editar el workflow.
+
+**Flujo esperado** tras mergear el plan a `dev`:
+
+1. `branch-flow-guard.yml` aprueba (es PR a `dev`).
+2. `migrate-db` corre Alembic — sin migrations nuevas para este plan
+   (no se modifica Neon).
+3. `detect-changes` lista `analytics` (carpeta nueva).
+4. `deploy-lambdas` matrix: aplica el deploy del nuevo Lambda a `dev`.
+5. Manual: `serverless run --stage=dev --lambda=db --event=events/seed_rate_limit_analytics.json`
+   para insertar la rule (la rule NO se versiona en codigo, vive en
+   DynamoDB).
+6. Smoke E2E (curl) contra `api.portfolio.dev.the-full-stack.com/analytics`.
+
+Promocion a `stage` y `prod` con el flujo normal (PR `dev -> stage` y
+`stage -> main`).
+
+## 10. Cost estimation
+
+| Item | Calculo | Costo/mes |
+|------|---------|-----------|
+| Lambda invocations | ~10 req/dia * 30 = 300 req/mes (free tier: 1M) | $0 |
+| Lambda GB-sec | 0.5 GB * 1s * 300 = 150 GB-sec/mes (free: 400k) | $0 |
+| API Gateway REST | 300 req/mes * $3.50/M | <$0.01 |
+| DynamoDB writes (cache + rate-limit buckets) | ~600 writes/mes | $0 (free) |
+| DynamoDB reads (cache hits + rules) | ~600 reads/mes | $0 (free) |
+| CloudWatch Logs | ~5 MB/mes | $0 (free 5GB) |
+| **Neon (queries)** | ~10 horas compute/mes (compartido con stream_processor) | $0 (free 191.9h) |
+| **Total** | | **<$0.01/mes** |
+
+El Lambda nuevo NO mueve la aguja sobre el free tier actual.
+
+[< 02-arquitectura](02-arquitectura.md) | [Siguiente: 04-queries-sql >](04-queries-sql.md)

--- a/docs/specs/analytics-dashboard-api/04-queries-sql.md
+++ b/docs/specs/analytics-dashboard-api/04-queries-sql.md
@@ -292,8 +292,18 @@ LIMIT :page_size OFFSET :offset;
 3 queries:
 
 ```sql
--- 1. La sesion
-SELECT * FROM vis_sessions WHERE session_id = :session_id;
+-- 1. La sesion (columnas explicitas para no filtrar PII no intencionada
+--    y evitar romper el Pydantic model si el schema agrega columnas)
+SELECT
+  session_id,
+  first_seen_at,
+  last_seen_at,
+  browser,
+  browser_version,
+  os,
+  device_type
+FROM vis_sessions
+WHERE session_id = :session_id;
 
 -- 2. Sus visits (todas, ordenadas)
 SELECT visit_id, started_at, ended_at, event_count, ip, country,
@@ -352,16 +362,50 @@ LIMIT :limit;
 ## 15. `geo/by-country`
 
 ```sql
+WITH session_data AS (
+  SELECT
+    COALESCE(country, 'XX') AS country,
+    session_id
+  FROM vis_session_visits
+  WHERE started_at >= :date_from AND started_at < :date_to
+),
+country_sessions_visits AS (
+  SELECT
+    country,
+    count(DISTINCT session_id) AS sessions,
+    count(*) AS visits
+  FROM session_data
+  GROUP BY country
+),
+country_events AS (
+  SELECT
+    sd.country,
+    count(*) AS events
+  FROM session_data sd
+  JOIN vis_tracking_events e
+    ON e.session_id = sd.session_id
+   AND e.occurred_at >= :date_from
+   AND e.occurred_at < :date_to
+  GROUP BY sd.country
+)
 SELECT
-  COALESCE(country, 'XX') AS country,
-  count(DISTINCT session_id) AS sessions,
-  count(*) AS visits
-FROM vis_session_visits
-WHERE started_at >= :date_from AND started_at < :date_to
-GROUP BY country
-ORDER BY sessions DESC
+  csv.country,
+  csv.sessions,
+  csv.visits,
+  COALESCE(ce.events, 0) AS events
+FROM country_sessions_visits csv
+LEFT JOIN country_events ce USING (country)
+ORDER BY csv.sessions DESC
 LIMIT :limit;
 ```
+
+El CTE `session_data` materializa las sesiones del rango con su country.
+`country_sessions_visits` cuenta sesiones y visits (PV) por pais.
+`country_events` hace `JOIN` (no `LEFT JOIN`) sobre `vis_tracking_events`
+limitado al mismo rango — paises sin eventos en el rango no aparecen aqui.
+El `LEFT JOIN ... USING (country)` final preserva paises con sesiones pero
+0 eventos: el `COALESCE(ce.events, 0)` garantiza `events: 0` (no NULL) en
+el response, cumpliendo el shape de AC-13 `{country, sessions, visits, events}`.
 
 ## 16. `devices/breakdown`
 

--- a/docs/specs/analytics-dashboard-api/04-queries-sql.md
+++ b/docs/specs/analytics-dashboard-api/04-queries-sql.md
@@ -1,0 +1,492 @@
+# 04 — Queries SQL por endpoint
+
+[< 03-infraestructura](03-infraestructura.md) | [Siguiente: 05-cache-layer >](05-cache-layer.md)
+
+> SQL plano por endpoint (no SQLAlchemy expression-style aqui — para
+> que sea legible y se pueda probar en `psql`). En el codigo, los
+> services usan `select(...).where(...)` con SQLAlchemy 2.x, pero la
+> semantica es la misma.
+
+## 0. Convenciones
+
+- `:date_from`, `:date_to`: parametros bindeados (psycopg quote-safe).
+- Particion: `vis_tracking_events` esta particionada por `created_at`
+  (mensual). Toda query DEBE incluir `created_at >= :date_from AND
+  created_at < :date_to` para podarPartitions.
+- `WHERE` por rango fechas usa `>= from AND < to + INTERVAL '1 day'`
+  (half-open) para alinear con la convencion ISO.
+- `LIMIT` siempre explicito.
+
+## 1. `analytics/overview`
+
+7 KPIs en una sola transaccion. Cada subquery es 1 round-trip a Neon.
+
+```sql
+-- sessions: visitantes unicos por first_seen_at en rango
+SELECT count(*) FROM vis_sessions
+WHERE first_seen_at >= :date_from AND first_seen_at < :date_to;
+
+-- visits: sesiones-visita (multiples por session)
+SELECT count(*) FROM vis_session_visits
+WHERE started_at >= :date_from AND started_at < :date_to;
+
+-- events: eventos totales
+SELECT count(*) FROM vis_tracking_events
+WHERE created_at >= :date_from AND created_at < :date_to;
+
+-- contacts: contactos recibidos
+SELECT count(*) FROM vis_contacts
+WHERE created_at >= :date_from AND created_at < :date_to;
+
+-- unique_visitors: sessions distintas con al menos 1 visit en el rango
+SELECT count(DISTINCT session_id) FROM vis_session_visits
+WHERE started_at >= :date_from AND started_at < :date_to;
+
+-- avg_visit_duration_sec: media de (ended_at - started_at) en segundos
+SELECT COALESCE(AVG(EXTRACT(epoch FROM (ended_at - started_at))), 0)
+FROM vis_session_visits
+WHERE ended_at IS NOT NULL
+  AND started_at >= :date_from AND started_at < :date_to;
+
+-- bounce_rate: visits con event_count == 1 / total visits
+SELECT count(*) FROM vis_session_visits
+WHERE event_count = 1
+  AND started_at >= :date_from AND started_at < :date_to;
+```
+
+**Optimizacion**: si las 7 queries en serie son > 500 ms, consolidar
+con UNION ALL + subqueries inline. Actual estimate: 7 * ~30 ms = ~200 ms.
+Aceptable.
+
+**Indices necesarios** (verificar que existan; si no, migration nueva):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_vis_sessions_first_seen_at
+  ON vis_sessions (first_seen_at);
+CREATE INDEX IF NOT EXISTS idx_vis_session_visits_started_at
+  ON vis_session_visits (started_at);
+CREATE INDEX IF NOT EXISTS idx_vis_contacts_created_at
+  ON vis_contacts (created_at);
+-- vis_tracking_events.created_at YA es partition key, no necesita indice extra.
+```
+
+## 2. `analytics/timeseries`
+
+```sql
+-- bucket=day | hour | week
+SELECT
+  date_trunc(:bucket, created_at) AS ts,
+  count(*) AS count
+FROM vis_tracking_events
+WHERE created_at >= :date_from AND created_at < :date_to
+  AND (:niche IS NULL OR niche = :niche)
+  AND (:event_type IS NULL OR event_type_id = (
+       SELECT id FROM tax_event_types WHERE code_name = :event_type
+     ))
+GROUP BY ts
+ORDER BY ts ASC
+LIMIT 8784;  -- max 1 year hourly
+```
+
+**Output shape**: `{bucket, points: [{timestamp, count}], from, to,
+filters: {niche, event_type}}`.
+
+## 3. `analytics/top-pages`
+
+```sql
+SELECT
+  page_path,
+  count(*) AS events,
+  count(DISTINCT session_id) AS unique_visitors,
+  count(DISTINCT visit_id) AS unique_visits
+FROM vis_tracking_events
+WHERE created_at >= :date_from AND created_at < :date_to
+  AND page_path IS NOT NULL
+  AND (:niche IS NULL OR niche = :niche)
+GROUP BY page_path
+ORDER BY events DESC
+LIMIT :limit;  -- default 10, max 50
+```
+
+**Output**: `{items: [{page_path, events, unique_visitors, unique_visits}]}`.
+
+## 4. `analytics/top-referrers`
+
+```sql
+SELECT
+  COALESCE(referrer, '(direct)') AS referrer,
+  count(*) AS visits,
+  count(DISTINCT session_id) AS unique_visitors
+FROM vis_session_visits
+WHERE started_at >= :date_from AND started_at < :date_to
+GROUP BY referrer
+ORDER BY visits DESC
+LIMIT :limit;
+```
+
+Variante adicional: rankings de UTM source/medium/campaign. Se devuelven
+en el mismo response bajo 4 listas:
+
+```sql
+-- UTM source
+SELECT utm_source, count(*) AS visits
+FROM vis_session_visits
+WHERE started_at >= :date_from AND started_at < :date_to
+  AND utm_source IS NOT NULL
+GROUP BY utm_source
+ORDER BY visits DESC LIMIT 20;
+
+-- idem medium / campaign / content / term
+```
+
+**Output**: `{referrers: [...], utm_sources: [...], utm_mediums: [...],
+utm_campaigns: [...]}`.
+
+## 5. `analytics/top-niches`
+
+```sql
+SELECT
+  COALESCE(niche, '(none)') AS niche,
+  count(*) AS visits,
+  count(DISTINCT session_id) AS unique_visitors
+FROM vis_session_visits
+WHERE started_at >= :date_from AND started_at < :date_to
+GROUP BY niche
+ORDER BY visits DESC
+LIMIT :limit;
+```
+
+## 6. `analytics/active-now`
+
+Cache TTL corto (10s) para que sea casi en tiempo real.
+
+```sql
+SELECT count(*) AS active_sessions
+FROM vis_sessions
+WHERE last_seen_at >= NOW() - INTERVAL '5 minutes';
+```
+
+**Output**: `{active_sessions, threshold_minutes: 5, as_of: <iso8601>}`.
+
+## 7. `analytics/retention`
+
+```sql
+-- new vs returning visitors en el rango
+WITH visits_in_range AS (
+  SELECT DISTINCT session_id
+  FROM vis_session_visits
+  WHERE started_at >= :date_from AND started_at < :date_to
+)
+SELECT
+  count(*) FILTER (WHERE s.first_seen_at >= :date_from AND s.first_seen_at < :date_to) AS new_visitors,
+  count(*) FILTER (WHERE s.first_seen_at < :date_from) AS returning_visitors,
+  count(*) AS total
+FROM visits_in_range v
+JOIN vis_sessions s ON s.session_id = v.session_id;
+```
+
+**Output**: `{new_visitors, returning_visitors, total, returning_rate}`.
+
+## 8. `events/distribution`
+
+```sql
+SELECT
+  COALESCE(t.code_name, '(unknown)') AS event_type,
+  count(*) AS count,
+  ROUND(100.0 * count(*) / SUM(count(*)) OVER (), 2) AS pct
+FROM vis_tracking_events e
+LEFT JOIN tax_event_types t ON t.id = e.event_type_id
+WHERE e.created_at >= :date_from AND e.created_at < :date_to
+GROUP BY t.code_name
+ORDER BY count DESC;
+```
+
+**Output**: `{items: [{event_type, count, pct}]}`.
+
+## 9. `events/list`
+
+Listado paginado. Filtros opcionales: `niche`, `event_type`, `session_id`,
+`page_path`.
+
+```sql
+SELECT
+  e.created_at,
+  e.visit_id,
+  e.page_id,
+  e.session_id,
+  e.page_path,
+  e.niche,
+  e.viewport_width,
+  e.viewport_height,
+  t.code_name AS event_type,
+  e.event_props
+FROM vis_tracking_events e
+LEFT JOIN tax_event_types t ON t.id = e.event_type_id
+WHERE e.created_at >= :date_from AND e.created_at < :date_to
+  AND (:niche IS NULL OR e.niche = :niche)
+  AND (:event_type IS NULL OR t.code_name = :event_type)
+  AND (:session_id IS NULL OR e.session_id = :session_id)
+  AND (:page_path IS NULL OR e.page_path = :page_path)
+ORDER BY e.created_at DESC
+LIMIT :page_size OFFSET :offset;
+
+-- count para `total`
+SELECT count(*) FROM vis_tracking_events e
+LEFT JOIN tax_event_types t ON t.id = e.event_type_id
+WHERE e.created_at >= :date_from AND e.created_at < :date_to
+  AND (:niche IS NULL OR e.niche = :niche)
+  AND (:event_type IS NULL OR t.code_name = :event_type)
+  AND (:session_id IS NULL OR e.session_id = :session_id)
+  AND (:page_path IS NULL OR e.page_path = :page_path);
+```
+
+**Output**: `{items: [...], page, page_size, total, has_more}`.
+
+> El count() en un listado paginado es costoso. Si el `total` resulta
+> lento (>500ms con 1M+ filas), cambiar a `has_more` calculado pidiendo
+> `LIMIT (page_size + 1)` y descartar el extra. Por ahora, `total`
+> exacto es aceptable (volumen actual ~15k events/mes).
+
+## 10. `events/heatmap`
+
+Dia de la semana (0=lunes ISO) x hora (0-23).
+
+```sql
+SELECT
+  EXTRACT(isodow FROM created_at)::int AS dow,
+  EXTRACT(hour FROM created_at)::int  AS hour,
+  count(*) AS count
+FROM vis_tracking_events
+WHERE created_at >= :date_from AND created_at < :date_to
+GROUP BY dow, hour
+ORDER BY dow, hour;
+```
+
+**Output**: `{cells: [{dow, hour, count}]}` (max 7*24=168 celdas).
+
+## 11. `sessions/list`
+
+```sql
+SELECT
+  s.session_id,
+  s.first_seen_at,
+  s.last_seen_at,
+  s.browser,
+  s.browser_version,
+  s.os,
+  s.device_type,
+  count(v.visit_id) AS visits_count
+FROM vis_sessions s
+LEFT JOIN vis_session_visits v ON v.session_id = s.session_id
+  AND v.started_at >= :date_from AND v.started_at < :date_to
+WHERE s.first_seen_at >= :date_from AND s.first_seen_at < :date_to
+  AND (:device_type IS NULL OR s.device_type = :device_type)
+  AND (:browser IS NULL OR s.browser = :browser)
+GROUP BY s.session_id
+ORDER BY s.last_seen_at DESC
+LIMIT :page_size OFFSET :offset;
+```
+
+## 12. `sessions/detail`
+
+3 queries:
+
+```sql
+-- 1. La sesion
+SELECT * FROM vis_sessions WHERE session_id = :session_id;
+
+-- 2. Sus visits (todas, ordenadas)
+SELECT visit_id, started_at, ended_at, event_count, ip, country,
+       utm_source, utm_medium, utm_campaign, referrer,
+       landing_page_path, niche
+FROM vis_session_visits
+WHERE session_id = :session_id
+ORDER BY started_at ASC;
+
+-- 3. Count de eventos
+SELECT count(*) FROM vis_tracking_events
+WHERE session_id = :session_id;
+```
+
+**Output**: `{session, visits: [...], events_count}` o
+`{is_valid: false, code: 4040, data: null}` si no existe.
+
+## 13. `visits/list`
+
+```sql
+SELECT
+  v.visit_id,
+  v.session_id,
+  v.started_at,
+  v.ended_at,
+  v.event_count,
+  v.ip,
+  v.country,
+  v.utm_source, v.utm_medium, v.utm_campaign,
+  v.referrer,
+  v.landing_page_path,
+  v.niche
+FROM vis_session_visits v
+WHERE v.started_at >= :date_from AND v.started_at < :date_to
+  AND (:niche IS NULL OR v.niche = :niche)
+  AND (:country IS NULL OR v.country = :country)
+ORDER BY v.started_at DESC
+LIMIT :page_size OFFSET :offset;
+```
+
+## 14. `visits/landing-pages`
+
+```sql
+SELECT
+  landing_page_path,
+  count(*) AS visits,
+  count(DISTINCT session_id) AS unique_visitors
+FROM vis_session_visits
+WHERE started_at >= :date_from AND started_at < :date_to
+  AND landing_page_path IS NOT NULL
+GROUP BY landing_page_path
+ORDER BY visits DESC
+LIMIT :limit;
+```
+
+## 15. `geo/by-country`
+
+```sql
+SELECT
+  COALESCE(country, 'XX') AS country,
+  count(DISTINCT session_id) AS sessions,
+  count(*) AS visits
+FROM vis_session_visits
+WHERE started_at >= :date_from AND started_at < :date_to
+GROUP BY country
+ORDER BY sessions DESC
+LIMIT :limit;
+```
+
+## 16. `devices/breakdown`
+
+3 distribuciones en un solo response:
+
+```sql
+-- device_types
+SELECT COALESCE(device_type, '(unknown)') AS device_type,
+       count(*) AS sessions
+FROM vis_sessions
+WHERE first_seen_at >= :date_from AND first_seen_at < :date_to
+GROUP BY device_type ORDER BY sessions DESC;
+
+-- browsers
+SELECT COALESCE(browser, '(unknown)') AS browser,
+       count(*) AS sessions
+FROM vis_sessions
+WHERE first_seen_at >= :date_from AND first_seen_at < :date_to
+GROUP BY browser ORDER BY sessions DESC LIMIT 20;
+
+-- os
+SELECT COALESCE(os, '(unknown)') AS os,
+       count(*) AS sessions
+FROM vis_sessions
+WHERE first_seen_at >= :date_from AND first_seen_at < :date_to
+GROUP BY os ORDER BY sessions DESC LIMIT 20;
+```
+
+**Output**: `{device_types: [...], browsers: [...], os: [...]}`.
+
+## 17. `funnel/conversion`
+
+```sql
+WITH s AS (SELECT count(*) AS n FROM vis_sessions
+           WHERE first_seen_at >= :date_from AND first_seen_at < :date_to),
+     v AS (SELECT count(DISTINCT session_id) AS n FROM vis_session_visits
+           WHERE started_at >= :date_from AND started_at < :date_to),
+     c AS (SELECT count(*) AS n FROM vis_contacts
+           WHERE created_at >= :date_from AND created_at < :date_to)
+SELECT s.n AS sessions, v.n AS visits, c.n AS contacts
+FROM s, v, c;
+```
+
+**Output**:
+
+```json
+{
+  "sessions": 1234,
+  "visits": 980,
+  "contacts": 42,
+  "session_to_visit_rate": 0.794,
+  "visit_to_contact_rate": 0.043,
+  "session_to_contact_rate": 0.034
+}
+```
+
+Rates calculados en Python (no en SQL) para manejar division por cero.
+
+## 18. `contacts/list`
+
+```sql
+SELECT
+  id, created_at, name, email, message, company, role,
+  service_type, budget, timeline, niche, status, session_id
+FROM vis_contacts
+WHERE created_at >= :date_from AND created_at < :date_to
+  AND (:status IS NULL OR status = :status)
+  AND (:niche IS NULL OR niche = :niche)
+ORDER BY created_at DESC
+LIMIT :page_size OFFSET :offset;
+```
+
+## 19. `contacts/by-status`
+
+```sql
+SELECT
+  status,
+  count(*) AS count,
+  ROUND(100.0 * count(*) / SUM(count(*)) OVER (), 2) AS pct
+FROM vis_contacts
+WHERE created_at >= :date_from AND created_at < :date_to
+GROUP BY status
+ORDER BY count DESC;
+```
+
+## 20. Resumen de indices necesarios
+
+Antes de mergear, verificar que existan estos indices en Neon. Si
+alguno falta, agregar una migration Alembic separada (no parte de este
+plan, pero **prerequisito**):
+
+```sql
+-- vis_sessions
+CREATE INDEX IF NOT EXISTS idx_vis_sessions_first_seen_at ON vis_sessions (first_seen_at);
+CREATE INDEX IF NOT EXISTS idx_vis_sessions_last_seen_at  ON vis_sessions (last_seen_at);
+CREATE INDEX IF NOT EXISTS idx_vis_sessions_device_type   ON vis_sessions (device_type);
+CREATE INDEX IF NOT EXISTS idx_vis_sessions_browser       ON vis_sessions (browser);
+
+-- vis_session_visits
+CREATE INDEX IF NOT EXISTS idx_vsv_started_at ON vis_session_visits (started_at);
+CREATE INDEX IF NOT EXISTS idx_vsv_session_id ON vis_session_visits (session_id);
+CREATE INDEX IF NOT EXISTS idx_vsv_country    ON vis_session_visits (country);
+CREATE INDEX IF NOT EXISTS idx_vsv_niche      ON vis_session_visits (niche);
+CREATE INDEX IF NOT EXISTS idx_vsv_referrer   ON vis_session_visits (referrer);
+
+-- vis_tracking_events (la tabla esta particionada por created_at; los indices son local a particion)
+CREATE INDEX IF NOT EXISTS idx_vte_session_id  ON vis_tracking_events (session_id);
+CREATE INDEX IF NOT EXISTS idx_vte_event_type  ON vis_tracking_events (event_type_id);
+CREATE INDEX IF NOT EXISTS idx_vte_page_path   ON vis_tracking_events (page_path);
+CREATE INDEX IF NOT EXISTS idx_vte_niche       ON vis_tracking_events (niche);
+
+-- vis_contacts
+CREATE INDEX IF NOT EXISTS idx_vc_created_at  ON vis_contacts (created_at);
+CREATE INDEX IF NOT EXISTS idx_vc_status      ON vis_contacts (status);
+CREATE INDEX IF NOT EXISTS idx_vc_niche       ON vis_contacts (niche);
+```
+
+Comando para verificar en dev:
+
+```bash
+DB_URL="$(grep -m1 '^DB_URL=' docker/env/server/.dev | cut -d= -f2-)" \
+  psql "$DB_URL" -c "\\d+ vis_sessions" | grep Indexes -A 20
+```
+
+Si falta alguno, agregar como **fase 0.5** (Alembic migration nueva
+ANTES de empezar a deployar el Lambda).
+
+[< 03-infraestructura](03-infraestructura.md) | [Siguiente: 05-cache-layer >](05-cache-layer.md)

--- a/docs/specs/analytics-dashboard-api/05-cache-layer.md
+++ b/docs/specs/analytics-dashboard-api/05-cache-layer.md
@@ -1,0 +1,310 @@
+# 05 — Capa de cache
+
+[< 04-queries-sql](04-queries-sql.md) | [Siguiente: 06-testing >](06-testing.md)
+
+> Decisiones de cache para el Lambda `analytics`: que se cachea, con que
+> TTL, claves, tags, e invalidacion. Reusa `shared.cache` (DynamoDB
+> table `portfolio-cache-<stage>` con TTL nativo + lock distribuido +
+> stale-while-revalidate).
+
+## 1. Estrategia general
+
+| Categoria | Endpoints | TTL | Justificacion |
+|-----------|-----------|-----|---------------|
+| Agregada estandar | overview, top-pages, top-referrers, top-niches, retention, events/distribution, events/heatmap, visits/landing-pages, geo/by-country, devices/breakdown, funnel/conversion, contacts/by-status | 60s | Refrescos del dashboard < 60s no impactan Neon |
+| Agregada timeseries | analytics/timeseries | 60s | Idem |
+| Live | analytics/active-now | 10s | Casi-realtime sin saturar Neon |
+| Listado crudo | events/list, sessions/list, sessions/detail, visits/list, contacts/list | NO cache | Filtros distintos por request; cachear no ayuda |
+
+## 2. Como aplicar `@cached`
+
+`shared.cache.cached` es un decorator. Patron exacto del repo:
+
+```python
+from shared.cache import cached
+
+@cached(ttl=60, namespace='analytics:overview', tags=['analytics-aggregate'])
+def overview(*, date_from: date, date_to: date) -> dict[str, Any]:
+    ...
+```
+
+Reglas duras:
+
+- **SIEMPRE** keyword-only args en funciones cacheadas. El decorator
+  serializa `kwargs` para construir la clave; positional args harian
+  llaves distintas para llamadas equivalentes.
+- **SIEMPRE** los args deben ser tipos primitivos serializables
+  (`str`, `int`, `bool`, `date`, `None`). Pasar un `_Meta` o un
+  `Session` como kwarg ROMPE la serializacion.
+- **SIEMPRE** namespace = `analytics:<action>` (kebab-case mantenido).
+- **SIEMPRE** tags = `['analytics-aggregate']` (mas tags especificos
+  si aplica). Permite invalidacion por tag.
+- **NUNCA** cachear listados crudos (page=2 con filtros distintos = key
+  diferente, pero cada filtro raro corre 1 query nueva igual; el
+  espacio cache se llena sin beneficio).
+- **NUNCA** cachear `sessions/detail` — un session puede llegar a tener
+  N visits y M events, no es paginado, el filtro es `session_id` unico.
+- **NUNCA** poner `IP` o `country` del visitante en la clave de cache.
+  La data de analytics es global, no por-IP del que consulta.
+
+## 3. Composicion de claves
+
+`shared.cache.cached` arma la clave asi:
+
+```text
+cache_key = SHA256(namespace || ":" || canonical_kwargs)[0:16]
+```
+
+Donde `canonical_kwargs` es JSON ordenado por key de los kwargs.
+
+Para `overview(date_from=2026-04-27, date_to=2026-05-27)`:
+
+```text
+namespace = "analytics:overview"
+kwargs    = {"date_from": "2026-04-27", "date_to": "2026-05-27"}
+key       = SHA256("analytics:overview:{\"date_from\":\"2026-04-27\",...}")[0:16]
+```
+
+Esto significa: dos requests identicas (mismas dates) -> mismo cache
+key -> hit. Dos requests con dates distintas -> miss.
+
+## 4. Tags e invalidacion
+
+Tags permiten invalidar grupos de keys con `shared.cache.invalidate_tag()`.
+
+| Tag | Que invalida | Cuando invalidar |
+|-----|--------------|------------------|
+| `analytics-aggregate` | TODAS las queries agregadas | Manual via Lambda `db` con command nuevo si fuera necesario (NO automatico) |
+| `analytics-overview` | Solo overview | Idem (no implementado en este plan) |
+| `analytics-funnel` | Solo funnel | Idem |
+
+**Decision**: NO invalidar automaticamente. El TTL 60s ya da freshness
+suficiente. Si en el futuro el dashboard necesita "force refresh", se
+agrega un command en la Lambda `db`:
+
+```bash
+serverless run --stage=dev --lambda=db \
+  --event=events/invalidate_analytics_cache.json
+```
+
+Con payload `{"command": "cache-invalidate", "args": {"tag":
+"analytics-aggregate"}}`.
+
+## 5. Cache para `active-now`
+
+TTL 10s. Razon:
+
+- `active-now` es "live counter" — el dashboard puede refrescarlo cada
+  5-10s para feedback visual.
+- Sin cache: 1 query a Neon cada 5s = 12 queries/min/cliente.
+- Con TTL 10s: maximo 6 queries/min/cliente (mitad del trafico DB).
+- Trade-off: el counter puede estar hasta 10s atrasado. Aceptable para
+  un dashboard de un visitante (no es ticker de bolsa).
+
+```python
+@cached(ttl=10, namespace='analytics:active-now', tags=['analytics-live'])
+def active_now() -> dict[str, Any]:
+    with db_session() as s:
+        active = s.scalar(
+            select(func.count())
+            .select_from(Session)
+            .where(Session.last_seen_at >= func.now() - func.make_interval(0, 0, 0, 0, 0, 5, 0))
+        )
+    return {
+        'active_sessions': int(active or 0),
+        'threshold_minutes': 5,
+        'as_of': datetime.utcnow().isoformat() + 'Z',
+    }
+```
+
+NOTA: la function `now()` se evalua en Neon, asi que el cache es
+correcto durante 10s, despues miss y nueva eval.
+
+## 6. Que NO se cachea — racionales individuales
+
+### `events/list`
+
+- Filtros por session_id, page_path, niche, event_type con N
+  combinaciones.
+- Pagina N con filtro X cambia con cada visit nuevo (`ORDER BY
+  created_at DESC`).
+- Cachear 60s significa que la primera pagina puede no mostrar la
+  ultima visita. Mala UX para listado.
+
+### `sessions/list`
+
+- Idem `events/list`. Ademas el orden es por `last_seen_at DESC` que
+  cambia minuto a minuto.
+
+### `sessions/detail`
+
+- Una session por request. La data de una session especifica casi no
+  cambia (solo si el visitante vuelve mientras se consulta).
+- Cachear seria correcto pero el espacio es proporcional al numero de
+  sessions consultadas — el dashboard lista N sessions, usuario clickea
+  uno, raramente el mismo. ROI bajo.
+
+### `visits/list` y `contacts/list`
+
+- Mismos argumentos que `events/list`.
+
+## 7. Cold cache vs warm cache
+
+Primera invocacion del dia (cold cache + cold Lambda):
+
+```
+SnapStart Restore     ~ 800ms
+Handler init          ~ 0ms (warm via SnapStart)
+extract_request       ~ 5ms
+guard (rate-limit)    ~ 20ms (1 DynamoDB GetItem rule + Query bucket)
+service.overview      ~ 200ms (cache miss + 7 SQL queries)
+serialize             ~ 5ms
+TOTAL primera req     ~ 1030ms
+```
+
+Segunda invocacion misma query (warm cache + warm Lambda):
+
+```
+extract_request       ~ 5ms
+guard (rate-limit)    ~ 15ms
+@cached (hit)         ~ 15ms (1 DynamoDB GetItem)
+serialize             ~ 5ms
+TOTAL                 ~ 40ms
+```
+
+Segunda invocacion con cache miss (warm Lambda, cache expirado):
+
+```
+extract_request       ~ 5ms
+guard (rate-limit)    ~ 15ms
+@cached miss + DB     ~ 200ms
+@cached set           ~ 10ms (background, no bloquea)
+serialize             ~ 5ms
+TOTAL                 ~ 225ms
+```
+
+## 8. Observabilidad del cache
+
+Cada acceso al cache emite metric:
+
+- `AnalyticsCacheHit` (dimensions: Operation, Action) — incrementa en hit
+- `AnalyticsCacheMiss` (dimensions: Operation, Action) — incrementa en miss
+
+Metric implicito que ya emite `shared.cache`:
+
+- `CacheHit` / `CacheMiss` con dimension `Namespace`
+
+Logs estructurados (level INFO):
+
+```json
+{
+  "level": "INFO",
+  "message": "cache hit",
+  "namespace": "analytics:overview",
+  "cache_key": "ab12cd34ef567890",
+  "ttl_remaining_sec": 42
+}
+```
+
+```json
+{
+  "level": "INFO",
+  "message": "cache miss",
+  "namespace": "analytics:overview",
+  "cache_key": "ab12cd34ef567890",
+  "computed_in_ms": 187
+}
+```
+
+## 9. Cache stampede prevention
+
+`shared.cache` usa lock distribuido con `ConditionExpression` en
+DynamoDB. Cuando 2 requests llegan al mismo tiempo con el mismo key:
+
+1. Request A: cache miss -> intenta `PutItem(lock_key,
+   ConditionExpression='attribute_not_exists(lock_key)')` -> exito.
+2. Request B: cache miss -> intenta el mismo `PutItem` -> falla
+   (`ConditionalCheckFailedException`) -> espera 100ms y reintenta cache
+   read.
+3. Request A: computa la query (~200ms) -> guarda en cache -> libera
+   lock.
+4. Request B (despues de 100ms): cache hit -> retorna.
+
+Asi 100 requests concurrentes a `overview` resultan en 1 sola query a
+Neon, no 100. Probado en el repo con `tracking_pixel`.
+
+## 10. Tabla DynamoDB `portfolio-cache-<stage>`
+
+Schema (ya existe, no se modifica):
+
+```yaml
+hash_key:      cache_key  (S)
+ttl_attribute: expires_at (N — Unix epoch seconds)
+billing_mode:  PAY_PER_REQUEST
+```
+
+Items que escribimos:
+
+```json
+{
+  "cache_key":  "ab12cd34ef567890",
+  "namespace":  "analytics:overview",
+  "tags":       ["analytics-aggregate"],
+  "value":      "{\"sessions\":123,\"visits\":...}",
+  "created_at": "2026-05-27T14:00:00Z",
+  "expires_at": 1748358060,
+  "lock_owner": null
+}
+```
+
+Lock items (efimeros, TTL ~5s):
+
+```json
+{
+  "cache_key":  "ab12cd34ef567890::lock",
+  "lock_owner": "<request_id>",
+  "expires_at": 1748357065
+}
+```
+
+## 11. Tamano estimado del cache
+
+| Endpoint | items teoricos | items reales | tamano/item | total |
+|----------|----------------|--------------|-------------|-------|
+| overview | infinitos (rangos de date) | ~30 unicos/dia | ~500 B | 15 KB/dia |
+| timeseries | mismo orden | ~50/dia | ~3 KB | 150 KB/dia |
+| top-* | mismo orden | ~30/dia | ~1 KB | 30 KB/dia |
+| heatmap | pocos | ~10/dia | ~5 KB | 50 KB/dia |
+| funnel | mismo orden | ~10/dia | ~500 B | 5 KB/dia |
+| active-now | 1 unico | TTL 10s, ~8640/dia escrituras | ~200 B | 2 KB/dia |
+| **Total** | | | | **~250 KB/dia** |
+
+DynamoDB free tier: 25 GB storage. El cache ocupa <0.001% del free tier.
+TTL nativo borra items vencidos sin costo.
+
+## 12. Helpers de testing
+
+Para tests unit, mockear el decorator es complejo (queremos testear el
+service real, no su shell cacheada). Patron:
+
+- En `tests/unit/services/`: pass `_force_compute=True` kwarg o
+  decoradores via `monkeypatch` que vuelven el decorator un no-op.
+- En `tests/integration/`: usar la tabla real (test stage) con un
+  namespace de prefijo unico (`analytics-test:overview`) para no
+  colisionar con prod.
+
+Implementacion del bypass:
+
+```python
+# tests/conftest.py
+@pytest.fixture
+def no_cache(monkeypatch):
+    """Reemplaza @cached por un passthrough para tests unit."""
+    def _passthrough(*decorator_args, **decorator_kwargs):
+        def _wrap(fn):
+            return fn  # sin cache
+        return _wrap
+    monkeypatch.setattr('shared.cache.cached', _passthrough)
+```
+
+[< 04-queries-sql](04-queries-sql.md) | [Siguiente: 06-testing >](06-testing.md)

--- a/docs/specs/analytics-dashboard-api/05-cache-layer.md
+++ b/docs/specs/analytics-dashboard-api/05-cache-layer.md
@@ -102,20 +102,31 @@ TTL 10s. Razon:
   un dashboard de un visitante (no es ticker de bolsa).
 
 ```python
+from datetime import datetime, timezone
+
 @cached(ttl=10, namespace='analytics:active-now', tags=['analytics-live'])
 def active_now() -> dict[str, Any]:
     with db_session() as s:
         active = s.scalar(
             select(func.count())
             .select_from(Session)
-            .where(Session.last_seen_at >= func.now() - func.make_interval(0, 0, 0, 0, 0, 5, 0))
+            .where(Session.last_seen_at >= func.now() - func.make_interval(mins=5))
         )
     return {
         'active_sessions': int(active or 0),
         'threshold_minutes': 5,
-        'as_of': datetime.utcnow().isoformat() + 'Z',
+        'as_of': datetime.now(timezone.utc).isoformat(),
     }
 ```
+
+NOTAS:
+
+- `datetime.now(timezone.utc)` reemplaza al deprecado `datetime.utcnow()`
+  (DeprecationWarning desde Python 3.12). `isoformat()` ya emite el
+  sufijo `+00:00`; no se concatena `'Z'` para evitar duplicacion del
+  marcador UTC.
+- `func.make_interval(mins=5)` es equivalente a `make_interval(0,0,0,0,0,5,0)`
+  pero legible: solo el argumento relevante por nombre.
 
 NOTA: la function `now()` se evalua en Neon, asi que el cache es
 correcto durante 10s, despues miss y nueva eval.

--- a/docs/specs/analytics-dashboard-api/06-testing.md
+++ b/docs/specs/analytics-dashboard-api/06-testing.md
@@ -1,0 +1,383 @@
+# 06 — Testing
+
+[< 05-cache-layer](05-cache-layer.md) | [Siguiente: 07-archivos-afectados >](07-archivos-afectados.md)
+
+## 1. Niveles
+
+| Nivel | Ubicacion | Que se prueba | Aisla |
+|-------|-----------|---------------|-------|
+| Unit modelo | `tests/unit/models/test_<input>_<escenario>.py` | Pydantic models (defaults, validators, errores) | Sin Neon, sin DynamoDB |
+| Unit service | `tests/unit/services/test_<service>_<action>_<escenario>.py` | Logica + queries SQL | Mock `db_session` con `MagicMock(scalar=...)` |
+| Unit controller | `tests/unit/controllers/test_<action>_<escenario>.py` | Orquestacion: guard + service + shape | Mock del service + mock de `check_or_raise` |
+| Unit handler | `tests/unit/handler/test_handler_<escenario>.py` | Routing: event -> operation -> controller | Mock del controller |
+| Integration | `tests/integration/test_<flow>_e2e.py` | Flujo completo: HTTP event -> Lambda -> Neon | Neon test branch, DynamoDB test tables |
+
+## 2. Regla de oro
+
+> Un archivo = un escenario = una funcion `test_*`. El nombre del archivo
+> ES el caso. El docstring del modulo describe Given/When/Then. El cuerpo
+> es Arrange-Act-Assert.
+
+Ejemplo:
+
+```python
+# tests/unit/models/test_overview_input_when_no_dates_then_defaults_last_30d.py
+"""
+Given una request sin from/to,
+When se valida OverviewInput,
+Then date_to=hoy y date_from=hoy-30d.
+"""
+from datetime import date, timedelta
+
+from core.models.analytics import OverviewInput
+
+
+def test_overview_input_when_no_dates_then_defaults_last_30d():
+    # Arrange
+    raw = {}
+
+    # Act
+    parsed = OverviewInput.model_validate(raw)
+
+    # Assert
+    today = date.today()
+    assert parsed.date_to == today
+    assert parsed.date_from == today - timedelta(days=30)
+```
+
+## 3. `conftest.py` raiz (unit)
+
+`tests/conftest.py`:
+
+```python
+"""Conftest unit del Lambda analytics.
+
+- Setea env vars que el Lambda necesita en runtime (sin valores reales).
+- Agrega core/ al sys.path.
+- Provee fixtures de mocking para shared.db, shared.cache, shared.rate_limit.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# 1. sys.path: agregar core/ Y shared/ resolvible
+_LAMBDA_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(_LAMBDA_ROOT))
+sys.path.insert(0, str(_LAMBDA_ROOT.parent.parent / 'shared'))  # dev sin vendoring
+
+
+# 2. Env vars de runtime
+os.environ.setdefault('LOG_LEVEL', 'DEBUG')
+os.environ.setdefault('POWERTOOLS_SERVICE_NAME', 'analytics-test')
+os.environ.setdefault('POWERTOOLS_METRICS_NAMESPACE', 'Portfolio/AnalyticsTest')
+os.environ.setdefault('CORS_ALLOWED_ORIGINS', '*')
+os.environ.setdefault('RATE_LIMIT_ENDPOINT', '/analytics')
+
+
+# 3. Mocks compartidos
+@pytest.fixture
+def mock_db_session(mocker):
+    """Mockea shared.db.db_session como context manager que devuelve un MagicMock."""
+    session = MagicMock(name='SQLAlchemySession')
+    cm = MagicMock()
+    cm.__enter__.return_value = session
+    cm.__exit__.return_value = None
+    mocker.patch('shared.db.db_session', return_value=cm)
+    return session
+
+
+@pytest.fixture
+def mock_check_or_raise(mocker):
+    """Mockea shared.rate_limit.check_or_raise (no-op por default)."""
+    return mocker.patch('shared.rate_limit.check_or_raise', return_value=None)
+
+
+@pytest.fixture
+def no_cache(mocker):
+    """Convierte @cached en passthrough — testea el computo real, no la shell."""
+    def _passthrough(**_dec_kwargs):
+        def _wrap(fn):
+            return fn
+        return _wrap
+    mocker.patch('shared.cache.cached', side_effect=_passthrough)
+```
+
+## 4. `conftest.py` integration
+
+`tests/integration/conftest.py`:
+
+```python
+"""Conftest integration: tests E2E contra Neon test branch + DynamoDB test tables.
+
+REQUIERE:
+- AWS_PROFILE configurado (tfs-dev)
+- DB_URL en docker/env/server/.dev apuntando al branch test
+- Tablas DynamoDB `portfolio-cache-dev`, `portfolio-rate-limit-*-dev` existentes
+"""
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+_LAMBDA_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_LAMBDA_ROOT / 'core'))
+
+
+@pytest.fixture(scope='session')
+def db_url() -> str:
+    """Resuelve DB_URL leyendo solo la key del .env (NUNCA volcarlo entero)."""
+    import subprocess
+    result = subprocess.run(
+        ['grep', '-m1', '^DB_URL=', 'docker/env/server/.dev'],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip().split('=', 1)[1]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_namespace(monkeypatch):
+    """Cada test corre con un namespace de cache aislado para no colisionar."""
+    test_ns = f'analytics-test-{uuid.uuid4().hex[:8]}'
+    monkeypatch.setenv('CACHE_NAMESPACE_PREFIX', test_ns)
+    yield
+    # cleanup: borrar items del cache con ese prefix
+    # (implementacion: scan + batch_delete via shared.cache.invalidate_namespace)
+```
+
+## 5. Tests obligatorios por capa
+
+### 5.1 Models — minimo (por accion)
+
+Para CADA OperationInput, 4 tests minimo:
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_<X>_input_when_valid_then_returns_parsed.py` | Happy path |
+| `test_<X>_input_when_no_dates_then_defaults_last_30d.py` | Defaults |
+| `test_<X>_input_when_range_over_90d_then_raises.py` | AC-3 |
+| `test_<X>_input_when_invalid_field_then_raises.py` | Validacion campo (segun accion) |
+
+Para acciones con paginacion (events/list, sessions/list, visits/list,
+contacts/list) sumar:
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_<X>_input_when_page_size_over_max_then_raises.py` | AC-10 |
+| `test_<X>_input_when_page_zero_then_raises.py` | page >= 1 |
+
+### 5.2 Services — minimo (por funcion)
+
+Para cada service function, 3 tests minimo:
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_<service>_<action>_when_data_then_returns_shape.py` | Happy path con mock data |
+| `test_<service>_<action>_when_empty_db_then_zeros.py` | Edge: DB sin filas |
+| `test_<service>_<action>_when_db_error_then_raises_service_error.py` | Error handling |
+
+Mocking pattern:
+
+```python
+def test_overview_when_data_then_returns_shape(mock_db_session, no_cache):
+    # Arrange: hacer que cada scalar() devuelva un valor distinto en orden
+    mock_db_session.scalar.side_effect = [
+        100,   # sessions
+        80,    # visits
+        500,   # events
+        5,     # contacts
+        75,    # unique_visitors
+        45.5,  # avg_visit_duration
+        12,    # bounce_visits
+    ]
+    from datetime import date
+    from core.services.analytics_service import overview
+
+    # Act
+    result = overview(date_from=date(2026, 4, 27), date_to=date(2026, 5, 27))
+
+    # Assert
+    assert result == {
+        'sessions': 100, 'visits': 80, 'events': 500, 'contacts': 5,
+        'unique_visitors': 75, 'avg_visit_duration_sec': 45.5,
+        'bounce_rate': 0.15,  # 12/80
+        'from': '2026-04-27', 'to': '2026-05-27',
+    }
+```
+
+### 5.3 Controllers — minimo
+
+Para cada controller, 3 tests:
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_<action>_controller_when_valid_then_calls_service_and_returns_ok.py` | Happy path |
+| `test_<action>_controller_when_rate_limited_then_raises.py` | AC-5 / guard delega |
+| `test_<action>_controller_when_blacklisted_then_raises.py` | AC-6 |
+
+### 5.4 Handler — minimo
+
+| Archivo | Escenario |
+|---------|-----------|
+| `test_handler_when_known_operation_then_dispatches.py` | Routing |
+| `test_handler_when_unknown_operation_then_returns_400.py` | AC-4 |
+| `test_handler_when_get_with_query_params_then_extracts_data.py` | GET parsing |
+| `test_handler_when_options_then_returns_cors_headers.py` | preflight (si aplica) |
+
+### 5.5 Integration — flujos seleccionados
+
+NO se prueba cada combinacion. Solo flujos representativos:
+
+| Archivo | Escenario | AC |
+|---------|-----------|----|
+| `test_overview_e2e_happy_path.py` | GET overview con dates -> 200 + shape | AC-1, AC-2 |
+| `test_overview_e2e_range_too_wide.py` | from/to > 90d -> 400 | AC-3 |
+| `test_rate_limit_e2e_block_after_10_requests.py` | 11 requests/min -> 429 | AC-5 |
+| `test_sessions_detail_e2e_not_found.py` | session_id inexistente -> 404 | AC-11 |
+| `test_cache_e2e_hit_returns_same_data.py` | 2 requests -> 2da hit | AC-8 |
+| `test_funnel_e2e_with_seeded_data.py` | seed sessions+visits+contacts -> rates | AC-15 |
+
+## 6. Coverage
+
+Threshold: **80% per-file en `core/`**. Enforced por `serverless tests
+--type=coverage --lambda=analytics`.
+
+Archivos que deben llegar al 80%:
+
+- `core/handler.py`
+- `core/settings/config.py`
+- `core/settings/operations.py`
+- `core/models/_common.py`
+- `core/models/<dominio>.py` (8 archivos)
+- `core/controllers/<dominio>/<action>.py` (19 archivos)
+- `core/services/<dominio>_service.py` (8 archivos)
+- `core/utils/rate_limit_guard.py`
+
+Total archivos: ~40. Cada uno con su test mirror.
+
+Comando:
+
+```bash
+python devtools/run.py serverless tests --type=coverage --lambda=analytics
+```
+
+## 7. Asserts EXACTOS
+
+Regla del repo: NUNCA asserts vagos. Ejemplos:
+
+```python
+# MAL
+assert result['sessions'] > 0
+assert 'sessions' in result
+assert isinstance(result, dict)
+
+# BIEN
+assert result['sessions'] == 100
+assert list(result.keys()) == ['sessions', 'visits', 'events', 'contacts',
+                               'unique_visitors', 'avg_visit_duration_sec',
+                               'bounce_rate', 'from', 'to']
+```
+
+Si el valor es no-determinista (un timestamp, un UUID), usar mocking
+para fijarlo:
+
+```python
+mocker.patch('core.services.analytics_service.datetime')\
+      .utcnow.return_value = datetime(2026, 5, 27, 14, 0, 0)
+```
+
+## 8. Property-based testing (Hypothesis)
+
+Solo donde aporta valor — validators puros, parsing de fechas. Ejemplos:
+
+```python
+# tests/unit/models/test_date_range_property.py
+"""
+Property: para cualquier rango (from, to) con span <= 90d,
+DateRange.model_validate no lanza.
+"""
+from datetime import date, timedelta
+from hypothesis import given, strategies as st
+
+from core.models._common import DateRange
+
+
+@given(
+    days_back=st.integers(min_value=0, max_value=90),
+    span_days=st.integers(min_value=0, max_value=90),
+)
+def test_date_range_property_span_under_90d_never_raises(days_back, span_days):
+    if days_back + span_days > 365:  # solo rangos del ultimo year
+        return
+    today = date.today()
+    date_to = today - timedelta(days=days_back)
+    date_from = date_to - timedelta(days=span_days)
+
+    parsed = DateRange.model_validate({'from': date_from.isoformat(), 'to': date_to.isoformat()})
+
+    assert parsed.date_from == date_from
+    assert parsed.date_to == date_to
+```
+
+## 9. Testing del cache (integration)
+
+Test del flujo de cache hit:
+
+```python
+# tests/integration/test_cache_e2e_hit_returns_same_data.py
+"""
+Given el cache vacio,
+When llega el primer GET overview,
+Then la respuesta se computa y se guarda.
+When llega un segundo GET overview identico dentro de 60s,
+Then la respuesta viene del cache (mismo body).
+"""
+def test_cache_overview_hit(_clean_cache):
+    from core.handler import lambda_handler
+
+    event = _build_event('analytics', 'overview', from_='2026-04-27', to='2026-05-27')
+
+    # Act 1: cache miss
+    resp1 = lambda_handler(event, None)
+    body1 = json.loads(resp1['body'])
+
+    # Act 2: cache hit (segundo request identico)
+    resp2 = lambda_handler(event, None)
+    body2 = json.loads(resp2['body'])
+
+    # Assert: misma data
+    assert body1['data'] == body2['data']
+    # Assert: la segunda fue cache hit (verificable via logs o cuenta de SQL queries
+    # con sqlalchemy event listener)
+```
+
+## 10. Smoke tests post-deploy
+
+NO van en `tests/` (no son automaticos). Son comandos curl que se corren
+manualmente tras deploy a dev/stage/prod. Estan en
+[11-verificacion-e2e.md](11-verificacion-e2e.md).
+
+## 11. Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Multiples `test_*` en el mismo archivo | Rompe el estandar | Un archivo por escenario |
+| Mockear el controller en su propio test | Test que no prueba nada | Mockear solo el service + check_or_raise |
+| Mockear el service en su propio test | Idem | Mockear solo `db_session` |
+| `assert result is not None` | Vago | `assert result == {...}` |
+| Tests integration que fallan si la DB esta lenta | Flaky | Timeouts explicitos + retry con backoff |
+| Tests integration que dejan basura en el cache | Cross-test pollution | Namespace aislado por test |
+| Cachear los kwargs con `mock_db_session` | El mock no es serializable | Pass `no_cache` fixture |
+| Hardcodear `date.today()` | Test flaky cuando cruza medianoche | Mock `date.today()` o usar `freezegun` |
+
+[< 05-cache-layer](05-cache-layer.md) | [Siguiente: 07-archivos-afectados >](07-archivos-afectados.md)

--- a/docs/specs/analytics-dashboard-api/06-testing.md
+++ b/docs/specs/analytics-dashboard-api/06-testing.md
@@ -100,12 +100,20 @@ def mock_check_or_raise(mocker):
 
 @pytest.fixture
 def no_cache(mocker):
-    """Convierte @cached en passthrough — testea el computo real, no la shell."""
+    """Convierte @cached en passthrough — testea el computo real, no la shell.
+
+    Usa `new=...` (no `side_effect`): `side_effect` invocaria el callable
+    con los kwargs del decorador y retornaria su resultado SIN reemplazar
+    al callable patcheado, dejando que el cache real se ejecute igual
+    (falsos positivos en todos los tests que dependen del fixture).
+    `new=_passthrough` reemplaza el simbolo `shared.cache.cached` en su
+    namespace, asi `@cached(ttl=60)` evalua a `_passthrough(ttl=60)` que
+    retorna el decorador identidad."""
     def _passthrough(**_dec_kwargs):
         def _wrap(fn):
             return fn
         return _wrap
-    mocker.patch('shared.cache.cached', side_effect=_passthrough)
+    mocker.patch('shared.cache.cached', new=_passthrough)
 ```
 
 ## 4. `conftest.py` integration

--- a/docs/specs/analytics-dashboard-api/07-archivos-afectados.md
+++ b/docs/specs/analytics-dashboard-api/07-archivos-afectados.md
@@ -1,0 +1,289 @@
+# 07 — Archivos afectados
+
+[< 06-testing](06-testing.md) | [Siguiente: 08-descomposicion-paralelizacion >](08-descomposicion-paralelizacion.md)
+
+> Listado completo de archivos creados/modificados con su verificacion
+> ejecutable. Convierte la lista en un checklist accionable.
+
+## Crear
+
+### Documentacion del plan (efimero — se elimina al mergear)
+
+- `docs/specs/analytics-dashboard-api/README.md`
+  - Verificar: `markdownlint docs/specs/analytics-dashboard-api/*.md` (warnings ok, errors no)
+- `docs/specs/analytics-dashboard-api/01-contexto-y-decision.md` — idem
+- `docs/specs/analytics-dashboard-api/02-arquitectura.md` — idem
+- `docs/specs/analytics-dashboard-api/03-infraestructura.md` — idem
+- `docs/specs/analytics-dashboard-api/04-queries-sql.md` — idem
+- `docs/specs/analytics-dashboard-api/05-cache-layer.md` — idem
+- `docs/specs/analytics-dashboard-api/06-testing.md` — idem
+- `docs/specs/analytics-dashboard-api/07-archivos-afectados.md` — este archivo
+- `docs/specs/analytics-dashboard-api/08-descomposicion-paralelizacion.md`
+- `docs/specs/analytics-dashboard-api/09-commits.md`
+- `docs/specs/analytics-dashboard-api/10-paralelizacion-worktrees.md`
+- `docs/specs/analytics-dashboard-api/11-verificacion-e2e.md`
+
+### Lambda nuevo — Infraestructura (Fase 1)
+
+- `serverless/lambda/services/analytics/manifest.yaml`
+  - Verificar: `python devtools/run.py serverless lint-deps --lambda=analytics` exit 0
+  - Verificar: `python devtools/run.py serverless status --lambda=analytics --stage=local` no error
+- `serverless/lambda/services/analytics/pyproject.toml`
+  - Verificar: `cd serverless/lambda/services/analytics && uv sync` exit 0
+- `serverless/lambda/services/analytics/.gitignore`
+  - Excluye `build/`, `build.zip`, `.venv/`, `__pycache__/`, `*.pyc`
+- `serverless/lambda/services/analytics/README.md`
+  - Corto, linkea a `docs/specs/analytics-dashboard-api/`
+
+### Lambda nuevo — Settings (Fase 1)
+
+- `serverless/lambda/services/analytics/core/__init__.py` (vacio)
+- `serverless/lambda/services/analytics/core/settings/__init__.py` (vacio)
+- `serverless/lambda/services/analytics/core/settings/config.py`
+  - Verificar: `python -m compileall -q core/settings/config.py`
+- `serverless/lambda/services/analytics/core/settings/operations.py`
+  - Verificar: `python -c "from core.settings.operations import OPERATIONS; assert 'analytics' in OPERATIONS"`
+
+### Lambda nuevo — Models (Fase 2)
+
+- `serverless/lambda/services/analytics/core/models/__init__.py` (vacio)
+- `serverless/lambda/services/analytics/core/models/_common.py`
+  - Verificar: `pytest tests/unit/models/test__common*.py -v`
+- `serverless/lambda/services/analytics/core/models/analytics.py`
+  - Verificar: `pytest tests/unit/models/test_overview_*.py tests/unit/models/test_timeseries_*.py ... -v`
+- `serverless/lambda/services/analytics/core/models/events.py`
+- `serverless/lambda/services/analytics/core/models/sessions.py`
+- `serverless/lambda/services/analytics/core/models/visits.py`
+- `serverless/lambda/services/analytics/core/models/geo.py`
+- `serverless/lambda/services/analytics/core/models/devices.py`
+- `serverless/lambda/services/analytics/core/models/funnel.py`
+- `serverless/lambda/services/analytics/core/models/contacts.py`
+
+### Lambda nuevo — Handler + Utils (Fase 1-2)
+
+- `serverless/lambda/services/analytics/core/handler.py`
+  - Verificar: `python -m compileall -q core/handler.py`
+  - Verificar: `pytest tests/unit/handler/ -v`
+- `serverless/lambda/services/analytics/core/utils/__init__.py` (vacio)
+- `serverless/lambda/services/analytics/core/utils/rate_limit_guard.py`
+  - Verificar: `pytest tests/unit/utils/test_rate_limit_guard*.py -v`
+- `serverless/lambda/services/analytics/core/runtime_hooks.py` (Fase 10, SnapStart)
+
+### Lambda nuevo — Controllers (Fases 3-7)
+
+#### Operation `analytics`
+
+- `core/controllers/__init__.py` (vacio)
+- `core/controllers/analytics/__init__.py` (vacio)
+- `core/controllers/analytics/overview.py`
+- `core/controllers/analytics/timeseries.py`
+- `core/controllers/analytics/top_pages.py`
+- `core/controllers/analytics/top_referrers.py`
+- `core/controllers/analytics/top_niches.py`
+- `core/controllers/analytics/active_now.py`
+- `core/controllers/analytics/retention.py`
+
+#### Operation `events`
+
+- `core/controllers/events/__init__.py` (vacio)
+- `core/controllers/events/distribution.py`
+- `core/controllers/events/list.py`
+- `core/controllers/events/heatmap.py`
+
+#### Operation `sessions`
+
+- `core/controllers/sessions/__init__.py` (vacio)
+- `core/controllers/sessions/list.py`
+- `core/controllers/sessions/detail.py`
+
+#### Operation `visits`
+
+- `core/controllers/visits/__init__.py` (vacio)
+- `core/controllers/visits/list.py`
+- `core/controllers/visits/landing_pages.py`
+
+#### Operation `geo`
+
+- `core/controllers/geo/__init__.py` (vacio)
+- `core/controllers/geo/by_country.py`
+
+#### Operation `devices`
+
+- `core/controllers/devices/__init__.py` (vacio)
+- `core/controllers/devices/breakdown.py`
+
+#### Operation `funnel`
+
+- `core/controllers/funnel/__init__.py` (vacio)
+- `core/controllers/funnel/conversion.py`
+
+#### Operation `contacts`
+
+- `core/controllers/contacts/__init__.py` (vacio)
+- `core/controllers/contacts/list.py`
+- `core/controllers/contacts/by_status.py`
+
+Verificacion por controller (mismo patron):
+
+- `python -m compileall -q core/controllers/<dominio>/<action>.py`
+- `pytest tests/unit/controllers/<dominio>/test_<action>_*.py -v`
+
+### Lambda nuevo — Services (Fases 3-7)
+
+- `core/services/__init__.py` (vacio)
+- `core/services/analytics_service.py` (Fase 3)
+  - Verificar: `pytest tests/unit/services/test_analytics_*.py -v`
+- `core/services/events_service.py` (Fase 4)
+- `core/services/sessions_service.py` (Fase 5)
+- `core/services/visits_service.py` (Fase 5)
+- `core/services/geo_service.py` (Fase 6)
+- `core/services/devices_service.py` (Fase 6)
+- `core/services/funnel_service.py` (Fase 7)
+- `core/services/contacts_service.py` (Fase 7)
+
+### Lambda nuevo — Events de ejemplo
+
+- `serverless/lambda/services/analytics/events/overview.json`
+- `serverless/lambda/services/analytics/events/timeseries.json`
+- `serverless/lambda/services/analytics/events/top_pages.json`
+- `serverless/lambda/services/analytics/events/top_referrers.json`
+- `serverless/lambda/services/analytics/events/top_niches.json`
+- `serverless/lambda/services/analytics/events/active_now.json`
+- `serverless/lambda/services/analytics/events/retention.json`
+- `serverless/lambda/services/analytics/events/events_distribution.json`
+- `serverless/lambda/services/analytics/events/events_list.json`
+- `serverless/lambda/services/analytics/events/events_heatmap.json`
+- `serverless/lambda/services/analytics/events/sessions_list.json`
+- `serverless/lambda/services/analytics/events/sessions_detail.json`
+- `serverless/lambda/services/analytics/events/visits_list.json`
+- `serverless/lambda/services/analytics/events/visits_landing_pages.json`
+- `serverless/lambda/services/analytics/events/geo_by_country.json`
+- `serverless/lambda/services/analytics/events/devices_breakdown.json`
+- `serverless/lambda/services/analytics/events/funnel_conversion.json`
+- `serverless/lambda/services/analytics/events/contacts_list.json`
+- `serverless/lambda/services/analytics/events/contacts_by_status.json`
+
+Verificacion: cada JSON parseable con `python -m json.tool < events/<X>.json`.
+
+### Tests del Lambda
+
+#### Unit — models (~40 archivos)
+
+`tests/unit/models/test_<input>_<escenario>.py` (uno por accion + uno
+por escenario):
+
+- `test__common/test_date_range_when_no_dates_then_defaults_30d.py`
+- `test__common/test_date_range_when_range_over_90d_then_raises.py`
+- `test__common/test_date_range_when_from_greater_than_to_then_raises.py`
+- `test__common/test_pagination_when_page_size_over_max_then_raises.py`
+- `test__common/test_pagination_when_page_zero_then_raises.py`
+- `test_analytics/test_overview_input_when_valid_then_parses.py`
+- `test_analytics/test_timeseries_input_when_invalid_bucket_then_raises.py`
+- ... 1 archivo por escenario significativo (~30 archivos)
+
+#### Unit — services (~30 archivos)
+
+`tests/unit/services/test_<service>_<action>_<escenario>.py`:
+
+- `test_analytics_overview_when_data_then_returns_shape.py`
+- `test_analytics_overview_when_empty_db_then_zeros.py`
+- `test_analytics_overview_when_visits_zero_then_bounce_rate_zero.py`
+- ... etc
+
+#### Unit — controllers (~25 archivos)
+
+- `test_overview_controller_when_valid_then_calls_service.py`
+- `test_overview_controller_when_blacklisted_then_raises.py`
+- `test_overview_controller_when_rate_limited_then_raises.py`
+- ... etc
+
+#### Unit — handler (~5 archivos)
+
+- `test_handler_when_known_op_then_dispatches.py`
+- `test_handler_when_unknown_op_then_400.py`
+- `test_handler_when_unknown_action_then_400.py`
+- `test_handler_when_get_then_extracts_query_params.py`
+
+#### Unit — utils (~3 archivos)
+
+- `test_rate_limit_guard_when_meta_none_then_uses_unknown.py`
+- `test_rate_limit_guard_when_blacklisted_then_raises.py`
+- `test_rate_limit_guard_when_rate_limited_then_raises.py`
+
+#### Integration (~6 archivos)
+
+- `tests/integration/test_overview_e2e_happy_path.py`
+- `tests/integration/test_overview_e2e_range_too_wide.py`
+- `tests/integration/test_rate_limit_e2e_block_after_10_requests.py`
+- `tests/integration/test_sessions_detail_e2e_not_found.py`
+- `tests/integration/test_cache_e2e_hit_returns_same_data.py`
+- `tests/integration/test_funnel_e2e_with_seeded_data.py`
+
+#### Tests helpers
+
+- `tests/conftest.py`
+- `tests/unit/_helpers.py`
+- `tests/integration/conftest.py`
+- `tests/integration/_fixtures/__init__.py`
+- `tests/integration/_fixtures/event_builder.py`
+- `tests/integration/_fixtures/seed_data.py`
+
+## Modificar
+
+### Lambda `db` — agregar command `seed-rate-limit-rule`
+
+- `serverless/lambda/services/db/core/commands/seed_rate_limit_rule.py` (NUEVO)
+  - Verificar: `pytest serverless/lambda/services/db/tests/unit/commands/test_seed_rate_limit_rule.py -v`
+- `serverless/lambda/services/db/core/handler.py` (registrar el command)
+  - Verificar: `pytest serverless/lambda/services/db/tests/unit/handler/ -v`
+- `serverless/lambda/services/db/events/seed_rate_limit_analytics.json` (NUEVO event)
+  - Verificar: `python -m json.tool < events/seed_rate_limit_analytics.json`
+- `serverless/lambda/services/db/manifest.yaml`
+  - Solo si el command necesita un table nuevo en `uses`; en este caso `rate-limit-rules: read-write` ya esta (o se agrega).
+
+### CI/CD
+
+- `.github/workflows/deploy-backend.yml` — **NO se modifica** (auto-detect del nuevo Lambda).
+- `.github/workflows/ci.yml` — **NO se modifica**.
+
+### Documentacion permanente
+
+Promocion de aprendizajes de la spec (al cerrar el plan):
+
+- `.claude/docs/serverless-backend/03-lambdas.md`
+  - Agregar entrada de `analytics` en la tabla de Lambdas (ya hay 6,
+    sumar la 7ma).
+  - Verificar: `markdownlint .claude/docs/serverless-backend/03-lambdas.md`
+- `CLAUDE.md` (root)
+  - En la tabla "Arbol de conocimiento" sumar referencia al Lambda
+    nuevo si aporta valor (probablemente NO, ya cae bajo
+    `serverless-backend`).
+
+## Eliminar
+
+- `docs/specs/analytics-dashboard-api/` — al cerrar el PR `feature/X ->
+  dev`. Ultimo commit del plan: `git rm -r
+  docs/specs/analytics-dashboard-api/`.
+  - Verificar: `test ! -d docs/specs/analytics-dashboard-api`
+
+## Resumen cuantitativo
+
+| Categoria | Archivos |
+|-----------|----------|
+| Spec docs (efimero) | 12 |
+| Lambda config (manifest, pyproject, .gitignore, README) | 4 |
+| Lambda settings (config, operations) | 2 |
+| Lambda models (_common + 8 dominios) | 9 |
+| Lambda controllers (19 actions) | 19 |
+| Lambda services (8 dominios) | 8 |
+| Lambda handler + utils | 3 |
+| Lambda runtime_hooks (SnapStart) | 1 |
+| Lambda events de ejemplo | 19 |
+| Unit tests (models + services + controllers + handler + utils) | ~100 |
+| Integration tests | 6 |
+| Tests fixtures + conftest | 6 |
+| Lambda `db` mods (command + event) | 3 |
+| Docs permanente (knowledge tree) | 1-2 |
+| **Total approx** | **~190 archivos** |
+
+[< 06-testing](06-testing.md) | [Siguiente: 08-descomposicion-paralelizacion >](08-descomposicion-paralelizacion.md)

--- a/docs/specs/analytics-dashboard-api/08-descomposicion-paralelizacion.md
+++ b/docs/specs/analytics-dashboard-api/08-descomposicion-paralelizacion.md
@@ -1,0 +1,267 @@
+# 08 — Descomposicion para paralelizacion
+
+[< 07-archivos-afectados](07-archivos-afectados.md) | [Siguiente: 09-commits >](09-commits.md)
+
+> Tareas atomicas que pueden ejecutarse por agentes paralelos (humanos o
+> Claude subagents) en git worktrees independientes. Cada tarea respeta:
+>
+> 1. **File Exclusivity** — ningun archivo aparece en dos tareas
+>    paralelas.
+> 2. **Interface Stability** — los modulos compartidos
+>    (`shared/`, `_common.py`, `OPERATIONS`) NO se modifican una vez
+>    comprometidos en la base secuencial.
+> 3. **Bounded Scope** — cada tarea entrega una unidad cerrada con
+>    tests verdes propios.
+
+## Base secuencial (NO paralelizable)
+
+Estas tareas son prerequisito de todo el resto. Se ejecutan en el orden
+listado, una sola persona/agente, en la rama principal de trabajo.
+
+| # | Tarea | Archivos | Verify | Done |
+|---|-------|----------|--------|------|
+| B-1 | Crear carpeta del plan + docs | `docs/specs/analytics-dashboard-api/**` (12 archivos .md) | `markdownlint docs/specs/analytics-dashboard-api/*.md` | Plan completo escrito |
+| B-2 | Verificar indices Neon + agregar migration si faltan | `serverless/lambda/shared/db/alembic/versions/<rev>_analytics_indexes.py` (condicional) | `psql -c "\\di vis_*"`; si falta indice, migration y `serverless run --lambda=db --event=events/migrate.json --stage=dev` | Indices presentes en dev |
+| B-3 | Scaffold del Lambda + manifest + pyproject + .gitignore + README | `serverless/lambda/services/analytics/{manifest.yaml,pyproject.toml,.gitignore,README.md,core/__init__.py}` | `uv sync` en la carpeta; `serverless lint-deps --lambda=analytics` exit 0 | Lambda visible para devtools |
+| B-4 | Settings: `config.py` + `operations.py` con TODOS los entries declarados (controllers vacios despues los rellenamos) | `core/settings/{config.py,operations.py,__init__.py}` | `python -c "from core.settings.operations import OPERATIONS; assert len(OPERATIONS) == 8"` | OPERATIONS registrado |
+| B-5 | Modelos comunes + handler skeleton + rate_limit_guard | `core/models/_common.py`, `core/handler.py`, `core/utils/rate_limit_guard.py` | `pytest tests/unit/models/test__common*.py tests/unit/utils/ -v` | Handler boots con OPERATIONS vacio (404 unknown op) |
+| B-6 | conftest.py raiz + estructura de tests | `tests/conftest.py`, `tests/unit/__init__.py`, `tests/unit/_helpers.py`, `tests/integration/conftest.py`, `tests/integration/_fixtures/**` | `pytest tests/ -v` (todos pasan; ninguno aun) | Test infra lista |
+| B-7 | Lambda `db`: command `seed-rate-limit-rule` + event JSON | `serverless/lambda/services/db/core/commands/seed_rate_limit_rule.py`, handler.py mod, `events/seed_rate_limit_analytics.json`, tests del command | `pytest serverless/lambda/services/db/tests/unit/commands/test_seed_rate_limit_rule.py`; `serverless run --stage=local --lambda=db --event=events/seed_rate_limit_analytics.json` | Rule seeder funciona en local |
+
+**Total base secuencial**: 7 tareas. Estimado: 1-2 dias de trabajo.
+
+Tras B-7, las **7 fases siguientes son paralelizables** porque cada
+una toca archivos disjuntos: 1 dominio = 1 worktree.
+
+## Fases paralelizables (worktree-safe)
+
+Cada fase corresponde a un dominio. Cada controlador es independiente
+del otro, comparten solo `_common.py` (ya commiteado) y `OPERATIONS`
+(ya commiteado).
+
+### P-1: Operation `analytics` (7 actions)
+
+**Worktree**: `feature/analytics-op-analytics`
+
+| Archivos | Tests |
+|----------|-------|
+| `core/models/analytics.py` | `tests/unit/models/test_overview_*.py`, `test_timeseries_*.py`, ... |
+| `core/services/analytics_service.py` | `tests/unit/services/test_analytics_*.py` |
+| `core/controllers/analytics/overview.py` | `tests/unit/controllers/analytics/test_overview_*.py` |
+| `core/controllers/analytics/timeseries.py` | `test_timeseries_*.py` |
+| `core/controllers/analytics/top_pages.py` | `test_top_pages_*.py` |
+| `core/controllers/analytics/top_referrers.py` | `test_top_referrers_*.py` |
+| `core/controllers/analytics/top_niches.py` | `test_top_niches_*.py` |
+| `core/controllers/analytics/active_now.py` | `test_active_now_*.py` |
+| `core/controllers/analytics/retention.py` | `test_retention_*.py` |
+| `events/overview.json`, `events/timeseries.json`, ... (7) | — |
+
+**AC referenciados**: AC-1, AC-2, AC-3, AC-4, AC-7, AC-8, AC-17, AC-18.
+
+**Depende de**: B-1 a B-7. **Paralelizable con**: P-2..P-7.
+
+**Verify**:
+```bash
+python -m compileall -q serverless/lambda/services/analytics/core
+python devtools/run.py serverless tests --type=unit --lambda=analytics -- -k "analytics or overview or timeseries or top_pages or top_referrers or top_niches or active_now or retention"
+python devtools/run.py serverless run --stage=local --lambda=analytics --event=events/overview.json
+```
+
+**Done**: 7 actions corren contra DB local, devuelven shape correcta.
+
+---
+
+### P-2: Operation `events` (3 actions)
+
+**Worktree**: `feature/analytics-op-events`
+
+| Archivos | Tests |
+|----------|-------|
+| `core/models/events.py` | `tests/unit/models/test_distribution_*.py`, `test_events_list_*.py`, `test_heatmap_*.py` |
+| `core/services/events_service.py` | `tests/unit/services/test_events_*.py` |
+| `core/controllers/events/distribution.py` | `tests/unit/controllers/events/test_distribution_*.py` |
+| `core/controllers/events/list.py` | `test_list_*.py` |
+| `core/controllers/events/heatmap.py` | `test_heatmap_*.py` |
+| `events/events_distribution.json`, `events/events_list.json`, `events/events_heatmap.json` | — |
+
+**AC**: AC-4, AC-9, AC-10.
+
+**Depende de**: B-1 a B-7. **Paralelizable con**: P-1, P-3..P-7.
+
+---
+
+### P-3: Operation `sessions` (2 actions)
+
+**Worktree**: `feature/analytics-op-sessions`
+
+| Archivos | Tests |
+|----------|-------|
+| `core/models/sessions.py` | `tests/unit/models/test_sessions_list_*.py`, `test_sessions_detail_*.py` |
+| `core/services/sessions_service.py` | `tests/unit/services/test_sessions_*.py` |
+| `core/controllers/sessions/list.py`, `core/controllers/sessions/detail.py` | `tests/unit/controllers/sessions/...` |
+| `events/sessions_list.json`, `events/sessions_detail.json` | — |
+
+**AC**: AC-11, AC-12.
+
+---
+
+### P-4: Operation `visits` (2 actions)
+
+**Worktree**: `feature/analytics-op-visits`
+
+| Archivos | Tests |
+|----------|-------|
+| `core/models/visits.py` | `tests/unit/models/test_visits_*.py` |
+| `core/services/visits_service.py` | `tests/unit/services/test_visits_*.py` |
+| `core/controllers/visits/list.py`, `core/controllers/visits/landing_pages.py` | `tests/unit/controllers/visits/...` |
+| `events/visits_list.json`, `events/visits_landing_pages.json` | — |
+
+**AC**: AC-9.
+
+---
+
+### P-5: Operations `geo` + `devices` (2 actions, 1 worktree)
+
+**Worktree**: `feature/analytics-op-geo-devices`
+
+Razon de combinar: son operations chicas (1 action c/u). Manejarlas en
+un solo worktree reduce overhead de gestion.
+
+| Archivos | Tests |
+|----------|-------|
+| `core/models/geo.py`, `core/models/devices.py` | `tests/unit/models/test_geo_*.py`, `test_devices_*.py` |
+| `core/services/geo_service.py`, `core/services/devices_service.py` | `tests/unit/services/test_geo_*.py`, `test_devices_*.py` |
+| `core/controllers/geo/by_country.py` | `tests/unit/controllers/geo/...` |
+| `core/controllers/devices/breakdown.py` | `tests/unit/controllers/devices/...` |
+| `events/geo_by_country.json`, `events/devices_breakdown.json` | — |
+
+**AC**: AC-13, AC-14.
+
+---
+
+### P-6: Operation `funnel` (1 action)
+
+**Worktree**: `feature/analytics-op-funnel`
+
+| Archivos | Tests |
+|----------|-------|
+| `core/models/funnel.py` | `tests/unit/models/test_funnel_*.py` |
+| `core/services/funnel_service.py` | `tests/unit/services/test_funnel_*.py` |
+| `core/controllers/funnel/conversion.py` | `tests/unit/controllers/funnel/test_conversion_*.py` |
+| `events/funnel_conversion.json` | — |
+
+**AC**: AC-15.
+
+---
+
+### P-7: Operation `contacts` (2 actions)
+
+**Worktree**: `feature/analytics-op-contacts`
+
+| Archivos | Tests |
+|----------|-------|
+| `core/models/contacts.py` | `tests/unit/models/test_contacts_*.py` |
+| `core/services/contacts_service.py` | `tests/unit/services/test_contacts_*.py` |
+| `core/controllers/contacts/list.py`, `core/controllers/contacts/by_status.py` | `tests/unit/controllers/contacts/...` |
+| `events/contacts_list.json`, `events/contacts_by_status.json` | — |
+
+**AC**: AC-16.
+
+## Fases finales (post-merge de paralelas)
+
+Despues de mergear P-1..P-7 al branch principal:
+
+| # | Tarea | Archivos | Verify | Done |
+|---|-------|----------|--------|------|
+| F-1 | Tests integration (6 flujos) | `tests/integration/test_*_e2e.py` (6) | `serverless tests --type=integration --lambda=analytics` | 6 integration tests verdes |
+| F-2 | Runtime hooks SnapStart | `core/runtime_hooks.py` | `serverless deploy --lambda=analytics --stage=dev`; CloudWatch verifica Restore Duration | Restore Duration < 1500ms |
+| F-3 | Seed rate-limit rule (manual via CLI) | (sin codigo: comando) | `serverless run --stage=dev --lambda=db --event=events/seed_rate_limit_analytics.json --aws-profile=tfs-dev` (idem stage/prod) | Rule en DDB en los 3 envs |
+| F-4 | Coverage gate | (revision) | `serverless tests --type=coverage --lambda=analytics` >= 80% per-file | AC-21 |
+| F-5 | Smoke E2E + docs permanente | `.claude/docs/serverless-backend/03-lambdas.md` mod | `curl https://api.portfolio.dev.../analytics?...` para cada action; bateria pasa | AC-22 |
+| F-6 | Eliminar carpeta del plan + ultimo commit | `git rm -r docs/specs/analytics-dashboard-api/` | `test ! -d docs/specs/analytics-dashboard-api` | Spec archivada |
+
+## Diagrama de dependencias
+
+```text
+B-1 ──> B-2 ──> B-3 ──> B-4 ──> B-5 ──> B-6 ──> B-7
+                                                  │
+                            ┌─────────────────────┼─────────────────────┐
+                            │       │       │       │       │       │       │
+                           P-1     P-2     P-3     P-4     P-5     P-6     P-7
+                            │       │       │       │       │       │       │
+                            └───────┴───────┴───────┴───────┴───────┴───────┘
+                                                  │
+                                          merge a feature/X
+                                                  │
+                                                F-1 ──> F-2 ──> F-3 ──> F-4 ──> F-5 ──> F-6
+                                                                                          │
+                                                                                       PR -> dev
+```
+
+## Validacion del paralelismo (File Exclusivity)
+
+Matriz de archivos por fase. Una columna = una fase. Una "X" significa
+"esta fase toca este archivo". Ninguna fila tiene mas de una "X" entre
+P-1..P-7:
+
+| Archivo / Fase | B | P-1 | P-2 | P-3 | P-4 | P-5 | P-6 | P-7 | F |
+|----------------|---|-----|-----|-----|-----|-----|-----|-----|---|
+| `core/handler.py` | X | | | | | | | | |
+| `core/settings/operations.py` | X | | | | | | | | |
+| `core/settings/config.py` | X | | | | | | | | |
+| `core/models/_common.py` | X | | | | | | | | |
+| `core/utils/rate_limit_guard.py` | X | | | | | | | | |
+| `core/models/analytics.py` | | X | | | | | | | |
+| `core/models/events.py` | | | X | | | | | | |
+| `core/models/sessions.py` | | | | X | | | | | |
+| `core/models/visits.py` | | | | | X | | | | |
+| `core/models/geo.py` | | | | | | X | | | |
+| `core/models/devices.py` | | | | | | X | | | |
+| `core/models/funnel.py` | | | | | | | X | | |
+| `core/models/contacts.py` | | | | | | | | X | |
+| `core/services/analytics_service.py` | | X | | | | | | | |
+| `core/services/events_service.py` | | | X | | | | | | |
+| `core/services/sessions_service.py` | | | | X | | | | | |
+| `core/services/visits_service.py` | | | | | X | | | | |
+| `core/services/geo_service.py` | | | | | | X | | | |
+| `core/services/devices_service.py` | | | | | | X | | | |
+| `core/services/funnel_service.py` | | | | | | | X | | |
+| `core/services/contacts_service.py` | | | | | | | | X | |
+| `core/controllers/analytics/**` | | X | | | | | | | |
+| `core/controllers/events/**` | | | X | | | | | | |
+| `core/controllers/sessions/**` | | | | X | | | | | |
+| `core/controllers/visits/**` | | | | | X | | | | |
+| `core/controllers/geo/**` | | | | | | X | | | |
+| `core/controllers/devices/**` | | | | | | X | | | |
+| `core/controllers/funnel/**` | | | | | | | X | | |
+| `core/controllers/contacts/**` | | | | | | | | X | |
+| `events/*.json` | X (event template) | X (7) | X (3) | X (2) | X (2) | X (2) | X (1) | X (2) | |
+| `tests/integration/` | X (conftest) | | | | | | | | X |
+| `core/runtime_hooks.py` | | | | | | | | | X |
+
+**Validacion**: ninguna fila tiene 2+ "X" entre P-1..P-7. Las celdas con
+"X" en `B` son intocables tras B-7. **OK** para paralelizar.
+
+## Granularidad
+
+- 7 tareas base secuenciales.
+- 7 fases paralelizables (P-1..P-7), cada una entrega 1 operation
+  completa.
+- 6 tareas finales.
+- **Total**: 20 unidades de trabajo. Tamano: Medium-Large.
+
+Limite recomendado para subagentes concurrentes: **5-7 agentes**. P-1
+a P-7 = 7 agentes = en el limite. Si se prefiere mas seguridad,
+agrupar P-5+P-6 y P-3+P-4 -> 5 agentes.
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Editar `core/settings/operations.py` desde una fase P-X | Es base; rompe el commit anchor | Si una action nueva sale en una fase, mergear secuencialmente al main del feature |
+| Tocar `core/models/_common.py` desde P-X | Es base | Idem |
+| Crear un controller que pisa otra fase (ej. P-1 toca `events/`) | Rompe file exclusivity | Mover al worktree correcto |
+| Lanzar P-X antes de commitear B-7 | Conflictos garantizados | Esperar a tener B-7 mergeado al feature branch local |
+| Olvidar registrar la action en `OPERATIONS` | El handler tira 404 | Revisar el archivo `operations.py` ya tiene la entrada (lo dejamos completo en B-4) |
+
+[< 07-archivos-afectados](07-archivos-afectados.md) | [Siguiente: 09-commits >](09-commits.md)

--- a/docs/specs/analytics-dashboard-api/09-commits.md
+++ b/docs/specs/analytics-dashboard-api/09-commits.md
@@ -1,0 +1,467 @@
+# 09 — Commits
+
+[< 08-descomposicion-paralelizacion](08-descomposicion-paralelizacion.md) | [Siguiente: 10-paralelizacion-worktrees >](10-paralelizacion-worktrees.md)
+
+> Lista de commits incrementales del plan. Cada commit es atomico,
+> deja el repo verde, y se redacta en Conventional Commits espanol (ver
+> [.claude/rules/git-workflow.md](../../.claude/rules/git-workflow.md)).
+> Cada commit pasa SU verificacion ANTES de commitearse — la
+> verificacion no se difiere al final.
+
+## Branch
+
+```bash
+# Desde dev:
+git checkout dev && git pull
+git checkout -b feature/analytics-dashboard-api
+```
+
+NO se trabaja directo en `dev`/`stage`/`main` (rules protegen).
+
+## Secuencia
+
+### Commit 1 — Plan escrito
+
+```text
+docs(specs): agrega plan analytics-dashboard-api
+
+- Define lambda nuevo `analytics` con GET /analytics, operations+actions, rate-limit 10/min/IP y cache 60s
+- Documenta 22 criterios de aceptacion numerados, 19 actions distribuidos en 8 operations
+- Detalla queries SQL por endpoint, capa de cache, testing por capa, archivos afectados (~190)
+- Define descomposicion paralelizable en 7 worktrees + base secuencial de 7 tareas
+- Incluye seccion de verificacion E2E (gate del PR) con bateria de comandos reales
+```
+
+Archivos:
+
+- `docs/specs/analytics-dashboard-api/README.md`
+- `docs/specs/analytics-dashboard-api/01-contexto-y-decision.md`
+- `docs/specs/analytics-dashboard-api/02-arquitectura.md`
+- ... (12 archivos de la spec)
+
+Verify:
+
+```bash
+ls docs/specs/analytics-dashboard-api/ | wc -l   # == 12
+markdownlint docs/specs/analytics-dashboard-api/*.md
+```
+
+---
+
+### Commit 2 — (Condicional) Indices Neon
+
+Solo si en B-2 detectamos indices faltantes. Si todos existen, este
+commit no se hace.
+
+```text
+feat(db): agrega indices analytics para queries del dashboard
+
+- Indices en vis_sessions (first_seen_at, last_seen_at, device_type, browser)
+- Indices en vis_session_visits (started_at, session_id, country, niche, referrer)
+- Indices en vis_tracking_events (session_id, event_type_id, page_path, niche)
+- Indices en vis_contacts (created_at, status, niche)
+- Migration Alembic forward-only; downgrade re-aplica DROP INDEX
+```
+
+Archivos:
+
+- `serverless/lambda/shared/db/alembic/versions/<rev>_analytics_indexes.py`
+
+Verify:
+
+```bash
+serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev
+psql "$(grep -m1 '^DB_URL=' docker/env/server/.dev | cut -d= -f2-)" \
+  -c "SELECT indexname FROM pg_indexes WHERE schemaname='public' AND indexname LIKE 'idx_vis%';" | grep idx_vsv_started_at
+```
+
+---
+
+### Commit 3 — Scaffold + manifest + pyproject
+
+```text
+feat(analytics): scaffold del lambda con manifest + pyproject
+
+- Lambda `analytics` en serverless/lambda/services/analytics/
+- GET /analytics, runtime python3.13 arm64, memory 512MB, timeout 30s
+- SnapStart habilitado, neon-url secret, tablas cache + rate-limit-*
+- pyproject sin deps de runtime (cierre transitivo de shared/)
+- Env vars de defaults (paginacion, fechas, TTL cache)
+```
+
+Archivos:
+
+- `serverless/lambda/services/analytics/manifest.yaml`
+- `serverless/lambda/services/analytics/pyproject.toml`
+- `serverless/lambda/services/analytics/.gitignore`
+- `serverless/lambda/services/analytics/README.md`
+- `serverless/lambda/services/analytics/core/__init__.py`
+
+Verify:
+
+```bash
+cd serverless/lambda/services/analytics && uv sync && cd -
+python devtools/run.py serverless lint-deps --lambda=analytics  # exit 0
+```
+
+---
+
+### Commit 4 — Settings (config + operations)
+
+```text
+feat(analytics): registra OPERATIONS con 8 dominios y 19 actions
+
+- ErrorCode enum con codes 0/1000-1003/4030-4290/5100/6000
+- LogMetricType para metricas custom (Query{Ok,Rejected,Error}, Cache{Hit,Miss})
+- OPERATIONS mapea cada (op, action) a su controller_module + class
+```
+
+Archivos:
+
+- `core/settings/__init__.py`
+- `core/settings/config.py`
+- `core/settings/operations.py`
+
+Verify:
+
+```bash
+python -c "from core.settings.operations import OPERATIONS; \
+  assert set(OPERATIONS.keys()) == {'analytics','events','sessions','visits','geo','devices','funnel','contacts'}"
+```
+
+---
+
+### Commit 5 — Handler + utils + modelos comunes
+
+```text
+feat(analytics): handler skeleton + rate_limit_guard + DateRange/Pagination
+
+- Handler GET via shared.http.http_handler con event_model construido
+- rate_limit_guard delega a shared.rate_limit con endpoint='/analytics'
+- DateRange con defaults 30d, max 90d, error 1001 si span > 90d
+- Pagination con page>=1, page_size 1-200, default 50
+- _Meta (alias _meta) recibe ip/country/user_agent inyectados por http_handler
+```
+
+Archivos:
+
+- `core/handler.py`
+- `core/utils/__init__.py`
+- `core/utils/rate_limit_guard.py`
+- `core/models/__init__.py`
+- `core/models/_common.py`
+
+Verify:
+
+```bash
+python -m compileall -q serverless/lambda/services/analytics/core
+```
+
+(Tests aun no, se agregan en commit 6.)
+
+---
+
+### Commit 6 — Test infrastructure (conftest + helpers)
+
+```text
+test(analytics): conftest unit + integration + helpers
+
+- conftest raiz con sys.path setup, env vars de runtime, fixtures
+  mock_db_session, mock_check_or_raise, no_cache
+- conftest integration con db_url fixture (lee solo la key) y
+  namespace de cache aislado
+- helpers para construir eventos GET y seedear data
+- Tests de models comunes (DateRange + Pagination) verdes
+```
+
+Archivos:
+
+- `tests/conftest.py`
+- `tests/__init__.py`, `tests/unit/__init__.py`, `tests/integration/__init__.py`
+- `tests/unit/_helpers.py`
+- `tests/integration/conftest.py`
+- `tests/integration/_fixtures/__init__.py`
+- `tests/integration/_fixtures/event_builder.py`
+- `tests/integration/_fixtures/seed_data.py`
+- `tests/unit/models/test__common/test_date_range_when_no_dates_then_defaults_30d.py`
+- `tests/unit/models/test__common/test_date_range_when_range_over_90d_then_raises.py`
+- `tests/unit/models/test__common/test_date_range_when_from_greater_than_to_then_raises.py`
+- `tests/unit/models/test__common/test_pagination_when_page_size_over_max_then_raises.py`
+- `tests/unit/models/test__common/test_pagination_when_page_zero_then_raises.py`
+- `tests/unit/utils/test_rate_limit_guard_when_meta_none_then_uses_unknown.py`
+- `tests/unit/utils/test_rate_limit_guard_when_blacklisted_then_raises.py`
+- `tests/unit/utils/test_rate_limit_guard_when_rate_limited_then_raises.py`
+
+Verify:
+
+```bash
+python devtools/run.py serverless tests --type=unit --lambda=analytics -- -k "_common or rate_limit_guard"
+```
+
+---
+
+### Commit 7 — Lambda `db`: seed-rate-limit-rule command
+
+```text
+feat(db): agrega command seed-rate-limit-rule para insertar reglas
+
+- Command parsea {rule_key, kind, limit, window_seconds, algorithm, description}
+- PutItem con ConditionExpression: crea si no existe, sino actualiza
+- Devuelve {action: created|updated, rule_key}
+- Event JSON para insertar la rule /analytics 10 req/min/IP
+- Tests unit: create + update + valor invalido + missing args
+```
+
+Archivos:
+
+- `serverless/lambda/services/db/core/commands/seed_rate_limit_rule.py`
+- `serverless/lambda/services/db/core/handler.py` (registrar command)
+- `serverless/lambda/services/db/events/seed_rate_limit_analytics.json`
+- `serverless/lambda/services/db/tests/unit/commands/test_seed_rate_limit_rule_when_new_then_creates.py`
+- `serverless/lambda/services/db/tests/unit/commands/test_seed_rate_limit_rule_when_existing_then_updates.py`
+- `serverless/lambda/services/db/tests/unit/commands/test_seed_rate_limit_rule_when_missing_args_then_raises.py`
+- `serverless/lambda/services/db/tests/unit/commands/test_seed_rate_limit_rule_when_invalid_kind_then_raises.py`
+
+Verify:
+
+```bash
+python devtools/run.py serverless tests --type=unit --lambda=db -- -k seed_rate_limit_rule
+```
+
+---
+
+### Commits 8-14 — Operations (P-1..P-7 paralelizables)
+
+Cada uno es UN commit por fase paralelizable. Pueden hacerse en
+paralelo en worktrees distintos (ver [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md)).
+
+#### Commit 8 — Operation `analytics` (P-1)
+
+```text
+feat(analytics): operation analytics con 7 actions y queries SQL
+
+- Models: OverviewInput, TimeseriesInput, TopPagesInput, TopReferrersInput,
+  TopNichesInput, ActiveNowInput, RetentionInput
+- Service: overview (7 KPIs), timeseries (bucket day|hour|week),
+  top-pages, top-referrers (+ UTM), top-niches, active-now (TTL 10s),
+  retention (new vs returning)
+- Controllers: 7 archivos, cada uno con guard + service + shape
+- Events de ejemplo: 7 JSONs
+- Tests unit: models + service + controllers + parametricos para edge cases
+```
+
+#### Commit 9 — Operation `events` (P-2)
+
+```text
+feat(analytics): operation events (distribution + list + heatmap)
+
+- distribution: events agrupados por event_type_id con porcentaje
+- list: paginado, filtros niche/event_type/session_id/page_path
+- heatmap: dia_semana (ISO) x hora con count
+- Cache 60s en distribution + heatmap; list sin cache
+- Tests unit por accion incluyendo edge cases de paginacion
+```
+
+#### Commit 10 — Operation `sessions` (P-3)
+
+```text
+feat(analytics): operation sessions (list + detail)
+
+- list: paginado con join a vis_session_visits para visits_count
+- detail: 3 queries (session + visits + count events); 404 si no existe
+- Filtros device_type/browser en list
+- Tests unit + edge cases (session_id inexistente, sin visits)
+```
+
+#### Commit 11 — Operation `visits` (P-4)
+
+```text
+feat(analytics): operation visits (list + landing-pages)
+
+- list: paginado con UTM, referrer, landing_page_path, niche, country
+- landing-pages: ranking por visits agrupado por landing_page_path
+- Cache 60s en landing-pages; list sin cache
+- Tests unit por accion
+```
+
+#### Commit 12 — Operations geo + devices (P-5)
+
+```text
+feat(analytics): operations geo (by-country) y devices (breakdown)
+
+- geo/by-country: count distinct session_id agrupado por country (ISO-2)
+- devices/breakdown: 3 distribuciones simultaneas (device_type, browser, os)
+- Cache 60s en ambos
+- Tests unit
+```
+
+#### Commit 13 — Operation funnel (P-6)
+
+```text
+feat(analytics): operation funnel (conversion)
+
+- CTE con counts de sessions / visits / contacts en el rango
+- Calcula 3 rates (session_to_visit, visit_to_contact, session_to_contact)
+- Manejo de division por cero en Python (no en SQL)
+- Cache 60s
+```
+
+#### Commit 14 — Operation contacts (P-7)
+
+```text
+feat(analytics): operation contacts (list + by-status)
+
+- list: paginado con filtros status/niche
+- by-status: distribucion por status (new/contacted/qualified/converted/rejected)
+- Cache 60s en by-status; list sin cache
+- Tests unit
+```
+
+---
+
+### Commit 15 — Tests integration (F-1)
+
+```text
+test(analytics): tests integration E2E contra dev DB
+
+- test_overview_e2e_happy_path: GET overview con dates -> 200 + shape
+- test_overview_e2e_range_too_wide: from/to > 90d -> 400 code 1001
+- test_rate_limit_e2e_block_after_10_requests: 11va request -> 429
+- test_sessions_detail_e2e_not_found: session_id inexistente -> 404
+- test_cache_e2e_hit_returns_same_data: 2 requests identicas -> hit
+- test_funnel_e2e_with_seeded_data: seed + GET funnel -> rates correctos
+```
+
+Archivos:
+
+- `tests/integration/test_overview_e2e_happy_path.py`
+- `tests/integration/test_overview_e2e_range_too_wide.py`
+- `tests/integration/test_rate_limit_e2e_block_after_10_requests.py`
+- `tests/integration/test_sessions_detail_e2e_not_found.py`
+- `tests/integration/test_cache_e2e_hit_returns_same_data.py`
+- `tests/integration/test_funnel_e2e_with_seeded_data.py`
+
+Verify:
+
+```bash
+python devtools/run.py serverless tests --type=integration --lambda=analytics --aws-profile=tfs-dev
+```
+
+---
+
+### Commit 16 — SnapStart runtime hooks (F-2)
+
+```text
+feat(analytics): runtime hooks SnapStart para acelerar cold start
+
+- before_checkpoint: precalienta build_event_model y carga OPERATIONS
+- after_restore: registra log marker (sin abrir conexion DB)
+- Patron espejo de contact_form
+```
+
+Archivos:
+
+- `core/runtime_hooks.py`
+
+Verify:
+
+```bash
+python devtools/run.py serverless deploy --lambda=analytics --stage=dev --aws-profile=tfs-dev
+# CloudWatch: aws logs tail /aws/lambda/portfolio-analytics-dev --follow
+# Verificar Restore Duration < 1500ms en la metric REPORT
+```
+
+---
+
+### Commit 17 — Promocion docs permanente + cleanup
+
+```text
+docs(serverless): agrega lambda analytics al knowledge tree y elimina spec efimera
+
+- .claude/docs/serverless-backend/03-lambdas.md: agrega entrada de analytics
+- docs/specs/analytics-dashboard-api/: eliminada (efimera, plan implementado)
+```
+
+Archivos:
+
+- `.claude/docs/serverless-backend/03-lambdas.md` (modificar)
+- `git rm -r docs/specs/analytics-dashboard-api/`
+
+Este commit incluye la **verificacion E2E completa** (seccion 11):
+
+- Bateria de curls contra dev (los 19 endpoints)
+- Coverage gate verde
+- Logs CloudWatch sin ERROR
+- Rate-limit rule confirmada en DDB
+
+Verify (ANTES de commit):
+
+```bash
+# Bateria completa — todo verde
+python devtools/run.py serverless tests --type=unit --lambda=analytics
+python devtools/run.py serverless tests --type=integration --lambda=analytics --aws-profile=tfs-dev
+python devtools/run.py serverless tests --type=coverage --lambda=analytics  # >= 80% per-file
+python devtools/run.py serverless lint-deps --lambda=analytics
+# Smoke contra dev (curl con cada operation+action)
+bash docs/specs/analytics-dashboard-api/scripts/smoke.sh dev  # si lo armamos
+```
+
+---
+
+## Resumen de secuencia
+
+| Commit | Branch | Verde despues | Tests del scope |
+|--------|--------|---------------|-----------------|
+| 1 | feature/X | docs only | `markdownlint` |
+| 2 (cond) | feature/X | + migration | `db migrate; \d` |
+| 3 | feature/X | + scaffold | `lint-deps` |
+| 4 | feature/X | + settings | `python -c "..."` |
+| 5 | feature/X | + handler skel | `compileall` |
+| 6 | feature/X | + test infra | unit `_common` + `rate_limit_guard` |
+| 7 | feature/X | + db seeder | unit `db` seeder |
+| 8 (P-1) | feature/X (o worktree) | + analytics op | unit analytics |
+| 9 (P-2) | + worktree | + events op | unit events |
+| 10 (P-3) | + worktree | + sessions op | unit sessions |
+| 11 (P-4) | + worktree | + visits op | unit visits |
+| 12 (P-5) | + worktree | + geo + devices | unit geo + devices |
+| 13 (P-6) | + worktree | + funnel | unit funnel |
+| 14 (P-7) | + worktree | + contacts | unit contacts |
+| 15 | feature/X | + integration | integration 6 flujos |
+| 16 | feature/X | + SnapStart | deploy dev + Restore < 1500ms |
+| 17 | feature/X | + docs + cleanup | bateria E2E completa |
+
+## PR
+
+Un solo PR: `feature/analytics-dashboard-api -> dev`.
+
+Body del PR (ver `git-workflow.md`, 4 secciones):
+
+```markdown
+## Problema
+1. El backend persiste sessions/visits/events/contacts en Neon pero no hay forma de leerlos sin abrir `psql`.
+2. El dashboard de analytics del portfolio necesita una API HTTP que exponga KPIs, timeseries, rankings y listados paginados.
+
+## Solucion
+1. Nuevo Lambda `analytics` (GET `/analytics?operation=...&action=...`) con 19 actions distribuidos en 8 operations.
+2. Rate-limit 10 req/min/IP via `shared.rate_limit`, cache 60s via `shared.cache` en queries agregadas, SnapStart habilitado.
+
+## Como probar
+```bash
+# Tests
+python devtools/run.py serverless tests --type=unit --lambda=analytics
+python devtools/run.py serverless tests --type=integration --lambda=analytics --aws-profile=tfs-dev
+python devtools/run.py serverless tests --type=coverage --lambda=analytics  # >= 80% per-file
+# Deploy dev
+python devtools/run.py serverless deploy --lambda=analytics --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless run --stage=dev --lambda=db \
+  --event=events/seed_rate_limit_analytics.json --aws-profile=tfs-dev
+# Smoke
+curl "https://api.portfolio.dev.the-full-stack.com/analytics?operation=analytics&action=overview&from=2026-04-27&to=2026-05-27"
+```
+
+## TODO
+- Auth real (Cloudflare Access o Bearer en SSM) — fuera de scope; se agregara cuando el dashboard frontend se exponga.
+- Frontend Astro del dashboard — proxima iteracion.
+```
+
+[< 08-descomposicion-paralelizacion](08-descomposicion-paralelizacion.md) | [Siguiente: 10-paralelizacion-worktrees >](10-paralelizacion-worktrees.md)

--- a/docs/specs/analytics-dashboard-api/09-commits.md
+++ b/docs/specs/analytics-dashboard-api/09-commits.md
@@ -402,8 +402,9 @@ python devtools/run.py serverless tests --type=unit --lambda=analytics
 python devtools/run.py serverless tests --type=integration --lambda=analytics --aws-profile=tfs-dev
 python devtools/run.py serverless tests --type=coverage --lambda=analytics  # >= 80% per-file
 python devtools/run.py serverless lint-deps --lambda=analytics
-# Smoke contra dev (curl con cada operation+action)
-bash docs/specs/analytics-dashboard-api/scripts/smoke.sh dev  # si lo armamos
+# Smoke contra dev: usar los curls de la bateria B.1..B.6 en el archivo
+# 11-verificacion-e2e.md (no hay smoke.sh dedicado, los `curl` inline son
+# la fuente de verdad del test E2E manual).
 ```
 
 ---

--- a/docs/specs/analytics-dashboard-api/10-paralelizacion-worktrees.md
+++ b/docs/specs/analytics-dashboard-api/10-paralelizacion-worktrees.md
@@ -1,0 +1,191 @@
+# 10 — Paralelizacion con git worktrees
+
+[< 09-commits](09-commits.md) | [Siguiente: 11-verificacion-e2e >](11-verificacion-e2e.md)
+
+> Como ejecutar las fases paralelizables (P-1..P-7) en git worktrees
+> independientes para que multiples agentes/devs avancen en paralelo
+> sin pisarse. Reglas, base secuencial obligatoria, y fases NO
+> paralelizables.
+
+## Punto de partida (la base secuencial)
+
+NO se lanza ningun worktree hasta tener mergeados los commits 1-7 en
+`feature/analytics-dashboard-api`. Esos commits dejan listos:
+
+- Carpeta del plan
+- Indices Neon (si aplica)
+- Scaffold completo del Lambda
+- `OPERATIONS` con TODAS las entradas (controllers aun vacios)
+- Handler + utils + `_common.py` + rate_limit_guard
+- Test infrastructure (conftests + helpers)
+- Command `seed-rate-limit-rule` en Lambda `db`
+
+Con esa base, cualquier worktree puede importar:
+
+- `core.settings.operations` -> sus entradas ya estan listas
+- `core.models._common` -> DateRange + Pagination estables
+- `core.handler` -> stub funcional, no se modifica desde worktrees
+- `shared.*` -> congelado por la base
+
+## Fases worktree-safe
+
+Las **7 fases paralelizables** (P-1..P-7) tocan archivos DISJUNTOS por
+operation/dominio. La matriz de file exclusivity esta en
+[08-descomposicion-paralelizacion.md](08-descomposicion-paralelizacion.md).
+
+| Worktree | Branch | Operation(s) | Archivos disjuntos | Commit final |
+|----------|--------|--------------|---------------------|--------------|
+| `wt-p1-analytics` | `feature/analytics-op-analytics` | `analytics` (7 actions) | `core/models/analytics.py`, `core/services/analytics_service.py`, `core/controllers/analytics/**`, `tests/unit/{models,services,controllers}/analytics/**`, `events/{overview,timeseries,top_pages,top_referrers,top_niches,active_now,retention}.json` | Commit 8 |
+| `wt-p2-events` | `feature/analytics-op-events` | `events` (3 actions) | `core/models/events.py`, `core/services/events_service.py`, `core/controllers/events/**`, tests | Commit 9 |
+| `wt-p3-sessions` | `feature/analytics-op-sessions` | `sessions` (2 actions) | `core/models/sessions.py`, `core/services/sessions_service.py`, `core/controllers/sessions/**`, tests | Commit 10 |
+| `wt-p4-visits` | `feature/analytics-op-visits` | `visits` (2 actions) | `core/models/visits.py`, `core/services/visits_service.py`, `core/controllers/visits/**`, tests | Commit 11 |
+| `wt-p5-geo-devices` | `feature/analytics-op-geo-devices` | `geo` + `devices` (2 actions total) | `core/models/{geo,devices}.py`, `core/services/{geo,devices}_service.py`, `core/controllers/{geo,devices}/**`, tests | Commit 12 |
+| `wt-p6-funnel` | `feature/analytics-op-funnel` | `funnel` (1 action) | `core/models/funnel.py`, `core/services/funnel_service.py`, `core/controllers/funnel/**`, tests | Commit 13 |
+| `wt-p7-contacts` | `feature/analytics-op-contacts` | `contacts` (2 actions) | `core/models/contacts.py`, `core/services/contacts_service.py`, `core/controllers/contacts/**`, tests | Commit 14 |
+
+## Como lanzar cada worktree
+
+Desde el repo raiz (asumiendo que `feature/analytics-dashboard-api` ya
+tiene commits 1-7):
+
+```bash
+# Worktree raiz (ya estas ahi):
+cd /home/bypabloc/projects/bypabloc/portfolio
+git checkout feature/analytics-dashboard-api
+
+# Lanzar worktree P-1 (analytics op)
+git worktree add ../portfolio-wt-p1-analytics \
+  -b feature/analytics-op-analytics
+
+# Lanzar worktree P-2 (events op) en paralelo
+git worktree add ../portfolio-wt-p2-events \
+  -b feature/analytics-op-events
+
+# ... idem P-3 a P-7
+```
+
+Cada worktree es una **copia independiente del working tree** del repo,
+con su propio `.git` apuntando al mismo objeto-store. Cambios en uno NO
+afectan a los otros HASTA que se mergea.
+
+Al terminar el trabajo en un worktree:
+
+```bash
+cd ../portfolio-wt-p1-analytics
+# ... implementar, testear ...
+python devtools/run.py serverless tests --type=unit --lambda=analytics
+# tests verdes -> commit (segun seccion 09)
+git add core/ tests/ events/
+git commit -m "feat(analytics): operation analytics con 7 actions y queries SQL"
+git push -u origin feature/analytics-op-analytics
+
+# Volver al worktree principal y mergear
+cd /home/bypabloc/projects/bypabloc/portfolio
+git checkout feature/analytics-dashboard-api
+git merge --no-ff feature/analytics-op-analytics
+
+# Cleanup del worktree
+git worktree remove ../portfolio-wt-p1-analytics
+git branch -d feature/analytics-op-analytics
+```
+
+## Lo que NO se paraleliza
+
+Estas tareas son secuenciales por dependencia o por riesgo:
+
+| # | Tarea | Razon de no-paralelizar |
+|---|-------|------------------------|
+| Commits 1-7 (base) | Plan + indices + scaffold + settings + handler + test infra + db seeder | Establecen contratos que todas las fases consumen. Paralelizar generaria conflictos en `OPERATIONS`, `_common`, `handler`. |
+| Commit 15 (integration tests) | Tests E2E contra dev DB | Necesita TODAS las operations mergeadas + Lambda deployado. Tocar `tests/integration/` desde un worktree paralelo genera conflictos en `conftest.py`. |
+| Commit 16 (SnapStart) | `runtime_hooks.py` | Es 1 archivo + deploy + observacion CloudWatch. Tarea atomica, no se beneficia de paralelismo. |
+| Commit 17 (cleanup) | Eliminar spec efimera + actualizar knowledge tree + bateria E2E | Ultima fase, secuencial obligatorio. |
+| Seed de rate-limit rule en DDB | `serverless run --lambda=db --event=seed_rate_limit_analytics.json` | Comando manual + idempotente. Se corre 3 veces (dev/stage/prod) cuando cada env esta listo. NO se paraleliza con CI. |
+| Promocion `dev -> stage -> main` | PRs encadenados | Politica del repo, ver `git-workflow.md`. |
+
+## Reglas de oro para worktrees
+
+- **NUNCA** desde un worktree paralelo editar archivos de la base
+  (`OPERATIONS`, `handler.py`, `_common.py`, `rate_limit_guard.py`,
+  `config.py`, `shared/**`).
+- **SIEMPRE** correr `serverless lint-deps --lambda=analytics` antes del
+  commit (cada worktree tiene la misma copia de `shared/`).
+- **NUNCA** intentar arreglar un bug detectado en la base desde un
+  worktree paralelo — abrir un commit dedicado en el worktree raiz,
+  rebasar los demas worktrees sobre el commit nuevo.
+- **SIEMPRE** los worktrees comparten `.git/objects` — los `git
+  fetch`/`push` son seguros, NO se crean blobs duplicados.
+- **NUNCA** hacer `git worktree remove` con cambios sin commitear (la
+  data se pierde silenciosamente).
+- **SIEMPRE** correr `git worktree list` antes de empezar a editar para
+  saber donde estoy y que branches estan vivos.
+
+## Estrategia de merge
+
+Cuando los 7 worktrees terminan:
+
+```bash
+cd /home/bypabloc/projects/bypabloc/portfolio
+git checkout feature/analytics-dashboard-api
+
+# Mergear en orden alfabetico (no importa el orden por file exclusivity,
+# pero consistencia ayuda al review):
+for branch in \
+  feature/analytics-op-analytics \
+  feature/analytics-op-contacts \
+  feature/analytics-op-events \
+  feature/analytics-op-funnel \
+  feature/analytics-op-geo-devices \
+  feature/analytics-op-sessions \
+  feature/analytics-op-visits ; do
+    git merge --no-ff "$branch" -m "merge: $branch"
+done
+
+# Verificar nada se rompio
+python devtools/run.py serverless lint-deps --lambda=analytics
+python devtools/run.py serverless tests --type=unit --lambda=analytics
+
+# Cleanup worktrees
+for wt in ../portfolio-wt-p*; do git worktree remove "$wt"; done
+for branch in feature/analytics-op-*; do git branch -d "$branch"; done
+```
+
+## Conflictos esperados (cero)
+
+Por la matriz de file exclusivity, los merges deberian aplicarse
+**linealmente sin conflictos**. Los unicos riesgos:
+
+1. **`events/`** — si en la base no creamos los 19 JSON vacios y cada
+   worktree los suma, no hay conflicto (archivos disjuntos). Si dos
+   worktrees crearan el mismo `events/X.json` -> conflicto. Por eso la
+   tabla de file exclusivity asigna los JSON por dominio.
+2. **`__init__.py`** vacios de `controllers/<dominio>/` — un worktree
+   por dominio, sin colision.
+3. **Tests fixtures compartidos** — `tests/unit/_helpers.py` lo
+   commiteamos en la base (commit 6). Si una fase necesita un helper
+   nuevo, lo agrega en su propio archivo `tests/unit/<dominio>/_helpers.py`
+   para no tocar el compartido.
+
+## Si decides NO paralelizar
+
+Esta seccion describe el camino paralelizable. **Si lo haces secuencial**
+(1 dev, sin worktrees), simplemente corres los commits 8-14 uno tras
+otro en `feature/analytics-dashboard-api` directamente. Misma cantidad
+de codigo, mismo PR final. El plan funciona en ambas modalidades.
+
+Tiempo estimado:
+
+- Secuencial (1 dev): ~5-7 dias de trabajo activo.
+- Paralelizado (3-7 worktrees con devs/agentes distintos): ~2-3 dias.
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Lanzar worktrees ANTES de commitear la base | Cada worktree no ve `OPERATIONS`, falla en runtime | Esperar commit 7 mergeado |
+| Editar `OPERATIONS` desde un worktree para "agregar mi action" | Las entradas ya estan en commit 4 | Si necesitas una action nueva, va en un commit aparte en feature/X |
+| Worktrees en branches sin sufijo `op-<X>` | Confusion en `git worktree list` | Convencion: `feature/analytics-op-<dominio>` |
+| Olvidar `git worktree remove` despues del merge | Worktrees viejos quedan vivos, ocupan disco | Cleanup post-merge |
+| Hacer `git stash` y cambiar worktree | El stash es global; podes desestabilizar otro | Cada worktree resuelve sus cambios sin stash |
+| Confiar en CI para detectar conflictos | Tarde y caro | Validar file exclusivity en este doc ANTES de lanzar |
+
+[< 09-commits](09-commits.md) | [Siguiente: 11-verificacion-e2e >](11-verificacion-e2e.md)

--- a/docs/specs/analytics-dashboard-api/10-paralelizacion-worktrees.md
+++ b/docs/specs/analytics-dashboard-api/10-paralelizacion-worktrees.md
@@ -137,7 +137,7 @@ for branch in \
   feature/analytics-op-geo-devices \
   feature/analytics-op-sessions \
   feature/analytics-op-visits ; do
-    git merge --no-ff "$branch" -m "merge: $branch"
+    git merge --no-ff "$branch" -m "chore(analytics): merge $branch"
 done
 
 # Verificar nada se rompio

--- a/docs/specs/analytics-dashboard-api/11-verificacion-e2e.md
+++ b/docs/specs/analytics-dashboard-api/11-verificacion-e2e.md
@@ -1,0 +1,410 @@
+# 11 — Verificacion E2E iterativa (gate del PR)
+
+[< 10-paralelizacion-worktrees](10-paralelizacion-worktrees.md) | [< README](README.md)
+
+> Fase final del plan. Es la **ultima fase y el ultimo commit**. NO se
+> hace `git push` ni se abre el PR hasta que toda esta bateria pase
+> completa en verde. Es el gate de cierre, no un paso intermedio.
+
+## Bucle de cierre
+
+```text
+loop:
+  ejecutar bateria completa
+  if alguna parte falla:
+    diagnosticar -> corregir -> commit fix
+    continue
+  else:
+    push + abrir PR
+    salir
+```
+
+No se marca completa con un comando fallando, un test rojo o coverage
+< 80%.
+
+---
+
+## Parte A — Refactor de tests (limpieza)
+
+Antes de la bateria, asegurar que NINGUN test viejo apunta a codigo
+eliminado o renombrado en el camino.
+
+### A.1 Barrido global de referencias huerfanas
+
+```bash
+# Buscar referencias a paths que ya no existen (deberian dar 0)
+rg -l "core\\.controllers\\.analytics\\.<deprecated>" tests/  # 0 resultados
+rg -l "from core\\.<deleted_module>" tests/                    # 0 resultados
+rg -l "fixture_<deprecated>" tests/                            # 0 resultados
+```
+
+Si aparecen resultados: el test referencia codigo viejo. Eliminar el
+test o re-apuntarlo.
+
+### A.2 Tests en ruta y convencion correcta
+
+```bash
+# Convencion: tests en tests/unit o tests/integration
+find tests -type f -name "test_*.py" | grep -v "^tests/\\(unit\\|integration\\)/" \
+  | wc -l    # debe dar 0
+
+# Cada test_*.py tiene UN test function (regla del repo)
+for f in $(find tests/unit -type f -name "test_*.py"); do
+  n=$(grep -c "^def test_" "$f")
+  if [ "$n" != "1" ]; then echo "BAD: $f tiene $n funciones test_*"; fi
+done | grep BAD     # debe dar 0
+```
+
+### A.3 conftest.py limpio
+
+```bash
+# conftest no debe tener fixtures muertos (no referenciados desde ningun test)
+# Esto es manual o via pytest --collect-only -q
+python devtools/run.py serverless tests --type=unit --lambda=analytics -- --collect-only -q | head -50
+```
+
+---
+
+## Parte B — Bateria de comandos reales
+
+### B.0 Pre-flight (local, no deploys)
+
+```bash
+# 1. Sintaxis Python (compileall) — debe pasar 100%
+python -m compileall -q serverless/lambda/services/analytics
+python -m compileall -q serverless/lambda/services/db   # por el seed command nuevo
+
+# 2. Lint-deps (shared-only imports + dedup)
+python devtools/run.py serverless lint-deps --lambda=analytics    # exit 0
+python devtools/run.py serverless lint-deps --lambda=db           # exit 0
+
+# 3. Unit tests del nuevo Lambda
+python devtools/run.py serverless tests --type=unit --lambda=analytics
+# Esperado: 100+ tests verdes, 0 fails, 0 errors
+
+# 4. Unit tests del Lambda `db` (seed command nuevo)
+python devtools/run.py serverless tests --type=unit --lambda=db -- -k seed_rate_limit_rule
+# Esperado: 4 tests verdes
+
+# 5. Coverage gate
+python devtools/run.py serverless tests --type=coverage --lambda=analytics
+# Esperado: coverage per-file >= 80% en core/ (AC-21)
+
+# 6. Markdownlint del plan (NO debe fallar antes del rm)
+markdownlint docs/specs/analytics-dashboard-api/*.md
+# Esperado: warnings ok, errors NO
+```
+
+### B.1 Run local del Lambda contra Neon dev (con RIE)
+
+```bash
+# Levantar el Lambda en modo RIE (Runtime Interface Emulator)
+# y disparar cada accion con su event JSON.
+# RIE corre el Lambda en un container Docker local.
+
+for evt in events/*.json; do
+  echo "--- $evt ---"
+  python devtools/run.py serverless run --stage=local --lambda=analytics \
+    --event="$evt" --runtime-mode=rie
+done
+```
+
+Verificar para cada response:
+
+- HTTP status = 200 (o 4xx esperado segun event)
+- Body es JSON valido
+- `data` tiene la shape definida en los AC
+
+### B.2 Deploy a dev + seed rule
+
+```bash
+# 1. Deploy el Lambda
+python devtools/run.py serverless deploy --lambda=analytics --stage=dev \
+  --aws-profile=tfs-dev
+# Esperado: exit 0, archivo de estado actualizado
+
+# 2. Verificar status
+python devtools/run.py serverless status --lambda=analytics --stage=dev \
+  --aws-profile=tfs-dev
+# Esperado: estado SYNCED
+
+# 3. Seed de la rate-limit rule
+python devtools/run.py serverless run --stage=dev --lambda=db \
+  --event=events/seed_rate_limit_analytics.json --aws-profile=tfs-dev
+# Esperado: {action: created|updated, rule_key: "/analytics"}
+
+# 4. Confirmar la rule en DynamoDB
+aws dynamodb get-item \
+  --table-name portfolio-rate-limit-rules-dev \
+  --key '{"rule_key":{"S":"/analytics"},"kind":{"S":"ip"}}' \
+  --region us-east-1 --profile tfs-dev
+# Esperado: Item con limit=10, window_seconds=60
+```
+
+### B.3 Smoke E2E contra dev (curl, 19 endpoints)
+
+URL base: `https://api.portfolio.dev.the-full-stack.com/analytics`.
+
+```bash
+BASE="https://api.portfolio.dev.the-full-stack.com/analytics"
+FROM="2026-04-27"
+TO="2026-05-27"
+
+# 1. analytics/overview                  AC-1
+curl -sS "$BASE?operation=analytics&action=overview&from=$FROM&to=$TO" | jq .
+
+# 2. analytics/timeseries (bucket=day)   AC-7
+curl -sS "$BASE?operation=analytics&action=timeseries&from=$FROM&to=$TO&bucket=day" | jq .
+
+# 3. analytics/top-pages
+curl -sS "$BASE?operation=analytics&action=top-pages&from=$FROM&to=$TO&limit=10" | jq .
+
+# 4. analytics/top-referrers
+curl -sS "$BASE?operation=analytics&action=top-referrers&from=$FROM&to=$TO" | jq .
+
+# 5. analytics/top-niches
+curl -sS "$BASE?operation=analytics&action=top-niches&from=$FROM&to=$TO" | jq .
+
+# 6. analytics/active-now                AC-17
+curl -sS "$BASE?operation=analytics&action=active-now" | jq .
+
+# 7. analytics/retention                 AC-18
+curl -sS "$BASE?operation=analytics&action=retention&from=$FROM&to=$TO" | jq .
+
+# 8. events/distribution
+curl -sS "$BASE?operation=events&action=distribution&from=$FROM&to=$TO" | jq .
+
+# 9. events/list                         AC-9
+curl -sS "$BASE?operation=events&action=list&from=$FROM&to=$TO&page=1&page_size=50" | jq '.data | {page, page_size, total, has_more, items_count: (.items|length)}'
+
+# 10. events/heatmap
+curl -sS "$BASE?operation=events&action=heatmap&from=$FROM&to=$TO" | jq '.data.cells | length'
+
+# 11. sessions/list
+curl -sS "$BASE?operation=sessions&action=list&from=$FROM&to=$TO&page=1&page_size=20" | jq '.data | {page, total}'
+
+# 12. sessions/detail (con un session_id real)         AC-12
+SID=$(curl -sS "$BASE?operation=sessions&action=list&from=$FROM&to=$TO&page=1&page_size=1" | jq -r '.data.items[0].session_id')
+curl -sS "$BASE?operation=sessions&action=detail&session_id=$SID" | jq '.data | keys'
+
+# 13. visits/list
+curl -sS "$BASE?operation=visits&action=list&from=$FROM&to=$TO&page=1&page_size=20" | jq '.data | {page, total}'
+
+# 14. visits/landing-pages
+curl -sS "$BASE?operation=visits&action=landing-pages&from=$FROM&to=$TO" | jq .
+
+# 15. geo/by-country                     AC-13
+curl -sS "$BASE?operation=geo&action=by-country&from=$FROM&to=$TO" | jq '.data.items | length'
+
+# 16. devices/breakdown                  AC-14
+curl -sS "$BASE?operation=devices&action=breakdown&from=$FROM&to=$TO" | jq '.data | keys'
+
+# 17. funnel/conversion                  AC-15
+curl -sS "$BASE?operation=funnel&action=conversion&from=$FROM&to=$TO" | jq .
+
+# 18. contacts/list                      AC-16
+curl -sS "$BASE?operation=contacts&action=list&from=$FROM&to=$TO&page=1" | jq '.data | {page, total}'
+
+# 19. contacts/by-status
+curl -sS "$BASE?operation=contacts&action=by-status&from=$FROM&to=$TO" | jq .
+```
+
+Cada response debe tener:
+
+- HTTP 200
+- Header `Content-Type: application/json`
+- Body con `is_valid: true, code: 0, data: {...}`
+
+### B.4 Smoke de errores
+
+```bash
+# Operation invalida -> 400 code 1000 (AC-4)
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  "$BASE?operation=foo&action=bar"
+# Esperado: 400
+
+# Action invalida -> 400 code 1000 (AC-4)
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  "$BASE?operation=analytics&action=bogus"
+# Esperado: 400
+
+# Rango fechas > 90d -> 400 code 1001 (AC-3)
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  "$BASE?operation=analytics&action=overview&from=2025-01-01&to=2026-05-27"
+# Esperado: 400
+
+# page_size > max -> 400 code 1002 (AC-10)
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  "$BASE?operation=events&action=list&from=$FROM&to=$TO&page_size=500"
+# Esperado: 400
+
+# sessions/detail con session_id inexistente -> 404 (AC-11)
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  "$BASE?operation=sessions&action=detail&session_id=does-not-exist"
+# Esperado: 404
+
+# 11 requests/min desde la misma IP -> 429 (AC-5)
+for i in {1..11}; do
+  curl -sS -o /dev/null -w "$i: %{http_code}\n" \
+    "$BASE?operation=analytics&action=active-now"
+done
+# Esperado: las primeras 10 con 200, la 11va con 429
+```
+
+### B.5 Cache hit verificacion (AC-8)
+
+```bash
+# Llamada 1 (cache miss)
+T1=$(date +%s%N)
+curl -sS "$BASE?operation=analytics&action=overview&from=$FROM&to=$TO" > /tmp/r1.json
+T2=$(date +%s%N)
+
+# Llamada 2 inmediata (cache hit)
+T3=$(date +%s%N)
+curl -sS "$BASE?operation=analytics&action=overview&from=$FROM&to=$TO" > /tmp/r2.json
+T4=$(date +%s%N)
+
+# Las dos responses deben ser IDENTICAS
+diff /tmp/r1.json /tmp/r2.json  # 0 diff
+
+# La segunda debe ser sensiblemente mas rapida (TTL hit)
+MS1=$(( (T2 - T1) / 1000000 ))
+MS2=$(( (T4 - T3) / 1000000 ))
+echo "miss: ${MS1}ms, hit: ${MS2}ms"
+# Esperado: MS2 < MS1 / 3 (hit es al menos 3x mas rapido)
+```
+
+### B.6 SnapStart verificacion (AC-19)
+
+```bash
+# Forzar cold start: redeploy + esperar
+python devtools/run.py serverless deploy --lambda=analytics --stage=dev --aws-profile=tfs-dev
+sleep 30  # esperar que el snapshot se publique
+
+# Llamada 1 (cold start con SnapStart Restore)
+time curl -sS "$BASE?operation=analytics&action=active-now" > /dev/null
+
+# Verificar en CloudWatch Logs el campo "Restore Duration"
+aws logs tail /aws/lambda/portfolio-analytics-dev \
+  --since 5m --format short --profile tfs-dev | grep "Restore Duration"
+# Esperado: Restore Duration < 1500ms (AC-19)
+```
+
+### B.7 Logs CloudWatch — sin ERROR/WARN sostenido
+
+```bash
+# Tras la bateria, revisar logs:
+aws logs tail /aws/lambda/portfolio-analytics-dev \
+  --since 15m --filter-pattern '?ERROR ?WARNING' \
+  --format short --profile tfs-dev
+# Esperado: solo INFO. Si hay ERROR/WARN, diagnosticar.
+```
+
+### B.8 Sin tests/coverage rotos
+
+```bash
+python devtools/run.py serverless tests --type=unit --lambda=analytics
+# Esperado: passed=N, failed=0, errors=0
+
+python devtools/run.py serverless tests --type=integration --lambda=analytics \
+  --aws-profile=tfs-dev
+# Esperado: passed=6, failed=0, errors=0 (segun seccion 6)
+
+python devtools/run.py serverless tests --type=coverage --lambda=analytics
+# Esperado: coverage per-file >= 80% en core/
+```
+
+### B.9 (Opcional) Promocion a stage + smoke
+
+Solo si dev pasa todo y se quiere validar antes del PR:
+
+```bash
+# Crear PR feature/X -> dev primero. Luego, tras merge a dev, el flujo
+# normal dev -> stage -> main se ejecuta via los workflows.
+# Cuando llega a stage:
+python devtools/run.py serverless run --stage=stage --lambda=db \
+  --event=events/seed_rate_limit_analytics.json --aws-profile=tfs-dev
+
+# Repetir B.3 y B.4 con BASE=https://api.portfolio.stage.the-full-stack.com/analytics
+```
+
+---
+
+## Cierre del plan
+
+Cuando TODA la bateria pasa en verde:
+
+```bash
+# 1. Limpiar la carpeta de la spec (decision documentada en README)
+git rm -r docs/specs/analytics-dashboard-api/
+
+# 2. Actualizar knowledge tree con el Lambda nuevo
+# (editar .claude/docs/serverless-backend/03-lambdas.md y agregar entrada)
+
+# 3. Hacer el ultimo commit
+git add .claude/docs/serverless-backend/03-lambdas.md
+git commit -m "$(cat <<'EOF'
+docs(serverless): agrega lambda analytics al knowledge tree y elimina spec efimera
+
+- .claude/docs/serverless-backend/03-lambdas.md: agrega entrada de analytics
+- docs/specs/analytics-dashboard-api/: eliminada (efimera, plan implementado)
+- Bateria de verificacion E2E (seccion 11) pasa completa en dev:
+  19 endpoints OK + 6 cases de error + cache hit + SnapStart < 1500ms
+  + coverage >= 80%
+EOF
+)"
+
+# 4. Push y abrir PR
+git push -u origin feature/analytics-dashboard-api
+gh pr create --base dev --title "feat(analytics): nuevo Lambda analytics con dashboard API" \
+  --body "$(cat <<'EOF'
+## Problema
+1. El backend persiste sessions/visits/events/contacts en Neon pero no hay forma de leerlos sin abrir `psql`.
+2. El dashboard de analytics del portfolio necesita una API HTTP que exponga KPIs, timeseries, rankings y listados.
+
+## Solucion
+1. Nuevo Lambda `analytics` (GET `/analytics?operation=...&action=...`) con 19 actions distribuidos en 8 operations.
+2. Rate-limit 10 req/min/IP via `shared.rate_limit`, cache 60s via `shared.cache` en queries agregadas, SnapStart habilitado.
+
+## Como probar
+- `python devtools/run.py serverless tests --type=coverage --lambda=analytics` (>= 80%)
+- Smoke contra dev: ver `docs/specs/analytics-dashboard-api/11-verificacion-e2e.md` seccion B.3 (eliminado al mergear, pero esta en este PR todavia).
+- `curl "https://api.portfolio.dev.the-full-stack.com/analytics?operation=analytics&action=overview&from=2026-04-27&to=2026-05-27"` -> 200 con shape esperada.
+
+## TODO
+- Auth real (Cloudflare Access o Bearer en SSM) — fuera de scope.
+- Frontend Astro del dashboard — proxima iteracion.
+EOF
+)"
+```
+
+---
+
+## Si algo falla en la bateria
+
+Procedimiento:
+
+1. **NO** marcar el plan completo.
+2. **NO** abrir el PR.
+3. Diagnosticar el fallo:
+   - ¿Sintaxis? -> compileall te dice el archivo.
+   - ¿Test unitario? -> reproducir local, fix, re-correr.
+   - ¿Deploy? -> revisar logs `serverless deploy` + Cloudformation.
+   - ¿Smoke 4xx inesperado? -> CloudWatch logs del Lambda.
+   - ¿Smoke 5xx? -> CloudWatch + tracer X-Ray.
+4. Hacer commit de FIX (NO usar `--amend` salvo en local antes de
+   push).
+5. Re-correr la bateria COMPLETA desde el inicio (no spot-fix).
+6. Repetir hasta verde.
+
+## Anti-patrones del cierre
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| `git push --force` para "limpiar" la historia del feature | Se pierde trazabilidad de los fixes | Mergear con `--no-ff` y dejar la historia |
+| Abrir PR con "fix later" en TODO | Va contra el gate | Fixear antes |
+| Cachear el `tmp/r1.json` y `tmp/r2.json` en disco luego de la bateria | Se mezclan resultados de runs | `rm -f /tmp/r*.json` al final |
+| Saltarse B.4 (errores) porque B.3 (happy path) pasa | Los errores pueden estar mal mapeados | Bateria completa o nada |
+| Asumir que stage/prod tienen la rule porque dev la tiene | Cada env es independiente | Correr `db seed_rate_limit_analytics` en cada env |
+
+[< 10-paralelizacion-worktrees](10-paralelizacion-worktrees.md) | [< README](README.md)

--- a/docs/specs/analytics-dashboard-api/11-verificacion-e2e.md
+++ b/docs/specs/analytics-dashboard-api/11-verificacion-e2e.md
@@ -44,15 +44,16 @@ test o re-apuntarlo.
 ### A.2 Tests en ruta y convencion correcta
 
 ```bash
-# Convencion: tests en tests/unit o tests/integration
-find tests -type f -name "test_*.py" | grep -v "^tests/\\(unit\\|integration\\)/" \
+# Convencion: tests en tests/unit o tests/integration. Usar `rg` (no
+# `find`): en WSL2 `find` esta aliasado a `fd` y la sintaxis GNU falla.
+rg --files -g 'test_*.py' tests | rg -v '^tests/(unit|integration)/' \
   | wc -l    # debe dar 0
 
 # Cada test_*.py tiene UN test function (regla del repo)
-for f in $(find tests/unit -type f -name "test_*.py"); do
-  n=$(grep -c "^def test_" "$f")
+for f in $(rg --files -g 'test_*.py' tests/unit); do
+  n=$(rg -c '^def test_' "$f")
   if [ "$n" != "1" ]; then echo "BAD: $f tiene $n funciones test_*"; fi
-done | grep BAD     # debe dar 0
+done | rg BAD     # debe dar 0
 ```
 
 ### A.3 conftest.py limpio
@@ -250,6 +251,15 @@ for i in {1..11}; do
 done
 # Esperado: las primeras 10 con 200, la 11va con 429
 ```
+
+**Known limitation**: el test asume que las 11 requests salen con la
+misma IP de origen. Detras de NAT corporativo, VPN o cuando el cliente
+usa un pool de IPs (CGNAT movil, ciertos proxies), la IP extraida por
+API Gateway puede rotar entre requests y el contador del rate-limit no
+acumula sobre el mismo bucket. Si la 11va request devuelve 200 en lugar
+de 429, verificar con `curl --interface <iface>` o ejecutar el bucle
+desde una conexion con IP estable (laptop en wifi residencial) antes
+de declarar regresion.
 
 ### B.5 Cache hit verificacion (AC-8)
 

--- a/docs/specs/analytics-dashboard-api/README.md
+++ b/docs/specs/analytics-dashboard-api/README.md
@@ -1,0 +1,110 @@
+# Plan: Lambda `analytics` — Dashboard API read-only
+
+> Lambda Python nuevo (`serverless/lambda/services/analytics/`) que expone
+> un API GET `/analytics?operation=<X>&action=<Y>&...` para alimentar un
+> dashboard de visitas/tracking. Lee de Neon (tablas `vis_*` + `tax_*`),
+> aplica rate-limit 10 req/min/IP via `shared.rate_limit`, cachea queries
+> agregadas con TTL 60s via `shared.cache`. SnapStart habilitado.
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| Problema, solucion, AC numerados | [01-contexto-y-decision.md](01-contexto-y-decision.md) |
+| Arquitectura: operations/actions, Pydantic, controllers, services | [02-arquitectura.md](02-arquitectura.md) |
+| Infraestructura: manifest, API GW, rate-limit rules, IAM, SnapStart | [03-infraestructura.md](03-infraestructura.md) |
+| Queries SQL por endpoint + indices necesarios | [04-queries-sql.md](04-queries-sql.md) |
+| Capa de cache: claves, TTL, tags, que NO se cachea | [05-cache-layer.md](05-cache-layer.md) |
+| Estrategia de testing (unit por capa + integration smoke) | [06-testing.md](06-testing.md) |
+| Listado de archivos afectados con verificacion por archivo | [07-archivos-afectados.md](07-archivos-afectados.md) |
+| Descomposicion en tareas atomicas paralelizables | [08-descomposicion-paralelizacion.md](08-descomposicion-paralelizacion.md) |
+| Commits incrementales (Conventional Commits espanol) | [09-commits.md](09-commits.md) |
+| Paralelizacion con git worktrees | [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md) |
+| Verificacion E2E iterativa (fase final, gate del PR) | [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Estado por fase
+
+| Fase | Descripcion | Estado |
+|------|-------------|--------|
+| 0 | Plan escrito + carpeta `docs/specs/analytics-dashboard-api/` commiteada | pending |
+| 1 | Scaffold + manifest + AppConfig + handler vacio | pending |
+| 2 | EventModel + OPERATIONS + modelos Pydantic por dominio | pending |
+| 3 | Service `analytics` (overview, timeseries, top-pages, top-referrers, top-niches, active-now, retention) | pending |
+| 4 | Service `events` (distribution, list, heatmap) | pending |
+| 5 | Service `sessions` (list, detail) + `visits` (list, landing-pages) | pending |
+| 6 | Service `geo` (by-country) + `devices` (breakdown) | pending |
+| 7 | Service `funnel` (conversion) + `contacts` (list, by-status) | pending |
+| 8 | Capa de cache (`@cached`) en queries agregadas | pending |
+| 9 | Rate-limit rule + integracion `check_or_raise` | pending |
+| 10 | SnapStart + warmup hook + ajustes manifest | pending |
+| 11 | Verificacion E2E + limpieza de `docs/specs/analytics-dashboard-api/` | pending |
+
+## Decisiones no-reabribles
+
+Estas decisiones se cerraron en el dialogo previo y NO se vuelven a
+discutir en la fase de implementacion:
+
+1. **Auth**: solo rate-limit por ahora. Bearer/OIDC se agrega despues si
+   el dashboard se abre a terceros.
+2. **Rate limit**: 10 req/min/IP estricto (regla self-managed via
+   `shared.rate_limit`, NO WAF).
+3. **HTTP**: GET con query params, parseado por `http_handler` del repo
+   (operation y action son query params; el resto del payload tambien).
+4. **Nombre Lambda**: `analytics` (NO `dashboard` ni `admin`).
+5. **Ruta API GW**: `GET /analytics`.
+6. **Operations**: 7 dominios (`analytics`, `events`, `sessions`, `visits`,
+   `geo`, `devices`, `funnel`, `contacts`).
+7. **PII**: exponer crudo (IP, country, user_agent). El dashboard es
+   privado de facto (sin link publico).
+8. **Cache**: DynamoDB TTL 60s SOLO en queries agregadas (overview,
+   timeseries, rankings, distribuciones). Listados crudos NO se cachean.
+9. **Defaults de paginacion**: `from`/`to` default 30d, max 90d.
+   `page_size` default 50, max 200.
+10. **SnapStart**: habilitado.
+11. **Frontend**: backend-only por ahora. CORS `cors_origin='public'`
+    para poder testear desde browser local mas adelante sin redeploy.
+12. **DB**: Neon PostgreSQL (no DynamoDB) — la data ya esta proyectada
+    ahi por `stream_processor` + `contact_worker` + `tracking_worker`.
+
+## Reglas criticas (siempre activas)
+
+- **SIEMPRE** los services importan paquetes externos via
+  `shared.<subpaquete>` (ver
+  [.claude/rules/lambda-shared-imports.md](../../.claude/rules/lambda-shared-imports.md)).
+- **SIEMPRE** un controller por action; nombre de clase
+  `action.capitalize()`.
+- **SIEMPRE** la logica de negocio vive en `core/services/`, NUNCA en el
+  handler ni en los controllers.
+- **SIEMPRE** verificar antes de commitear (lint + tests unit del scope).
+- **NUNCA** queries `SELECT *` sin LIMIT explicito; siempre paginar.
+- **NUNCA** loguear valores de `DATABASE_URL`, IP de visitantes o
+  contenido del email/message de un contact.
+- **NUNCA** ejecutar la query del listado de `vis_tracking_events` sin
+  filtro `created_at >= X` (la tabla esta particionada por mes).
+
+## Matriz de verificacion (rapida)
+
+| Capa | Comando |
+|------|---------|
+| Sintaxis Python | `python -m compileall -q serverless/lambda/services/analytics` |
+| Imports shared-only | `python devtools/run.py serverless lint-deps --lambda=analytics` |
+| Tests unit | `python devtools/run.py serverless tests --type=unit --lambda=analytics` |
+| Tests integration | `python devtools/run.py serverless tests --type=integration --lambda=analytics` |
+| Coverage | `python devtools/run.py serverless tests --type=coverage --lambda=analytics` |
+| Run local (RIE) | `python devtools/run.py serverless run --stage=local --lambda=analytics --event=events/overview.json` |
+| Deploy dev | `python devtools/run.py serverless deploy --lambda=analytics --stage=dev --aws-profile=tfs-dev` |
+| Smoke E2E | `curl "https://api.portfolio.dev.the-full-stack.com/analytics?operation=analytics&action=overview&from=2026-04-27&to=2026-05-27"` |
+
+## Bibliografia interna
+
+- [.claude/rules/lambda-controller.md](../../.claude/rules/lambda-controller.md) — formato Lambda Python
+- [.claude/rules/lambda-shared-imports.md](../../.claude/rules/lambda-shared-imports.md) — catalogo de portadores
+- [.claude/rules/neon-management.md](../../.claude/rules/neon-management.md) — Neon en runtime
+- [.claude/rules/serverless-secrets.md](../../.claude/rules/serverless-secrets.md) — SSM + IAM scopes
+- [.claude/rules/ci-cd-pipeline.md](../../.claude/rules/ci-cd-pipeline.md) — `deploy-backend.yml` auto-detect
+- [.claude/docs/serverless-backend/README.md](../../.claude/docs/serverless-backend/README.md) — arquitectura general
+- [.claude/docs/serverless-rate-limit/README.md](../../.claude/docs/serverless-rate-limit/README.md) — sliding window
+- [.claude/docs/dynamodb-cache/README.md](../../.claude/docs/dynamodb-cache/README.md) — @cached
+- [docs/diagrams/db-er.mmd](../../diagrams/db-er.mmd) — schema Neon
+- [serverless/lambda/services/cv/](../../../serverless/lambda/services/cv/) — Lambda analogo (GET + SQL + JSON)
+- [serverless/lambda/services/tracking_pixel/](../../../serverless/lambda/services/tracking_pixel/) — Lambda analogo (rate-limit + cache)

--- a/docs/specs/dashboard/01-contexto-y-decision.md
+++ b/docs/specs/dashboard/01-contexto-y-decision.md
@@ -44,7 +44,7 @@ Para resolverlo:
   planes. Cuando el backend este vivo, el flag `NEXT_PUBLIC_USE_MSW`
   se desactiva.
 - 5 research files generados consolidan 7783 lineas de docs sobre
-  Next.js 16 SPA, React 18 patterns, shadcn + Atomic Design hibrido,
+  Next.js 16.2.6 SPA, React 19.2.6 patterns, shadcn + Atomic Design hibrido,
   JWT auth security, Cloudflare Pages deploy
   (`tmp/research/dashboard/01..05-*.md`).
 
@@ -53,15 +53,19 @@ Para resolverlo:
 Dashboard SPA en `dashboard/` (carpeta nueva en root del repo, entra al
 pnpm workspace como `@portfolio/dashboard`). Stack:
 
-- **Next.js 16** con `output: 'export'` (estatica, Cloudflare Pages).
-- **React 18.3** + TypeScript 6 strict + **Biome v2** (sin ESLint).
+- **Next.js 16.2.6** con `output: 'export'` (estatica, Cloudflare Pages).
+- **React 19.2.6** (obligatorio en Next 16.x; Compiler stable habilitado;
+  `useActionState`, `useFormStatus`, `useOptimistic`, `useDeferredValue`
+  con `initialValue`, ref-as-prop sin `forwardRef`, Document Metadata
+  nativo, View Transitions, `useEffectEvent`, Activity Component) +
+  TypeScript 6.0.6 strict + **Biome v2** (sin ESLint).
 - **Tailwind v4** con `@theme` inline + tokens compartidos con el
   Design System del monorepo.
 - **shadcn/ui** (Radix primitives, copy-paste) + **Tanstack Query v5**
   + **Tanstack Table v8** + **Tanstack Virtual** + **Recharts** (via
   shadcn add chart) + **lucide-react** + **sonner**.
-- **Zustand** para auth (in-memory accessToken, persist user) + theme
-  (next-themes).
+- **Zustand 5.0.14** para auth (tokens en `localStorage` via `persist`
+  — SPA cross-origin, decision detallada abajo) + theme (next-themes).
 - **react-hook-form + Zod** para forms.
 - **MSW** para mocks dev + tests; **Vitest + Testing Library** unit;
   **Playwright** E2E (suite del monorepo).
@@ -82,8 +86,10 @@ Estructura **Hybrid Atomic Design**:
 
 Auth:
 
-- Access JWT in-memory (Zustand). Refresh en HttpOnly cookie
-  (preferido).
+- Access, refresh y temp JWT en `localStorage` via Zustand `persist`.
+  NO HttpOnly cookies — el dashboard es SPA cross-origin (admin vs
+  api). Defensa: CSP estricta + SRI + access JWT corto (15 min) +
+  family_id refresh rotation.
 - **Mutex** en el fetch wrapper: 1 sola `/session/refresh` in-flight,
   evita reuse detection del backend.
 - Magic link callback decodifica fragment hash (`#access=...`) en
@@ -118,11 +124,18 @@ dev. Aceptamos el trade-off porque el dashboard NO es de uso masivo
 (panel admin para 1-5 users) y la DX de file-based routing es mejor
 para mantenimiento futuro.
 
-**Decision 2: React 18.3 vs React 19** — React 18 esta validado por
-todas las libs del stack (Tanstack v5, react-hook-form, shadcn).
-React 19 introduce hooks (`use()`, `useFormStatus`, `useActionState`)
-pensados para Server Components y Server Actions — features NO
-disponibles en `output: 'export'`. No hay valor en migrar.
+**Decision 2: React 19.2.6** — obligatorio en Next 16.x (no
+negotiable). El ecosystem 2026 lo soporta plenamente: shadcn 2.x
+(ref-as-prop, sin `forwardRef`), Tanstack Query v5 (con
+`useSuspenseQuery` + `useOptimistic`), react-hook-form 7 (coexiste con
+`useActionState` — hybrid pattern), Zustand 5.0.14, Testing Library
+v16 (primer release con soporte oficial React 19). React Compiler
+stable habilitado (`reactCompiler: true` en `next.config.ts`) —
+auto-memoization sin `useMemo`/`useCallback` boilerplate. Hooks nuevos
+que SI aplican al SPA: `useActionState`, `useFormStatus`,
+`useOptimistic`, `useDeferredValue(value, initialValue)`,
+`useEffectEvent`, `<Activity>`. Hooks que NO aplican (server-only):
+Server Components con async fetch, Server Actions, `'use cache'`.
 
 **Decision 3: Hybrid Atomic Design vs Atomic clasico** — Atomic
 clasico (atoms/molecules/organisms/templates) genera debates infinitos
@@ -130,11 +143,21 @@ clasico (atoms/molecules/organisms/templates) genera debates infinitos
 2 buckets: generico vs especifico de feature. Promote a `ui/` solo
 con 2+ uses reales (premature abstraction es peor que duplicar).
 
-**Decision 4: JWT in-memory vs localStorage** — Access JWT in-memory
-(Zustand sin persist) reduce ventana de XSS exposure a 15 min (TTL del
-access). Refresh en HttpOnly cookie es inaccesible a JS (XSS-proof).
-Fallback: si el backend no puede setear cookie cross-domain, localStorage
-+ CSP estricta documentado como acceptable.
+**Decision 4: JWT storage — `localStorage` (NO HttpOnly cookies)** —
+El dashboard es SPA estatico cross-origin: vive en
+`admin.portfolio.{env}.the-full-stack.com`, consume el Lambda `auth`
+en `api.portfolio.{env}.the-full-stack.com`. Para que el backend
+pudiera setear cookies HttpOnly accesibles desde el dashboard, la
+cookie tendria que ser `SameSite=None; Secure; Domain=.the-full-stack.com`,
+lo que (a) abre vectores CSRF en los 6 niches publicos del portfolio
+y (b) rompe portabilidad (mobile app, embebido en widgets).
+**Decision**: los tres tokens (access, refresh, temp) viajan en el
+body de la respuesta y se persisten en `localStorage` via Zustand
+`persist`. Mitigaciones a XSS: (1) CSP estricta `default-src 'self'`
+sin `unsafe-inline`/`unsafe-eval` en scripts, (2) Subresource Integrity
+(SRI) obligatorio en third-party scripts (Turnstile), (3) access JWT
+corto (15 min TTL), (4) refresh rotation + family_id detection en el
+backend (RFC 9700, ya implementado por planes 01-02).
 
 **Decision 5: Mutex de refresh client-side** — Sin mutex, 5 requests
 concurrent con 401 disparan 5 `/session/refresh` → backend revoca

--- a/docs/specs/dashboard/01-contexto-y-decision.md
+++ b/docs/specs/dashboard/01-contexto-y-decision.md
@@ -1,0 +1,367 @@
+# 01 — Contexto, solucion y criterios de aceptacion
+
+[Volver al README](README.md) | [Siguiente: 02-diagramas >](02-diagramas.md)
+
+## 1. Contexto / Problema
+
+El portfolio (the-full-stack.com) tiene 6 sitios estaticos publicos
+(Astro 6 deployados a Cloudflare Pages) y un backend serverless en AWS
+(4 Lambdas Python: contact_form, tracking_pixel, stream_processor, db).
+La data generada por los visitantes — sessions, visits, tracking events,
+contacts — vive en Neon PostgreSQL (35 tablas, schema unificado).
+
+Hoy no hay forma de **ver** esa data: las queries hay que correrlas
+manualmente con `psql` o desde la consola de Neon. No hay metricas
+agregadas, no hay vista de funnel, no hay panel de contactos.
+
+Para resolverlo:
+
+- Los planes 01-auth-infra-basics + 02-auth-mfa
+  (`docs/specs/01-auth-infra-basics/`, `docs/specs/02-auth-mfa/`)
+  entregan el Lambda `auth` con registro/login/MFA. **Aun pending**.
+- El plan analytics-dashboard-api
+  (`docs/specs/analytics-dashboard-api/`) entrega el Lambda
+  `analytics` con 19 endpoints GET sobre la data. **Aun pending**.
+- **Este plan** entrega el **dashboard frontend SPA** que consume
+  ambos APIs y los presenta como panel admin.
+
+### Hallazgos de exploracion
+
+- El monorepo ya tiene Cloudflare Pages deploy automatizado via
+  `devtools/cloudflare_setup/` + `.github/workflows/deploy-apps.yml`.
+  18 projects = 6 niches x 3 envs (dev/stage/prod). Sumar el
+  dashboard = 21 projects.
+- El subdomain standard
+  (`.claude/docs/subdomain-standard/`) cubre el caso:
+  `admin.portfolio.{env}.the-full-stack.com` es valido (component
+  `admin` + product `portfolio`).
+- El sitekey de Turnstile (`0x4AAAAAADPSoiQA_-LcRafo`) ya cubre los 6
+  subdomains. Agregar `admin.portfolio.*` al widget en Cloudflare.
+- Los planes auth + analytics aun NO estan implementados → el dashboard
+  no puede ser end-to-end-testeado contra backend real hasta que se
+  mergeen. Solucion: **MSW (Mock Service Worker)** con handlers que
+  reflejen exactamente el contrato del backend documentado en los
+  planes. Cuando el backend este vivo, el flag `NEXT_PUBLIC_USE_MSW`
+  se desactiva.
+- 5 research files generados consolidan 7783 lineas de docs sobre
+  Next.js 16 SPA, React 18 patterns, shadcn + Atomic Design hibrido,
+  JWT auth security, Cloudflare Pages deploy
+  (`tmp/research/dashboard/01..05-*.md`).
+
+## 2. Solucion Propuesta
+
+Dashboard SPA en `dashboard/` (carpeta nueva en root del repo, entra al
+pnpm workspace como `@portfolio/dashboard`). Stack:
+
+- **Next.js 16** con `output: 'export'` (estatica, Cloudflare Pages).
+- **React 18.3** + TypeScript 6 strict + **Biome v2** (sin ESLint).
+- **Tailwind v4** con `@theme` inline + tokens compartidos con el
+  Design System del monorepo.
+- **shadcn/ui** (Radix primitives, copy-paste) + **Tanstack Query v5**
+  + **Tanstack Table v8** + **Tanstack Virtual** + **Recharts** (via
+  shadcn add chart) + **lucide-react** + **sonner**.
+- **Zustand** para auth (in-memory accessToken, persist user) + theme
+  (next-themes).
+- **react-hook-form + Zod** para forms.
+- **MSW** para mocks dev + tests; **Vitest + Testing Library** unit;
+  **Playwright** E2E (suite del monorepo).
+
+Estructura **Hybrid Atomic Design**:
+
+- `src/components/ui/` — primitivos genericos (shadcn + custom como
+  MetricCard, DataTable).
+- `src/features/<feature>/` — un dominio por carpeta
+  (`auth`, `analytics`, `sessions`, `events`, `visits`, `geo`,
+  `devices`, `funnel`, `contacts`, `settings`, `dashboard-shell`),
+  cada una con `components/`, `hooks/`, `api/`, `store/`, `types.ts`,
+  `index.ts`.
+- `src/app/` — Next App Router con dos groups:
+  - `(auth)/` — `login`, `register`, `verify`, `callback`, `set-password`.
+  - `(dashboard)/` — `layout.tsx` con AuthGuard + sidebar, pages para
+    cada feature.
+
+Auth:
+
+- Access JWT in-memory (Zustand). Refresh en HttpOnly cookie
+  (preferido).
+- **Mutex** en el fetch wrapper: 1 sola `/session/refresh` in-flight,
+  evita reuse detection del backend.
+- Magic link callback decodifica fragment hash (`#access=...`) en
+  `/auth/callback`, guarda en Zustand, limpia con
+  `history.replaceState`, redirect a `/dashboard`.
+- `BroadcastChannel('portfolio_auth')` para multi-tab logout sync.
+- Auto-refresh proactivo: timer client-side dispara `/session/refresh`
+  30s antes del `exp` del access. Page Visibility API re-check al volver
+  a la tab.
+
+Deploy:
+
+- 3 projects Cloudflare Pages (`portfolio-dashboard-{dev,stage,}`) via
+  REST API en `devtools/cloudflare_setup/config.py` (extension para
+  soportar `app_type='nextjs'` + `build_output_dir='out'`).
+- Branch mapping: `dev`/`stage`/`main`.
+- Custom domain attached automatico, SSL via Cloudflare ACM per-hostname.
+- `_redirects` (`/* /index.html 200`) + `_headers` (CSP estricta) en
+  `dashboard/public/`.
+- Env vars `NEXT_PUBLIC_*` sincronizadas via `sync_secrets
+  --category=client` (extension de `devtools/sync_secrets/catalog.py`).
+- `.github/workflows/deploy-apps.yml` matrix agrega el dashboard como
+  entrada `include` con `dist-dir: dashboard/out`.
+
+### Decisiones clave
+
+**Decision 1: Next.js 16 SPA vs Vite + Tanstack Router** — Next gana
+por consistency con el ecosystem React, file-based routing, y un
+ecosystem mas grande de tutorials/libs. Trade-off: Vite es 25% mas
+chico de bundle (~65KB vs ~107KB gzipped), 10x mas rapido en startup
+dev. Aceptamos el trade-off porque el dashboard NO es de uso masivo
+(panel admin para 1-5 users) y la DX de file-based routing es mejor
+para mantenimiento futuro.
+
+**Decision 2: React 18.3 vs React 19** — React 18 esta validado por
+todas las libs del stack (Tanstack v5, react-hook-form, shadcn).
+React 19 introduce hooks (`use()`, `useFormStatus`, `useActionState`)
+pensados para Server Components y Server Actions — features NO
+disponibles en `output: 'export'`. No hay valor en migrar.
+
+**Decision 3: Hybrid Atomic Design vs Atomic clasico** — Atomic
+clasico (atoms/molecules/organisms/templates) genera debates infinitos
+("MetricCard es molecule u organism?") sin valor. Hybrid resuelve con
+2 buckets: generico vs especifico de feature. Promote a `ui/` solo
+con 2+ uses reales (premature abstraction es peor que duplicar).
+
+**Decision 4: JWT in-memory vs localStorage** — Access JWT in-memory
+(Zustand sin persist) reduce ventana de XSS exposure a 15 min (TTL del
+access). Refresh en HttpOnly cookie es inaccesible a JS (XSS-proof).
+Fallback: si el backend no puede setear cookie cross-domain, localStorage
++ CSP estricta documentado como acceptable.
+
+**Decision 5: Mutex de refresh client-side** — Sin mutex, 5 requests
+concurrent con 401 disparan 5 `/session/refresh` → backend revoca
+familia entera (RFC 9700 reuse detection). Mutex garantiza 1 sola call,
+los 4 restantes esperan el resultado y reintentan. Critico para
+correctness.
+
+**Decision 6: Magic link UX con fragment hash** — Backend redirect
+302 a `/auth/callback#access=X&user_id=Y&email=Z`. Tokens en fragment
+(`#...`) NUNCA viajan al server (no van en Referer ni logs). Frontend
+decodea client-side y limpia el URL con `history.replaceState` para
+que ni siquiera quede en browser history.
+
+**Decision 7: MSW como mock layer** — Los planes auth + analytics aun
+no estan deployados. MSW handlers replican EXACTAMENTE el contrato
+(operations/actions/data shapes) documentado en
+`docs/specs/01-auth-infra-basics/` y
+`docs/specs/analytics-dashboard-api/`. Cuando el backend este vivo,
+basta apagar el flag `NEXT_PUBLIC_USE_MSW=true` y todo funciona contra
+el real. Esto permite mergear el dashboard ANTES que el backend este
+listo.
+
+**Decision 8: Carpeta `dashboard/` en root (no `apps/dashboard/`)** —
+User choice explicito. El usuario pidio "una nueva carpeta en el root
+llamada dashboard/*". Implementamos como pidio. devtools/cloudflare_setup
+maneja la diferencia (root_dir: 'dashboard' vs 'apps/<niche>').
+
+**Decision 9: BroadcastChannel para multi-tab** — Standard 2025-2026.
+SafariOS lo soporta desde 15.4 (mar 2022). Para SSR/build safety:
+guard `typeof BroadcastChannel === 'undefined'`.
+
+**Decision 10: Subdomain `admin.portfolio.{env}.the-full-stack.com`** —
+Sigue el subdomain-standard. Reservar `admin` en
+`.claude/docs/subdomain-standard/02-naming-rules.md`.
+
+## 3. Criterios de Aceptacion (AC)
+
+Numerados, formato BDD (`Given/When/Then`). Cada AC referenciado por
+tests (ver seccion 08-tests).
+
+### Setup y estructura
+
+- **AC-1**: Given el repo con `dashboard/` creado y configurado, When
+  se corre `pnpm install` desde root, Then `@portfolio/dashboard`
+  aparece como package del workspace y todas las deps se instalan sin
+  errores.
+
+- **AC-2**: Given `dashboard/` con configs (next.config.ts, tsconfig,
+  biome.json override, components.json), When se corre
+  `pnpm --filter @portfolio/dashboard typecheck`, Then sin errores.
+
+- **AC-3**: Given `dashboard/`, When se corre
+  `pnpm --filter @portfolio/dashboard lint`, Then Biome reporta 0
+  errores y 0 warnings (con override aplicado en `components/ui/*`).
+
+- **AC-4**: Given `dashboard/` con `next.config.ts` que define
+  `output: 'export'`, When se corre
+  `pnpm --filter @portfolio/dashboard build`, Then se genera
+  `dashboard/out/` con `index.html`, `_next/static/`, `404.html`,
+  `_redirects`, `_headers`.
+
+### UI y theming
+
+- **AC-5**: Given el dashboard renderizado en browser, When el OS esta
+  en dark mode preference, Then el dashboard arranca en modo dark sin
+  flash (FOUC) y todos los tokens (`--background`, `--foreground`,
+  `--primary`) reflejan los valores de la paleta dark.
+
+- **AC-6**: Given el dashboard en dark mode, When el user clickea el
+  ThemeToggle y elige "Light", Then `data-theme="light"` se setea en
+  `<html>`, los tokens cambian a la paleta light, y el setting se
+  persiste en `localStorage` (clave `theme`).
+
+- **AC-7**: Given el dashboard rendered, When el user navega entre
+  pages (`/dashboard`, `/dashboard/analytics`, `/dashboard/sessions`),
+  Then el sidebar persiste sin remontarse (gracias al layout
+  compartido del `(dashboard)` group).
+
+### Auth — registro
+
+- **AC-8**: Given el LoginForm rendered, When el user ingresa email
+  invalido y submit, Then Zod muestra el error `"Email invalido"` en
+  el FormMessage del field email y NO se llama al API.
+
+- **AC-9**: Given el RegisterForm con email valido y Turnstile token,
+  When el user submit, Then el dashboard POST a
+  `/auth?operation=register&action=start` con el body correcto, el
+  store guarda `tempToken`, redirige a `/verify?flow=register`, y
+  muestra toast "Te enviamos un email...".
+
+- **AC-10**: Given el RegisterForm con email ya registrado
+  (`exists@test.com`), When submit, Then el response 409 muestra
+  `"Email ya registrado"` en un Alert y NO redirige.
+
+- **AC-11**: Given la page `/verify?flow=register` con tempToken en
+  store, When el user ingresa el code `"12345678"` (8 chars Crockford)
+  en el InputOTP y submit, Then llama
+  `/auth?operation=register&action=verify-code`, recibe `access_token`
+  + `user`, los guarda en store, y redirige a `/dashboard`.
+
+### Auth — magic link callback
+
+- **AC-12**: Given la URL
+  `/auth/callback#access=<jwt>&user_id=usr_01&email=u@t.com&refresh_exp=<epoch>`,
+  When la page se carga, Then: (a) decodifica el fragment, (b)
+  valida el JWT shape con `jwt-decode`, (c) guarda `accessToken` +
+  `user` en Zustand, (d) llama `history.replaceState(null, '',
+  '/dashboard')` para limpiar el URL, (e) redirige a `/dashboard`,
+  (f) muestra toast "Sesion iniciada".
+
+- **AC-13**: Given la URL `/auth/callback` SIN fragment, Then redirige
+  a `/login` con toast "Link invalido".
+
+### Auth — refresh rotation con mutex
+
+- **AC-14**: Given el user con `accessToken` expirado y 5 requests
+  concurrent a `/analytics`, When todos los requests reciben 401,
+  Then SOLO 1 call a `/session/refresh` se dispara (mutex), los 5
+  requests esperan el resultado, y todos reintentan con el nuevo
+  token (assert exact: `refreshCount === 1`).
+
+- **AC-15**: Given el user con sesion activa, When el `accessToken`
+  esta a 30 segundos de expirar (`NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS`),
+  Then `useAuthTimer` dispara `/session/refresh` proactivamente.
+
+- **AC-16**: Given la tab oculta por >5 min, When vuelve a foco
+  (Page Visibility API), Then se valida el JWT y dispara refresh si
+  esta proximo a expirar.
+
+### Auth — logout
+
+- **AC-17**: Given user logueado, When clickea logout, Then: (a)
+  POST a `/auth?operation=session&action=logout`, (b) reset del store
+  (acceso/user/temp), (c) `queryClient.clear()`, (d) emit
+  `BroadcastChannel({type: 'LOGOUT'})`, (e) redirect a `/login`, (f)
+  toast "Sesion cerrada".
+
+- **AC-18**: Given 2 tabs abiertas con sesion activa, When user
+  hace logout en tab A, Then tab B detecta el `LOGOUT` por
+  BroadcastChannel y resetea su Zustand sin recargar la page.
+
+### AuthGuard
+
+- **AC-19**: Given user sin sesion, When accede a
+  `/dashboard/analytics`, Then redirect a
+  `/login?next=%2Fdashboard%2Fanalytics`.
+
+- **AC-20**: Given user con sesion + `accessToken` valido, When
+  accede a `/dashboard/sessions`, Then la page renderiza sin redirect.
+
+### Analytics
+
+- **AC-21**: Given el dashboard en `/dashboard`, When el AnalyticsCards
+  monta, Then se hace `useQuery(['analytics', 'overview', {from, to}])`
+  con `staleTime: 60000`, se renderizan 7 MetricCards (sessions,
+  visits, events, contacts, unique_visitors, avg_duration, bounce_rate)
+  con los valores del response.
+
+- **AC-22**: Given el TimeseriesChart en `/dashboard/analytics`, When
+  el user cambia el DateRangePicker, Then el `useTimeseriesQuery`
+  refetch con el nuevo rango y el chart se actualiza.
+
+### Tables (sessions, events, contacts)
+
+- **AC-23**: Given `/dashboard/sessions`, When la page carga, Then
+  llama `useSessionsList()`, renderiza el `DataTable` con columnas
+  (session_id, first_seen_at formateada, country, device_type,
+  event_count), permite sort por columna, y muestra paginator (Prev/Next).
+
+- **AC-24**: Given `/dashboard/events` con 1000+ events, When la lista
+  se renderiza, Then se usa `useVirtualizer` (Tanstack Virtual), solo
+  los visible rows se montan (~10-20 simultaneamente).
+
+### Contacts
+
+- **AC-25**: Given un contact en estado `new`, When el user clickea
+  "Mark as contacted" en `/dashboard/contacts`, Then se llama un
+  mutation que actualiza el estado a `contacted`, el query de la
+  lista invalida y refetch.
+
+### MFA (plan 02, opcional en este plan)
+
+- **AC-26**: Given user en `/dashboard/settings/security`, When clickea
+  "Setup TOTP", Then se llama `/auth?operation=mfa&action=setup-totp`,
+  el response trae `{secret, otpauth_url, qr_code_svg}`, y se renderiza
+  el QR + un InputOTP para confirmar el primer code.
+
+### Build y deploy
+
+- **AC-27**: Given el dashboard buildeado, When se inspecciona
+  `dashboard/out/`, Then existen `index.html`, `404.html`,
+  `_next/static/chunks/*.js`, `_next/static/css/*.css`,
+  `_redirects`, `_headers`.
+
+- **AC-28**: Given `_redirects` con `/* /index.html 200`, When un
+  visitor accede a `/dashboard/sessions/sess_01`, Then Cloudflare Pages
+  sirve `index.html` y el client-side router renderiza la session
+  detail page.
+
+- **AC-29**: Given `_headers` con CSP estricta, When un visitor abre
+  el dashboard, Then el header `Content-Security-Policy` se sirve
+  correctamente y bloquea scripts inline NO permitidos (validado con
+  curl + grep).
+
+- **AC-30**: Given `devtools/cloudflare_setup/config.py` con el
+  dashboard agregado, When se corre `python devtools/run.py
+  cloudflare_setup status --env=dev`, Then el project
+  `portfolio-dashboard-dev` existe + custom domain
+  `admin.portfolio.dev.the-full-stack.com` attached + SSL emitido.
+
+- **AC-31**: Given push a la branch `dev`, When `deploy-apps.yml`
+  corre, Then los 7 apps se buildean en paralelo (workspace concurrency
+  7), el dashboard deploya a `portfolio-dashboard-dev`, y
+  `verify-deploy` confirma HTTP 200 en
+  `https://admin.portfolio.dev.the-full-stack.com/`.
+
+### Verificacion E2E
+
+- **AC-32**: Given el stack local arriba + MSW activado, When se
+  corren los specs `tests/feature/dashboard/*.spec.ts` con Playwright,
+  Then los 5 flujos golden path pasan: login con code, register +
+  verify, magic-link callback, AuthGuard redirect, logout
+  multi-tab sync.
+
+- **AC-33**: Given el dashboard built, When se corre `pnpm --filter
+  @portfolio/dashboard test:coverage`, Then coverage >= 80% per-file en
+  todos los archivos modificados/creados (excluyendo `components/ui/*`
+  + barrel `index.ts` + layouts).
+
+[Volver al README](README.md) | [Siguiente: 02-diagramas >](02-diagramas.md)

--- a/docs/specs/dashboard/01-contexto-y-decision.md
+++ b/docs/specs/dashboard/01-contexto-y-decision.md
@@ -151,9 +151,14 @@ pudiera setear cookies HttpOnly accesibles desde el dashboard, la
 cookie tendria que ser `SameSite=None; Secure; Domain=.the-full-stack.com`,
 lo que (a) abre vectores CSRF en los 6 niches publicos del portfolio
 y (b) rompe portabilidad (mobile app, embebido en widgets).
-**Decision**: los tres tokens (access, refresh, temp) viajan en el
-body de la respuesta y se persisten en `localStorage` via Zustand
-`persist`. Mitigaciones a XSS: (1) CSP estricta `default-src 'self'`
+**Decision**: los tokens viajan en el body de la respuesta. El **refreshToken**,
+`refreshExpiry` y `user` se persisten en `localStorage` via Zustand
+`persist` (`partialize`). El **accessToken** queda solo en memoria del store
+(NO persist) — rota en cada `/session/refresh`, persistirlo solo deja stale
+token tras reload. El **tempToken** tambien queda solo en memoria
+(efimero, 5 min). Al reload, `useAuthTimer` detecta `refreshToken` con
+`refreshExpiry > now` y dispara `/session/refresh` para rehidratar el
+accessToken en memoria. Mitigaciones a XSS: (1) CSP estricta `default-src 'self'`
 sin `unsafe-inline`/`unsafe-eval` en scripts, (2) Subresource Integrity
 (SRI) obligatorio en third-party scripts (Turnstile), (3) access JWT
 corto (15 min TTL), (4) refresh rotation + family_id detection en el

--- a/docs/specs/dashboard/02-diagramas.md
+++ b/docs/specs/dashboard/02-diagramas.md
@@ -35,8 +35,8 @@ Dashboard admin: NO EXISTE
 Admin browser (1-5 users)
   -> https://admin.portfolio.{dev|stage|prod}.the-full-stack.com
   -> Cloudflare Pages (portfolio-dashboard-{env})
-       -> Next.js 16 SPA estatico (dashboard/out/)
-            -> React 18 + Zustand (auth, theme)
+       -> Next.js 16.2.6 SPA estatico (dashboard/out/)
+            -> React 19.2.6 + Zustand 5 (auth, theme)
                  -> Tanstack Query (con persister + mutex refresh)
                       -> lib/api-client.ts
                            -> https://api.portfolio.{env}.the-full-stack.com
@@ -95,8 +95,9 @@ Las 6 apps Astro: SIN CAMBIOS (continuan en sus subdominios)
     - User vuelve a /verify, ingresa code 8 chars en InputOTP
     - POST /auth?operation=register&action=verify-code body: {code, temp_token}
     - Backend valida hash + ttl + attempts < 5
-    - Response 200 {access_token, refresh_token (HttpOnly cookie), expires_in, user}
-    - Frontend: Zustand.setAccessToken + setUser, redirect /dashboard
+    - Response 200 {access_token, refresh_token, expires_in, user}
+    - Frontend: Zustand.setTokens(access, refresh, user), redirect /dashboard
+      (tokens persistidos en localStorage via Zustand persist)
 ```
 
 ## Flujo de auth: login con magic link / code

--- a/docs/specs/dashboard/02-diagramas.md
+++ b/docs/specs/dashboard/02-diagramas.md
@@ -1,0 +1,334 @@
+# 02 — Diagramas
+
+[< 01-contexto-y-decision](01-contexto-y-decision.md) | [Siguiente: 03-estructura >](03-estructura.md)
+
+## Flujo end-to-end del dashboard
+
+### Antes (estado actual)
+
+```text
+Visitor browser
+  -> apps/generic/...     -> Cloudflare Pages -> Astro estatico
+  -> apps/hub/...
+  -> apps/fintech/...
+  -> apps/architect/...
+  -> apps/leader/...
+  -> apps/vibe/...
+
+Backend Lambdas:
+  -> contact_form
+  -> tracking_pixel
+  -> stream_processor
+  -> db (migrations)
+
+Data:
+  -> DynamoDB (contacts, tracking, cache, rate-limit-*)
+  -> Neon PostgreSQL (35 tablas, schema unificado)
+
+Dashboard admin: NO EXISTE
+  -> data en Neon solo se ve con `psql` o consola web
+```
+
+### Despues (estado objetivo de este plan)
+
+```text
+Admin browser (1-5 users)
+  -> https://admin.portfolio.{dev|stage|prod}.the-full-stack.com
+  -> Cloudflare Pages (portfolio-dashboard-{env})
+       -> Next.js 16 SPA estatico (dashboard/out/)
+            -> React 18 + Zustand (auth, theme)
+                 -> Tanstack Query (con persister + mutex refresh)
+                      -> lib/api-client.ts
+                           -> https://api.portfolio.{env}.the-full-stack.com
+                                -> Lambda auth (planes 01-02)
+                                -> Lambda analytics (plan analytics-dashboard-api)
+                                -> Lambdas existentes (contact_form, tracking_pixel)
+
+Las 6 apps Astro: SIN CAMBIOS (continuan en sus subdominios)
+```
+
+## Flujo de auth: registro con magic link
+
+```text
+1. User en /register llena email + Turnstile -> submit
+        |
+        v
+2. POST /auth?operation=register&action=start
+   body: {email, cf_turnstile_response}
+        |
+   [Backend Lambda auth]
+        |
+        v
+3. Backend:
+   - Valida Turnstile
+   - Crea row auth_users(status=pending)
+   - Genera magic-link token (32 bytes b64url, hash en Neon)
+   - Genera code 8 chars Crockford (hash en Neon + espejo en DDB)
+   - Publica 2 mensajes SQS (magic-link email + code email)
+   - Issue temp_token (JWT typ=temp, exp=5min)
+        |
+        v
+4. Response 201 {temp_token, user_id, expires_in: 300}
+        |
+        v
+5. Frontend:
+   - Zustand.setTempToken(token)
+   - router.push('/verify?flow=register')
+   - toast.success('Te enviamos un link y un code...')
+        |
+        v
+6. ramificacion: el user elige magic-link O code
+
+6a. Magic link:
+    - User clickea link en email
+    - URL: https://api.portfolio.../auth?operation=register&action=verify-magic-link&token=<X>
+    - Backend valida token_hash, marca consumed, issue access+refresh
+    - HTTP 302 Location: https://admin.portfolio.../auth/callback#access=<jwt>&user_id=<id>&email=<x>&refresh_exp=<epoch>
+    - Browser carga /auth/callback (Next SPA)
+    - useEffect decodifica fragment hash
+    - Zustand.setAccessToken + setUser
+    - history.replaceState(null, '', '/dashboard')
+    - router.replace('/dashboard')
+    - toast.success('Sesion iniciada')
+
+6b. Code:
+    - User vuelve a /verify, ingresa code 8 chars en InputOTP
+    - POST /auth?operation=register&action=verify-code body: {code, temp_token}
+    - Backend valida hash + ttl + attempts < 5
+    - Response 200 {access_token, refresh_token (HttpOnly cookie), expires_in, user}
+    - Frontend: Zustand.setAccessToken + setUser, redirect /dashboard
+```
+
+## Flujo de auth: login con magic link / code
+
+```text
+1. /login - email + Turnstile (+ password opcional plan 02)
+   POST /auth?operation=login&action=start
+        |
+        v
+2. Backend:
+   - Si email NO existe: 404 {error: EMAIL_NOT_FOUND, suggest_register: true}
+   - Si email existe (status=active sin MFA): 200 {temp_token, methods: ['magic-link', 'email-code']}
+   - Si email existe + password match + MFA configurado: 200 {temp_token, methods: ['totp', 'webauthn', 'email-code']}
+        |
+        v
+3. Frontend:
+   - Si 404: muestra Alert "Email no esta registrado" + boton "Registrate"
+   - Si 200 sin MFA: redirect /verify?flow=login + similar a register
+   - Si 200 con MFA: redirect /verify?flow=login + render input segun method preferred
+```
+
+## Flujo de refresh con mutex
+
+```text
+                    [5 requests concurrent]
+                       /      |      \
+                  GET /A   GET /B   GET /C
+                     |        |        |
+                     v        v        v
+                  [HTTP 401] (access expirado)
+                     |        |        |
+                     +---+----+----+---+
+                         |
+                         v
+              ┌────[ mutex check ]────┐
+              |   inFlight === null?  |
+              └──────────┬────────────┘
+                         |
+            ┌────────────┴────────────┐
+            |                         |
+        [primer caller]          [otros callers]
+            |                         |
+            v                         v
+    inFlight = refresh()      await inFlight
+            |                         |
+            v                         |
+   POST /session/refresh              |
+   (backend rota familia)             |
+            |                         |
+    accessToken nuevo                 |
+            |                         |
+            v                         v
+       inFlight = null         (resuelve)
+            |                         |
+            v                         v
+    retry GET /A           retry GET /B y /C
+                           (con accessToken nuevo)
+
+  Sin mutex: 5 calls a /session/refresh
+  -> backend ve 4 reuse -> revoca familia -> logout forzado
+  Con mutex: 1 call -> 5 requests reintentan -> todo verde
+```
+
+## Flujo deploy a Cloudflare Pages
+
+```text
+1. Dev push a branch `dev`:
+   git push origin feature/dashboard-frontend -> PR -> merge a dev
+        |
+        v
+2. GitHub Actions:
+   - branch-flow-guard.yml: valida cadena dev<-feature (OK)
+   - ci.yml: lint + build dashboard + apps Astro (verifica que pasa)
+   - deploy-apps.yml triggered en push a dev
+        |
+        v
+3. deploy-apps.yml:
+   job build-apps:
+     environment: dev   <- lee GH Variables del env dev
+     env:
+       NEXT_PUBLIC_API_ENDPOINT: vars.NEXT_PUBLIC_API_ENDPOINT
+       NEXT_PUBLIC_TURNSTILE_SITEKEY: vars.NEXT_PUBLIC_TURNSTILE_SITEKEY
+       NEXT_PUBLIC_DASHBOARD_URL: vars.NEXT_PUBLIC_DASHBOARD_URL
+     steps:
+       - pnpm install --frozen-lockfile
+       - pnpm -r --filter "./apps/*" --filter "@portfolio/dashboard" \
+         --workspace-concurrency=7 run build
+       - upload-artifact apps/*/dist + dashboard/out
+        |
+        v
+4. job deploy-pages (matrix include con dashboard):
+   strategy.matrix.include:
+     - name: dashboard, dist-dir: dashboard/out, project: dashboard
+     - name: generic, ...
+     - name: hub, ...
+     ...
+   - cloudflare/wrangler-action: pages deploy <dist-dir> --project-name=portfolio-<project>-dev
+        |
+        v
+5. Cloudflare Pages:
+   - Recibe upload
+   - Sirve en https://portfolio-dashboard-dev.pages.dev
+   - Custom domain admin.portfolio.dev.the-full-stack.com -> CNAME -> pages.dev
+        |
+        v
+6. job verify-deploy:
+   - curl -sI https://admin.portfolio.dev.the-full-stack.com/ | head -1 | grep 200
+        |
+        v
+7. Done. Promocion: PR dev->stage->main, mismo flujo en cada env.
+```
+
+## Arquitectura de auth state (frontend)
+
+```text
+┌────────────────────────────────────────────────────────────────┐
+│                       Zustand auth store                       │
+│  ┌──────────────────────┐         ┌──────────────────────┐     │
+│  │  accessToken (mem)   │         │  tempToken (mem)     │     │
+│  │  null | JWT string   │         │  null | JWT string   │     │
+│  └──────────────────────┘         └──────────────────────┘     │
+│                                                                │
+│  ┌──────────────────────┐         ┌──────────────────────┐     │
+│  │  user (persist)      │         │  refreshExpiry       │     │
+│  │  {id, email, status} │         │  null | epoch ms     │     │
+│  └──────────────────────┘         └──────────────────────┘     │
+│                                                                │
+│  Actions: setAccessToken, setUser, setTempToken, reset         │
+│  Derived: isAuthenticated(), isAccessExpired()                 │
+└────────────────────────────────────────────────────────────────┘
+                       ▲              ▲
+                       |              |
+       ┌───────────────┴────┐  ┌──────┴──────────────────┐
+       │                    │  │                         │
+┌──────┴──────┐   ┌─────────┴──┴────────┐   ┌────────────┴──────┐
+│ useLogout   │   │ useAuthTimer        │   │ useMultiTabSync   │
+│ - reset     │   │ - jwt-decode exp    │   │ - BroadcastChannel│
+│ - broadcast │   │ - setTimeout refresh│   │   ('portfolio_auth│
+│ - clear()   │   │ - PageVisibility    │   │   '): LOGOUT      │
+│ - redirect  │   │   re-check          │   │   TOKEN_REFRESH   │
+└─────────────┘   └─────────────────────┘   └───────────────────┘
+
+┌──────────────────────────────────────────────────────────────────┐
+│              fetch wrapper (lib/api-client.ts)                    │
+│  1. Read accessToken de Zustand                                   │
+│  2. fetch(url, {Authorization: Bearer <token>, credentials: incl})│
+│  3. Si 401 && !skipRefresh:                                       │
+│       refreshed = await withRefreshMutex(performRefresh)          │
+│       if refreshed: retry con token nuevo                          │
+│       else: performLocalLogout (reset + broadcast)                │
+│  4. Parse JSON + throw ApiError si !ok                            │
+└──────────────────────────────────────────────────────────────────┘
+                       ▲
+                       |  (mutex: 1 sola call a /session/refresh)
+                       ▼
+┌──────────────────────────────────────────────────────────────────┐
+│            refresh-mutex.ts (singleton in-flight Promise)         │
+│  let inFlight: Promise<boolean> | null = null                     │
+│  export async function withRefreshMutex(fn) {                     │
+│    if (inFlight) return inFlight                                  │
+│    inFlight = (async () => { ... }).finally(() => inFlight=null) │
+│    return inFlight                                                │
+│  }                                                                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## ER del state del dashboard (frontend, NO DB)
+
+```text
+[AuthStore] 1--1 [User?]
+                  - id, email, status, has_password, mfa_methods
+
+[QueryCache]
+  ['analytics', 'overview', {from, to}]  -> OverviewResponse
+  ['analytics', 'timeseries', {from, to, bucket}] -> TimeseriesResponse
+  ['sessions', 'list', {page, page_size}] -> SessionsListResponse
+  ['sessions', 'detail', sessionId] -> SessionDetailResponse
+  ['events', 'list', {page, page_size}] -> EventsListResponse
+  ['contacts', 'list', {page, page_size, status?}] -> ContactsListResponse
+  ...
+
+[FiltersStore] (Zustand local de cada feature)
+  analytics: {date_range, niche?, event_type?}
+  sessions: {date_range, country?, device_type?}
+  events: {date_range, event_type?}
+
+[ThemeProvider] (next-themes)
+  theme: 'light' | 'dark' | 'system'
+  data-theme: applied on <html>
+```
+
+(Este "ER" no es de DB sino de estructura de state — el dashboard NO
+tiene DB propia.)
+
+## Estructura de carpetas (vista alta)
+
+```text
+portfolio/  (repo root)
+├── apps/                     # 6 apps Astro (sin cambios)
+├── packages/                 # 5 packages compartidos (sin cambios)
+├── dashboard/                # NUEVO — dashboard SPA
+│   ├── src/
+│   │   ├── app/              # Next App Router
+│   │   ├── components/ui/    # shadcn primitives + custom genericos
+│   │   ├── features/         # auth, analytics, sessions, ...
+│   │   ├── lib/              # api-client, env, utils
+│   │   ├── providers/        # query, theme, root
+│   │   ├── hooks/            # globales
+│   │   ├── styles/
+│   │   └── types/
+│   ├── public/               # _redirects, _headers, favicon
+│   ├── tests/                # unit (Vitest) + mocks (MSW)
+│   ├── package.json
+│   ├── next.config.ts
+│   ├── tsconfig.json
+│   ├── biome.json
+│   ├── components.json
+│   └── postcss.config.mjs
+├── docker/
+│   └── env/client/.example   # +NEXT_PUBLIC_* nuevas
+├── devtools/
+│   ├── cloudflare_setup/
+│   │   └── config.py         # +APP_DASHBOARD
+│   └── sync_secrets/
+│       └── catalog.py        # +NEXT_PUBLIC_* nuevas
+├── .github/workflows/
+│   └── deploy-apps.yml       # +dashboard al matrix
+├── tests/feature/
+│   └── dashboard/            # NUEVO — Playwright specs
+└── docs/specs/dashboard/     # ESTE PLAN (efimero)
+```
+
+(Ver detalle completo en [03-estructura.md](03-estructura.md).)
+
+[< 01-contexto-y-decision](01-contexto-y-decision.md) | [Siguiente: 03-estructura >](03-estructura.md)

--- a/docs/specs/dashboard/02-diagramas.md
+++ b/docs/specs/dashboard/02-diagramas.md
@@ -96,8 +96,8 @@ Las 6 apps Astro: SIN CAMBIOS (continuan en sus subdominios)
     - POST /auth?operation=register&action=verify-code body: {code, temp_token}
     - Backend valida hash + ttl + attempts < 5
     - Response 200 {access_token, refresh_token, expires_in, user}
-    - Frontend: Zustand.setTokens(access, refresh, user), redirect /dashboard
-      (tokens persistidos en localStorage via Zustand persist)
+    - Frontend: Zustand.setTokens(access, refresh, user, refreshExpiry), redirect /dashboard
+      (accessToken queda en memoria; refreshToken + refreshExpiry + user persistidos en localStorage)
 ```
 
 ## Flujo de auth: login con magic link / code
@@ -215,18 +215,30 @@ Las 6 apps Astro: SIN CAMBIOS (continuan en sus subdominios)
 ```text
 ┌────────────────────────────────────────────────────────────────┐
 │                       Zustand auth store                       │
+│                                                                │
+│  EN MEMORIA (NO persist) — rotan / expiran:                    │
 │  ┌──────────────────────┐         ┌──────────────────────┐     │
-│  │  accessToken (mem)   │         │  tempToken (mem)     │     │
-│  │  null | JWT string   │         │  null | JWT string   │     │
+│  │  accessToken         │         │  tempToken           │     │
+│  │  null | JWT (15 min) │         │  null | JWT (5 min)  │     │
 │  └──────────────────────┘         └──────────────────────┘     │
 │                                                                │
+│  PERSISTIDO en localStorage (partialize):                      │
 │  ┌──────────────────────┐         ┌──────────────────────┐     │
-│  │  user (persist)      │         │  refreshExpiry       │     │
-│  │  {id, email, status} │         │  null | epoch ms     │     │
+│  │  refreshToken        │         │  refreshExpiry       │     │
+│  │  null | JWT (rot.)   │         │  null | epoch ms     │     │
 │  └──────────────────────┘         └──────────────────────┘     │
+│  ┌──────────────────────┐                                      │
+│  │  user                │                                      │
+│  │  {id, email, status} │                                      │
+│  └──────────────────────┘                                      │
 │                                                                │
-│  Actions: setAccessToken, setUser, setTempToken, reset         │
+│  Actions: setTokens, setAccessToken, setUser, setTempToken,    │
+│           setRefreshExpiry, clearTokens, reset                 │
 │  Derived: isAuthenticated(), isAccessExpired()                 │
+│                                                                │
+│  Bootstrap on reload: accessToken arranca null. useAuthTimer   │
+│  detecta refreshToken + refreshExpiry > now -> dispara         │
+│  /session/refresh para hidratar accessToken en memoria.        │
 └────────────────────────────────────────────────────────────────┘
                        ▲              ▲
                        |              |

--- a/docs/specs/dashboard/03-estructura.md
+++ b/docs/specs/dashboard/03-estructura.md
@@ -1,0 +1,563 @@
+# 03 — Estructura completa de archivos
+
+[< 02-diagramas](02-diagramas.md) | [Siguiente: 04-setup-base >](04-setup-base.md)
+
+## Aclaracion
+
+Esta seccion lista TODOS los archivos que crea el plan. La descripcion
+detallada de cada uno vive en las secciones 04-08. Aqui solo el
+inventario para chequeo rapido de "que tengo que crear".
+
+Estructura completa Hybrid Atomic Design (referencia en
+`.claude/docs/dashboard/02-structure.md`):
+
+## `dashboard/` (carpeta root nueva)
+
+### Configs (raiz)
+
+```
+dashboard/
+├── package.json                       # nombre @portfolio/dashboard, scripts, deps
+├── next.config.ts                     # output: 'export', trailingSlash, images.unoptimized
+├── tsconfig.json                      # strict + noUncheckedIndexedAccess + paths @/*
+├── biome.json                         # extends del root + override components/ui/*
+├── components.json                    # shadcn config
+├── postcss.config.mjs                 # tailwindcss + autoprefixer
+├── vitest.config.ts                   # happy-dom + coverage + alias
+├── next-env.d.ts                      # generado por next dev (gitignored)
+├── README.md                          # corto, link a knowledge tree y plan
+└── .gitignore                         # .next, out, node_modules, *.tsbuildinfo
+```
+
+### `dashboard/src/styles/`
+
+```
+src/styles/
+└── globals.css                        # @import tailwind + tokens HSL + @theme inline + base
+```
+
+### `dashboard/src/lib/`
+
+```
+src/lib/
+├── env.ts                             # Zod schema validacion NEXT_PUBLIC_*
+├── utils.ts                           # cn() de shadcn
+├── api-client.ts                      # fetch wrapper + auth interceptor + mutex
+├── routes.ts                          # constantes de paths (ROUTES.dashboard.analytics)
+├── format/
+│   ├── date.ts                        # formatDate, relativeTime
+│   ├── number.ts                      # formatNumber, formatPercent
+│   └── duration.ts                    # formatDurationMs (00:01:23)
+└── validation/
+    ├── auth.ts                        # loginSchema, registerSchema, verifyCodeSchema
+    └── filters.ts                     # dateRangeSchema, paginationSchema
+```
+
+### `dashboard/src/types/`
+
+```
+src/types/
+├── api.ts                             # types de responses /auth y /analytics
+├── models.ts                          # User, Session, Visit, Event, Contact
+└── env.d.ts                           # type-safe NEXT_PUBLIC_*
+```
+
+### `dashboard/src/providers/`
+
+```
+src/providers/
+├── theme-provider.tsx                 # next-themes wrapper
+├── query-provider.tsx                 # Tanstack Query + PersistQueryClient
+└── root-providers.tsx                 # composicion (ThemeProvider > QueryProvider)
+```
+
+### `dashboard/src/hooks/`
+
+```
+src/hooks/                             # globales (no de feature)
+├── use-debounce.ts
+├── use-media-query.ts
+├── use-local-storage.ts               # type-safe wrapper
+└── use-mounted.ts                     # evitar hydration warnings
+```
+
+### `dashboard/src/components/ui/` — shadcn primitives + custom
+
+```
+src/components/ui/
+# shadcn primitives (via pnpm dlx shadcn add):
+├── alert.tsx
+├── badge.tsx
+├── button.tsx
+├── calendar.tsx
+├── card.tsx
+├── chart.tsx                          # Recharts wrapper de shadcn
+├── checkbox.tsx
+├── command.tsx                        # cmdk
+├── dialog.tsx
+├── dropdown-menu.tsx
+├── form.tsx
+├── input.tsx
+├── input-otp.tsx                      # para code 8 chars register/login
+├── label.tsx
+├── popover.tsx
+├── select.tsx
+├── separator.tsx
+├── sheet.tsx                          # mobile sidebar
+├── skeleton.tsx
+├── sonner.tsx                         # Toaster
+├── switch.tsx
+├── table.tsx
+├── tabs.tsx
+├── tooltip.tsx
+
+# Custom UI primitives (genericos, no shadcn):
+├── metric-card.tsx                    # title/value/delta/icon
+├── data-table.tsx                     # Tanstack Table wrapper
+├── date-range-picker.tsx              # Popover + Calendar
+├── empty-state.tsx                    # icon + title + description + action
+├── error-alert.tsx                    # Alert variant=destructive con retry
+├── loading-spinner.tsx
+├── theme-toggle.tsx                   # ciclo dark/light/system
+└── index.ts                           # barrel
+```
+
+### `dashboard/src/features/` — un dominio por carpeta
+
+#### `features/auth/`
+
+```
+features/auth/
+├── components/
+│   ├── login-form.tsx
+│   ├── register-form.tsx
+│   ├── verify-code-input.tsx          # InputOTP 8 chars Crockford
+│   ├── magic-link-prompt.tsx          # "te enviamos un link..."
+│   ├── set-password-form.tsx
+│   ├── totp-setup.tsx                 # QR + InputOTP (plan 02)
+│   ├── recovery-codes-modal.tsx
+│   ├── webauthn-register-button.tsx   # @simplewebauthn/browser
+│   ├── auth-guard.tsx                 # HOC para proteger rutas
+│   └── turnstile-widget.tsx
+├── hooks/
+│   ├── use-register-start.ts
+│   ├── use-register-verify-code.ts
+│   ├── use-login-start.ts
+│   ├── use-login-verify-code.ts
+│   ├── use-login-verify-totp.ts
+│   ├── use-set-password.ts
+│   ├── use-resend-code.ts
+│   ├── use-session-refresh.ts
+│   ├── use-logout.ts
+│   ├── use-auth-timer.ts              # auto-refresh + PageVisibility
+│   ├── use-multi-tab-sync.ts          # BroadcastChannel
+│   └── use-protected-route.ts         # alternative al AuthGuard
+├── api/
+│   ├── auth-client.ts                 # endpoints typed
+│   └── query-keys.ts
+├── store/
+│   └── use-auth-store.ts              # Zustand (accessToken mem + user persist)
+├── lib/
+│   ├── refresh-mutex.ts               # singleton in-flight Promise
+│   ├── broadcast.ts                   # BroadcastChannel helpers
+│   └── token-expiry.ts                # jwt-decode helpers
+├── types.ts                           # AuthResponse, User, Method, MfaMethod
+└── index.ts                           # barrel
+```
+
+#### `features/dashboard-shell/`
+
+```
+features/dashboard-shell/
+├── components/
+│   ├── sidebar.tsx                    # nav links + user menu
+│   ├── header.tsx                     # breadcrumb + theme + logout
+│   └── mobile-sidebar.tsx             # Sheet
+├── lib/
+│   └── nav-items.ts                   # array de items con href, icon, label
+└── index.ts
+```
+
+#### `features/analytics/`
+
+```
+features/analytics/
+├── components/
+│   ├── overview-cards.tsx             # 7 MetricCard
+│   ├── timeseries-chart.tsx           # AreaChart
+│   ├── top-pages-chart.tsx            # BarChart
+│   ├── top-referrers-table.tsx        # DataTable
+│   ├── top-niches-chart.tsx           # BarChart
+│   ├── active-now-card.tsx            # refetchInterval 15s
+│   ├── retention-chart.tsx
+│   └── analytics-filters.tsx          # DateRangePicker + niche Select
+├── hooks/
+│   ├── use-overview-query.ts
+│   ├── use-timeseries-query.ts
+│   ├── use-top-pages-query.ts
+│   ├── use-top-referrers-query.ts
+│   ├── use-top-niches-query.ts
+│   ├── use-active-now-query.ts
+│   ├── use-retention-query.ts
+│   └── use-analytics-filters.ts       # Zustand local
+├── api/
+│   ├── analytics-client.ts
+│   └── query-keys.ts
+├── store/
+│   └── use-analytics-filters.ts       # date_range, niche
+├── types.ts
+└── index.ts
+```
+
+#### `features/sessions/`
+
+```
+features/sessions/
+├── components/
+│   ├── sessions-table.tsx
+│   ├── session-detail-dialog.tsx
+│   └── sessions-filters.tsx
+├── hooks/
+│   ├── use-sessions-list.ts
+│   ├── use-session-detail.ts
+│   └── use-sessions-filters.ts
+├── api/
+│   ├── sessions-client.ts
+│   └── query-keys.ts
+├── store/
+│   └── use-sessions-filters.ts
+├── types.ts
+└── index.ts
+```
+
+#### `features/events/`
+
+```
+features/events/
+├── components/
+│   ├── events-distribution-chart.tsx
+│   ├── events-list-table.tsx          # con Tanstack Virtual
+│   └── events-heatmap.tsx             # dia_semana x hora
+├── hooks/
+│   ├── use-events-distribution.ts
+│   ├── use-events-list.ts
+│   └── use-events-heatmap.ts
+├── api/
+│   ├── events-client.ts
+│   └── query-keys.ts
+├── types.ts
+└── index.ts
+```
+
+#### `features/visits/`
+
+```
+features/visits/
+├── components/
+│   ├── visits-list-table.tsx
+│   └── landing-pages-chart.tsx
+├── hooks/
+├── api/
+├── types.ts
+└── index.ts
+```
+
+#### `features/geo/`
+
+```
+features/geo/
+├── components/
+│   └── geo-by-country-chart.tsx
+├── hooks/
+├── api/
+├── types.ts
+└── index.ts
+```
+
+#### `features/devices/`
+
+```
+features/devices/
+├── components/
+│   ├── device-pie-chart.tsx
+│   ├── browser-bar-chart.tsx
+│   └── os-bar-chart.tsx
+├── hooks/
+├── api/
+├── types.ts
+└── index.ts
+```
+
+#### `features/funnel/`
+
+```
+features/funnel/
+├── components/
+│   └── funnel-chart.tsx
+├── hooks/
+├── api/
+├── types.ts
+└── index.ts
+```
+
+#### `features/contacts/`
+
+```
+features/contacts/
+├── components/
+│   ├── contacts-table.tsx
+│   ├── contacts-by-status-chart.tsx
+│   ├── contact-detail-dialog.tsx
+│   └── update-status-button.tsx       # mutation
+├── hooks/
+│   ├── use-contacts-list.ts
+│   ├── use-contacts-by-status.ts
+│   └── use-update-contact-status.ts
+├── api/
+│   ├── contacts-client.ts
+│   └── query-keys.ts
+├── types.ts
+└── index.ts
+```
+
+#### `features/settings/`
+
+```
+features/settings/
+├── components/
+│   ├── profile-form.tsx
+│   ├── change-password-form.tsx
+│   ├── mfa-methods-list.tsx
+│   ├── webauthn-credentials-list.tsx
+│   └── recovery-codes-section.tsx
+├── hooks/
+├── api/
+├── types.ts
+└── index.ts
+```
+
+### `dashboard/src/app/` — Next App Router
+
+```
+src/app/
+├── layout.tsx                         # RootLayout: providers + Toaster + fonts
+├── page.tsx                           # / -> redirect a /dashboard si logueado, else /login
+├── error.tsx                          # error boundary global
+├── global-error.tsx                   # fallback ultimo
+├── not-found.tsx                      # 404
+│
+├── (auth)/                            # route group, sin layout compartido
+│   ├── login/page.tsx
+│   ├── register/page.tsx
+│   ├── verify/page.tsx                # ?flow=register|login, input de code
+│   ├── callback/page.tsx              # decodea fragment hash del magic link
+│   └── set-password/page.tsx          # opcional post-registro
+│
+└── (dashboard)/                       # route group, layout protegido
+    ├── layout.tsx                     # AuthGuard + Sidebar + Header
+    ├── page.tsx                       # /dashboard (overview)
+    ├── analytics/page.tsx
+    ├── sessions/
+    │   ├── page.tsx                   # list
+    │   └── [id]/page.tsx              # detail (client-fetch por params.id)
+    ├── events/page.tsx
+    ├── visits/page.tsx
+    ├── geo/page.tsx
+    ├── devices/page.tsx
+    ├── funnel/page.tsx
+    ├── contacts/page.tsx
+    └── settings/
+        ├── page.tsx                   # profile
+        └── security/page.tsx          # MFA setup
+```
+
+### `dashboard/public/`
+
+```
+public/
+├── _redirects                         # /* /index.html 200 + /api/* 404
+├── _headers                           # CSP + HSTS + cache
+├── favicon.ico
+├── og-image.png
+└── mockServiceWorker.js               # generado por `npx msw init public/`
+```
+
+### `dashboard/tests/`
+
+```
+tests/
+├── setup.ts                           # vitest setup global
+├── utils/
+│   └── render.tsx                     # render wrapper con providers
+├── mocks/
+│   ├── server.ts                      # setupServer (Node)
+│   ├── browser.ts                     # setupWorker (browser dev)
+│   └── handlers/
+│       ├── auth.ts
+│       ├── analytics.ts
+│       ├── sessions.ts
+│       ├── events.ts
+│       ├── visits.ts
+│       ├── geo.ts
+│       ├── devices.ts
+│       ├── funnel.ts
+│       └── contacts.ts
+├── fixtures/
+│   ├── users.ts
+│   ├── sessions.ts
+│   ├── events.ts
+│   └── analytics.ts
+└── unit/                              # mirror de src/
+    ├── lib/
+    │   ├── api-client.test.ts         # crit: mutex refresh test
+    │   ├── env.test.ts
+    │   ├── routes.test.ts
+    │   └── format/
+    │       ├── date.test.ts
+    │       ├── number.test.ts
+    │       └── duration.test.ts
+    ├── components/ui/
+    │   ├── metric-card.test.tsx
+    │   ├── data-table.test.tsx
+    │   ├── empty-state.test.tsx
+    │   └── theme-toggle.test.tsx
+    └── features/
+        ├── auth/
+        │   ├── components/
+        │   │   ├── login-form.test.tsx
+        │   │   ├── register-form.test.tsx
+        │   │   ├── verify-code-input.test.tsx
+        │   │   ├── auth-guard.test.tsx
+        │   │   └── turnstile-widget.test.tsx
+        │   ├── hooks/
+        │   │   ├── use-login-start.test.ts
+        │   │   ├── use-logout.test.ts
+        │   │   ├── use-auth-timer.test.ts
+        │   │   └── use-multi-tab-sync.test.ts
+        │   ├── store/
+        │   │   └── use-auth-store.test.ts
+        │   ├── lib/
+        │   │   ├── refresh-mutex.test.ts
+        │   │   ├── broadcast.test.ts
+        │   │   └── token-expiry.test.ts
+        │   └── api/
+        │       └── auth-client.test.ts
+        ├── analytics/
+        │   ├── components/
+        │   │   ├── overview-cards.test.tsx
+        │   │   ├── timeseries-chart.test.tsx
+        │   │   └── analytics-filters.test.tsx
+        │   ├── hooks/
+        │   │   ├── use-overview-query.test.ts
+        │   │   └── use-analytics-filters.test.ts
+        │   └── store/
+        │       └── use-analytics-filters.test.ts
+        ├── sessions/
+        │   ├── components/
+        │   │   ├── sessions-table.test.tsx
+        │   │   └── session-detail-dialog.test.tsx
+        │   └── hooks/
+        ├── events/
+        ├── visits/
+        ├── geo/
+        ├── devices/
+        ├── funnel/
+        ├── contacts/
+        │   ├── components/
+        │   │   ├── contacts-table.test.tsx
+        │   │   └── update-status-button.test.tsx
+        │   └── hooks/
+        └── settings/
+```
+
+## Cambios a archivos existentes (no del dashboard)
+
+### Root del repo
+
+```
+pnpm-workspace.yaml                    # +'dashboard' al array packages
+.gitignore                             # +dashboard/.next, dashboard/out, etc.
+```
+
+### `docker/env/client/`
+
+```
+.example                               # +NEXT_PUBLIC_API_ENDPOINT, NEXT_PUBLIC_TURNSTILE_SITEKEY, NEXT_PUBLIC_DASHBOARD_URL, NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS
+.local                                 # (gitignored, dev local)
+.dev, .stage, .prod                    # (gitignored, sync_secrets los lee)
+```
+
+### `devtools/cloudflare_setup/`
+
+```
+config.py                              # +APP_DASHBOARD AppConfig (app_type='nextjs', build_output_dir='out')
+                                       # +funciones para custom_domain_for, env_vars_for con dashboard
+README.md                              # mencionar el dashboard como 7mo app
+```
+
+### `devtools/sync_secrets/`
+
+```
+catalog.py                             # +4 entradas SecretDefinition para NEXT_PUBLIC_*
+README.md                              # mencionar las nuevas keys
+```
+
+### `.github/workflows/`
+
+```
+deploy-apps.yml                        # +dashboard al matrix include
+                                       # +env vars NEXT_PUBLIC_* al build-apps job
+                                       # +dashboard al verify-deploy matrix
+ci.yml                                 # +dashboard al filter del build step
+```
+
+### `.claude/docs/subdomain-standard/`
+
+```
+02-naming-rules.md                     # +'admin' a la lista de reservados
+```
+
+### `tests/feature/`
+
+```
+dashboard/
+├── 01-login-magic-link.spec.ts
+├── 02-register-verify-code.spec.ts
+├── 03-callback-fragment-hash.spec.ts
+├── 04-auth-guard-redirect.spec.ts
+├── 05-logout-multi-tab.spec.ts
+├── 06-analytics-navigation.spec.ts
+└── 07-sessions-table-pagination.spec.ts
+```
+
+## Conteo de archivos
+
+| Tipo | Cantidad |
+|------|----------|
+| Configs raiz (dashboard/) | 9 |
+| `src/lib/` | 8 |
+| `src/types/` | 3 |
+| `src/providers/` | 3 |
+| `src/hooks/` (globales) | 4 |
+| `src/styles/` | 1 |
+| `src/components/ui/` (shadcn) | 24 |
+| `src/components/ui/` (custom) | 7 |
+| `src/features/auth/` | ~25 |
+| `src/features/dashboard-shell/` | 4 |
+| `src/features/analytics/` | ~17 |
+| `src/features/sessions/` | ~10 |
+| `src/features/events/` | ~10 |
+| `src/features/visits/` | ~6 |
+| `src/features/geo/` | ~4 |
+| `src/features/devices/` | ~7 |
+| `src/features/funnel/` | ~4 |
+| `src/features/contacts/` | ~11 |
+| `src/features/settings/` | ~10 |
+| `src/app/` (pages + layouts) | ~17 |
+| `tests/` (mocks + fixtures + unit) | ~50 |
+| `tests/feature/dashboard/` (Playwright) | 7 |
+| Cambios fuera de `dashboard/` | ~7 |
+
+**Total estimado**: ~250 archivos nuevos + ~7 modificados. Plan **Large**.
+
+[< 02-diagramas](02-diagramas.md) | [Siguiente: 04-setup-base >](04-setup-base.md)

--- a/docs/specs/dashboard/03-estructura.md
+++ b/docs/specs/dashboard/03-estructura.md
@@ -156,7 +156,7 @@ features/auth/
 │   ├── auth-client.ts                 # endpoints typed
 │   └── query-keys.ts
 ├── store/
-│   └── use-auth-store.ts              # Zustand (accessToken mem + user persist)
+│   └── use-auth-store.ts              # Zustand (accessToken + tempToken en memoria; refreshToken + user + refreshExpiry persist en localStorage)
 ├── lib/
 │   ├── refresh-mutex.ts               # singleton in-flight Promise
 │   ├── broadcast.ts                   # BroadcastChannel helpers
@@ -215,7 +215,7 @@ features/analytics/
 features/sessions/
 ├── components/
 │   ├── sessions-table.tsx
-│   ├── session-detail-dialog.tsx
+│   ├── session-detail-drawer.tsx     # Sheet lateral, lee ?session=<id> con useSearchParams
 │   └── sessions-filters.tsx
 ├── hooks/
 │   ├── use-sessions-list.ts
@@ -357,9 +357,7 @@ src/app/
     ├── layout.tsx                     # AuthGuard + Sidebar + Header
     ├── page.tsx                       # /dashboard (overview)
     ├── analytics/page.tsx
-    ├── sessions/
-    │   ├── page.tsx                   # list
-    │   └── [id]/page.tsx              # detail (client-fetch por params.id)
+    ├── sessions/page.tsx              # list + SessionDetailDrawer (deep-link via ?session=<id>; NO ruta dinamica [id], incompatible con output: 'export')
     ├── events/page.tsx
     ├── visits/page.tsx
     ├── geo/page.tsx
@@ -455,7 +453,7 @@ tests/
         ├── sessions/
         │   ├── components/
         │   │   ├── sessions-table.test.tsx
-        │   │   └── session-detail-dialog.test.tsx
+        │   │   └── session-detail-drawer.test.tsx
         │   └── hooks/
         ├── events/
         ├── visits/
@@ -482,7 +480,7 @@ pnpm-workspace.yaml                    # +'dashboard' al array packages
 ### `docker/env/client/`
 
 ```
-.example                               # +NEXT_PUBLIC_API_ENDPOINT, NEXT_PUBLIC_TURNSTILE_SITEKEY, NEXT_PUBLIC_DASHBOARD_URL, NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS
+.example                               # +6 vars del dashboard: NEXT_PUBLIC_API_ENDPOINT, NEXT_PUBLIC_TURNSTILE_SITEKEY, NEXT_PUBLIC_DASHBOARD_URL, NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS, NEXT_PUBLIC_FEATURE_MFA, NEXT_PUBLIC_WEBAUTHN_RP_ID
 .local                                 # (gitignored, dev local)
 .dev, .stage, .prod                    # (gitignored, sync_secrets los lee)
 ```

--- a/docs/specs/dashboard/04-setup-base.md
+++ b/docs/specs/dashboard/04-setup-base.md
@@ -16,10 +16,10 @@ permanente). Aqui solo el plan ejecutable: que archivo, que verifica.
 | `dashboard/package.json` | name `@portfolio/dashboard`, engines node>=24, scripts dev/build/lint/typecheck/test, deps de la seccion 01-stack del KT | `pnpm install` sin errores |
 | `dashboard/.gitignore` | `.next`, `out`, `node_modules`, `*.tsbuildinfo`, `.env*.local`, `coverage` | `git status` no muestra basura |
 | `dashboard/next.config.ts` | `output: 'export'`, `images.unoptimized: true`, `trailingSlash: true`, `poweredByHeader: false` | `pnpm exec next build` arranca |
-| `dashboard/tsconfig.json` | strict + `noUncheckedIndexedAccess` + paths `@/*` apuntando a `./src/*` | `pnpm typecheck` sin errores |
+| `dashboard/tsconfig.json` | strict + `noUncheckedIndexedAccess` + paths `@/*` apuntando a `./src/*` + paths `@tests/*` apuntando a `./tests/*` (necesario para que `await import('@tests/mocks/browser')` resuelva en build/tests; `tests/` esta fuera de `src/`) | `pnpm typecheck` sin errores |
 | `dashboard/biome.json` | `extends: ["../biome.json"]` + override `src/components/ui/**` | `pnpm lint` sin errores |
 | `dashboard/postcss.config.mjs` | `@tailwindcss/postcss` plugin | (validado en build) |
-| `dashboard/vitest.config.ts` | happy-dom + coverage + alias `@` | `pnpm test` corre sin archivos |
+| `dashboard/vitest.config.ts` | happy-dom + coverage + alias `@` (= `./src`) y `@tests` (= `./tests`) en `resolve.alias`, espejando los paths del `tsconfig.json` | `pnpm test` corre sin archivos |
 | `dashboard/README.md` | corto, link a knowledge tree + plan | (revision visual) |
 | `pnpm-workspace.yaml` | agregar `'dashboard'` al array `packages` | `pnpm install` recoge el package |
 

--- a/docs/specs/dashboard/04-setup-base.md
+++ b/docs/specs/dashboard/04-setup-base.md
@@ -1,0 +1,114 @@
+# 04 — Setup base + configs + scaffolding
+
+[< 03-estructura](03-estructura.md) | [Siguiente: 05-ui-components >](05-ui-components.md)
+
+## Aclaracion
+
+Esta seccion describe **que** se crea en las fases 1-6 (setup base).
+El **codigo concreto** de cada archivo vive en
+`.claude/docs/dashboard/01-stack.md` y `04-auth.md` (knowledge tree
+permanente). Aqui solo el plan ejecutable: que archivo, que verifica.
+
+## Fase 1 — Scaffold `dashboard/`
+
+| Archivo | Descripcion | Verificar |
+|---------|-------------|-----------|
+| `dashboard/package.json` | name `@portfolio/dashboard`, engines node>=24, scripts dev/build/lint/typecheck/test, deps de la seccion 01-stack del KT | `pnpm install` sin errores |
+| `dashboard/.gitignore` | `.next`, `out`, `node_modules`, `*.tsbuildinfo`, `.env*.local`, `coverage` | `git status` no muestra basura |
+| `dashboard/next.config.ts` | `output: 'export'`, `images.unoptimized: true`, `trailingSlash: true`, `poweredByHeader: false` | `pnpm exec next build` arranca |
+| `dashboard/tsconfig.json` | strict + `noUncheckedIndexedAccess` + paths `@/*` apuntando a `./src/*` | `pnpm typecheck` sin errores |
+| `dashboard/biome.json` | `extends: ["../biome.json"]` + override `src/components/ui/**` | `pnpm lint` sin errores |
+| `dashboard/postcss.config.mjs` | `@tailwindcss/postcss` plugin | (validado en build) |
+| `dashboard/vitest.config.ts` | happy-dom + coverage + alias `@` | `pnpm test` corre sin archivos |
+| `dashboard/README.md` | corto, link a knowledge tree + plan | (revision visual) |
+| `pnpm-workspace.yaml` | agregar `'dashboard'` al array `packages` | `pnpm install` recoge el package |
+
+**Commit**: `feat(dashboard): scaffold inicial Next.js 16 SPA`
+
+## Fase 2 — CSS / theming base
+
+| Archivo | Descripcion | Verificar |
+|---------|-------------|-----------|
+| `dashboard/src/styles/globals.css` | `@import tailwind` + import fonts `@fontsource/space-grotesk` y `@fontsource/space-mono` + tokens HSL `:root` y `[data-theme="light"]` + `@theme inline` mapping a HSL + `@layer base` + `prefers-reduced-motion` (ver `01-stack.md` del KT) | `pnpm build` genera CSS |
+| `dashboard/src/providers/theme-provider.tsx` | `next-themes` con `attribute="data-theme"`, `defaultTheme="system"`, `enableSystem`, `disableTransitionOnChange` | preview muestra theme aplicado |
+| `dashboard/src/components/ui/theme-toggle.tsx` | DropdownMenu con Sun/Moon/Monitor icons, ciclo dark/light/system, persist en localStorage | toggle funciona en preview |
+
+**Commit**: `feat(dashboard): tema dark/light con next-themes + tokens compartidos del DS`
+
+## Fase 3 — shadcn init + componentes base
+
+| Comando / Archivo | Descripcion | Verificar |
+|-------------------|-------------|-----------|
+| `cd dashboard && pnpm dlx shadcn@latest init` | Genera `components.json`, no `tailwind.config.ts` (v4 inline), aliases `@/components`, `@/lib/utils`, baseColor zinc | `components.json` existe |
+| `pnpm dlx shadcn@latest add alert badge button card chart checkbox dialog dropdown-menu form input input-otp label popover select separator sheet skeleton sonner switch table tabs tooltip` | Crea ~24 primitivos en `src/components/ui/*.tsx` | Lint pasa en cada archivo |
+| `pnpm dlx shadcn@latest add calendar command` | Para DateRangePicker (Calendar + Command para search) | Idem |
+| `pnpm install` | Instala deps de Radix que shadcn pidio | OK |
+
+**Commit**: `feat(dashboard): shadcn init + agregar 24 primitivos UI (Radix + Tailwind v4)`
+
+## Fase 4 — Custom UI primitives genericos
+
+| Archivo | Descripcion | Tests | AC |
+|---------|-------------|-------|-----|
+| `src/components/ui/metric-card.tsx` | `MetricCard({title, value, delta?, trend?, icon?})` | unit | AC-21 |
+| `src/components/ui/data-table.tsx` | Tanstack Table wrapper generico (`columns, data, isLoading, emptyMessage`) | unit | AC-23 |
+| `src/components/ui/date-range-picker.tsx` | Popover + Calendar (single range), default last 30d | unit | AC-22 |
+| `src/components/ui/empty-state.tsx` | `EmptyState({icon, title, description?, action?})` | unit | — |
+| `src/components/ui/error-alert.tsx` | shadcn Alert variant=destructive con retry button | unit | — |
+| `src/components/ui/loading-spinner.tsx` | spinner accesible (role=status, aria-label) | unit | — |
+| `src/components/ui/index.ts` | barrel exports | (typecheck) | — |
+
+**Commit**: `feat(dashboard): custom UI primitives (MetricCard, DataTable, DateRangePicker, EmptyState)`
+
+## Fase 5 — Lib base (env + api-client)
+
+| Archivo | Descripcion | Tests | AC |
+|---------|-------------|-------|-----|
+| `src/lib/env.ts` | Zod schema valida `NEXT_PUBLIC_*` en cold start | unit | — |
+| `src/lib/utils.ts` | `cn(...classes)` con `clsx` + `tailwind-merge` | unit | — |
+| `src/lib/routes.ts` | `ROUTES.dashboard.analytics`, `ROUTES.auth.callback`, etc. constants | (typecheck) | — |
+| `src/lib/api-client.ts` | `apiFetch` wrapper con `ApiError` class, auth interceptor, mutex refresh, `skipAuth/skipRefresh` flags | unit (critico: test concurrent 401s) | AC-14 |
+| `src/lib/format/date.ts` | `formatDate`, `relativeTime` (date-fns o Temporal API) | unit | — |
+| `src/lib/format/number.ts` | `formatNumber`, `formatPercent` (Intl.NumberFormat) | unit | — |
+| `src/lib/format/duration.ts` | `formatDurationMs` (00:01:23) | unit | — |
+| `src/lib/validation/auth.ts` | Zod schemas: loginSchema, registerSchema, verifyCodeSchema | unit (cubre via component test) | AC-8 |
+| `src/lib/validation/filters.ts` | dateRangeSchema, paginationSchema | unit | — |
+| `src/types/api.ts` | typed responses /auth y /analytics (mirrors backend) | (typecheck) | — |
+| `src/types/models.ts` | User, Session, Visit, Event, Contact domain types | (typecheck) | — |
+
+**Commit**: `feat(dashboard): lib base (env validation con Zod, api-client con mutex refresh, types)`
+
+## Fase 6 — Providers + RootLayout
+
+| Archivo | Descripcion | Tests | AC |
+|---------|-------------|-------|-----|
+| `src/providers/query-provider.tsx` | QueryClient con defaults (refetchOnWindowFocus: false, retry: 1 menos 401/403/422), PersistQueryClientProvider con lz-string compression, dehydrate filter (NO persistir contacts list ni events list) | unit (smoke) | — |
+| `src/providers/root-providers.tsx` | Composicion `ThemeProvider > QueryProvider` | (typecheck) | — |
+| `src/app/layout.tsx` | RootLayout: import `globals.css`, RootProviders, Toaster (sonner position top-right richColors), `<html suppressHydrationWarning>` lang="es", `import '@/lib/env'` (fail-fast en build), metadata con `robots: noindex,nofollow` | preview funciona | AC-4 |
+| `src/app/page.tsx` | Redirect a `/login` o `/dashboard` segun `isAuthenticated()` | (smoke) | — |
+| `src/app/error.tsx` | Error boundary global con button retry | (smoke) | — |
+| `src/app/global-error.tsx` | Fallback ultimo (Error en RootLayout) | (smoke) | — |
+| `src/app/not-found.tsx` | 404 page con link a `/` | (smoke) | — |
+
+**Commit**: `feat(dashboard): providers (Query con persister, Theme) + RootLayout + 404 + error boundaries`
+
+## Verificacion al final de fase 6 (gate intermedio)
+
+```bash
+# Desde root
+pnpm install
+pnpm --filter @portfolio/dashboard typecheck
+pnpm --filter @portfolio/dashboard lint
+pnpm --filter @portfolio/dashboard test
+pnpm --filter @portfolio/dashboard build
+ls dashboard/out/index.html dashboard/out/_next/static  # debe existir
+
+# Preview manual
+pnpm --filter @portfolio/dashboard preview &
+curl -sI http://localhost:3000/ | head -3        # 200
+curl -sI http://localhost:3000/login/ | head -3  # 404 (page no existe aun, OK por ahora)
+```
+
+Si todo verde, fases 1-6 OK. Proceder con fases 7+ (features).
+
+[< 03-estructura](03-estructura.md) | [Siguiente: 05-ui-components >](05-ui-components.md)

--- a/docs/specs/dashboard/05-ui-components.md
+++ b/docs/specs/dashboard/05-ui-components.md
@@ -1,0 +1,136 @@
+# 05 — UI components (referencia del knowledge tree)
+
+[< 04-setup-base](04-setup-base.md) | [Siguiente: 06-auth-feature >](06-auth-feature.md)
+
+## Aclaracion
+
+Los componentes UI primitivos (shadcn + custom) ya quedaron creados en
+la **fase 3-4** (ver 04-setup-base.md). Esta seccion documenta las
+**reglas** que aplican al construir componentes en `src/features/<X>/
+components/` y la integracion con Recharts / Tanstack Table / Virtual.
+
+Ver detalle en `.claude/docs/dashboard/03-ui.md` (KT permanente).
+
+## Reglas duras al construir componentes de feature
+
+1. **SIEMPRE** componer sobre `components/ui/` primitives. NUNCA estilizar
+   inline un primitivo con `className` sobre-escribiendo comportamiento
+   base. Si necesitas otra variante: crear una nueva variant CVA en el
+   primitivo.
+2. **SIEMPRE** Client Components (`'use client'` en primera linea).
+3. **SIEMPRE** props tipadas (`interface Props { ... }`).
+4. **SIEMPRE** filename `kebab-case.tsx`, component `PascalCase`.
+5. **SIEMPRE** si necesita data, recibirla por prop O usar el hook de
+   la feature. NUNCA hacer fetch directo desde el componente.
+6. **NUNCA** importar de otra feature (`features/B` desde `features/A`).
+7. **NUNCA** atribucion a IA en docstrings ni JSX.
+
+## Componentes de feature — patron
+
+```tsx
+// src/features/<feature>/components/<component>.tsx
+'use client'
+
+import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
+import {MetricCard} from '@/components/ui/metric-card'
+import {useOverviewQuery} from '../hooks/use-overview-query'
+import {Skeleton} from '@/components/ui/skeleton'
+import {ErrorAlert} from '@/components/ui/error-alert'
+
+export function AnalyticsOverviewCards() {
+  const {data, isLoading, isError, error, refetch} = useOverviewQuery()
+
+  if (isError) return <ErrorAlert error={error} onRetry={() => refetch()} />
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {(isLoading ? Array.from({length: 4}) : [
+        {title: 'Sessions', value: data?.sessions ?? 0},
+        {title: 'Visits', value: data?.visits ?? 0},
+        {title: 'Events', value: data?.events ?? 0},
+        {title: 'Contacts', value: data?.contacts ?? 0},
+      ]).map((card, i) => (
+        card === undefined ? (
+          <Skeleton key={i} className="h-32" />
+        ) : (
+          <MetricCard
+            key={card.title}
+            title={card.title}
+            value={String(card.value)}
+          />
+        )
+      ))}
+    </div>
+  )
+}
+```
+
+## Charts con shadcn + Recharts — patron
+
+Ver `.claude/docs/dashboard/03-ui.md` para el ejemplo completo de
+TimeseriesChart. Reglas:
+
+- **SIEMPRE** colors via CSS vars (`hsl(var(--primary))`), NO hex.
+- **SIEMPRE** envolver en `<ChartContainer config={...}>` para responsive
+  + theming.
+- **SIEMPRE** `<ChartTooltip content={<ChartTooltipContent />} />`.
+- **NUNCA** `width` / `height` fijo en px (usar className con h-[300px]).
+
+## Tanstack Table — patron
+
+Usar el wrapper `DataTable` de `components/ui/`. Definir columnas en el
+componente de feature:
+
+```tsx
+const columns: ColumnDef<Session>[] = [
+  {accessorKey: 'session_id', header: 'Session'},
+  {
+    accessorKey: 'first_seen_at',
+    header: 'Inicio',
+    cell: ({row}) => formatDate(row.getValue('first_seen_at') as string),
+  },
+  // ...
+]
+```
+
+Para listas grandes (events list >500 rows): usar `useVirtualizer` de
+Tanstack Virtual directamente (ver patron en
+`.claude/docs/dashboard/03-ui.md`).
+
+## Forms con react-hook-form + Zod + shadcn — patron
+
+Ver `.claude/docs/dashboard/03-ui.md` para LoginForm completo. Reglas:
+
+- **SIEMPRE** Zod schema en `lib/validation/<feature>.ts`.
+- **SIEMPRE** `zodResolver(schema)` en `useForm`.
+- **SIEMPRE** shadcn `<Form>`, `<FormField>`, `<FormControl>`,
+  `<FormMessage>`.
+- **SIEMPRE** mostrar errores del mutation con `<Alert variant="destructive">`
+  o `toast.error()`.
+
+## Loading states
+
+- **SIEMPRE** `<Skeleton>` realistic (forma del componente final) sobre
+  spinner generico.
+- **SIEMPRE** todo Suspense boundary tiene fallback (loading.tsx en App
+  Router o Skeleton inline).
+
+## Empty states
+
+- **SIEMPRE** `<EmptyState>` cuando no hay data. Icon + title +
+  description corta + action button (recargar / cambiar filtro).
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| `useEffect(() => fetch(...))` en componente | Sin cache, sin retry, sin invalidation | Mover a hook con `useQuery` |
+| `<PrimaryButton>` wrappeando `<Button variant="primary">` | Sin valor | `<Button variant="primary">` directo |
+| Importar `@radix-ui/react-X` directo | Pierde theming | Pasar por `@/components/ui/X` |
+| Recharts `fill="#FF0000"` | Rompe dark/light | `fill="hsl(var(--primary))"` |
+| Spinner generico mientras carga MetricCard | Mala UX | Skeleton con forma de Card |
+| Mostrar mensaje "Error" sin retry | Dead-end | `<ErrorAlert error onRetry />` |
+| Form con `onChange` manual + state local | Boilerplate | react-hook-form + Zod |
+| Tabla sin sort/paginator | Mala UX en >50 rows | DataTable wrapper o feature-specific |
+
+[< 04-setup-base](04-setup-base.md) | [Siguiente: 06-auth-feature >](06-auth-feature.md)

--- a/docs/specs/dashboard/06-auth-feature.md
+++ b/docs/specs/dashboard/06-auth-feature.md
@@ -11,25 +11,33 @@ el inventario ejecutable.
 
 Zustand 5 store con `persist` middleware a `localStorage`. Campos:
 
-- `accessToken: string | null` (persist en localStorage)
-- `refreshToken: string | null` (persist en localStorage)
-- `tempToken: string | null` (in-memory, NO persist — flujo corto register/login)
+- `accessToken: string | null` (**in-memory, NO persist** — rotado en cada refresh; persistirlo deja stale token tras reload)
+- `tempToken: string | null` (in-memory, NO persist — flujo corto register/login, 5 min)
+- `refreshToken: string | null` (persist en localStorage — sobrevive reload, necesario para reanudar sesion)
+- `refreshExpiry: number | null` (persist; epoch ms del `exp` del refresh, evita decodear el JWT en cada render)
 - `user: User | null` (persist en localStorage)
-- Actions: `setTokens(access, refresh, user)`, `setTempToken`,
+- Actions: `setTokens(access, refresh, user, refreshExpiry)`, `setTempToken`,
   `setAccessToken`, `clearTokens`, `reset`
 - Derived: `isAuthenticated()`, `isAccessExpired()`
 
-**SIEMPRE** `partialize: (state) => ({accessToken, refreshToken, user})`. NUNCA persist `tempToken` (es efimero, 5 min).
+**SIEMPRE** `partialize: (state) => ({refreshToken, refreshExpiry, user})`.
+NUNCA persistir `accessToken` (rota en cada `/session/refresh`; persistido queda stale).
+NUNCA persistir `tempToken` (es efimero, 5 min).
 **SIEMPRE** `name: 'portfolio-dashboard-auth'` + `storage: createJSONStorage(() => localStorage)`.
+
+**Bootstrap al cargar la app**: el `accessToken` arranca en `null` (no persistido).
+`useAuthTimer` detecta `refreshToken + refreshExpiry > now` y dispara
+`/session/refresh` automaticamente para hidratar el `accessToken` en memoria.
+Si el refresh esta expirado, `reset()` + redirect a `/login`.
 
 **Tests** (`tests/unit/features/auth/store/use-auth-store.test.ts`):
 
-- `setTokens` actualiza access + refresh + user
+- `setTokens` actualiza access (memoria) + refresh + refreshExpiry + user
 - `isAuthenticated()` retorna false sin token
 - `isAccessExpired()` retorna true con JWT expirado (mock con `exp` pasado)
 - `clearTokens()` y `reset()` limpian estado y localStorage
-- `partialize` excluye `tempToken` (verificar localStorage no contiene tempToken)
-- Persistencia: setTokens -> reload pagina simulada -> tokens restaurados
+- `partialize` excluye `accessToken` y `tempToken` (assert exacto: `JSON.parse(localStorage.getItem('portfolio-dashboard-auth')).state` solo contiene `refreshToken`, `refreshExpiry`, `user`)
+- Persistencia: setTokens -> reload simulado (re-crear store) -> `accessToken === null`, `refreshToken` y `user` restaurados
 
 ### `src/features/auth/lib/refresh-mutex.ts`
 
@@ -266,15 +274,26 @@ import {setupWorker} from 'msw/browser'
 export const worker = setupWorker(...)
 ```
 
-Init en dev opcional via `NEXT_PUBLIC_USE_MSW=true`:
+Init en dev opcional via `NEXT_PUBLIC_USE_MSW=true`. El alias `@/`
+apunta a `./src/*` y la carpeta `tests/` esta FUERA de `src/` — usar
+import relativo (`../../tests/...`) o agregar un segundo alias dedicado.
+Recomendado: agregar `"@tests/*": ["../tests/*"]` a `tsconfig.json#paths`
+y al `vitest.config.ts#resolve.alias` para que el import compile en build
+y en tests:
 
 ```typescript
-// src/app/layout.tsx (en useEffect del provider)
+// src/app/layout.tsx (en un Client Component wrapper con useEffect)
 if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_USE_MSW === 'true') {
-  const {worker} = await import('@/tests/mocks/browser')
+  const {worker} = await import('@tests/mocks/browser')
   await worker.start({onUnhandledRequest: 'bypass'})
 }
 ```
+
+Si NO se quiere agregar el alias, usar el path relativo explicito desde
+el archivo que importa (ej. `../../tests/mocks/browser` desde
+`src/app/layout.tsx`). NUNCA usar `@/tests/...` porque `@/` se resuelve
+a `src/tests/` que no existe — el build de Next + el typecheck fallan
+con `Module not found`.
 
 Tambien: `npx msw init public/` para generar `mockServiceWorker.js`.
 

--- a/docs/specs/dashboard/06-auth-feature.md
+++ b/docs/specs/dashboard/06-auth-feature.md
@@ -9,23 +9,27 @@ el inventario ejecutable.
 
 ### `src/features/auth/store/use-auth-store.ts`
 
-Zustand store con campos:
-- `accessToken: string | null` (in-memory ONLY, no persist)
-- `tempToken: string | null` (in-memory)
-- `refreshExpiry: number | null` (epoch ms, persist)
-- `user: User | null` (persist via `partialize`)
-- Actions: `setAccessToken`, `setTempToken`, `setUser`,
-  `setRefreshExpiry`, `reset`
+Zustand 5 store con `persist` middleware a `localStorage`. Campos:
+
+- `accessToken: string | null` (persist en localStorage)
+- `refreshToken: string | null` (persist en localStorage)
+- `tempToken: string | null` (in-memory, NO persist — flujo corto register/login)
+- `user: User | null` (persist en localStorage)
+- Actions: `setTokens(access, refresh, user)`, `setTempToken`,
+  `setAccessToken`, `clearTokens`, `reset`
 - Derived: `isAuthenticated()`, `isAccessExpired()`
 
-**SIEMPRE** `partialize: (state) => ({user: state.user, refreshExpiry: state.refreshExpiry})`. NUNCA persist `accessToken` ni `tempToken`.
+**SIEMPRE** `partialize: (state) => ({accessToken, refreshToken, user})`. NUNCA persist `tempToken` (es efimero, 5 min).
+**SIEMPRE** `name: 'portfolio-dashboard-auth'` + `storage: createJSONStorage(() => localStorage)`.
 
 **Tests** (`tests/unit/features/auth/store/use-auth-store.test.ts`):
-- `setAccessToken` actualiza el estado
+
+- `setTokens` actualiza access + refresh + user
 - `isAuthenticated()` retorna false sin token
 - `isAccessExpired()` retorna true con JWT expirado (mock con `exp` pasado)
-- `reset()` limpia todo
-- `partialize` excluye accessToken (verificar localStorage)
+- `clearTokens()` y `reset()` limpian estado y localStorage
+- `partialize` excluye `tempToken` (verificar localStorage no contiene tempToken)
+- Persistencia: setTokens -> reload pagina simulada -> tokens restaurados
 
 ### `src/features/auth/lib/refresh-mutex.ts`
 

--- a/docs/specs/dashboard/06-auth-feature.md
+++ b/docs/specs/dashboard/06-auth-feature.md
@@ -1,0 +1,308 @@
+# 06 — Feature `auth` + pages `(auth)/`
+
+[< 05-ui-components](05-ui-components.md) | [Siguiente: 07-dashboard-features >](07-dashboard-features.md)
+
+## Fase 7 — Feature `auth/` completa
+
+Codigo concreto en `.claude/docs/dashboard/04-auth.md` (KT). Aqui solo
+el inventario ejecutable.
+
+### `src/features/auth/store/use-auth-store.ts`
+
+Zustand store con campos:
+- `accessToken: string | null` (in-memory ONLY, no persist)
+- `tempToken: string | null` (in-memory)
+- `refreshExpiry: number | null` (epoch ms, persist)
+- `user: User | null` (persist via `partialize`)
+- Actions: `setAccessToken`, `setTempToken`, `setUser`,
+  `setRefreshExpiry`, `reset`
+- Derived: `isAuthenticated()`, `isAccessExpired()`
+
+**SIEMPRE** `partialize: (state) => ({user: state.user, refreshExpiry: state.refreshExpiry})`. NUNCA persist `accessToken` ni `tempToken`.
+
+**Tests** (`tests/unit/features/auth/store/use-auth-store.test.ts`):
+- `setAccessToken` actualiza el estado
+- `isAuthenticated()` retorna false sin token
+- `isAccessExpired()` retorna true con JWT expirado (mock con `exp` pasado)
+- `reset()` limpia todo
+- `partialize` excluye accessToken (verificar localStorage)
+
+### `src/features/auth/lib/refresh-mutex.ts`
+
+Singleton in-flight Promise pattern. Ver codigo en KT.
+
+**Tests** (`tests/unit/features/auth/lib/refresh-mutex.test.ts`):
+- Single call: ejecuta `refreshFn` 1 vez
+- 5 calls concurrent: ejecuta `refreshFn` 1 vez (assert exacto)
+- Tras finalizar, `inFlight` vuelve a null
+- Si `refreshFn` throws, `inFlight` se limpia
+
+### `src/features/auth/lib/broadcast.ts`
+
+```typescript
+export function broadcastAuth(message: {type: 'LOGOUT' | 'TOKEN_REFRESH'; token?: string}): void
+```
+
+Guard `typeof BroadcastChannel === 'undefined'` para SSR/build safety.
+
+### `src/features/auth/lib/token-expiry.ts`
+
+```typescript
+export function getJwtExpiry(token: string): number | null  // epoch ms
+export function isJwtExpired(token: string): boolean
+```
+
+### `src/features/auth/api/auth-client.ts`
+
+10 endpoints typed (registerStart, registerVerifyCode, loginStart,
+loginVerifyCode, loginVerifyTotp, setPassword, resendCode,
+sessionRefresh, sessionLogout, + plan 02: mfa*, webauthn*).
+
+`sessionRefresh` siempre con `skipRefresh: true` (evitar recursion en
+mutex).
+
+### `src/features/auth/api/query-keys.ts`
+
+```typescript
+export const authKeys = {
+  all: ['auth'] as const,
+  user: () => [...authKeys.all, 'user'] as const,
+  methods: (email: string) => [...authKeys.all, 'methods', email] as const,
+}
+```
+
+### Hooks (`src/features/auth/hooks/`)
+
+| Hook | Tipo | Funcion |
+|------|------|---------|
+| `useRegisterStart` | `useMutation` | POST register.start, setTempToken, redirect `/verify?flow=register` |
+| `useRegisterVerifyCode` | `useMutation` | POST register.verify-code, setAccessToken + setUser, redirect `/dashboard` |
+| `useLoginStart` | `useMutation` | POST login.start (con email + Turnstile), maneja 404 (suggest_register) y 200 (methods) |
+| `useLoginVerifyCode` | `useMutation` | POST login.verify-code, setAccessToken + setUser, redirect |
+| `useLoginVerifyTotp` | `useMutation` | (plan 02) POST login.verify-totp |
+| `useSetPassword` | `useMutation` | POST verify.set-password |
+| `useResendCode` | `useMutation` | POST verify.resend-code |
+| `useSessionRefresh` | `useMutation` | POST session.refresh (mayoria de tiempo manejado por useAuthTimer) |
+| `useLogout` | `useMutation` | POST session.logout, reset store, broadcastAuth LOGOUT, queryClient.clear, redirect `/login` |
+| `useAuthTimer` | `useEffect` hook | Auto-refresh proactivo basado en `exp` del access. + Page Visibility re-check |
+| `useMultiTabSync` | `useEffect` hook | BroadcastChannel listener → reset al recibir LOGOUT |
+
+**Tests**: cada hook tiene su test mirror. Critico:
+- `useLogout`: verifica reset + broadcast + queryClient.clear + redirect.
+- `useAuthTimer`: usar `vi.useFakeTimers()` + `vi.advanceTimersByTime` para testear el setTimeout.
+- `useMultiTabSync`: mock BroadcastChannel manual + simular postMessage.
+
+### Components (`src/features/auth/components/`)
+
+| Componente | Funcion | AC |
+|-----------|---------|-----|
+| `LoginForm` | email + (opcional plan 02) password + TurnstileWidget. Submit dispara `useLoginStart`. Maneja 404 (Alert con boton "Registrate"), 200 (redirect /verify), 401 (Alert error) | AC-8, AC-9 |
+| `RegisterForm` | email + TurnstileWidget. Submit dispara `useRegisterStart`. Maneja 409 (Alert) | AC-9, AC-10 |
+| `VerifyCodeInput` | shadcn InputOTP 8 chars (alfabeto Crockford: A-HJ-NP-Z2-9). Submit dispara `useRegisterVerifyCode` o `useLoginVerifyCode` segun `?flow=` query param | AC-11 |
+| `MagicLinkPrompt` | Estatico: "Te enviamos un email con un link, click ahi para continuar" + Button "Reenviar email" → `useResendCode` | — |
+| `SetPasswordForm` | password + confirmPassword con Zod refine | — |
+| `TotpSetup` | (plan 02) Renderiza `qr_code_svg` del response + InputOTP de 6 digitos | AC-26 |
+| `RecoveryCodesModal` | (plan 02) Lista 10 codes + buttons Download/Copy | — |
+| `WebAuthnRegisterButton` | (plan 02) `@simplewebauthn/browser` + `startRegistration` | — |
+| `AuthGuard` | Hook `isAuthenticated()`. Si false, redirect a `/login?next=<path>`. Si true, render children. Hooks: useAuthTimer + useMultiTabSync | AC-19, AC-20 |
+| `TurnstileWidget` | Wrapper `@marsidev/react-turnstile` con sitekey de `env.NEXT_PUBLIC_TURNSTILE_SITEKEY` | — |
+
+**Tests**: cada componente con BDD-style. Critico:
+- `LoginForm`: simular submit con email invalido (Zod error), valido (mutation call), email no existente (Alert + redirect button).
+- `AuthGuard`: simular sesion sin token → redirect. Con token → renderiza children.
+- `MagicLinkPrompt`: clickear "Reenviar" llama mutation correcto.
+
+**Commit**: `feat(dashboard,auth): store Zustand + mutex refresh + hooks (login/register/verify/logout) + AuthGuard + Turnstile + tests`
+
+## Fase 8 — Pages `(auth)/`
+
+### `src/app/(auth)/login/page.tsx`
+
+```tsx
+'use client'
+
+import {LoginForm} from '@/features/auth/components/login-form'
+import Link from 'next/link'
+
+export default function LoginPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-6">
+      <div className="w-full max-w-sm space-y-6">
+        <h1 className="text-2xl font-bold">Iniciar sesion</h1>
+        <LoginForm />
+        <p className="text-center text-sm text-muted-foreground">
+          No tenes cuenta? <Link href="/register" className="text-primary hover:underline">Registrate</Link>
+        </p>
+      </div>
+    </div>
+  )
+}
+```
+
+### `src/app/(auth)/register/page.tsx`
+
+Mismo patron con `RegisterForm`.
+
+### `src/app/(auth)/verify/page.tsx`
+
+```tsx
+'use client'
+
+import {useSearchParams} from 'next/navigation'
+import {Suspense} from 'react'
+import {VerifyCodeInput} from '@/features/auth/components/verify-code-input'
+import {MagicLinkPrompt} from '@/features/auth/components/magic-link-prompt'
+import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs'
+
+function VerifyContent() {
+  const params = useSearchParams()
+  const flow = params.get('flow') as 'register' | 'login'
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-6">
+      <div className="w-full max-w-sm space-y-6">
+        <h1 className="text-2xl font-bold">Verifica tu email</h1>
+        <Tabs defaultValue="code">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="code">Code</TabsTrigger>
+            <TabsTrigger value="magic-link">Magic link</TabsTrigger>
+          </TabsList>
+          <TabsContent value="code">
+            <VerifyCodeInput flow={flow} />
+          </TabsContent>
+          <TabsContent value="magic-link">
+            <MagicLinkPrompt />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  )
+}
+
+export default function VerifyPage() {
+  return (
+    <Suspense fallback={<div>Cargando...</div>}>
+      <VerifyContent />
+    </Suspense>
+  )
+}
+```
+
+> Importante: `useSearchParams()` necesita Suspense boundary en export
+> mode (ver `.claude/docs/dashboard/01-stack.md` limitacion 3).
+
+### `src/app/(auth)/callback/page.tsx`
+
+Ver codigo completo en `.claude/docs/dashboard/04-auth.md`. Resumen:
+
+- Lee `window.location.hash` (fragment), parsea con `URLSearchParams`.
+- Si no hay `access` → redirect `/login` + toast error.
+- Decodea JWT con `jwt-decode` (solo shape, no firma).
+- `setAccessToken`, `setUser`, `setRefreshExpiry`.
+- `history.replaceState(null, '', '/dashboard')` ANTES de navegar.
+- `router.replace('/dashboard')` + toast.success.
+- `useRef(false)` para evitar doble exec en StrictMode dev.
+
+**Cumple**: AC-12, AC-13.
+
+### `src/app/(auth)/set-password/page.tsx`
+
+`SetPasswordForm` que usa `useSetPassword`. Redirect a `/dashboard`
+on success.
+
+**Commit**: `feat(dashboard,auth): pages (auth)/ login/register/verify/callback/set-password`
+
+## Fase 9 — MSW setup + Vitest setup
+
+### `dashboard/tests/setup.ts`
+
+Ver codigo completo en `.claude/docs/dashboard/06-testing.md`.
+Resumen:
+
+- Importa `@testing-library/jest-dom`.
+- Polyfill `BroadcastChannel` (happy-dom no la tiene).
+- `vi.stubEnv` para `NEXT_PUBLIC_*`.
+- `beforeAll`: `server.listen()`.
+- `afterEach`: `cleanup()`, `server.resetHandlers()`, reset Zustand,
+  `localStorage.clear()`.
+- `afterAll`: `server.close()`.
+
+### `dashboard/tests/mocks/handlers/auth.ts`
+
+Mocks de los endpoints `/auth`. Cubrir:
+- `register.start` con email valido + email duplicado
+- `register.verify-code` con code valido + invalido
+- `login.start` con email valido + inexistente (404 + suggest_register)
+- `login.verify-code`
+- `session.refresh`
+- `session.logout` (204)
+
+Helper `makeJwt({sub, email, exp})` para generar JWTs fake.
+
+### `dashboard/tests/mocks/handlers/analytics.ts`
+
+Mocks de `/analytics?operation=...&action=...`. Cubrir las 19 actions
+con responses representativos (fixtures sinteticos).
+
+### `dashboard/tests/mocks/server.ts`
+
+```typescript
+import {setupServer} from 'msw/node'
+import {authHandlers} from './handlers/auth'
+import {analyticsHandlers} from './handlers/analytics'
+
+export const server = setupServer(...authHandlers, ...analyticsHandlers)
+```
+
+### `dashboard/tests/mocks/browser.ts`
+
+```typescript
+import {setupWorker} from 'msw/browser'
+// ...mismos handlers
+export const worker = setupWorker(...)
+```
+
+Init en dev opcional via `NEXT_PUBLIC_USE_MSW=true`:
+
+```typescript
+// src/app/layout.tsx (en useEffect del provider)
+if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_USE_MSW === 'true') {
+  const {worker} = await import('@/tests/mocks/browser')
+  await worker.start({onUnhandledRequest: 'bypass'})
+}
+```
+
+Tambien: `npx msw init public/` para generar `mockServiceWorker.js`.
+
+### `dashboard/tests/utils/render.tsx`
+
+Render wrapper con providers (ThemeProvider + QueryClient test + Toaster).
+Ver codigo en KT.
+
+### Fixtures (`dashboard/tests/fixtures/`)
+
+- `users.ts`: 3 users (active, pending, locked)
+- `sessions.ts`: 50 sessions sinteticas
+- `events.ts`: 200 events
+- `analytics.ts`: overview, timeseries, top-pages, top-niches
+
+**Commit**: `feat(dashboard,tests): MSW handlers (auth + analytics) + Vitest setup + render wrapper + fixtures`
+
+## Verificacion al final de fase 9 (gate intermedio)
+
+```bash
+# Unit tests del auth feature deben pasar
+pnpm --filter @portfolio/dashboard test tests/unit/features/auth
+
+# Coverage del auth >= 80% per-file
+pnpm --filter @portfolio/dashboard test:coverage tests/unit/features/auth
+
+# Build estatico OK
+pnpm --filter @portfolio/dashboard build
+
+# Preview manual: probar login con MSW
+NEXT_PUBLIC_USE_MSW=true pnpm --filter @portfolio/dashboard dev &
+# Abrir http://localhost:3000/login → submit con user@test.com / Turnstile success → verify code 12345678 → redirect /dashboard (que aun no existe, OK)
+```
+
+[< 05-ui-components](05-ui-components.md) | [Siguiente: 07-dashboard-features >](07-dashboard-features.md)

--- a/docs/specs/dashboard/07-dashboard-features.md
+++ b/docs/specs/dashboard/07-dashboard-features.md
@@ -103,6 +103,31 @@ export default function DashboardLayout({children}: {children: ReactNode}) {
 
 **Commit**: `feat(dashboard,shell): Sidebar + Header + MobileSidebar + (dashboard)/layout protegido`
 
+## Fases 11-15 — Nota de seguridad sobre el backend `/analytics`
+
+> **GAP CONOCIDO** — el plan `docs/specs/analytics-dashboard-api/`
+> (Decision 1) declara explicitamente que el Lambda `analytics` NO
+> valida el JWT en su primera entrega: solo aplica rate-limit por IP.
+> El dashboard manda `Authorization: Bearer <accessToken>` en todos
+> los requests a `/analytics` (consistencia con el resto del API y
+> compatibilidad forward cuando el plan agregue auth), pero el backend
+> lo ignora hasta que se mergee la fase posterior del plan analytics.
+>
+> Implicacion: cualquier cliente que conozca el endpoint puede leer la
+> data analitica del portfolio (sessions, visits, geo, devices,
+> events, contacts) sin auth.
+>
+> **Bloqueante para merge a `main`**: si los datos de la feature
+> `contacts/` (Fase 15) incluyen PII real (email del visitante,
+> mensaje), el cutover a prod del dashboard DEBE esperar a que la fase
+> de auth del plan analytics-dashboard-api este mergeada. Mientras
+> tanto, prod queda capada al subset publico-safe (analytics
+> agregadas, no contacts).
+>
+> No requiere cambios en el codigo del dashboard mas alla de mandar el
+> Bearer; cuando el backend habilite la validacion, el flujo ya esta
+> listo y no cambia el contrato cliente.
+
 ## Fase 11 — Feature `analytics/` (7 endpoints)
 
 Hooks (Tanstack Query):
@@ -147,12 +172,18 @@ Pages:
 
 Componentes:
 - `SessionsTable` (DataTable con columnas: session_id, first_seen_at, country, device_type, event_count, action)
-- `SessionDetailDialog` (Dialog con info de session + lista de visits + event_count)
+- `SessionDetailDrawer` (shadcn Sheet lateral right con info de session + lista de visits + event_count; abre desde la fila + URL search param `?session=<id>` para deep-link sin ruta dinamica)
 - `SessionsFilters` (DateRangePicker + country/device Select)
 
 Pages:
-- `src/app/(dashboard)/sessions/page.tsx`: SessionsFilters + SessionsTable
-- `src/app/(dashboard)/sessions/[id]/page.tsx`: client-fetch por `useParams().id` + render detail. NO usa `generateStaticParams` (route dinamica client-side).
+- `src/app/(dashboard)/sessions/page.tsx`: SessionsFilters + SessionsTable + SessionDetailDrawer. El drawer lee `?session=<id>` (via `useSearchParams`, dentro de Suspense boundary). Clickear una fila ejecuta `router.push('/sessions/?session=<id>', {scroll: false})`. Cerrar el drawer hace `router.push('/sessions/')`.
+
+> Decision: NO usar ruta dinamica `sessions/[id]/page.tsx`. Next 16 con
+> `output: 'export'` rechaza rutas dinamicas sin `generateStaticParams()`
+> (build fail fatal). Como las sessions son data-driven (no pre-renderizables
+> a build time), el detalle vive en un drawer lateral con deep-link via
+> query param. Patron consistente con el resto del dashboard (SPA puro,
+> sin rutas dinamicas estaticas).
 
 **Commit**: `feat(dashboard,sessions): hooks list + detail + tabla + dialog detail`
 
@@ -230,9 +261,19 @@ Pages:
 - `src/app/(dashboard)/settings/page.tsx`: Tabs con Profile + Security
 - `src/app/(dashboard)/settings/security/page.tsx`: MfaMethodsList + WebAuthnCredentialsList + RecoveryCodesSection
 
-**Nota**: las acciones MFA (TOTP setup, WebAuthn registration) son del
-plan 02 — si el backend aun no las tiene, MSW provee mocks o
-deshabilitar las pages con feature flag `NEXT_PUBLIC_FEATURE_MFA=false`.
+**Notas**:
+
+- Las acciones MFA (TOTP setup, WebAuthn registration) son del plan 02.
+  Mientras `02-auth-mfa` no este mergeado, MSW provee mocks O el flag
+  `NEXT_PUBLIC_FEATURE_MFA=false` esconde las pages de MFA. El flag esta
+  declarado en el catalogo de `sync_secrets` (commit 23) con valor `false`
+  por env en dev/stage/prod hasta el cutover.
+- WebAuthn requiere `NEXT_PUBLIC_WEBAUTHN_RP_ID` (hostname del dashboard
+  per env: `admin.portfolio.dev.the-full-stack.com`,
+  `admin.portfolio.stage.the-full-stack.com`,
+  `admin.portfolio.the-full-stack.com`). Se pasa a `navigator.credentials.create({publicKey: {rp: {id}}})`.
+  Sin esta var, el browser rechaza el flujo con `SecurityError`. Declarada
+  en el catalogo de `sync_secrets` junto con `NEXT_PUBLIC_FEATURE_MFA`.
 
 **Commit**: `feat(dashboard,settings): profile + change-password + MFA management + recovery codes`
 

--- a/docs/specs/dashboard/07-dashboard-features.md
+++ b/docs/specs/dashboard/07-dashboard-features.md
@@ -1,0 +1,265 @@
+# 07 — Dashboard features (analytics, sessions, events, ...)
+
+[< 06-auth-feature](06-auth-feature.md) | [Siguiente: 08-descomposicion >](08-descomposicion.md)
+
+## Aclaracion
+
+Las fases 10-16 implementan las features del dashboard. Cada feature
+sigue el patron Hybrid Atomic Design: `components/`, `hooks/`, `api/`,
+`store/` (si aplica), `types.ts`, `index.ts`. Tests con coverage >= 80%
+per-file.
+
+## Fase 10 — Feature `dashboard-shell/` + layout protegido
+
+### `src/features/dashboard-shell/components/sidebar.tsx`
+
+Sidebar con links a cada feature. Usa `lucide-react` icons. Mobile via
+shadcn `Sheet`.
+
+```tsx
+'use client'
+
+import Link from 'next/link'
+import {usePathname} from 'next/navigation'
+import {BarChart3, Users, MousePointer, MapPin, Smartphone, GitBranch, MessageSquare, Settings, Home} from 'lucide-react'
+import {cn} from '@/lib/utils'
+
+const navItems = [
+  {href: '/dashboard', label: 'Overview', icon: Home},
+  {href: '/dashboard/analytics', label: 'Analytics', icon: BarChart3},
+  {href: '/dashboard/sessions', label: 'Sessions', icon: Users},
+  {href: '/dashboard/events', label: 'Events', icon: MousePointer},
+  {href: '/dashboard/visits', label: 'Visits', icon: Home},
+  {href: '/dashboard/geo', label: 'Geo', icon: MapPin},
+  {href: '/dashboard/devices', label: 'Devices', icon: Smartphone},
+  {href: '/dashboard/funnel', label: 'Funnel', icon: GitBranch},
+  {href: '/dashboard/contacts', label: 'Contacts', icon: MessageSquare},
+  {href: '/dashboard/settings', label: 'Settings', icon: Settings},
+]
+
+export function Sidebar() {
+  const pathname = usePathname()
+  return (
+    <aside className="hidden h-screen w-60 border-r bg-card lg:flex lg:flex-col">
+      <div className="p-6">
+        <h2 className="font-mono text-sm uppercase tracking-widest text-muted-foreground">Admin</h2>
+      </div>
+      <nav className="flex-1 space-y-1 px-3">
+        {navItems.map(({href, label, icon: Icon}) => (
+          <Link
+            key={href}
+            href={href}
+            className={cn(
+              'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+              pathname === href || (href !== '/dashboard' && pathname.startsWith(href))
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+            )}
+          >
+            <Icon className="h-4 w-4" />
+            {label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  )
+}
+```
+
+### `src/features/dashboard-shell/components/header.tsx`
+
+Header con breadcrumb dinamico + ThemeToggle + UserMenu (dropdown con
+logout).
+
+### `src/features/dashboard-shell/components/mobile-sidebar.tsx`
+
+Sheet de shadcn para mobile (renderiza el mismo `Sidebar` pero dentro
+de un Sheet trigger).
+
+### `src/app/(dashboard)/layout.tsx`
+
+```tsx
+'use client'
+
+import type {ReactNode} from 'react'
+import {AuthGuard} from '@/features/auth/components/auth-guard'
+import {Sidebar} from '@/features/dashboard-shell/components/sidebar'
+import {Header} from '@/features/dashboard-shell/components/header'
+
+export default function DashboardLayout({children}: {children: ReactNode}) {
+  return (
+    <AuthGuard>
+      <div className="flex min-h-screen">
+        <Sidebar />
+        <div className="flex flex-1 flex-col">
+          <Header />
+          <main className="flex-1 overflow-auto p-6">{children}</main>
+        </div>
+      </div>
+    </AuthGuard>
+  )
+}
+```
+
+**Commit**: `feat(dashboard,shell): Sidebar + Header + MobileSidebar + (dashboard)/layout protegido`
+
+## Fase 11 — Feature `analytics/` (7 endpoints)
+
+Hooks (Tanstack Query):
+
+| Hook | Endpoint | Key | staleTime |
+|------|----------|-----|-----------|
+| `useOverviewQuery` | `analytics.overview` | `['analytics', 'overview', range]` | 60_000 |
+| `useTimeseriesQuery` | `analytics.timeseries` | `['analytics', 'timeseries', {range, bucket, niche, event_type}]` | 60_000 |
+| `useTopPagesQuery` | `analytics.top-pages` | `['analytics', 'top-pages', {range, limit, niche}]` | 60_000 |
+| `useTopReferrersQuery` | `analytics.top-referrers` | `['analytics', 'top-referrers', {range, limit}]` | 60_000 |
+| `useTopNichesQuery` | `analytics.top-niches` | `['analytics', 'top-niches', range]` | 60_000 |
+| `useActiveNowQuery` | `analytics.active-now` | `['analytics', 'active-now']` | 10_000 + refetchInterval: 15_000 |
+| `useRetentionQuery` | `analytics.retention` | `['analytics', 'retention', range]` | 60_000 |
+
+Componentes:
+- `OverviewCards` (7 MetricCards) — usa `useOverviewQuery`
+- `TimeseriesChart` (Recharts AreaChart)
+- `TopPagesChart` (BarChart horizontal)
+- `TopReferrersTable` (DataTable)
+- `TopNichesChart` (BarChart)
+- `ActiveNowCard` (live count + last sessions list)
+- `RetentionChart` (BarChart new vs returning)
+- `AnalyticsFilters` (DateRangePicker + niche Select + event_type Select)
+
+Store (Zustand local):
+- `useAnalyticsFiltersStore`: `dateRange: {from, to}`, `niche: string | null`, `eventType: string | null`. Persist en sessionStorage (no localStorage — filtros son ephimeros).
+
+Pages:
+- `src/app/(dashboard)/page.tsx`: solo `OverviewCards`.
+- `src/app/(dashboard)/analytics/page.tsx`: AnalyticsFilters + OverviewCards + TimeseriesChart + grid de Top* + ActiveNow + Retention.
+
+**Tests**: cada hook y componente con BDD-style.
+
+**Commit**: `feat(dashboard,analytics): 7 hooks + componentes (Overview, Timeseries, TopPages, TopReferrers, TopNiches, ActiveNow, Retention) + filters store`
+
+## Fase 12 — Feature `sessions/` (2 endpoints)
+
+| Hook | Endpoint | Key | staleTime |
+|------|----------|-----|-----------|
+| `useSessionsList` | `sessions.list` | `['sessions', 'list', {page, page_size, range, country, device}]` | 30_000 |
+| `useSessionDetail` | `sessions.detail` | `['sessions', 'detail', sessionId]` | 0 (siempre fresh) |
+
+Componentes:
+- `SessionsTable` (DataTable con columnas: session_id, first_seen_at, country, device_type, event_count, action)
+- `SessionDetailDialog` (Dialog con info de session + lista de visits + event_count)
+- `SessionsFilters` (DateRangePicker + country/device Select)
+
+Pages:
+- `src/app/(dashboard)/sessions/page.tsx`: SessionsFilters + SessionsTable
+- `src/app/(dashboard)/sessions/[id]/page.tsx`: client-fetch por `useParams().id` + render detail. NO usa `generateStaticParams` (route dinamica client-side).
+
+**Commit**: `feat(dashboard,sessions): hooks list + detail + tabla + dialog detail`
+
+## Fase 13 — Feature `events/` (3 endpoints)
+
+| Hook | Endpoint | staleTime |
+|------|----------|-----------|
+| `useEventsDistribution` | `events.distribution` | 60_000 |
+| `useEventsList` | `events.list` | 30_000 |
+| `useEventsHeatmap` | `events.heatmap` | 60_000 |
+
+Componentes:
+- `EventsDistributionChart` (Recharts BarChart con event_type + count + share)
+- `EventsListTable` con **Tanstack Virtual** (lista 500+ rows)
+- `EventsHeatmap` (grid 7x24 dia_semana x hora, intensidad por color)
+
+Page: `src/app/(dashboard)/events/page.tsx` (Tabs con 3 vistas)
+
+**Commit**: `feat(dashboard,events): distribution + list virtualizada + heatmap`
+
+## Fase 14 — Features `visits/`, `geo/`, `devices/`, `funnel/`
+
+### `visits/` (2 endpoints)
+- `useVisitsList`, `useVisitsLandingPages`
+- `VisitsListTable`, `LandingPagesChart`
+- Page `visits/page.tsx`
+
+### `geo/` (1 endpoint)
+- `useGeoByCountry`
+- `GeoByCountryChart` (BarChart top 10 countries)
+- Page `geo/page.tsx`
+
+### `devices/` (1 endpoint que devuelve 3 breakdowns)
+- `useDevicesBreakdown`
+- `DevicePieChart`, `BrowserBarChart`, `OsBarChart`
+- Page `devices/page.tsx` con 3 charts side-by-side
+
+### `funnel/` (1 endpoint)
+- `useFunnelConversion`
+- `FunnelChart` (sessions → visits → contacts con conversion rate %)
+- Page `funnel/page.tsx`
+
+**Commit**: `feat(dashboard,visits-geo-devices-funnel): 4 features con 5 endpoints`
+
+## Fase 15 — Feature `contacts/` (3 endpoints + mutation)
+
+| Hook | Tipo | Endpoint |
+|------|------|----------|
+| `useContactsList` | `useQuery` | `contacts.list` |
+| `useContactsByStatus` | `useQuery` | `contacts.by-status` |
+| `useUpdateContactStatus` | `useMutation` | (POST custom action, ej. `contacts.update-status` — depende del backend) |
+
+Componentes:
+- `ContactsTable` (DataTable con columnas: created_at, email, message preview, status badge, action)
+- `ContactsByStatusChart` (BarChart conteo por status)
+- `ContactDetailDialog` (Dialog con full message + metadata)
+- `UpdateStatusButton` (Select con statuses: new → contacted → qualified → converted | rejected. onSelect dispara mutation + invalidates list)
+
+Page: `src/app/(dashboard)/contacts/page.tsx`.
+
+**Tests**: critico el mutation (verifica optimistic update + invalidation).
+
+**Commit**: `feat(dashboard,contacts): list + by-status + detail dialog + mutation update-status`
+
+## Fase 16 — Feature `settings/` (profile + MFA setup)
+
+Componentes:
+- `ProfileForm` (email read-only, display_name editable)
+- `ChangePasswordForm` (current + new + confirm con Zod refine)
+- `MfaMethodsList` (Card por metodo: TOTP, WebAuthn, Email-code. Cada uno con botones Enable/Disable/SetPreferred)
+- `WebAuthnCredentialsList` (lista de credentials registradas con nickname + last_used_at + boton Delete)
+- `RecoveryCodesSection` (boton "Generate" → modal con 10 codes + download/copy)
+
+Pages:
+- `src/app/(dashboard)/settings/page.tsx`: Tabs con Profile + Security
+- `src/app/(dashboard)/settings/security/page.tsx`: MfaMethodsList + WebAuthnCredentialsList + RecoveryCodesSection
+
+**Nota**: las acciones MFA (TOTP setup, WebAuthn registration) son del
+plan 02 — si el backend aun no las tiene, MSW provee mocks o
+deshabilitar las pages con feature flag `NEXT_PUBLIC_FEATURE_MFA=false`.
+
+**Commit**: `feat(dashboard,settings): profile + change-password + MFA management + recovery codes`
+
+## Verificacion al final de fase 16 (gate intermedio)
+
+```bash
+# Tests de TODAS las features
+pnpm --filter @portfolio/dashboard test:coverage
+
+# Build OK
+pnpm --filter @portfolio/dashboard build
+ls dashboard/out/
+
+# Preview con MSW: navegar manualmente
+NEXT_PUBLIC_USE_MSW=true pnpm --filter @portfolio/dashboard dev &
+# Visitar:
+# - http://localhost:3000/login
+# - flow completo login → /dashboard
+# - navegar a /dashboard/analytics
+# - cambiar DateRangePicker
+# - navegar a /dashboard/sessions
+# - clickear una row → ver detail dialog
+# - navegar a /dashboard/events → verificar virtualizacion
+# - logout → /login
+```
+
+Si todo verde, proceder con fases 17-19 (deploy infrastructure) y 20-21
+(E2E + cleanup).
+
+[< 06-auth-feature](06-auth-feature.md) | [Siguiente: 08-descomposicion >](08-descomposicion.md)

--- a/docs/specs/dashboard/08-descomposicion.md
+++ b/docs/specs/dashboard/08-descomposicion.md
@@ -158,7 +158,7 @@ deben completar ANTES de paralelizar.
   - Tests mirror
 - **AC**: AC-15, AC-16, AC-17, AC-18
 - **Depende de**: B.1
-- **Paralelizable con**: C.1, D.1 (analytics primero — feature mas grande)
+- **Paralelizable con**: C.1 — NO con tareas del bloque D (D.1 a D.7 dependen transitivamente de B.2 via la cadena B.2 -> B.3 -> C.2; lanzar una tarea D antes de cerrar B.2 invalida el bloqueo de auth components y rompe el merge a feature/dashboard-frontend)
 - **Verify**: `pnpm test tests/unit/features/auth/hooks`
 - **Done**: 12 hooks + tests verdes
 
@@ -169,7 +169,7 @@ deben completar ANTES de paralelizar.
   - Tests mirror
 - **AC**: AC-8, AC-9, AC-10, AC-11, AC-19, AC-20, AC-26
 - **Depende de**: B.2
-- **Paralelizable con**: C.1, D.* (otras features no auth)
+- **Paralelizable con**: C.1 (dashboard-shell — no toca features/auth/). Tareas D y B.4 esperan a B.3 porque consumen `AuthGuard` y el barrel `features/auth/index.ts`.
 - **Verify**: `pnpm test:coverage tests/unit/features/auth`
 - **Done**: 10 componentes + tests >= 80%
 
@@ -224,8 +224,8 @@ correr en paralelo (limite 5-7 worktrees).
 
 #### D.2 — `sessions/` (fase 12)
 - **Archivos**:
-  - `dashboard/src/features/sessions/**`
-  - `dashboard/src/app/(dashboard)/sessions/{page,[id]/page}.tsx`
+  - `dashboard/src/features/sessions/**` (incluye `SessionDetailDrawer` con deep-link via `?session=<id>`)
+  - `dashboard/src/app/(dashboard)/sessions/page.tsx` (SOLO la list; el detalle vive en drawer lateral. NO se crea ruta dinamica `[id]` — Next 16 con `output: 'export'` la rechaza sin `generateStaticParams()`)
   - Tests mirror
 - **AC**: AC-23
 - **Depende de**: A.8, B.1, C.2
@@ -297,8 +297,8 @@ correr en paralelo (limite 5-7 worktrees).
 - **AC**: AC-30
 - **Depende de**: A.2 (existe el package)
 - **Paralelizable con**: D.* (toca archivos Python, no TS)
-- **Verify**: `python devtools/run.py cloudflare_setup status --env=dev --dry-run`
-- **Done**: dry-run lista el dashboard como 7mo project
+- **Verify**: `python devtools/run.py cloudflare_setup projects --env=dev --dry-run` (la fase `status` NO existe; las fases validas son projects / domains / triggers / all)
+- **Done**: dry-run lista el dashboard como 7mo project con app_type='nextjs' + build_output_dir='out'
 
 #### E.2 — devtools/sync_secrets + docker/env extension (fase 18)
 - **Archivos**:
@@ -363,11 +363,14 @@ A.1 -> A.2 -> A.3 -> A.4 -> A.5 -> A.6 -> A.7 -> A.8
                                           |
               B.4 (auth pages) <----------+
                                           |
-                +-------------------------+--------------+--------+--------+--------+--------+
-                |          |              |              |        |        |        |        |
-              D.1 anal.  D.2 sess.   D.3 events    D.4 v/g    D.5 d/f   D.6 cont   D.7 sett (paralelo, max 5-7 worktrees)
-                |          |              |              |        |        |        |        |
-                +----------+--------------+--------------+--------+--------+--------+--------+
+                +-------------------------+--------------+----------------+
+                |                |                 |                |
+              D.1 anal.   D.2 sess.+events    D.4 visits+geo    D.5 dev+fun
+                |                |                 |                |        D.6 cont +
+                |                |                 |                |        D.7 sett (consolidados, max 5-7 worktrees)
+                +----------------+-----------------+----------------+----+
+                |                                                        |
+                +--------------------------------------------------------+
                                           |
               (mientras tanto en otra worktree: E.1, E.2, E.3 paralelo a D)
                                           |
@@ -378,29 +381,45 @@ A.1 -> A.2 -> A.3 -> A.4 -> A.5 -> A.6 -> A.7 -> A.8
 
 ## Granularidad
 
-Total tareas: ~17 (A.1-A.8, B.1-B.4, C.1-C.2, D.1-D.7, E.1-E.3, F.1-F.2)
+Total tareas: **26** (A.1-A.8 = 8, B.1-B.4 = 4, C.1-C.2 = 2, D.1-D.7 = 7, E.1-E.3 = 3, F.1-F.2 = 2).
 
-Plan Large = 10-20 tareas. Cumple.
+Plan Large = 10-20 tareas. Con 26 tareas el plan esta por encima del
+limite alto, justificado por el scope: scaffold + auth + 7 features
+de data + infra de deploy + E2E. La paralelizacion via worktrees (ver
+seccion 10) consolida D.* en 5-6 worktrees concurrentes (limite
+recomendado por `.claude/rules/plan-format.md` capitulo 1).
 
 ## Lanzar worktrees (ejemplo)
 
 ```bash
-# Desde la rama feature/dashboard-frontend, despues de A.8 + B.2 + C.2:
+# Desde la rama feature/dashboard-frontend, despues de A.8 + B.3 + C.2.
+# CADA worktree usa SU PROPIA branch (-b) — no se puede reutilizar
+# feature/dashboard-frontend porque esa branch ya esta checked out en el
+# worktree principal y git lo rechaza (`fatal: ... is already checked out`).
 
-git worktree add ../portfolio-wt-analytics feature/dashboard-frontend
-git worktree add ../portfolio-wt-sessions feature/dashboard-frontend
-git worktree add ../portfolio-wt-events feature/dashboard-frontend
-git worktree add ../portfolio-wt-contacts feature/dashboard-frontend
+git worktree add -b feature/dashboard-wt-analytics       ../portfolio-wt-analytics       feature/dashboard-frontend
+git worktree add -b feature/dashboard-wt-sessions-events ../portfolio-wt-sessions-events feature/dashboard-frontend
+git worktree add -b feature/dashboard-wt-contacts-settings ../portfolio-wt-contacts-settings feature/dashboard-frontend
+git worktree add -b feature/dashboard-wt-devtools        ../portfolio-wt-devtools        feature/dashboard-frontend
 
-# Cada uno trabaja una D.X distinta. Commits van a feature/dashboard-frontend
-# directamente (worktree es solo otro checkout). Coordinar push para evitar
-# conflictos en archivos compartidos (deberian ser cero por File Exclusivity).
+# Cada worktree commitea a SU branch. Despues del verify del scope, el
+# worktree principal mergea cada branch a feature/dashboard-frontend
+# con merge commit (sin rebase, ver .claude/rules/git-workflow.md):
+#   cd ../portfolio
+#   git checkout feature/dashboard-frontend
+#   git merge --no-ff feature/dashboard-wt-analytics
+#   git push origin feature/dashboard-frontend
+# Despues del merge, eliminar la branch del worktree (local + remoto).
 
-# Al terminar:
+# Al terminar todas las worktrees:
 git worktree remove ../portfolio-wt-analytics
-git worktree remove ../portfolio-wt-sessions
-git worktree remove ../portfolio-wt-events
-git worktree remove ../portfolio-wt-contacts
+git worktree remove ../portfolio-wt-sessions-events
+git worktree remove ../portfolio-wt-contacts-settings
+git worktree remove ../portfolio-wt-devtools
+
+# Limpiar branches mergeadas
+git branch -d feature/dashboard-wt-analytics feature/dashboard-wt-sessions-events feature/dashboard-wt-contacts-settings feature/dashboard-wt-devtools
+git push origin --delete feature/dashboard-wt-analytics feature/dashboard-wt-sessions-events feature/dashboard-wt-contacts-settings feature/dashboard-wt-devtools
 ```
 
 Ver detalle en [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md).

--- a/docs/specs/dashboard/08-descomposicion.md
+++ b/docs/specs/dashboard/08-descomposicion.md
@@ -1,0 +1,418 @@
+# 08 — Descomposicion para paralelizacion
+
+[< 07-dashboard-features](07-dashboard-features.md) | [Siguiente: 09-commits >](09-commits.md)
+
+## Filosofia
+
+Plan **Large** (21 fases, ~250 archivos). Paralelizable con git
+worktrees + subagentes en las fases donde los conjuntos de archivos NO
+colisionan. Fases secuenciales: las que modifican el mismo
+`package.json`, `globals.css`, o configs centrales.
+
+Limite: max 5-7 worktrees concurrentes (recurso de la maquina + cognitive
+overhead).
+
+## Reglas duras (recordatorio)
+
+Cada tarea pasa 3 checks:
+
+1. **File Exclusivity**: el set de archivos modificados/creados NO
+   intersecta con otra tarea concurrente.
+2. **Interface Stability**: las dependencias entre tareas (lo que una
+   exporta y otra consume) estan definidas y estables ANTES de
+   paralelizar.
+3. **Bounded Scope**: cada tarea es atomica, completa, y deja el repo
+   compilando + tests verdes.
+
+## Inventario de tareas
+
+Cada tarea tiene 6 campos:
+- **Archivos**: paths que crea/modifica
+- **AC**: criterios de aceptacion cubiertos
+- **Depende de**: tareas que deben completar antes
+- **Paralelizable con**: tareas que pueden correr al mismo tiempo
+- **Verify**: comando de verificacion al cierre
+- **Done**: criterio observable de completado
+
+### Bloque A — Base secuencial (NO paralelizable)
+
+Estas tareas tocan archivos centrales (package.json, configs root) y
+deben completar ANTES de paralelizar.
+
+#### A.1 — Carpeta del plan
+- **Archivos**: `docs/specs/dashboard/*.md` (12 archivos del plan)
+- **AC**: — (meta-task)
+- **Depende de**: nada
+- **Paralelizable con**: ninguna
+- **Verify**: `ls docs/specs/dashboard/README.md`
+- **Done**: PR feature/dashboard-frontend creado con la carpeta committed
+
+#### A.2 — Scaffold `dashboard/` (fase 1)
+- **Archivos**:
+  - `dashboard/package.json`
+  - `dashboard/next.config.ts`
+  - `dashboard/tsconfig.json`
+  - `dashboard/biome.json`
+  - `dashboard/postcss.config.mjs`
+  - `dashboard/vitest.config.ts`
+  - `dashboard/.gitignore`
+  - `dashboard/README.md`
+  - `pnpm-workspace.yaml` (modify)
+- **AC**: AC-1, AC-2, AC-3
+- **Depende de**: A.1
+- **Paralelizable con**: ninguna (toca workspace root)
+- **Verify**: `pnpm install && pnpm --filter @portfolio/dashboard typecheck && pnpm --filter @portfolio/dashboard lint`
+- **Done**: workspace recoge `@portfolio/dashboard`, lint y typecheck pasan en archivos vacios
+
+#### A.3 — Tokens + theme provider + ThemeToggle (fase 2)
+- **Archivos**:
+  - `dashboard/src/styles/globals.css`
+  - `dashboard/src/providers/theme-provider.tsx`
+  - `dashboard/src/components/ui/theme-toggle.tsx`
+- **AC**: AC-5, AC-6
+- **Depende de**: A.2
+- **Paralelizable con**: ninguna (CSS global)
+- **Verify**: `pnpm --filter @portfolio/dashboard build` (CSS se procesa)
+- **Done**: globals.css compila + theme provider OK
+
+#### A.4 — shadcn init + 24 primitivos (fase 3)
+- **Archivos**:
+  - `dashboard/components.json`
+  - `dashboard/src/components/ui/{alert,badge,button,calendar,card,chart,checkbox,command,dialog,dropdown-menu,form,input,input-otp,label,popover,select,separator,sheet,skeleton,sonner,switch,table,tabs,tooltip}.tsx`
+  - `dashboard/package.json` (modify, deps de Radix)
+- **AC**: AC-2, AC-3
+- **Depende de**: A.3
+- **Paralelizable con**: ninguna (toca package.json)
+- **Verify**: `pnpm --filter @portfolio/dashboard lint && pnpm --filter @portfolio/dashboard build`
+- **Done**: 24 primitivos en `src/components/ui/`
+
+#### A.5 — Custom UI primitives (fase 4)
+- **Archivos**:
+  - `dashboard/src/components/ui/{metric-card,data-table,date-range-picker,empty-state,error-alert,loading-spinner}.tsx`
+  - `dashboard/src/components/ui/index.ts`
+  - `dashboard/src/lib/utils.ts`
+  - Tests mirror
+- **AC**: AC-21, AC-23
+- **Depende de**: A.4
+- **Paralelizable con**: ninguna (depende de A.4 + cambia barrel index.ts)
+- **Verify**: `pnpm --filter @portfolio/dashboard test:coverage tests/unit/components/ui`
+- **Done**: 6 custom primitives + barrel + tests verdes (>= 80%)
+
+#### A.6 — Lib base (fase 5)
+- **Archivos**:
+  - `dashboard/src/lib/env.ts`
+  - `dashboard/src/lib/routes.ts`
+  - `dashboard/src/lib/api-client.ts`
+  - `dashboard/src/lib/format/{date,number,duration}.ts`
+  - `dashboard/src/lib/validation/{auth,filters}.ts`
+  - `dashboard/src/types/{api,models,env.d}.ts`
+  - Tests mirror (criticos: api-client.test.ts con mutex)
+- **AC**: AC-14
+- **Depende de**: A.5
+- **Paralelizable con**: ninguna (api-client tocado por mucho codigo downstream)
+- **Verify**: `pnpm --filter @portfolio/dashboard test:coverage tests/unit/lib`
+- **Done**: api-client + env + format + validation + types + tests >= 90%
+
+#### A.7 — Providers + RootLayout (fase 6)
+- **Archivos**:
+  - `dashboard/src/providers/{query-provider,root-providers}.tsx`
+  - `dashboard/src/app/{layout,page,error,global-error,not-found}.tsx`
+- **AC**: AC-4
+- **Depende de**: A.6
+- **Paralelizable con**: ninguna (RootLayout central)
+- **Verify**: `pnpm --filter @portfolio/dashboard build && curl preview /`
+- **Done**: build OK + RootLayout renderiza con providers
+
+#### A.8 — MSW setup + Vitest setup (fase 9, pero base de todos los tests)
+- **Archivos**:
+  - `dashboard/tests/setup.ts`
+  - `dashboard/tests/utils/render.tsx`
+  - `dashboard/tests/mocks/{server,browser}.ts`
+  - `dashboard/tests/mocks/handlers/{auth,analytics,sessions,events,visits,geo,devices,funnel,contacts}.ts`
+  - `dashboard/tests/fixtures/{users,sessions,events,analytics}.ts`
+  - `dashboard/public/mockServiceWorker.js` (via `npx msw init`)
+- **AC**: AC-33 (base infrastructure)
+- **Depende de**: A.7
+- **Paralelizable con**: ninguna (tests/ y mocks son base de todo testing)
+- **Verify**: `pnpm --filter @portfolio/dashboard test` (no archivos aun, pero setup OK)
+- **Done**: setup.ts + mocks + render wrapper + fixtures todos creados
+
+### Bloque B — Auth feature (parcialmente paralelizable con C-shell)
+
+#### B.1 — Auth store + lib + types + api-client (fase 7 parte 1)
+- **Archivos**:
+  - `dashboard/src/features/auth/store/use-auth-store.ts`
+  - `dashboard/src/features/auth/lib/{refresh-mutex,broadcast,token-expiry}.ts`
+  - `dashboard/src/features/auth/api/{auth-client,query-keys}.ts`
+  - `dashboard/src/features/auth/types.ts`
+  - Tests mirror
+- **AC**: AC-14, AC-17, AC-18
+- **Depende de**: A.8
+- **Paralelizable con**: C.1 (dashboard-shell — no toca features/auth)
+- **Verify**: `pnpm test tests/unit/features/auth/{store,lib,api}`
+- **Done**: store + lib + api typed + tests >= 90% (es critico el mutex test)
+
+#### B.2 — Auth hooks (fase 7 parte 2)
+- **Archivos**:
+  - `dashboard/src/features/auth/hooks/use-{register-start,register-verify-code,login-start,login-verify-code,login-verify-totp,set-password,resend-code,session-refresh,logout,auth-timer,multi-tab-sync,protected-route}.ts`
+  - Tests mirror
+- **AC**: AC-15, AC-16, AC-17, AC-18
+- **Depende de**: B.1
+- **Paralelizable con**: C.1, D.1 (analytics primero — feature mas grande)
+- **Verify**: `pnpm test tests/unit/features/auth/hooks`
+- **Done**: 12 hooks + tests verdes
+
+#### B.3 — Auth components (fase 7 parte 3)
+- **Archivos**:
+  - `dashboard/src/features/auth/components/{login-form,register-form,verify-code-input,magic-link-prompt,set-password-form,auth-guard,turnstile-widget,totp-setup,recovery-codes-modal,webauthn-register-button}.tsx`
+  - `dashboard/src/features/auth/index.ts`
+  - Tests mirror
+- **AC**: AC-8, AC-9, AC-10, AC-11, AC-19, AC-20, AC-26
+- **Depende de**: B.2
+- **Paralelizable con**: C.1, D.* (otras features no auth)
+- **Verify**: `pnpm test:coverage tests/unit/features/auth`
+- **Done**: 10 componentes + tests >= 80%
+
+#### B.4 — Auth pages (fase 8)
+- **Archivos**:
+  - `dashboard/src/app/(auth)/{login,register,verify,callback,set-password}/page.tsx`
+- **AC**: AC-12, AC-13
+- **Depende de**: B.3
+- **Paralelizable con**: C.2 (dashboard pages — no overlap)
+- **Verify**: `pnpm build && curl localhost:3000/login`
+- **Done**: 5 pages + build OK
+
+### Bloque C — Dashboard shell (paralelo con B)
+
+#### C.1 — `dashboard-shell` feature (fase 10)
+- **Archivos**:
+  - `dashboard/src/features/dashboard-shell/components/{sidebar,header,mobile-sidebar}.tsx`
+  - `dashboard/src/features/dashboard-shell/lib/nav-items.ts`
+  - `dashboard/src/features/dashboard-shell/index.ts`
+  - Tests mirror
+- **AC**: AC-7
+- **Depende de**: A.7 (no depende de B!) — puede correr en paralelo con B.1
+- **Paralelizable con**: B.* (no toca features/auth)
+- **Verify**: `pnpm test tests/unit/features/dashboard-shell`
+- **Done**: sidebar + header + nav-items + tests
+
+#### C.2 — `(dashboard)/layout.tsx` (fase 10 cierre)
+- **Archivos**:
+  - `dashboard/src/app/(dashboard)/layout.tsx`
+- **AC**: AC-7, AC-19
+- **Depende de**: B.3 (`AuthGuard`) + C.1 (Sidebar + Header)
+- **Paralelizable con**: ninguna (depende de B y C)
+- **Verify**: `pnpm build`
+- **Done**: layout protegido OK
+
+### Bloque D — Features de data (alta paralelizacion)
+
+Cada feature es independiente. Tocan archivos disjuntos
+(`src/features/<X>/*`). Despues de A.* + B.1 + B.2, todas D.* pueden
+correr en paralelo (limite 5-7 worktrees).
+
+#### D.1 — `analytics/` (fase 11) — la mas grande
+- **Archivos**:
+  - `dashboard/src/features/analytics/**` (componentes, hooks, api, store, types, index)
+  - `dashboard/src/app/(dashboard)/{page,analytics/page}.tsx`
+  - Tests mirror
+- **AC**: AC-21, AC-22
+- **Depende de**: A.8, B.1 (auth store para Authorization header), C.2 (layout)
+- **Paralelizable con**: D.2 - D.7
+- **Verify**: `pnpm test:coverage tests/unit/features/analytics && pnpm build`
+- **Done**: 7 hooks + 8 componentes + 2 pages + tests >= 80%
+
+#### D.2 — `sessions/` (fase 12)
+- **Archivos**:
+  - `dashboard/src/features/sessions/**`
+  - `dashboard/src/app/(dashboard)/sessions/{page,[id]/page}.tsx`
+  - Tests mirror
+- **AC**: AC-23
+- **Depende de**: A.8, B.1, C.2
+- **Paralelizable con**: D.1, D.3 - D.7
+- **Verify**: `pnpm test:coverage tests/unit/features/sessions`
+- **Done**: list + detail dialog + tests
+
+#### D.3 — `events/` (fase 13)
+- **Archivos**:
+  - `dashboard/src/features/events/**`
+  - `dashboard/src/app/(dashboard)/events/page.tsx`
+  - Tests mirror (incluye test de virtualization)
+- **AC**: AC-24
+- **Depende de**: A.8, B.1, C.2
+- **Paralelizable con**: D.1, D.2, D.4 - D.7
+- **Verify**: `pnpm test:coverage tests/unit/features/events`
+- **Done**: distribution + list virtual + heatmap + tests
+
+#### D.4 — `visits/` + `geo/` (fase 14a)
+- **Archivos**:
+  - `dashboard/src/features/{visits,geo}/**`
+  - `dashboard/src/app/(dashboard)/{visits,geo}/page.tsx`
+  - Tests mirror
+- **AC**: — (variantes de listado)
+- **Depende de**: A.8, B.1, C.2
+- **Paralelizable con**: D.1, D.2, D.3, D.5 - D.7
+- **Verify**: `pnpm test:coverage tests/unit/features/{visits,geo}`
+- **Done**: 2 features + 2 pages
+
+#### D.5 — `devices/` + `funnel/` (fase 14b)
+- **Archivos**:
+  - `dashboard/src/features/{devices,funnel}/**`
+  - `dashboard/src/app/(dashboard)/{devices,funnel}/page.tsx`
+  - Tests mirror
+- **AC**: —
+- **Depende de**: A.8, B.1, C.2
+- **Paralelizable con**: D.1 - D.4, D.6, D.7
+- **Verify**: `pnpm test:coverage tests/unit/features/{devices,funnel}`
+- **Done**: 2 features + 2 pages
+
+#### D.6 — `contacts/` (fase 15) — incluye mutation
+- **Archivos**:
+  - `dashboard/src/features/contacts/**`
+  - `dashboard/src/app/(dashboard)/contacts/page.tsx`
+  - Tests mirror (critico: test de mutation + invalidation)
+- **AC**: AC-25
+- **Depende de**: A.8, B.1, C.2
+- **Paralelizable con**: D.1 - D.5, D.7
+- **Verify**: `pnpm test:coverage tests/unit/features/contacts`
+- **Done**: list + by-status + detail + mutation + tests
+
+#### D.7 — `settings/` (fase 16)
+- **Archivos**:
+  - `dashboard/src/features/settings/**`
+  - `dashboard/src/app/(dashboard)/settings/{page,security/page}.tsx`
+  - Tests mirror
+- **AC**: AC-26
+- **Depende de**: A.8, B.1, C.2
+- **Paralelizable con**: D.1 - D.6
+- **Verify**: `pnpm test:coverage tests/unit/features/settings`
+- **Done**: profile + MFA management + recovery codes
+
+### Bloque E — Infraestructura de deploy (paralelizable con D parcialmente)
+
+#### E.1 — devtools/cloudflare_setup extension (fase 17)
+- **Archivos**:
+  - `devtools/cloudflare_setup/config.py` (modify: agregar `AppConfig` dashboard)
+  - `devtools/cloudflare_setup/README.md` (mencionar dashboard)
+- **AC**: AC-30
+- **Depende de**: A.2 (existe el package)
+- **Paralelizable con**: D.* (toca archivos Python, no TS)
+- **Verify**: `python devtools/run.py cloudflare_setup status --env=dev --dry-run`
+- **Done**: dry-run lista el dashboard como 7mo project
+
+#### E.2 — devtools/sync_secrets + docker/env extension (fase 18)
+- **Archivos**:
+  - `devtools/sync_secrets/catalog.py` (modify)
+  - `docker/env/client/.example` (modify: agregar NEXT_PUBLIC_*)
+- **AC**: AC-30
+- **Depende de**: A.2
+- **Paralelizable con**: D.*, E.1
+- **Verify**: `python devtools/run.py sync_secrets --env=dev --category=client --dry-run`
+- **Done**: dry-run muestra las 4 keys nuevas
+
+#### E.3 — GH Actions workflows extension (fase 19)
+- **Archivos**:
+  - `.github/workflows/deploy-apps.yml` (modify: matrix include dashboard + env vars NEXT_PUBLIC_*)
+  - `.github/workflows/ci.yml` (modify: filter incluye dashboard)
+  - `.claude/docs/subdomain-standard/02-naming-rules.md` (modify: agregar `admin` a reserved)
+- **AC**: AC-30, AC-31
+- **Depende de**: E.1, E.2
+- **Paralelizable con**: D.* (yaml + md, no codigo)
+- **Verify**: `act -W .github/workflows/ci.yml` (con skill github-actions)
+- **Done**: workflows YAML validos + ci local pasa
+
+### Bloque F — E2E + cierre (secuencial al final)
+
+#### F.1 — Playwright E2E specs (fase 20)
+- **Archivos**:
+  - `tests/feature/dashboard/01-login-magic-link.spec.ts`
+  - `tests/feature/dashboard/02-register-verify-code.spec.ts`
+  - `tests/feature/dashboard/03-callback-fragment-hash.spec.ts`
+  - `tests/feature/dashboard/04-auth-guard-redirect.spec.ts`
+  - `tests/feature/dashboard/05-logout-multi-tab.spec.ts`
+  - `tests/feature/dashboard/06-analytics-navigation.spec.ts`
+  - `tests/feature/dashboard/07-sessions-table-pagination.spec.ts`
+- **AC**: AC-32
+- **Depende de**: TODAS las B, C, D
+- **Paralelizable con**: ninguna (necesita el stack completo)
+- **Verify**: `python devtools/run.py docker up --env=local && python devtools/run.py test_runner --module=feature --type=feature --env=local`
+- **Done**: 7 specs E2E verdes
+
+#### F.2 — Verificacion E2E iterativa (fase 21) — la ultima
+- **Archivos**: ninguno nuevo. Es la fase de verify-before-done + limpieza de `docs/specs/dashboard/`.
+- **AC**: AC-32, AC-33 + TODOS los AC del plan
+- **Depende de**: F.1 + TODAS
+- **Paralelizable con**: ninguna
+- **Verify**: bateria completa de la seccion 11
+- **Done**: bateria verde + `git rm -r docs/specs/dashboard/` committed
+
+## Diagrama de paralelizacion
+
+```text
+A.1 -> A.2 -> A.3 -> A.4 -> A.5 -> A.6 -> A.7 -> A.8
+                                            |
+                +---------------------------+----+
+                |                                |
+              B.1 (auth store/lib/api)        C.1 (dashboard-shell)
+                |                                |
+              B.2 (auth hooks)                   |
+                |                                |
+              B.3 (auth components) -----+      |
+                                          v      |
+                                    C.2 (layout)<+
+                                          |
+              B.4 (auth pages) <----------+
+                                          |
+                +-------------------------+--------------+--------+--------+--------+--------+
+                |          |              |              |        |        |        |        |
+              D.1 anal.  D.2 sess.   D.3 events    D.4 v/g    D.5 d/f   D.6 cont   D.7 sett (paralelo, max 5-7 worktrees)
+                |          |              |              |        |        |        |        |
+                +----------+--------------+--------------+--------+--------+--------+--------+
+                                          |
+              (mientras tanto en otra worktree: E.1, E.2, E.3 paralelo a D)
+                                          |
+                                       F.1 (E2E Playwright) — necesita TODAS
+                                          |
+                                       F.2 (verificacion + limpieza) — gate del PR
+```
+
+## Granularidad
+
+Total tareas: ~17 (A.1-A.8, B.1-B.4, C.1-C.2, D.1-D.7, E.1-E.3, F.1-F.2)
+
+Plan Large = 10-20 tareas. Cumple.
+
+## Lanzar worktrees (ejemplo)
+
+```bash
+# Desde la rama feature/dashboard-frontend, despues de A.8 + B.2 + C.2:
+
+git worktree add ../portfolio-wt-analytics feature/dashboard-frontend
+git worktree add ../portfolio-wt-sessions feature/dashboard-frontend
+git worktree add ../portfolio-wt-events feature/dashboard-frontend
+git worktree add ../portfolio-wt-contacts feature/dashboard-frontend
+
+# Cada uno trabaja una D.X distinta. Commits van a feature/dashboard-frontend
+# directamente (worktree es solo otro checkout). Coordinar push para evitar
+# conflictos en archivos compartidos (deberian ser cero por File Exclusivity).
+
+# Al terminar:
+git worktree remove ../portfolio-wt-analytics
+git worktree remove ../portfolio-wt-sessions
+git worktree remove ../portfolio-wt-events
+git worktree remove ../portfolio-wt-contacts
+```
+
+Ver detalle en [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md).
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Paralelizar A.* | Tocan archivos centrales (package.json, configs) | Secuencial |
+| Paralelizar D.1 con D.2 sin completar B.1 antes | Auth store no existe, falla import | Esperar B.1 |
+| Paralelizar mas de 7 worktrees | Cognitive overhead + memoria de la maquina | Max 5-7 |
+| Crear commit en una worktree sin re-run de tests | Romper otra worktree | Verify antes de commit |
+| F.1 antes de TODAS las D.* | Specs E2E necesitan stack completo | Esperar |
+
+[< 07-dashboard-features](07-dashboard-features.md) | [Siguiente: 09-commits >](09-commits.md)

--- a/docs/specs/dashboard/09-commits.md
+++ b/docs/specs/dashboard/09-commits.md
@@ -18,7 +18,7 @@
 ```text
 docs(specs): agrega plan dashboard SPA admin.portfolio
 
-- Plan Large (~21 fases) para construir el dashboard admin SPA en Next.js 16 + React 18 + shadcn/ui + Tanstack Query + Zustand, deployado a Cloudflare Pages en admin.portfolio.{dev|stage|prod}.the-full-stack.com
+- Plan Large (~21 fases) para construir el dashboard admin SPA en Next.js 16.2.6 + React 19.2.6 (compiler stable) + shadcn/ui + Tanstack Query v5 + Zustand 5 con persist en localStorage, deployado a Cloudflare Pages en admin.portfolio.{dev|stage|prod}.the-full-stack.com
 - Carpeta docs/specs/dashboard/ con README + 11 secciones (contexto, diagramas, estructura, setup-base, ui, auth, dashboard-features, descomposicion, commits, worktrees, verificacion-e2e)
 - Scope: SOLO frontend. APIs auth (planes 01-02) y analytics (analytics-dashboard-api) se asumen existentes; MSW provee mocks hasta deploy
 - 33 criterios de aceptacion numerados, todos referenciados por tests
@@ -45,8 +45,8 @@ docs(dashboard): agrega skill /dashboard-stack + rule + knowledge tree
 feat(dashboard): scaffold inicial Next.js 16 SPA en carpeta dashboard/
 
 - Agrega dashboard/ a pnpm-workspace.yaml como @portfolio/dashboard
-- package.json con engines node>=24, scripts dev/build/lint/typecheck/test, deps Next 16 + React 18.3 + Tanstack v5 + shadcn + Zustand + sonner + lucide
-- next.config.ts con output: 'export', images.unoptimized, trailingSlash, poweredByHeader: false
+- package.json con engines node>=24, scripts dev/build/lint/typecheck/test, deps Next 16.2.6 + React 19.2.6 + react-is@19.2.6 (override Recharts) + Tanstack Query v5.52.3 + Tanstack Table v8.20.5 + shadcn + Zustand 5.0.14 + sonner 1.7.2 + lucide 0.416.0
+- next.config.ts con output: 'export', images.unoptimized, trailingSlash, poweredByHeader: false, reactCompiler: true
 - tsconfig.json strict + noUncheckedIndexedAccess + paths @/* -> ./src/*
 - biome.json extends del root con override en src/components/ui/** (shadcn primitives no respetan reglas strict)
 - postcss.config.mjs (@tailwindcss/postcss), vitest.config.ts (happy-dom + coverage)

--- a/docs/specs/dashboard/09-commits.md
+++ b/docs/specs/dashboard/09-commits.md
@@ -158,7 +158,7 @@ feat(dashboard,tests): MSW handlers (auth + analytics) + Vitest setup + render w
 ```text
 feat(dashboard,auth): Zustand store + refresh mutex + broadcast + auth-client typed
 
-- src/features/auth/store/use-auth-store.ts con persist partialize (solo user + refreshExpiry, NUNCA accessToken)
+- src/features/auth/store/use-auth-store.ts con persist partialize (solo refreshToken + refreshExpiry + user; NUNCA accessToken ni tempToken — rotan/expiran y dejarian estado stale tras reload). Bootstrap: `useAuthTimer` hidrata accessToken en memoria via /session/refresh al detectar refreshToken + refreshExpiry > now
 - src/features/auth/lib/refresh-mutex.ts singleton in-flight Promise
 - src/features/auth/lib/broadcast.ts BroadcastChannel helpers (LOGOUT, TOKEN_REFRESH) con guard SSR
 - src/features/auth/lib/token-expiry.ts (getJwtExpiry, isJwtExpired)
@@ -218,7 +218,20 @@ feat(dashboard,auth): pages (auth)/ login/register/verify/callback/set-password
 - Cumple AC-12, AC-13
 ```
 
-**Verify**: `pnpm --filter @portfolio/dashboard build && curl preview /login` (200)
+**Verify**:
+
+```bash
+pnpm --filter @portfolio/dashboard build
+pnpm --filter @portfolio/dashboard preview &
+PREVIEW_PID=$!
+sleep 3
+curl -sI http://localhost:3000/login/ | head -1 | grep -q "200" || echo "FAIL /login"
+curl -sI http://localhost:3000/register/ | head -1 | grep -q "200" || echo "FAIL /register"
+curl -sI http://localhost:3000/verify/ | head -1 | grep -q "200" || echo "FAIL /verify"
+curl -sI http://localhost:3000/callback/ | head -1 | grep -q "200" || echo "FAIL /callback"
+curl -sI http://localhost:3000/set-password/ | head -1 | grep -q "200" || echo "FAIL /set-password"
+kill $PREVIEW_PID
+```
 
 ### 14. Dashboard shell + layout protegido (fase 10)
 
@@ -233,7 +246,24 @@ feat(dashboard,shell): Sidebar + Header + MobileSidebar + (dashboard)/layout con
 - Cumple AC-7, AC-19, AC-20
 ```
 
-**Verify**: navegar entre pages mantiene sidebar (no remontaje)
+**Verify**:
+
+```bash
+pnpm --filter @portfolio/dashboard test tests/unit/features/dashboard-shell
+pnpm --filter @portfolio/dashboard build
+pnpm --filter @portfolio/dashboard preview &
+PREVIEW_PID=$!
+sleep 3
+# El (dashboard)/layout esta protegido por AuthGuard. Sin token, redirige a /login.
+# Verificar que la layout renderiza (sirve HTML del SPA, JS aplica el guard en el cliente):
+curl -sI http://localhost:3000/dashboard/ | head -1 | grep -q "200" || echo "FAIL /dashboard"
+curl -sI http://localhost:3000/dashboard/analytics/ | head -1 | grep -q "200" || echo "FAIL /dashboard/analytics"
+# Manual: con MSW activado (NEXT_PUBLIC_USE_MSW=true) y user logueado, navegar entre
+# /dashboard, /dashboard/analytics, /dashboard/sessions y confirmar que Sidebar no remontea
+# (verificar en React DevTools que el componente Sidebar mantiene su instancia, o que el
+# scroll del sidebar persiste entre navegaciones — comportamiento esperado del layout group).
+kill $PREVIEW_PID
+```
 
 ### 15-21. Features data (fases 11-16) — paralelizables
 
@@ -267,15 +297,18 @@ feat(devtools,dashboard): extiende cloudflare_setup para soportar app_type='next
 - Cumple AC-30
 ```
 
-**Verify**: `python devtools/run.py cloudflare_setup status --env=dev --dry-run`
+**Verify**: `python devtools/run.py cloudflare_setup projects --env=dev --dry-run` (la fase `status` NO existe; las fases validas son projects / domains / triggers / all). Aplica el config con `--dry-run` para validar sin tocar el remoto.
 
 ### 23. Devtools sync_secrets + docker/env (fase 18)
 
 ```text
 feat(devtools,dashboard): extiende sync_secrets catalog con NEXT_PUBLIC_*
 
-- devtools/sync_secrets/catalog.py: agrega 4 SecretDefinition (NEXT_PUBLIC_API_ENDPOINT, NEXT_PUBLIC_TURNSTILE_SITEKEY, NEXT_PUBLIC_DASHBOARD_URL, NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS)
-- docker/env/client/.example: agrega placeholders para los 4 nuevos
+- devtools/sync_secrets/catalog.py: agrega 6 SecretDefinition (NEXT_PUBLIC_API_ENDPOINT, NEXT_PUBLIC_TURNSTILE_SITEKEY, NEXT_PUBLIC_DASHBOARD_URL, NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS, NEXT_PUBLIC_FEATURE_MFA, NEXT_PUBLIC_WEBAUTHN_RP_ID)
+- docker/env/client/.example: agrega placeholders para los 6 nuevos
+- Valores por env:
+  - NEXT_PUBLIC_FEATURE_MFA: false en dev/stage/prod hasta que el plan 02-auth-mfa este mergeado; luego flip a true (rotacion puntual via --keys)
+  - NEXT_PUBLIC_WEBAUTHN_RP_ID: admin.portfolio.dev.the-full-stack.com (dev), admin.portfolio.stage.the-full-stack.com (stage), admin.portfolio.the-full-stack.com (prod). Requerido por `navigator.credentials.create({publicKey: {rp: {id}}})` en la Fase 16. Sin este valor el flujo de passkeys falla.
 ```
 
 **Verify**: `python devtools/run.py sync_secrets --env=dev --category=client --dry-run`

--- a/docs/specs/dashboard/09-commits.md
+++ b/docs/specs/dashboard/09-commits.md
@@ -1,0 +1,363 @@
+# 09 — Commits incrementales
+
+[< 08-descomposicion](08-descomposicion.md) | [Siguiente: 10-paralelizacion-worktrees >](10-paralelizacion-worktrees.md)
+
+## Reglas duras
+
+- Cada commit deja el repo verde (lint + typecheck + tests del scope).
+- Conventional Commits en **espanol** (subject + body imperativo).
+- Sin atribucion de IA. Sin emojis.
+- Primer commit: la carpeta del plan. Ultimo commit: verificacion E2E
+  + `git rm -r docs/specs/dashboard/`.
+- PR unico `feature/dashboard-frontend -> dev` con merge commit.
+
+## Secuencia de commits
+
+### 1. Plan committed
+
+```text
+docs(specs): agrega plan dashboard SPA admin.portfolio
+
+- Plan Large (~21 fases) para construir el dashboard admin SPA en Next.js 16 + React 18 + shadcn/ui + Tanstack Query + Zustand, deployado a Cloudflare Pages en admin.portfolio.{dev|stage|prod}.the-full-stack.com
+- Carpeta docs/specs/dashboard/ con README + 11 secciones (contexto, diagramas, estructura, setup-base, ui, auth, dashboard-features, descomposicion, commits, worktrees, verificacion-e2e)
+- Scope: SOLO frontend. APIs auth (planes 01-02) y analytics (analytics-dashboard-api) se asumen existentes; MSW provee mocks hasta deploy
+- 33 criterios de aceptacion numerados, todos referenciados por tests
+```
+
+**Verify**: `ls docs/specs/dashboard/README.md` + revisar paths internos OK
+
+### 2. Skill + rule + knowledge tree
+
+```text
+docs(dashboard): agrega skill /dashboard-stack + rule + knowledge tree
+
+- Skill .claude/skills/dashboard-stack/SKILL.md invocable manualmente, con resumen ejecutivo + comandos canonicos
+- Rule .claude/rules/dashboard.md con reglas SIEMPRE/NUNCA enforced (estructura Hybrid Atomic Design, auth, UI, deploy, env vars, tests)
+- Knowledge tree .claude/docs/dashboard/ con README + 6 capitulos (stack, structure, ui, auth, deploy, testing) totalizando ~3500 lineas
+- Validar invocacion con: claude --permission-mode bypassPermissions --disallowedTools WebSearch WebFetch --strict-mcp-config --mcp-config '{"mcpServers":{}}' --output-format json -p "como armo el dashboard SPA del portfolio"
+```
+
+**Verify**: `claude -p "dashboard structure"` y `claude -p "next.js 16 spa"` invocan la skill
+
+### 3. Scaffold base (fase 1)
+
+```text
+feat(dashboard): scaffold inicial Next.js 16 SPA en carpeta dashboard/
+
+- Agrega dashboard/ a pnpm-workspace.yaml como @portfolio/dashboard
+- package.json con engines node>=24, scripts dev/build/lint/typecheck/test, deps Next 16 + React 18.3 + Tanstack v5 + shadcn + Zustand + sonner + lucide
+- next.config.ts con output: 'export', images.unoptimized, trailingSlash, poweredByHeader: false
+- tsconfig.json strict + noUncheckedIndexedAccess + paths @/* -> ./src/*
+- biome.json extends del root con override en src/components/ui/** (shadcn primitives no respetan reglas strict)
+- postcss.config.mjs (@tailwindcss/postcss), vitest.config.ts (happy-dom + coverage)
+- Cumple AC-1, AC-2, AC-3
+```
+
+**Verify**:
+```bash
+pnpm install
+pnpm --filter @portfolio/dashboard typecheck
+pnpm --filter @portfolio/dashboard lint
+```
+
+### 4. Tokens + theme (fase 2)
+
+```text
+feat(dashboard): tokens CSS dark/light + theme provider con next-themes
+
+- src/styles/globals.css con @import tailwind + @fontsource (Space Grotesk + Space Mono) + tokens HSL para :root (dark) y [data-theme="light"] + @theme inline mapping + @layer base + prefers-reduced-motion
+- src/providers/theme-provider.tsx con next-themes attribute="data-theme" defaultTheme="system" enableSystem disableTransitionOnChange
+- src/components/ui/theme-toggle.tsx con DropdownMenu Sun/Moon/Monitor
+- Tokens reflejan los del DS del monorepo (.claude/rules/design-system.md)
+- Cumple AC-5, AC-6
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard build` (CSS compila)
+
+### 5. shadcn init + primitivos (fase 3)
+
+```text
+feat(dashboard): shadcn init + 24 primitivos UI (Radix + Tailwind v4)
+
+- components.json con style new-york, rsc false (export mode), baseColor zinc, aliases @/components/ui y @/lib/utils
+- Agrega via pnpm dlx shadcn@latest add: alert, badge, button, calendar, card, chart, checkbox, command, dialog, dropdown-menu, form, input, input-otp, label, popover, select, separator, sheet, skeleton, sonner, switch, table, tabs, tooltip
+- Deps Radix instaladas automaticamente por shadcn CLI
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard lint && pnpm --filter @portfolio/dashboard build`
+
+### 6. Custom UI primitives (fase 4)
+
+```text
+feat(dashboard,ui): primitivos custom genericos (MetricCard, DataTable, DateRangePicker, EmptyState)
+
+- src/components/ui/metric-card.tsx con title/value/delta/trend/icon
+- src/components/ui/data-table.tsx wrapper generico de Tanstack Table v8 con sort + paginator
+- src/components/ui/date-range-picker.tsx con Popover + Calendar (range, default last 30d)
+- src/components/ui/empty-state.tsx con icon + title + description + action
+- src/components/ui/error-alert.tsx con shadcn Alert variant=destructive + retry button
+- src/components/ui/loading-spinner.tsx accesible (role=status, aria-label)
+- src/components/ui/index.ts barrel
+- src/lib/utils.ts con cn() de shadcn (clsx + tailwind-merge)
+- Tests unit con coverage >= 80% en cada primitivo
+- Cumple AC-21, AC-23
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard test:coverage tests/unit/components/ui`
+
+### 7. Lib base (fase 5)
+
+```text
+feat(dashboard,lib): env validation + api-client con mutex refresh + types
+
+- src/lib/env.ts con Zod schema valida NEXT_PUBLIC_API_ENDPOINT, NEXT_PUBLIC_TURNSTILE_SITEKEY, NEXT_PUBLIC_DASHBOARD_URL, NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS (fail-fast en build)
+- src/lib/api-client.ts con apiFetch wrapper + ApiError class + auth interceptor + mutex refresh + flags skipAuth/skipRefresh
+- src/lib/routes.ts con constantes ROUTES.dashboard.*, ROUTES.auth.*
+- src/lib/format/{date,number,duration}.ts (formatDate, formatNumber, formatPercent, formatDurationMs)
+- src/lib/validation/{auth,filters}.ts (Zod schemas reusables)
+- src/types/{api,models}.ts (responses tipadas y domain models)
+- Tests unit con coverage >= 90% (critico: test mutex con 5 requests concurrent que solo dispara 1 refresh)
+- Cumple AC-14
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard test:coverage tests/unit/lib`
+
+### 8. Providers + RootLayout (fase 6)
+
+```text
+feat(dashboard,providers): RootLayout con Theme + Query (persister con lz-string)
+
+- src/providers/query-provider.tsx con QueryClient (refetchOnWindowFocus false, retry sin 401/403/422) + PersistQueryClientProvider con lz-string compression + dehydrate filter (no persistir contacts list ni events list)
+- src/providers/root-providers.tsx compone ThemeProvider > QueryProvider
+- src/app/layout.tsx con RootLayout (html lang es, suppressHydrationWarning) + RootProviders + Toaster (sonner top-right richColors) + import @/lib/env (fail-fast) + metadata robots noindex nofollow
+- src/app/{page,error,global-error,not-found}.tsx (home redirect, boundaries, 404)
+- Cumple AC-4
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard build` + preview en localhost:3000
+
+### 9. MSW setup + Vitest setup (fase 9, antes de features para usar en tests)
+
+```text
+feat(dashboard,tests): MSW handlers (auth + analytics) + Vitest setup + render wrapper
+
+- tests/setup.ts: import @testing-library/jest-dom + polyfill BroadcastChannel + vi.stubEnv NEXT_PUBLIC_* + server.listen/resetHandlers/close + reset Zustand entre tests
+- tests/mocks/server.ts (setupServer Node) + tests/mocks/browser.ts (setupWorker browser dev)
+- tests/mocks/handlers/auth.ts: registerStart, verify-code, loginStart, sessionRefresh, logout (con makeJwt helper)
+- tests/mocks/handlers/analytics.ts: overview, timeseries, sessions list, etc.
+- tests/utils/render.tsx wrapper con ThemeProvider + QueryClient de test + Toaster
+- tests/fixtures/{users,sessions,events,analytics}.ts data sintetica
+- public/mockServiceWorker.js generado con npx msw init public/
+- Cumple AC-33 (base infrastructure)
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard test` (setup OK aunque no haya tests aun)
+
+### 10. Auth store + lib + api (fase 7 parte 1)
+
+```text
+feat(dashboard,auth): Zustand store + refresh mutex + broadcast + auth-client typed
+
+- src/features/auth/store/use-auth-store.ts con persist partialize (solo user + refreshExpiry, NUNCA accessToken)
+- src/features/auth/lib/refresh-mutex.ts singleton in-flight Promise
+- src/features/auth/lib/broadcast.ts BroadcastChannel helpers (LOGOUT, TOKEN_REFRESH) con guard SSR
+- src/features/auth/lib/token-expiry.ts (getJwtExpiry, isJwtExpired)
+- src/features/auth/api/auth-client.ts: 10 endpoints typed (register/login/verify/session)
+- src/features/auth/api/query-keys.ts
+- src/features/auth/types.ts (User, AuthResponse, Method, MfaMethod)
+- Tests unit con coverage >= 90% (critico mutex test, store test, broadcast guard test)
+- Cumple AC-14, AC-17, AC-18
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard test:coverage tests/unit/features/auth/{store,lib,api}`
+
+### 11. Auth hooks (fase 7 parte 2)
+
+```text
+feat(dashboard,auth): 12 hooks Tanstack (login/register/verify/logout/refresh/auth-timer/multi-tab-sync)
+
+- src/features/auth/hooks/use-{register-start,register-verify-code,login-start,login-verify-code,login-verify-totp,set-password,resend-code,session-refresh,logout}.ts (useMutation con onSuccess/onError + toast + redirect)
+- src/features/auth/hooks/use-auth-timer.ts auto-refresh proactivo (setTimeout basado en jwt exp + lead ms) + Page Visibility API re-check
+- src/features/auth/hooks/use-multi-tab-sync.ts BroadcastChannel listener (LOGOUT, TOKEN_REFRESH)
+- src/features/auth/hooks/use-protected-route.ts hook alternativo al AuthGuard component
+- Tests unit con fake timers y mock BroadcastChannel
+- Cumple AC-15, AC-16, AC-17, AC-18
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard test tests/unit/features/auth/hooks`
+
+### 12. Auth components (fase 7 parte 3)
+
+```text
+feat(dashboard,auth): 10 componentes (LoginForm, RegisterForm, VerifyCodeInput, AuthGuard, TurnstileWidget, ...)
+
+- src/features/auth/components/{login-form,register-form}.tsx con react-hook-form + Zod + shadcn Form + TurnstileWidget
+- src/features/auth/components/verify-code-input.tsx con shadcn InputOTP 8 chars alfabeto Crockford
+- src/features/auth/components/magic-link-prompt.tsx con button Reenviar (useResendCode)
+- src/features/auth/components/set-password-form.tsx con Zod refine confirmPassword
+- src/features/auth/components/auth-guard.tsx con AuthGuard HOC (redirect /login?next=... si !isAuthenticated)
+- src/features/auth/components/turnstile-widget.tsx wrapper @marsidev/react-turnstile
+- src/features/auth/components/{totp-setup,recovery-codes-modal,webauthn-register-button}.tsx (plan 02, opcional)
+- src/features/auth/index.ts barrel
+- Tests unit con BDD-style + coverage >= 80%
+- Cumple AC-8, AC-9, AC-10, AC-11, AC-19, AC-20, AC-26
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard test:coverage tests/unit/features/auth`
+
+### 13. Auth pages (fase 8)
+
+```text
+feat(dashboard,auth): pages (auth)/ login/register/verify/callback/set-password
+
+- src/app/(auth)/login/page.tsx con LoginForm + link a /register
+- src/app/(auth)/register/page.tsx con RegisterForm + link a /login
+- src/app/(auth)/verify/page.tsx con Suspense + Tabs (code | magic-link) basado en ?flow= param
+- src/app/(auth)/callback/page.tsx CRITICO: decodea window.location.hash (fragment), valida JWT shape, guarda en Zustand, history.replaceState para limpiar URL, redirect /dashboard. useRef guard para StrictMode
+- src/app/(auth)/set-password/page.tsx con SetPasswordForm
+- Cumple AC-12, AC-13
+```
+
+**Verify**: `pnpm --filter @portfolio/dashboard build && curl preview /login` (200)
+
+### 14. Dashboard shell + layout protegido (fase 10)
+
+```text
+feat(dashboard,shell): Sidebar + Header + MobileSidebar + (dashboard)/layout con AuthGuard
+
+- src/features/dashboard-shell/components/sidebar.tsx con lucide icons + nav items (10 destinos) + active state segun pathname
+- src/features/dashboard-shell/components/header.tsx con breadcrumb dinamico + ThemeToggle + UserMenu (dropdown logout)
+- src/features/dashboard-shell/components/mobile-sidebar.tsx con shadcn Sheet
+- src/features/dashboard-shell/lib/nav-items.ts array con {href, label, icon}
+- src/app/(dashboard)/layout.tsx con AuthGuard wrappeando Sidebar + Header + main
+- Cumple AC-7, AC-19, AC-20
+```
+
+**Verify**: navegar entre pages mantiene sidebar (no remontaje)
+
+### 15-21. Features data (fases 11-16) — paralelizables
+
+Commits paralelos en worktrees distintas (D.1 - D.7). Cada uno
+similar:
+
+```text
+feat(dashboard,analytics): 7 hooks + 8 componentes (Overview, Timeseries, TopPages, ...) + filters store + 2 pages
+
+- 7 hooks useQuery con queryKeys estructurados + staleTime adaptado al cache backend (60s agregadas, 10s active-now)
+- 7+ componentes (OverviewCards, TimeseriesChart, TopPagesChart, TopReferrersTable, TopNichesChart, ActiveNowCard, RetentionChart, AnalyticsFilters)
+- Zustand local store useAnalyticsFiltersStore (date_range, niche, eventType) con persist sessionStorage
+- Pages src/app/(dashboard)/page.tsx (overview) + src/app/(dashboard)/analytics/page.tsx (full)
+- Tests unit con coverage >= 80% per-file
+- Cumple AC-21, AC-22
+```
+
+Idem para `sessions`, `events`, `visits/geo`, `devices/funnel`,
+`contacts`, `settings`. **7 commits paralelos en worktrees**.
+
+### 22. Devtools cloudflare_setup extension (fase 17)
+
+```text
+feat(devtools,dashboard): extiende cloudflare_setup para soportar app_type='nextjs'
+
+- devtools/cloudflare_setup/config.py: agrega APP_DASHBOARD (AppConfig con root_dir='dashboard', app_type='nextjs', build_output_dir='out')
+- Funciones output_dir_for() y env_vars_for() respetan app_type
+- custom_domain_for(): admin.portfolio.{env}.the-full-stack.com (prod sin sufijo)
+- env_vars del project Pages incluye NEXT_PUBLIC_* para dashboard
+- devtools/cloudflare_setup/README.md menciona el dashboard como 7mo app
+- Cumple AC-30
+```
+
+**Verify**: `python devtools/run.py cloudflare_setup status --env=dev --dry-run`
+
+### 23. Devtools sync_secrets + docker/env (fase 18)
+
+```text
+feat(devtools,dashboard): extiende sync_secrets catalog con NEXT_PUBLIC_*
+
+- devtools/sync_secrets/catalog.py: agrega 4 SecretDefinition (NEXT_PUBLIC_API_ENDPOINT, NEXT_PUBLIC_TURNSTILE_SITEKEY, NEXT_PUBLIC_DASHBOARD_URL, NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS)
+- docker/env/client/.example: agrega placeholders para los 4 nuevos
+```
+
+**Verify**: `python devtools/run.py sync_secrets --env=dev --category=client --dry-run`
+
+### 24. GH Actions workflows extension (fase 19)
+
+```text
+feat(ci,dashboard): extiende deploy-apps.yml matrix con dashboard + agrega admin a subdomain reserved
+
+- .github/workflows/deploy-apps.yml: matrix include {name: dashboard, dist-dir: dashboard/out, project: dashboard} en deploy-pages + verify-deploy. Job build-apps lee NEXT_PUBLIC_* desde vars + ejecuta workspace-concurrency=7 (6 Astro + 1 Next)
+- .github/workflows/ci.yml: filter incluye @portfolio/dashboard en lint + build
+- .claude/docs/subdomain-standard/02-naming-rules.md: agrega 'admin' a reserved components
+- Cumple AC-30, AC-31
+```
+
+**Verify**: `act -W .github/workflows/ci.yml` (con skill github-actions)
+
+### 25. E2E Playwright (fase 20)
+
+```text
+test(dashboard,e2e): 7 specs Playwright para flujos golden path
+
+- tests/feature/dashboard/01-login-magic-link.spec.ts
+- tests/feature/dashboard/02-register-verify-code.spec.ts
+- tests/feature/dashboard/03-callback-fragment-hash.spec.ts (critico: verifica hash limpio del URL post-decoder)
+- tests/feature/dashboard/04-auth-guard-redirect.spec.ts (verifica next param)
+- tests/feature/dashboard/05-logout-multi-tab.spec.ts (BroadcastChannel)
+- tests/feature/dashboard/06-analytics-navigation.spec.ts
+- tests/feature/dashboard/07-sessions-table-pagination.spec.ts
+- Corren contra stack local con MSW habilitado (NEXT_PUBLIC_USE_MSW=true)
+- Cumple AC-32
+```
+
+**Verify**: `python devtools/run.py docker up --env=local && python devtools/run.py test_runner --module=feature --type=feature --env=local`
+
+### 26. Verificacion E2E iterativa + cleanup (fase 21) — ultimo commit
+
+```text
+chore(dashboard): verificacion E2E completa + elimina docs/specs/dashboard/
+
+- Bateria completa pasa: lint + typecheck + unit + coverage (>= 80%) + build + E2E + smoke deploy a dev
+- Elimina docs/specs/dashboard/ (plan efimero). El conocimiento permanente vive en:
+  - .claude/rules/dashboard.md
+  - .claude/skills/dashboard-stack/SKILL.md
+  - .claude/docs/dashboard/ (7 archivos)
+- Cumple TODOS los AC (1-33)
+```
+
+**Verify**: ver seccion 11.
+
+## Resumen secuencia (sin paralelizacion)
+
+```text
+01. plan committed
+02. skill + rule + KT
+03. scaffold base                  <- secuencial (A.2)
+04. tokens + theme                 <- secuencial (A.3)
+05. shadcn primitivos              <- secuencial (A.4)
+06. custom UI primitives           <- secuencial (A.5)
+07. lib base                       <- secuencial (A.6)
+08. providers + RootLayout         <- secuencial (A.7)
+09. MSW setup                      <- secuencial (A.8)
+10-13. auth (store/lib/api -> hooks -> components -> pages)    <- secuencial (B.*)
+14. dashboard-shell + layout       <- secuencial (C.*)
+15-21. features data (D.1 - D.7)   <- PARALELO (max 5-7 worktrees)
+22. devtools cloudflare_setup      <- paralelo a D.*
+23. devtools sync_secrets          <- paralelo a D.*
+24. GH Actions workflows           <- depende de 22 + 23
+25. E2E Playwright                 <- secuencial (F.1, depende de TODAS)
+26. verificacion + cleanup         <- secuencial (F.2, el ultimo)
+```
+
+26 commits totales. Con paralelizacion via worktrees el wall-clock se
+reduce significativamente en las fases D.*.
+
+## PR
+
+Un solo PR `feature/dashboard-frontend -> dev`. Merge commit
+(`gh pr merge --merge --delete-branch`). Sin atribucion IA en el body.
+
+Despues, promocion `dev -> stage` y `stage -> main` via PRs separados
+con merge commit (sin `--delete-branch` — `dev`/`stage` son
+permanentes).
+
+[< 08-descomposicion](08-descomposicion.md) | [Siguiente: 10-paralelizacion-worktrees >](10-paralelizacion-worktrees.md)

--- a/docs/specs/dashboard/10-paralelizacion-worktrees.md
+++ b/docs/specs/dashboard/10-paralelizacion-worktrees.md
@@ -35,17 +35,17 @@ worktree-safe (file exclusivity garantizada).
 | Worktree | Fase | Archivos exclusivos | Verifica antes de push |
 |----------|------|---------------------|------------------------|
 | `wt-analytics` | D.1 (analytics) | `dashboard/src/features/analytics/**` + `dashboard/src/app/(dashboard)/{page,analytics/page}.tsx` + tests mirror | `pnpm test:coverage tests/unit/features/analytics` |
-| `wt-sessions` | D.2 (sessions) | `dashboard/src/features/sessions/**` + `dashboard/src/app/(dashboard)/sessions/**` + tests | `pnpm test:coverage tests/unit/features/sessions` |
-| `wt-events` | D.3 (events) | `dashboard/src/features/events/**` + `dashboard/src/app/(dashboard)/events/page.tsx` + tests | `pnpm test:coverage tests/unit/features/events` |
+| `wt-sessions-events` | D.2 + D.3 (sessions + events) | `dashboard/src/features/{sessions,events}/**` + `dashboard/src/app/(dashboard)/{sessions,events}/**` + tests | `pnpm test:coverage tests/unit/features/{sessions,events}` |
 | `wt-visits-geo` | D.4 (visits + geo) | `dashboard/src/features/{visits,geo}/**` + `dashboard/src/app/(dashboard)/{visits,geo}/page.tsx` + tests | `pnpm test:coverage tests/unit/features/{visits,geo}` |
 | `wt-devices-funnel` | D.5 (devices + funnel) | `dashboard/src/features/{devices,funnel}/**` + `dashboard/src/app/(dashboard)/{devices,funnel}/page.tsx` + tests | `pnpm test:coverage tests/unit/features/{devices,funnel}` |
-| `wt-contacts` | D.6 (contacts) | `dashboard/src/features/contacts/**` + `dashboard/src/app/(dashboard)/contacts/page.tsx` + tests | `pnpm test:coverage tests/unit/features/contacts` |
-| `wt-settings` | D.7 (settings) | `dashboard/src/features/settings/**` + `dashboard/src/app/(dashboard)/settings/**` + tests | `pnpm test:coverage tests/unit/features/settings` |
+| `wt-contacts-settings` | D.6 + D.7 (contacts + settings) | `dashboard/src/features/{contacts,settings}/**` + `dashboard/src/app/(dashboard)/{contacts,settings}/**` + tests | `pnpm test:coverage tests/unit/features/{contacts,settings}` |
 | `wt-devtools` | E.1 + E.2 | `devtools/cloudflare_setup/config.py` + `devtools/sync_secrets/catalog.py` + `docker/env/client/.example` | `python devtools/run.py {cloudflare_setup,sync_secrets} ... --dry-run` |
 
-Total: 8 worktrees posibles. **Limite recomendado: 5-7 concurrentes**
-(cognitive overhead + memoria de maquina). Si tenes 8GB RAM o menos,
-4-5 concurrent worktrees.
+Total: **6 worktrees** (dentro del limite 5-7 recomendado por
+`.claude/rules/plan-format.md` capitulo 1). Si tenes 8GB RAM o menos,
+limitar a 3-4 concurrentes. Cada worktree consolida features
+cercanas para mantener el conteo bajo el limite (D.2 + D.3 comparten
+patrones de Table/Drawer; D.6 + D.7 son ambas settings/admin).
 
 ## Lo que NO se paraleliza
 
@@ -63,13 +63,18 @@ Total: 8 worktrees posibles. **Limite recomendado: 5-7 concurrentes**
 git status                              # working tree clean
 git pull origin feature/dashboard-frontend  # sync
 
-# Crear worktree (otra carpeta apuntando a la misma branch)
-git worktree add ../portfolio-wt-analytics feature/dashboard-frontend
+# Crear worktree con SU PROPIA branch (clave: el flag -b crea una branch
+# nueva partiendo de feature/dashboard-frontend). NUNCA reutilizar
+# feature/dashboard-frontend como branch del worktree secundario — esa
+# branch ya esta checked out en el worktree principal y git lo rechaza
+# con "fatal: 'feature/dashboard-frontend' is already checked out"
+git worktree add -b feature/dashboard-wt-analytics \
+  ../portfolio-wt-analytics feature/dashboard-frontend
 cd ../portfolio-wt-analytics
 
-# Setup en el worktree
-pnpm install                            # comparte node_modules con el principal via .pnpm-store? NO, cada worktree tiene su node_modules
-# Mejor: para velocidad, usar symlink al pnpm store global
+# Setup en el worktree (cada worktree tiene su node_modules; pnpm store
+# global ya reduce el duplicado via hardlinks)
+pnpm install
 
 # Trabajar D.1 (analytics):
 # ... crear archivos, commits, tests ...
@@ -79,16 +84,23 @@ pnpm --filter @portfolio/dashboard test:coverage tests/unit/features/analytics
 pnpm --filter @portfolio/dashboard typecheck
 pnpm --filter @portfolio/dashboard lint
 
-# Commit
+# Commit en la branch del worktree
 git add dashboard/src/features/analytics dashboard/src/app/\(dashboard\)/page.tsx dashboard/src/app/\(dashboard\)/analytics dashboard/tests/unit/features/analytics
 git commit -m "feat(dashboard,analytics): 7 hooks + 8 componentes ..."
 
-# Push a la misma branch
+# Push de la branch del worktree
+git push -u origin feature/dashboard-wt-analytics
+
+# Integrar a feature/dashboard-frontend desde el worktree principal:
+cd ../portfolio
+git checkout feature/dashboard-frontend
+git merge --no-ff feature/dashboard-wt-analytics  # merge commit, sin rebase
 git push origin feature/dashboard-frontend
 
 # Limpiar al terminar
-cd ../portfolio  # volver al worktree principal
 git worktree remove ../portfolio-wt-analytics
+git branch -d feature/dashboard-wt-analytics       # ya mergeada
+git push origin --delete feature/dashboard-wt-analytics
 ```
 
 ## Coordinacion entre worktrees

--- a/docs/specs/dashboard/10-paralelizacion-worktrees.md
+++ b/docs/specs/dashboard/10-paralelizacion-worktrees.md
@@ -1,0 +1,176 @@
+# 10 — Paralelizacion con git worktrees
+
+[< 09-commits](09-commits.md) | [Siguiente: 11-verificacion-e2e >](11-verificacion-e2e.md)
+
+## Base secuencial obligatoria
+
+Antes de paralelizar, completar y commitear estas tareas (ver
+seccion 08):
+
+```text
+A.1 (plan) -> A.2 (scaffold) -> A.3 (theme) -> A.4 (shadcn) -> A.5 (custom UI) -> A.6 (lib) -> A.7 (providers) -> A.8 (MSW)
+              ↓
+              B.1 (auth store/lib/api)
+              ↓
+              B.2 (auth hooks)
+              ↓
+              B.3 (auth components)
+              ↓
+              C.1 (dashboard-shell) + B.4 (auth pages) en paralelo
+              ↓
+              C.2 ((dashboard)/layout)
+              ↓
+              <<<< CHECKPOINT: aqui empieza la paralelizacion >>>>
+```
+
+Hasta C.2 todo SECUENCIAL (mismo working tree, commit a `feature/dashboard-frontend`).
+Razon: tocan archivos centrales (package.json, configs, globals.css) o
+dependencias duras (auth store que TODAS las features consumen).
+
+## Fases paralelizables (worktree-safe)
+
+Una vez completado el checkpoint, las fases D.1 - D.7 + E.1 + E.2 son
+worktree-safe (file exclusivity garantizada).
+
+| Worktree | Fase | Archivos exclusivos | Verifica antes de push |
+|----------|------|---------------------|------------------------|
+| `wt-analytics` | D.1 (analytics) | `dashboard/src/features/analytics/**` + `dashboard/src/app/(dashboard)/{page,analytics/page}.tsx` + tests mirror | `pnpm test:coverage tests/unit/features/analytics` |
+| `wt-sessions` | D.2 (sessions) | `dashboard/src/features/sessions/**` + `dashboard/src/app/(dashboard)/sessions/**` + tests | `pnpm test:coverage tests/unit/features/sessions` |
+| `wt-events` | D.3 (events) | `dashboard/src/features/events/**` + `dashboard/src/app/(dashboard)/events/page.tsx` + tests | `pnpm test:coverage tests/unit/features/events` |
+| `wt-visits-geo` | D.4 (visits + geo) | `dashboard/src/features/{visits,geo}/**` + `dashboard/src/app/(dashboard)/{visits,geo}/page.tsx` + tests | `pnpm test:coverage tests/unit/features/{visits,geo}` |
+| `wt-devices-funnel` | D.5 (devices + funnel) | `dashboard/src/features/{devices,funnel}/**` + `dashboard/src/app/(dashboard)/{devices,funnel}/page.tsx` + tests | `pnpm test:coverage tests/unit/features/{devices,funnel}` |
+| `wt-contacts` | D.6 (contacts) | `dashboard/src/features/contacts/**` + `dashboard/src/app/(dashboard)/contacts/page.tsx` + tests | `pnpm test:coverage tests/unit/features/contacts` |
+| `wt-settings` | D.7 (settings) | `dashboard/src/features/settings/**` + `dashboard/src/app/(dashboard)/settings/**` + tests | `pnpm test:coverage tests/unit/features/settings` |
+| `wt-devtools` | E.1 + E.2 | `devtools/cloudflare_setup/config.py` + `devtools/sync_secrets/catalog.py` + `docker/env/client/.example` | `python devtools/run.py {cloudflare_setup,sync_secrets} ... --dry-run` |
+
+Total: 8 worktrees posibles. **Limite recomendado: 5-7 concurrentes**
+(cognitive overhead + memoria de maquina). Si tenes 8GB RAM o menos,
+4-5 concurrent worktrees.
+
+## Lo que NO se paraleliza
+
+- A.* (base secuencial) — tocan workspace root.
+- B.1, B.2, B.3, B.4 (auth) — encadenadas.
+- C.1, C.2 (shell) — C.2 depende de B.3.
+- E.3 (workflows) — depende de E.1 + E.2 ya pushados.
+- F.1 (E2E) — necesita TODAS las D.* + B.* + C.* mergeadas a la branch.
+- F.2 (verificacion + cleanup) — la ultima.
+
+## Como lanzar un worktree
+
+```bash
+# Asumiendo cwd = portfolio repo, branch actual = feature/dashboard-frontend
+git status                              # working tree clean
+git pull origin feature/dashboard-frontend  # sync
+
+# Crear worktree (otra carpeta apuntando a la misma branch)
+git worktree add ../portfolio-wt-analytics feature/dashboard-frontend
+cd ../portfolio-wt-analytics
+
+# Setup en el worktree
+pnpm install                            # comparte node_modules con el principal via .pnpm-store? NO, cada worktree tiene su node_modules
+# Mejor: para velocidad, usar symlink al pnpm store global
+
+# Trabajar D.1 (analytics):
+# ... crear archivos, commits, tests ...
+
+# Antes de commit/push: verify del scope
+pnpm --filter @portfolio/dashboard test:coverage tests/unit/features/analytics
+pnpm --filter @portfolio/dashboard typecheck
+pnpm --filter @portfolio/dashboard lint
+
+# Commit
+git add dashboard/src/features/analytics dashboard/src/app/\(dashboard\)/page.tsx dashboard/src/app/\(dashboard\)/analytics dashboard/tests/unit/features/analytics
+git commit -m "feat(dashboard,analytics): 7 hooks + 8 componentes ..."
+
+# Push a la misma branch
+git push origin feature/dashboard-frontend
+
+# Limpiar al terminar
+cd ../portfolio  # volver al worktree principal
+git worktree remove ../portfolio-wt-analytics
+```
+
+## Coordinacion entre worktrees
+
+### Conflictos potenciales (deberian ser CERO si file exclusivity OK)
+
+| Archivo | Worktrees que podrian tocar | Resolucion |
+|---------|------------------------------|-----------|
+| `dashboard/package.json` | Cualquiera que agregue dep | NO debe pasar: deps ya estan en A.2-A.4. Si una D.* necesita una dep nueva, primero rebase a feature/dashboard-frontend, agregar en el worktree principal, push, despues worktrees pull |
+| `dashboard/src/components/ui/index.ts` | Cualquiera que cree un primitivo nuevo | NO debe pasar: D.* NO crea primitivos nuevos. Si si: pedir promote en PR comment, NO hacer en worktree de feature |
+| `dashboard/tests/mocks/handlers/*.ts` | Cada feature actualiza su handler | Si los handlers de `analytics.ts` y `sessions.ts` estan en archivos separados (lo recomendado), no hay conflicto |
+| `pnpm-lock.yaml` | Cualquiera que `pnpm install` | Si se agrega dep: cada worktree corre `pnpm install` despues de pull → el lockfile diff puede generar conflicto. Mitigar: NO agregar deps en worktrees |
+
+### Estrategia de push y pull
+
+1. Cada worktree pull de `feature/dashboard-frontend` al empezar el dia.
+2. Cada worktree push despues de verificar su scope verde.
+3. Antes de push: `git pull --rebase origin feature/dashboard-frontend`
+   para integrar commits de otros worktrees.
+4. Si hay conflicto: resolver localmente (deberia ser raro por file
+   exclusivity), `git rebase --continue`, push.
+5. NO usar `--force` (excepto si vos sos el unico en el worktree y
+   sabes que es seguro).
+
+### Comunicacion entre dev humano y agentes (si usas subagentes)
+
+Si vos sos solo (no subagentes), los worktrees son herramienta de
+organizacion mental. Trabajar 1 worktree a la vez es valido — los
+worktrees solo aceleran si vos paralelizas mentalmente (raro).
+
+Si lanzas subagentes (`/spec-workflow` o agents custom), cada uno
+trabaja en SU worktree, output-en-disco en `docs/progress/<rol>_<scope>.md`
+(ver `.claude/rules/harness-protocol.md`).
+
+## Cuando NO usar worktrees
+
+- Cambio chico (< 5 archivos). Overhead > beneficio.
+- Trabajo serial mental (vos solo, sin paralelizar). El worktree no
+  acelera nada.
+- Si la maquina tiene < 8GB RAM. Cada worktree carga su node_modules.
+
+## Cuando SI usar worktrees
+
+- Trabajo paralelo con subagentes.
+- Vos + un colaborador trabajando en features distintas.
+- Necesitas tener 2 estados del codigo a la vez (ej. comparar
+  features/dashboard-frontend con dev).
+
+## Espacio en disco
+
+Cada worktree = ~500MB-1GB (node_modules + .next). 5 worktrees = ~5GB.
+Tener en cuenta si tu disco es chico.
+
+Tip: usar pnpm store global (ya configurado en el repo) reduce el
+duplicado. `pnpm install` en cada worktree usa hardlinks al store.
+
+## Cleanup al final
+
+```bash
+# Lista los worktrees activos
+git worktree list
+
+# Limpiar cada uno
+git worktree remove ../portfolio-wt-analytics
+git worktree remove ../portfolio-wt-sessions
+# ...
+
+# Verificar que el principal sigue OK
+cd ~/projects/bypabloc/portfolio
+git status
+```
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| Crear worktree antes de A.* completo | Cada worktree falla al instalar | Esperar checkpoint post-C.2 |
+| Editar el mismo archivo en 2 worktrees | Conflict al push | File exclusivity por feature folder |
+| Agregar deps en una D.* worktree | Lockfile conflict | Primero pull al main, agregar, push, worktrees pull |
+| Olvidar `pnpm install` en un worktree nuevo | Lint/typecheck rotos | `pnpm install` al cd al worktree |
+| Push sin verify del scope | Romper la branch para otros worktrees | Verify primero |
+| Tener 10+ worktrees | OOM + cognitive overhead | Max 5-7 |
+| `worktree remove` sin commit + push primero | Perdes trabajo | Commit + push siempre antes |
+
+[< 09-commits](09-commits.md) | [Siguiente: 11-verificacion-e2e >](11-verificacion-e2e.md)

--- a/docs/specs/dashboard/11-verificacion-e2e.md
+++ b/docs/specs/dashboard/11-verificacion-e2e.md
@@ -279,7 +279,7 @@ El PR `feature/dashboard-frontend -> dev` se crea con:
 
 ```bash
 gh pr create --base dev --head feature/dashboard-frontend \
-  --title "feat(dashboard): admin SPA Next.js 16 + React 18 + shadcn + Tanstack" \
+  --title "feat(dashboard): admin SPA Next.js 16.2.6 + React 19.2.6 + shadcn + Tanstack" \
   --body "$(cat <<'EOF'
 ## Problema
 
@@ -289,8 +289,9 @@ solo se accede con psql o consola Neon.
 
 ## Solucion
 
-Dashboard SPA estatico Next.js 16 + React 18 + shadcn/ui + Tanstack
-Query + Zustand, deployado a Cloudflare Pages en
+Dashboard SPA estatico Next.js 16.2.6 + React 19.2.6 (compiler stable) +
+shadcn/ui + Tanstack Query v5 + Zustand 5 (persist en localStorage),
+deployado a Cloudflare Pages en
 admin.portfolio.{dev|stage|prod}.the-full-stack.com.
 
 Estructura Hybrid Atomic Design:

--- a/docs/specs/dashboard/11-verificacion-e2e.md
+++ b/docs/specs/dashboard/11-verificacion-e2e.md
@@ -23,28 +23,31 @@ NO se marca completa con un comando fallando, un test rojo o coverage
 ### A.1 — Verifica que NO hay tests viejos huerfanos
 
 ```bash
-# Listar tests que referencien archivos eliminados o renombrados
-# (en este plan no hay archivos eliminados — todo es nuevo)
-find dashboard/tests -type f -name '*.test.*'
+# Listar tests que referencien archivos eliminados o renombrados.
+# (En este plan no hay archivos eliminados — todo es nuevo.)
+# OJO WSL2: `find` esta aliasado a `fd` y la sintaxis GNU falla silenciosamente.
+# Usar `rg --files` (mejor disponibilidad cross-platform) o `fd` directo.
+rg --files dashboard/tests/ -g '*.test.*'
 ```
 
 ### A.2 — Verifica que TODOS los tests nuevos estan en la ruta correcta
 
 ```bash
-# Mirror: cada src/<X>/<Y>.ts(x) debe tener tests/unit/<X>/<Y>.test.ts(x)
-# Listar fuentes
-find dashboard/src -type f \( -name '*.ts' -o -name '*.tsx' \) \
-  -not -path '*/components/ui/*' \
-  -not -name 'index.ts' \
-  -not -name '*.d.ts' \
-  -not -path '*/app/*' \
-  | sort > /tmp/dashboard-sources.txt
+# Mirror: cada src/<X>/<Y>.ts(x) debe tener tests/unit/<X>/<Y>.test.ts(x).
+# Usamos `rg --files` con globs (-g) en vez de `find` (aliasado a `fd` en WSL2).
+mkdir -p tmp
+rg --files dashboard/src/ \
+  -g '*.ts' -g '*.tsx' \
+  -g '!**/components/ui/**' \
+  -g '!**/app/**' \
+  -g '!**/index.ts' \
+  -g '!**/*.d.ts' \
+  | sort > tmp/dashboard-sources.txt
 
-# Listar tests
-find dashboard/tests/unit -type f -name '*.test.*' | sort > /tmp/dashboard-tests.txt
+rg --files dashboard/tests/unit/ -g '*.test.*' | sort > tmp/dashboard-tests.txt
 
-# Compare: cada source deberia tener test correspondiente
-# (revision manual o con script)
+# Comparar: cada source deberia tener test correspondiente (revision manual
+# con `diff` o script python en tmp/).
 ```
 
 ### A.3 — Barrido global de referencias eliminadas
@@ -67,10 +70,12 @@ rg -l "href=\"/dashboard" dashboard/src/  # debe estar SOLO en src/lib/routes.ts
 ### A.5 — Verifica que `process.env.NEXT_PUBLIC_*` solo se usa en `env.ts`
 
 ```bash
-# Todos los componentes deben importar `env` de @/lib/env (validacion Zod)
-# NUNCA process.env.* directo
-rg "process\.env\." dashboard/src/ --type ts --type tsx
-# Resultado esperado: SOLO src/lib/env.ts y vitest.config.ts (excluido)
+# Todos los componentes deben importar `env` de @/lib/env (validacion Zod).
+# NUNCA process.env.* directo. `tsx` NO es un type built-in de rg —
+# `rg --type ts` ya cubre .ts y .tsx via la definicion built-in `typescript`.
+# Confirmar con: rg --type-list | rg ^typescript
+rg "process\.env\." dashboard/src/ --type ts
+# Resultado esperado: SOLO src/lib/env.ts. vitest.config.ts vive fuera de dashboard/src/.
 ```
 
 ## Parte B — Bateria completa de comandos
@@ -160,18 +165,36 @@ sleep 5
 kill $DEV_PID
 ```
 
-### B.8 — Verify devtools cloudflare_setup dry-run
+### B.8 — Verify devtools cloudflare_setup config
 
 ```bash
-python devtools/run.py cloudflare_setup status --env=dev --dry-run
-# Esperado: lista el project portfolio-dashboard-dev con config correcta
+# El subcomando `status` NO existe en cloudflare_setup. Las fases validas
+# son: projects, domains, triggers, all. Para verificar que el
+# project del dashboard esta declarado correctamente en config.py,
+# re-aplicar la fase projects con --dry-run (idempotente, sin side
+# effects si el config matchea el remoto):
+export CLOUDFLARE_API_TOKEN=$(grep -m1 '^CLOUDFLARE_API_TOKEN=' docker/env/dev-cli/.dev | cut -d= -f2-)
+export ACCOUNT_ID=$(grep -m1 '^CLOUDFLARE_ACCOUNT_ID=' docker/env/dev-cli/.dev | cut -d= -f2-)
+python devtools/run.py cloudflare_setup projects --env=dev --dry-run
+# Esperado: lista los 7 projects (6 Astro + dashboard) con build_config + env_vars
+# diff. Sin --dry-run aplicaria los cambios al remoto.
+
+# Alternativa: leer la config declarada
+python -c "from devtools.cloudflare_setup.config import APPS, app_for; print(app_for('dashboard'))"
+# Esperado: AppConfig(name='dashboard', root_dir='dashboard', app_type='nextjs', build_output_dir='out', ...)
 ```
 
 ### B.9 — Verify devtools sync_secrets dry-run
 
 ```bash
 python devtools/run.py sync_secrets --env=dev --category=client --dry-run
-# Esperado: 4 keys NEXT_PUBLIC_* (DASHBOARD_URL, API_ENDPOINT, TURNSTILE_SITEKEY, AUTH_REFRESH_LEAD_MS) muestran su status (CREATE/PUSH/SKIP)
+# Esperado: las 6 keys NEXT_PUBLIC_* del dashboard muestran su status (CREATE/PUSH/SKIP):
+#   - NEXT_PUBLIC_API_ENDPOINT
+#   - NEXT_PUBLIC_TURNSTILE_SITEKEY
+#   - NEXT_PUBLIC_DASHBOARD_URL
+#   - NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS
+#   - NEXT_PUBLIC_FEATURE_MFA               (flag para activar la Fase 16 cuando plan 02-auth-mfa este mergeado)
+#   - NEXT_PUBLIC_WEBAUTHN_RP_ID            (hostname admin.portfolio.{env}.the-full-stack.com, requerido por la API WebAuthn)
 ```
 
 ### B.10 — GH Actions local (act + skill github-actions)
@@ -301,9 +324,16 @@ Estructura Hybrid Atomic Design:
   dashboard-shell)
 - src/app/ — Next App Router con groups (auth) y (dashboard)
 
-Auth contra Lambda `auth` (planes 01-02): JWT in-memory + refresh
-HttpOnly cookie + mutex client-side + magic link callback con fragment
-hash + BroadcastChannel multi-tab sync.
+Auth contra Lambda `auth` (planes 01-02): tokens en localStorage
+(accessToken en memoria Zustand, refreshToken + refreshExpiry + user
+persistidos). NO HttpOnly cookies cross-origin — el dashboard vive en
+admin.portfolio.{env}.the-full-stack.com y el API en api.portfolio.{env},
+una cookie HttpOnly tendria que ser SameSite=None + Domain=.the-full-stack.com
+y abrir CSRF en los 6 niches publicos. Defensa primaria contra XSS: CSP
+estricta sin unsafe-inline/unsafe-eval + SRI en third-party + access JWT
+corto (15 min) + family_id refresh rotation backend (RFC 9700). Mutex
+client-side garantiza 1 sola /session/refresh in-flight. Magic link
+callback con fragment hash + BroadcastChannel multi-tab sync.
 
 Data fetching contra Lambda `analytics` (plan analytics-dashboard-api):
 Tanstack Query v5 con persister + 19 endpoints typed.

--- a/docs/specs/dashboard/11-verificacion-e2e.md
+++ b/docs/specs/dashboard/11-verificacion-e2e.md
@@ -1,0 +1,364 @@
+# 11 — Verificacion E2E iterativa (gate del PR)
+
+[< 10-paralelizacion-worktrees](10-paralelizacion-worktrees.md) | [Volver al README](README.md)
+
+## Aclaracion
+
+Fase 21 — la **ultima** del plan. SIEMPRE es el ultimo commit del PR.
+Dos partes:
+
+- **Parte A — refactor de tests**: confirmar que ningun test viejo
+  referencia codigo eliminado; tests nuevos en ruta correcta; barrido
+  global con `rg -l` para verificar.
+- **Parte B — bateria de comandos reales**: ejecutar la verificacion
+  completa de punta a punta con el codigo final. Bucle "no parar hasta
+  que funcione": ejecutar → si falla → diagnosticar → corregir →
+  re-ejecutar la suite → repetir.
+
+NO se marca completa con un comando fallando, un test rojo o coverage
+< 80%.
+
+## Parte A — Refactor de tests + barrido
+
+### A.1 — Verifica que NO hay tests viejos huerfanos
+
+```bash
+# Listar tests que referencien archivos eliminados o renombrados
+# (en este plan no hay archivos eliminados — todo es nuevo)
+find dashboard/tests -type f -name '*.test.*'
+```
+
+### A.2 — Verifica que TODOS los tests nuevos estan en la ruta correcta
+
+```bash
+# Mirror: cada src/<X>/<Y>.ts(x) debe tener tests/unit/<X>/<Y>.test.ts(x)
+# Listar fuentes
+find dashboard/src -type f \( -name '*.ts' -o -name '*.tsx' \) \
+  -not -path '*/components/ui/*' \
+  -not -name 'index.ts' \
+  -not -name '*.d.ts' \
+  -not -path '*/app/*' \
+  | sort > /tmp/dashboard-sources.txt
+
+# Listar tests
+find dashboard/tests/unit -type f -name '*.test.*' | sort > /tmp/dashboard-tests.txt
+
+# Compare: cada source deberia tener test correspondiente
+# (revision manual o con script)
+```
+
+### A.3 — Barrido global de referencias eliminadas
+
+```bash
+# Verifica que no quedan imports a paths que no existen
+# (en este plan no aplica fuerte porque todo es nuevo)
+cd dashboard
+pnpm typecheck  # cualquier import roto sale aqui
+```
+
+### A.4 — Verifica que las routes del dashboard estan en `routes.ts`
+
+```bash
+# Las pages no deberian hardcodear paths — todo via ROUTES.dashboard.*
+# Esto es review humano, pero un grep ayuda
+rg -l "href=\"/dashboard" dashboard/src/  # debe estar SOLO en src/lib/routes.ts o tests
+```
+
+### A.5 — Verifica que `process.env.NEXT_PUBLIC_*` solo se usa en `env.ts`
+
+```bash
+# Todos los componentes deben importar `env` de @/lib/env (validacion Zod)
+# NUNCA process.env.* directo
+rg "process\.env\." dashboard/src/ --type ts --type tsx
+# Resultado esperado: SOLO src/lib/env.ts y vitest.config.ts (excluido)
+```
+
+## Parte B — Bateria completa de comandos
+
+Ejecutar EN ORDEN. Si alguno falla, **DETENER**, diagnosticar,
+corregir, RE-EJECUTAR LA SUITE COMPLETA. NO continuar hasta que todo
+pase.
+
+### B.1 — Sintaxis + linting
+
+```bash
+pnpm --filter @portfolio/dashboard lint
+# Esperado: 0 errors, 0 warnings
+```
+
+### B.2 — Typecheck
+
+```bash
+pnpm --filter @portfolio/dashboard typecheck
+# Esperado: sin errores
+```
+
+### B.3 — Unit tests
+
+```bash
+pnpm --filter @portfolio/dashboard test
+# Esperado: TODOS verdes
+```
+
+### B.4 — Coverage >= 80% per-file
+
+```bash
+pnpm --filter @portfolio/dashboard test:coverage
+# Esperado: report imprime per-file coverage
+# Si alguno < 80% (excluyendo components/ui/, app/, types/, env.d.ts, index.ts): FAIL
+```
+
+### B.5 — Build estatico
+
+```bash
+pnpm --filter @portfolio/dashboard build
+# Esperado:
+# - Sin errores
+# - dashboard/out/index.html existe
+# - dashboard/out/404.html existe
+# - dashboard/out/_next/static/chunks/ existe
+# - dashboard/out/_redirects existe
+# - dashboard/out/_headers existe
+ls -lah dashboard/out/index.html dashboard/out/_redirects dashboard/out/_headers
+```
+
+### B.6 — Preview manual (smoke test golden path)
+
+```bash
+# Servir el build estatico
+pnpm --filter @portfolio/dashboard preview &
+PREVIEW_PID=$!
+sleep 3
+
+# Status codes esperados
+curl -sI http://localhost:3000/ | head -1 | grep -q "200" || echo "FAIL /"
+curl -sI http://localhost:3000/login/ | head -1 | grep -q "200" || echo "FAIL /login"
+curl -sI http://localhost:3000/register/ | head -1 | grep -q "200" || echo "FAIL /register"
+
+# Smoke: HTML contiene el bundle Next.js
+curl -s http://localhost:3000/ | grep -q "_next/static" || echo "FAIL bundle"
+
+kill $PREVIEW_PID
+```
+
+### B.7 — Preview con MSW (golden path manual)
+
+```bash
+NEXT_PUBLIC_USE_MSW=true pnpm --filter @portfolio/dashboard dev &
+DEV_PID=$!
+sleep 5
+
+# Manual: abrir http://localhost:3000 en browser, probar:
+# 1. /login → email user@test.com + Turnstile success → submit
+# 2. /verify → input code "12345678" → submit
+# 3. Redirect a /dashboard → ver MetricCards
+# 4. Navegar a /dashboard/analytics → ver TimeseriesChart
+# 5. Cambiar DateRangePicker → ver refetch
+# 6. Click logout → redirect a /login
+# 7. Abrir 2da tab logueada, logout en 1 → 2da tab tambien logout (BroadcastChannel)
+
+kill $DEV_PID
+```
+
+### B.8 — Verify devtools cloudflare_setup dry-run
+
+```bash
+python devtools/run.py cloudflare_setup status --env=dev --dry-run
+# Esperado: lista el project portfolio-dashboard-dev con config correcta
+```
+
+### B.9 — Verify devtools sync_secrets dry-run
+
+```bash
+python devtools/run.py sync_secrets --env=dev --category=client --dry-run
+# Esperado: 4 keys NEXT_PUBLIC_* (DASHBOARD_URL, API_ENDPOINT, TURNSTILE_SITEKEY, AUTH_REFRESH_LEAD_MS) muestran su status (CREATE/PUSH/SKIP)
+```
+
+### B.10 — GH Actions local (act + skill github-actions)
+
+```bash
+# Validar yaml + dry-run con act
+act -W .github/workflows/ci.yml --container-architecture linux/amd64 --dry-run
+act -W .github/workflows/deploy-apps.yml --container-architecture linux/amd64 --dry-run
+# Esperado: sin syntax errors
+```
+
+### B.11 — E2E Playwright (con stack local arriba)
+
+```bash
+# Levantar stack local (nginx + apps)
+python devtools/run.py docker up --env=local
+
+# Esperar ~30s a que los servicios respondan
+sleep 30
+
+# Correr E2E del dashboard
+python devtools/run.py test_runner --module=feature --type=feature --env=local
+
+# Esperado: 7 specs en tests/feature/dashboard/ verdes:
+# - 01-login-magic-link.spec.ts
+# - 02-register-verify-code.spec.ts
+# - 03-callback-fragment-hash.spec.ts
+# - 04-auth-guard-redirect.spec.ts
+# - 05-logout-multi-tab.spec.ts
+# - 06-analytics-navigation.spec.ts
+# - 07-sessions-table-pagination.spec.ts
+
+# Bajar stack
+python devtools/run.py docker down --env=local
+```
+
+### B.12 — Smoke deploy real a dev
+
+Solo hacer **post-merge a `dev`** (CI deploya automaticamente):
+
+```bash
+# Tras merge, esperar ~3 min a que deploy-apps.yml termine
+gh run watch  # con la flag de seleccionar el run
+
+# Verificar URL responde
+curl -sI https://admin.portfolio.dev.the-full-stack.com/ | head -3
+# Esperado: HTTP/2 200
+
+# Verificar bundle Next.js sirve
+curl -s https://admin.portfolio.dev.the-full-stack.com/ | grep -q "_next/static"
+
+# Verificar CSP header se sirve
+curl -sI https://admin.portfolio.dev.the-full-stack.com/ | grep -i "content-security-policy"
+# Esperado: header con script-src 'self' 'wasm-unsafe-eval'; etc.
+
+# Verificar SSL OK
+openssl s_client -connect admin.portfolio.dev.the-full-stack.com:443 -showcerts < /dev/null 2>&1 \
+  | grep -E "subject|issuer" | head -4
+
+# Verificar el flow manual real: abrir admin.portfolio.dev en browser
+# Sin auth backend desplegado: las APIs fallaran (esto es esperado;
+# cuando se deploye el plan auth se podra hacer login real).
+```
+
+### B.13 — Limpieza del plan (ULTIMO PASO)
+
+```bash
+# Solo si TODO lo anterior (B.1-B.12) paso en verde:
+git rm -r docs/specs/dashboard/
+git commit -m "chore(dashboard): elimina docs/specs/dashboard/ tras mergear el plan
+
+- Plan dashboard SPA completado y mergeado a dev
+- El conocimiento permanente queda en:
+  - .claude/rules/dashboard.md
+  - .claude/skills/dashboard-stack/SKILL.md
+  - .claude/docs/dashboard/ (7 archivos)
+- Trazabilidad del plan en git log + PR
+
+Cumple TODOS los AC (1-33). Verificacion completa en seccion 11 del plan."
+
+# Push final
+git push origin feature/dashboard-frontend
+```
+
+## Bucle de correccion
+
+Si algun paso (B.1 - B.12) falla:
+
+1. **Diagnosticar**: leer el output completo del fail. Identificar root
+   cause.
+2. **Corregir**: editar el codigo (sin atajos, sin --no-verify).
+3. **Verify incremental**: ejecutar SOLO el paso que fallo + re-correr
+   tests del scope corregido.
+4. **Re-ejecutar suite**: empezar de nuevo desde B.1. NO confiar en
+   verde parcial.
+5. **Repetir** hasta que B.1 - B.12 pasen todos.
+
+## Regla de cierre
+
+**SIEMPRE** el `git push` final + creacion del PR pasa SOLO cuando
+B.1 - B.12 estan en verde. NUNCA con un test rojo, coverage < 80%, o
+build roto.
+
+El PR `feature/dashboard-frontend -> dev` se crea con:
+
+```bash
+gh pr create --base dev --head feature/dashboard-frontend \
+  --title "feat(dashboard): admin SPA Next.js 16 + React 18 + shadcn + Tanstack" \
+  --body "$(cat <<'EOF'
+## Problema
+
+El portfolio no tiene panel admin para ver la data analitica generada
+por los visitantes (sessions, visits, tracking events, contacts). Hoy
+solo se accede con psql o consola Neon.
+
+## Solucion
+
+Dashboard SPA estatico Next.js 16 + React 18 + shadcn/ui + Tanstack
+Query + Zustand, deployado a Cloudflare Pages en
+admin.portfolio.{dev|stage|prod}.the-full-stack.com.
+
+Estructura Hybrid Atomic Design:
+- src/components/ui/ — primitivos genericos (shadcn + custom)
+- src/features/<X>/ — 11 features por dominio (auth, analytics,
+  sessions, events, visits, geo, devices, funnel, contacts, settings,
+  dashboard-shell)
+- src/app/ — Next App Router con groups (auth) y (dashboard)
+
+Auth contra Lambda `auth` (planes 01-02): JWT in-memory + refresh
+HttpOnly cookie + mutex client-side + magic link callback con fragment
+hash + BroadcastChannel multi-tab sync.
+
+Data fetching contra Lambda `analytics` (plan analytics-dashboard-api):
+Tanstack Query v5 con persister + 19 endpoints typed.
+
+Mientras los planes backend no esten mergeados, MSW provee mocks
+completos (NEXT_PUBLIC_USE_MSW=true).
+
+## Como probar
+
+Local con MSW (sin backend live):
+```
+NEXT_PUBLIC_USE_MSW=true pnpm --filter @portfolio/dashboard dev
+# http://localhost:3000
+# - Login: user@test.com + Turnstile success + code 12345678
+# - Navegar /dashboard /dashboard/analytics /dashboard/sessions
+# - Logout (verificar multi-tab sync)
+```
+
+Tests:
+```
+pnpm --filter @portfolio/dashboard test:coverage  # >= 80% per-file
+pnpm --filter @portfolio/dashboard build           # genera dashboard/out
+```
+
+E2E:
+```
+python devtools/run.py docker up --env=local
+python devtools/run.py test_runner --module=feature --type=feature --env=local
+```
+
+Deploy preview en dev (tras merge):
+- admin.portfolio.dev.the-full-stack.com
+- (Auth real funcional cuando se mergeen los planes 01-02 + analytics)
+
+## TODO (out of scope)
+
+- Plan 01-auth-infra-basics no mergeado aun (bloqueante para
+  funcionalidad real de auth)
+- Plan analytics-dashboard-api no mergeado aun (bloqueante para data
+  real)
+- Plan 02-auth-mfa no mergeado aun (afecta features de MFA en settings;
+  componentes ya existen, mocks via MSW hasta entonces)
+EOF
+)"
+```
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| `git push --force` con tests rojos | Romper la branch para otros + reviewers | Esperar tests verdes |
+| Skip pasos de la bateria "porque ya los hice" | Verificacion stale | Re-ejecutar la suite completa |
+| `--no-verify` para saltar pre-push hook | Saltea quality gates | Diagnosticar el error real |
+| Crear PR sin coverage 80% | Plan-format lo prohibe | Agregar tests faltantes |
+| Mergear sin que CI termine en verde | Romper main | Esperar |
+| Eliminar `docs/specs/dashboard/` antes del cierre real | Pierde el plan | Solo al final (B.13) |
+| Atribuir a IA en commit del cleanup | Politica empresa | Mensaje limpio |
+
+[< 10-paralelizacion-worktrees](10-paralelizacion-worktrees.md) | [Volver al README](README.md)

--- a/docs/specs/dashboard/README.md
+++ b/docs/specs/dashboard/README.md
@@ -1,12 +1,14 @@
 # Plan: Dashboard SPA — admin.portfolio.{env}.the-full-stack.com
 
-> Plan Large (~20 fases). Dashboard admin Next.js 16 SPA estatico
-> (`output: 'export'`) + React 18 + shadcn/ui + Tanstack Query +
-> Zustand, deployado a Cloudflare Pages en
+> Plan Large (~20 fases). Dashboard admin **Next.js 16.2.6** SPA
+> estatico (`output: 'export'`) + **React 19.2.6** (React Compiler
+> stable, `useActionState`, `useOptimistic`, ref-as-prop, Document
+> Metadata nativo) + shadcn/ui + Tanstack Query v5 + Zustand 5,
+> deployado a Cloudflare Pages en
 > `admin.portfolio.{dev|stage|prod}.the-full-stack.com`. Consume el
 > Lambda `auth` (planes 01-02, aun pending) + Lambda `analytics` (plan
 > analytics-dashboard-api, aun pending). Mientras no esten deployadas,
-> MSW provee mocks completos.
+> MSW v2 provee mocks completos.
 >
 > Carpeta `dashboard/` en root del repo (no `apps/dashboard/`). Entra
 > al pnpm workspace como `@portfolio/dashboard`.
@@ -64,31 +66,54 @@ Las 25 decisiones cerradas en el Q&A inicial (ver
 [.claude/docs/dashboard/README.md](../../../.claude/docs/dashboard/README.md)
 seccion "Decisiones no-reabribles"). Resumen:
 
-1. **Next.js 16 SPA** (`output: 'export'`) — NO Vite, NO Astro.
-2. **React 18.3.x** — NO React 19.
+1. **Next.js 16.2.6 SPA** (`output: 'export'`) — NO Vite, NO Astro.
+2. **React 19.2.6** — obligatorio en Next 16.x. Compiler stable
+   habilitado. `useActionState`, `useFormStatus`, `useOptimistic`,
+   `useDeferredValue(value, initialValue)`, `useEffectEvent`, Activity
+   Component, View Transitions disponibles. `ref` como prop normal
+   (NUNCA `forwardRef`). Document Metadata nativo (`<title>`/`<meta>`
+   en componentes auto-hoisteado al `<head>`).
 3. **App Router** — NO Pages Router. Client Components todo.
-4. **TypeScript 6** strict + `noUncheckedIndexedAccess`.
+4. **TypeScript 6.0.6** strict + `noUncheckedIndexedAccess`.
 5. **Biome v2** sin ESLint. Override para `components/ui/*`.
-6. **Tailwind v4** con `@theme` inline.
-7. **shadcn/ui** (Radix primitives, copy-paste).
-8. **Tanstack Query v5** + persister localStorage + lz-string compression.
-9. **Zustand** para auth + theme. Tanstack Query para data.
-10. **react-hook-form + Zod + shadcn `<Form>`**.
-11. **next-themes** con `attribute="data-theme"`.
-12. **lucide-react** para iconos.
-13. **Recharts** via shadcn add chart.
-14. **Tanstack Table v8 + Tanstack Virtual** para listas grandes.
-15. **sonner** para toasts.
-16. **Vitest + Testing Library + MSW + Playwright**.
+6. **Tailwind v4.1.4** con `@theme` inline + `@tailwindcss/postcss`.
+7. **shadcn/ui** (Radix primitives, copy-paste; codegen sin `forwardRef`).
+8. **Tanstack Query v5.52.3** + `useSuspenseQuery` para data required +
+   persister `localStorage` + lz-string compression.
+9. **Zustand 5.0.14** (Jan 2026 state consistency fix) para auth + theme.
+   Tanstack Query para data.
+10. **Forms**: react-hook-form 7 + Zod + shadcn `<Form>` para complejos
+    (auth, multi-step). `useActionState` + `useFormStatus` para simples.
+11. **next-themes 0.4.8** con `attribute="data-theme"`.
+12. **lucide-react 0.416.0** para iconos.
+13. **Recharts 2.14.2** via shadcn add chart + override `react-is@19.2.6`.
+14. **Tanstack Table v8.20.5 + Tanstack Virtual 3.5.1** para listas grandes.
+15. **sonner 1.7.2** para toasts.
+16. **Vitest 2.2.5 + Testing Library v16.1.0 + happy-dom 16.5.1 + MSW
+    v2.3.2 + Playwright 1.48.2**.
 17. **Hybrid Atomic Design** — `components/ui/` + `features/<X>/`.
 18. **Carpeta `dashboard/`** en root (user choice).
 19. **Subdominio `admin.portfolio.{env}.the-full-stack.com`**.
 20. **Cloudflare Pages** via devtools/cloudflare_setup.
 21. **Prefijo `NEXT_PUBLIC_*`** para env vars del cliente.
-22. **JWT in-memory (access) + HttpOnly cookie (refresh preferido)**.
-23. **Magic link callback** con fragment hash (NO query params).
-24. **BroadcastChannel API** para multi-tab logout sync.
-25. **Plan scope** SOLO frontend; MSW mocks hasta que el backend exista.
+22. **Auth — storage**: tokens (access, refresh, temp) en `localStorage`
+    via Zustand `persist`. **NO HttpOnly cookies** — el dashboard es
+    SPA cross-origin (subdomain admin vs api), una cookie HttpOnly
+    requeriria `SameSite=None` cross-site + `Domain=.the-full-stack.com`,
+    abriendo CSRF en los 6 niches publicos y rompiendo portabilidad.
+    Defensa: CSP estricta sin `unsafe-inline`/`unsafe-eval` + SRI en
+    third-party + access JWT corto (15 min) + family_id refresh rotation.
+23. **Magic link callback** con fragment hash (NO query params). Backend
+    redirect 302 a `/auth/callback#access=X&refresh=Y&user=...`.
+    Frontend decodea + guarda en `localStorage` via Zustand + limpia
+    con `history.replaceState`.
+24. **BroadcastChannel API** para multi-tab logout sync + fallback
+    `storage` event de `localStorage`.
+25. **React Compiler** habilitado via `reactCompiler: true` en
+    `next.config.ts`. Opt-out per file con `'use no memo'` solo si
+    rompe algo medido.
+26. **Plan scope** SOLO frontend; MSW v2 mocks hasta que el backend
+    exista (toggle via `NEXT_PUBLIC_USE_MSW=true`).
 
 ## Reglas criticas (siempre activas)
 

--- a/docs/specs/dashboard/README.md
+++ b/docs/specs/dashboard/README.md
@@ -28,7 +28,7 @@
 | UI: shadcn + Tailwind v4 + theming + componentes ui/ | [05-ui-components.md](05-ui-components.md) |
 | Auth feature: store + hooks + magic link + MSW handlers | [06-auth-feature.md](06-auth-feature.md) |
 | Dashboard features: analytics + sessions + events + ... | [07-dashboard-features.md](07-dashboard-features.md) |
-| Tests (unit + E2E) + cobertura | [08-tests.md](08-tests.md) |
+| Descomposicion para paralelizacion + tests (unit + E2E) + cobertura | [08-descomposicion.md](08-descomposicion.md) |
 | Deploy: devtools + GH Actions + Cloudflare Pages | [09-commits.md](09-commits.md) (incluye fase de deploy) |
 | Paralelizacion con git worktrees | [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md) |
 | Verificacion E2E iterativa (fase final, gate del PR) | [11-verificacion-e2e.md](11-verificacion-e2e.md) |
@@ -123,7 +123,17 @@ seccion "Decisiones no-reabribles"). Resumen:
 - **SIEMPRE** Hybrid Atomic: `components/ui/` (genericos, 2+ features
   uses) vs `features/<X>/components/` (especificos).
 - **SIEMPRE** rama de trabajo `feature/dashboard-frontend` (NUNCA
-  trabajar en `dev`/`stage`/`main` directo).
+  trabajar en `dev`/`stage`/`main` directo). Bootstrap explicito (ANTES
+  del primer commit del plan):
+
+  ```bash
+  git checkout dev && git pull origin dev
+  git checkout -b feature/dashboard-frontend
+  ```
+
+  Si la rama actual al iniciar el plan no es `feature/dashboard-frontend`,
+  ese par de comandos es la primera accion del implementador. NUNCA
+  asumir que la rama actual coincide.
 - **SIEMPRE** verificar incrementalmente por commit (lint + typecheck +
   unit del scope).
 - **SIEMPRE** push + PR SOLO con la bateria de la seccion 11 completa
@@ -143,7 +153,7 @@ seccion "Decisiones no-reabribles"). Resumen:
 | Build estatico | `pnpm --filter @portfolio/dashboard build` |
 | Preview local | `pnpm --filter @portfolio/dashboard preview` |
 | Dev con MSW | `NEXT_PUBLIC_USE_MSW=true pnpm --filter @portfolio/dashboard dev` |
-| Devtools cloudflare config | `python devtools/run.py cloudflare_setup status --env=dev` |
+| Devtools cloudflare config | `python devtools/run.py cloudflare_setup projects --env=dev --dry-run` |
 | Devtools sync_secrets | `python devtools/run.py sync_secrets --env=dev --category=client --dry-run` |
 | E2E Playwright (cuando stack arriba) | `python devtools/run.py test_runner --module=feature --type=feature --env=local` |
 | CI local | `act -W .github/workflows/ci.yml` (skill github-actions) |

--- a/docs/specs/dashboard/README.md
+++ b/docs/specs/dashboard/README.md
@@ -1,0 +1,151 @@
+# Plan: Dashboard SPA — admin.portfolio.{env}.the-full-stack.com
+
+> Plan Large (~20 fases). Dashboard admin Next.js 16 SPA estatico
+> (`output: 'export'`) + React 18 + shadcn/ui + Tanstack Query +
+> Zustand, deployado a Cloudflare Pages en
+> `admin.portfolio.{dev|stage|prod}.the-full-stack.com`. Consume el
+> Lambda `auth` (planes 01-02, aun pending) + Lambda `analytics` (plan
+> analytics-dashboard-api, aun pending). Mientras no esten deployadas,
+> MSW provee mocks completos.
+>
+> Carpeta `dashboard/` en root del repo (no `apps/dashboard/`). Entra
+> al pnpm workspace como `@portfolio/dashboard`.
+>
+> **Scope**: SOLO frontend. La implementacion del backend es problema
+> de los planes 01-auth-infra-basics, 02-auth-mfa y
+> analytics-dashboard-api.
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| Problema, solucion, AC numerados | [01-contexto-y-decision.md](01-contexto-y-decision.md) |
+| Diagramas de flujo (auth, dashboard, deploy) | [02-diagramas.md](02-diagramas.md) |
+| Estructura completa de archivos (Hybrid Atomic Design) | [03-estructura.md](03-estructura.md) |
+| Setup base: pnpm workspace + configs + scaffolding | [04-setup-base.md](04-setup-base.md) |
+| UI: shadcn + Tailwind v4 + theming + componentes ui/ | [05-ui-components.md](05-ui-components.md) |
+| Auth feature: store + hooks + magic link + MSW handlers | [06-auth-feature.md](06-auth-feature.md) |
+| Dashboard features: analytics + sessions + events + ... | [07-dashboard-features.md](07-dashboard-features.md) |
+| Tests (unit + E2E) + cobertura | [08-tests.md](08-tests.md) |
+| Deploy: devtools + GH Actions + Cloudflare Pages | [09-commits.md](09-commits.md) (incluye fase de deploy) |
+| Paralelizacion con git worktrees | [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md) |
+| Verificacion E2E iterativa (fase final, gate del PR) | [11-verificacion-e2e.md](11-verificacion-e2e.md) |
+
+## Estado por fase
+
+| Fase | Descripcion | Estado |
+|------|-------------|--------|
+| 0 | Plan + carpeta `docs/specs/dashboard/` commiteada en `feature/dashboard-frontend` | pending |
+| 1 | Scaffold `dashboard/` (package.json, configs, pnpm workspace, biome.json override) | pending |
+| 2 | Setup CSS/theming (`globals.css` + tokens compartidos con DS, `next-themes` provider) | pending |
+| 3 | shadcn init + agregar componentes base (button, card, form, table, etc.) | pending |
+| 4 | Custom UI primitives en `components/ui/` (metric-card, data-table, date-range-picker, empty-state, theme-toggle) | pending |
+| 5 | `lib/env.ts` + `lib/api-client.ts` (fetch wrapper + auth interceptor + mutex refresh) | pending |
+| 6 | Providers (QueryProvider con persister, RootProviders, layout.tsx) | pending |
+| 7 | Feature `auth`: store Zustand + hooks (register/login/verify/logout/refresh) + componentes (LoginForm, RegisterForm, VerifyCodeInput, MagicLinkCallback, AuthGuard, TurnstileWidget) | pending |
+| 8 | Pages `(auth)`: login, register, verify, callback, set-password | pending |
+| 9 | MSW setup (handlers auth + analytics, server.ts, browser.ts) + tests setup | pending |
+| 10 | Feature `dashboard-shell`: sidebar, header, theme toggle, layout `(dashboard)` con AuthGuard | pending |
+| 11 | Feature `analytics`: overview, timeseries, top-pages, top-referrers, top-niches, active-now, retention | pending |
+| 12 | Feature `sessions`: list + detail | pending |
+| 13 | Feature `events`: distribution, list (con Tanstack Virtual), heatmap | pending |
+| 14 | Feature `visits` + `geo` + `devices` + `funnel` | pending |
+| 15 | Feature `contacts`: list + by-status + update status mutation | pending |
+| 16 | Feature `settings`: profile + MFA setup (TOTP + WebAuthn + recovery codes) | pending |
+| 17 | Extension `devtools/cloudflare_setup/config.py` para incluir el dashboard (app_type=nextjs) | pending |
+| 18 | Extension `devtools/sync_secrets/catalog.py` con nuevas NEXT_PUBLIC_* + actualizar `docker/env/client/.example` | pending |
+| 19 | Extension `.github/workflows/deploy-apps.yml` matrix con `dashboard` (dist-dir: dashboard/out) | pending |
+| 20 | Tests E2E Playwright en `tests/feature/dashboard/*.spec.ts` | pending |
+| 21 | Verificacion E2E iterativa + limpieza `docs/specs/dashboard/` | pending |
+
+## Decisiones no-reabribles
+
+Las 25 decisiones cerradas en el Q&A inicial (ver
+[.claude/docs/dashboard/README.md](../../../.claude/docs/dashboard/README.md)
+seccion "Decisiones no-reabribles"). Resumen:
+
+1. **Next.js 16 SPA** (`output: 'export'`) — NO Vite, NO Astro.
+2. **React 18.3.x** — NO React 19.
+3. **App Router** — NO Pages Router. Client Components todo.
+4. **TypeScript 6** strict + `noUncheckedIndexedAccess`.
+5. **Biome v2** sin ESLint. Override para `components/ui/*`.
+6. **Tailwind v4** con `@theme` inline.
+7. **shadcn/ui** (Radix primitives, copy-paste).
+8. **Tanstack Query v5** + persister localStorage + lz-string compression.
+9. **Zustand** para auth + theme. Tanstack Query para data.
+10. **react-hook-form + Zod + shadcn `<Form>`**.
+11. **next-themes** con `attribute="data-theme"`.
+12. **lucide-react** para iconos.
+13. **Recharts** via shadcn add chart.
+14. **Tanstack Table v8 + Tanstack Virtual** para listas grandes.
+15. **sonner** para toasts.
+16. **Vitest + Testing Library + MSW + Playwright**.
+17. **Hybrid Atomic Design** — `components/ui/` + `features/<X>/`.
+18. **Carpeta `dashboard/`** en root (user choice).
+19. **Subdominio `admin.portfolio.{env}.the-full-stack.com`**.
+20. **Cloudflare Pages** via devtools/cloudflare_setup.
+21. **Prefijo `NEXT_PUBLIC_*`** para env vars del cliente.
+22. **JWT in-memory (access) + HttpOnly cookie (refresh preferido)**.
+23. **Magic link callback** con fragment hash (NO query params).
+24. **BroadcastChannel API** para multi-tab logout sync.
+25. **Plan scope** SOLO frontend; MSW mocks hasta que el backend exista.
+
+## Reglas criticas (siempre activas)
+
+- **SIEMPRE** Client Components (`'use client'`). NO Server Components.
+- **SIEMPRE** API calls via `lib/api-client.ts` (fetch wrapper con
+  auth interceptor + mutex refresh).
+- **SIEMPRE** Hybrid Atomic: `components/ui/` (genericos, 2+ features
+  uses) vs `features/<X>/components/` (especificos).
+- **SIEMPRE** rama de trabajo `feature/dashboard-frontend` (NUNCA
+  trabajar en `dev`/`stage`/`main` directo).
+- **SIEMPRE** verificar incrementalmente por commit (lint + typecheck +
+  unit del scope).
+- **SIEMPRE** push + PR SOLO con la bateria de la seccion 11 completa
+  en verde.
+- **NUNCA** API routes, middleware, Server Components async.
+- **NUNCA** tokens JWT en URL query, persistir accessToken, logear JWT.
+- **NUNCA** atribucion IA en commits/PRs.
+
+## Matriz de verificacion (rapida)
+
+| Capa | Comando |
+|------|---------|
+| Lint + format | `pnpm --filter @portfolio/dashboard lint` |
+| Typecheck | `pnpm --filter @portfolio/dashboard typecheck` |
+| Unit tests | `pnpm --filter @portfolio/dashboard test` |
+| Coverage (>= 80% per-file) | `pnpm --filter @portfolio/dashboard test:coverage` |
+| Build estatico | `pnpm --filter @portfolio/dashboard build` |
+| Preview local | `pnpm --filter @portfolio/dashboard preview` |
+| Dev con MSW | `NEXT_PUBLIC_USE_MSW=true pnpm --filter @portfolio/dashboard dev` |
+| Devtools cloudflare config | `python devtools/run.py cloudflare_setup status --env=dev` |
+| Devtools sync_secrets | `python devtools/run.py sync_secrets --env=dev --category=client --dry-run` |
+| E2E Playwright (cuando stack arriba) | `python devtools/run.py test_runner --module=feature --type=feature --env=local` |
+| CI local | `act -W .github/workflows/ci.yml` (skill github-actions) |
+
+## Tamano del plan
+
+Large (~20 fases, ~80-100 archivos nuevos). Duracion estimada
+2-3 semanas de trabajo continuo con paralelizacion via git worktrees
+en fases independientes (ver seccion 10).
+
+## Ciclo de vida de la carpeta
+
+Esta carpeta `docs/specs/dashboard/` es **efimera**. Se elimina con
+`git rm -r docs/specs/dashboard/` en el ultimo commit del PR (fase 21,
+seccion 11). La trazabilidad queda en `git log` y en el PR mergeado.
+
+El conocimiento permanente vive en:
+- `.claude/rules/dashboard.md` (enforcement)
+- `.claude/skills/dashboard-stack/SKILL.md` (referencia invocable)
+- `.claude/docs/dashboard/` (knowledge tree, 7 capitulos)
+
+## Bibliografia interna
+
+- Skill: [`/dashboard-stack`](../../../.claude/skills/dashboard-stack/SKILL.md)
+- Rule: [`.claude/rules/dashboard.md`](../../../.claude/rules/dashboard.md)
+- Knowledge tree: [`.claude/docs/dashboard/`](../../../.claude/docs/dashboard/)
+- Plan auth: [`docs/specs/01-auth-infra-basics/`](../01-auth-infra-basics/) (pending)
+- Plan MFA: [`docs/specs/02-auth-mfa/`](../02-auth-mfa/) (pending)
+- Plan analytics: [`docs/specs/analytics-dashboard-api/`](../analytics-dashboard-api/) (pending)
+- Research raw (efimero): `tmp/research/dashboard/` (7783 lineas)


### PR DESCRIPTION
## Problema

El plan `docs/specs/dashboard/` (12 archivos, ~3.6k lineas) salio del review con 3 bloqueantes, 6 riesgos y 6 mejoras accionables. Si se implementaba tal cual: build fail por ruta dinamica `sessions/[id]/page.tsx` (Next 16 export mode), `Module not found` por import MSW con alias roto, contrato del Zustand store contradictorio entre 3 archivos, comando inexistente del CLI de devtools, falta de feature flag para MFA, PR body que documentaba un modelo de seguridad distinto al implementado, y mas.

## Solucion

Aplica los 15 hallazgos del review al plan, sin tocar codigo del dashboard (aun no existe).

### Bloqueantes (3)

1. **partialize unificado**: `accessToken` + `tempToken` en memoria; `refreshToken` + `refreshExpiry` + `user` en localStorage. `useAuthTimer` hidrata el accessToken en cold start via `/session/refresh`. Coherente en 03/06/09/02/01.
2. **MSW import path**: agrega alias `@tests/*` a `tsconfig.json` + `vitest.config.ts` (o usar path relativo). El alias `@/` apunta a `src/` y `tests/` esta fuera.
3. **Ruta dinamica eliminada**: `sessions/[id]/page.tsx` reemplazada por `SessionDetailDrawer` (shadcn Sheet) con deep-link via `?session=<id>`. Compatible con `output: 'export'`.

### Riesgos (6)

4. `git worktree add` con `-b feature/dashboard-wt-<X>`: cada worktree tiene su branch, mergea a `feature/dashboard-frontend` con merge commit.
5. `B.2` paralelizable solo con `C.1` (no con `D.*` por dependencia transitiva via `B.3 -> C.2`).
6. `NEXT_PUBLIC_FEATURE_MFA` + `NEXT_PUBLIC_WEBAUTHN_RP_ID` agregadas al catalogo de `sync_secrets` (6 keys en total).
7. PR body template corregido: `localStorage` + CSP estricta + SRI, NO HttpOnly cookies cross-origin.
8. `cloudflare_setup status` (no existe) reemplazado por `cloudflare_setup projects --dry-run`.
9. Gap conocido documentado: el Lambda analytics no valida JWT en su primera entrega; el dashboard manda Bearer igual, pero el cutover a prod espera al fix backend si `contacts` incluye PII.

### Mejoras (6)

10. Link roto `08-tests.md` -> `08-descomposicion.md`.
11. Bootstrap explicito de rama: `git checkout dev && git checkout -b feature/dashboard-frontend`.
12. Conteo correcto: 26 tareas (no 17). Worktrees consolidados a 6 (D.2+D.3 y D.6+D.7 en uno cada uno) para respetar el limite 5-7.
13. Verificaciones ejecutables en commits 13 y 14 con `preview` + `curl`.
14. Sustituye `find` (aliasado a `fd` en WSL2) y `rg --type tsx` (no built-in) por `rg --files` con globs y `rg --type ts`.
15. `NEXT_PUBLIC_WEBAUTHN_RP_ID` documentado por env en Fase 16 (passkeys).

## Como probar

Esto es un cambio de docs solamente, no afecta `apps/`, `packages/`, ni Python.

```bash
git pull origin feature/backend-dashboard-suite
ls docs/specs/dashboard/
wc -l docs/specs/dashboard/*.md

# Validar consistencia del partialize en los 4 archivos clave
rg "partialize" docs/specs/dashboard/

# Validar que no quedan menciones obsoletas
rg "08-tests\.md" docs/specs/dashboard/
rg "\[id\]/page\.tsx" docs/specs/dashboard/
rg "cloudflare_setup status" docs/specs/dashboard/
```

Pre-commit + pre-push pasaron (sin cambios en `apps/*` ni `packages/*`).

## TODO (out of scope)

- Implementacion del dashboard SPA: el plan queda listo para iniciar en una rama `feature/dashboard-frontend` cuando los planes backend avancen.
- Resolver el gap de auth en el Lambda `analytics` antes del cutover de `contacts` a prod (issue separado en el plan `analytics-dashboard-api`).