### PR TITLE
docs(claude): rule + skill + docs/auth-system para el plan 01-auth-infra-basics

### DIFF
--- a/.claude/docs/auth-system/01-jwt-lifecycle.md
+++ b/.claude/docs/auth-system/01-jwt-lifecycle.md
@@ -1,0 +1,124 @@
+# JWT lifecycle — temp / access / refresh
+
+## Tres tipos de JWT
+
+| Tipo | TTL | Estado | Uso |
+|------|-----|--------|-----|
+| `temp` | 5 min | Stateless + rolling | Vive entre pasos de un flujo (register/login/verify) |
+| `access` | 15 min | Stateless con blacklist | Auth de cada request normal del dashboard |
+| `refresh` | 30 dias | Stateful (`family_id` + rotation) | Renueva el access cuando expira |
+
+Todos firmados con HS256. Secret: `/portfolio/${stage}/jwt-secret`
+(SSM SecureString + KMS). Leido en cold start con `@cached_property` en
+`AppConfig.jwt_secret` — NUNCA env var directa.
+
+## Claims canonicos
+
+```python
+class JwtClaims(BaseModel):
+    sub: UUID                          # subject = user_id (NO email)
+    jti: UUID                          # JWT ID (uuidv7)
+    typ: Literal['temp', 'access', 'refresh']
+    iat: int                           # issued at (unix)
+    exp: int                           # expires at (unix)
+    iss: str = 'portfolio-auth'
+    aud: str = 'portfolio'
+    flow: str | None = None            # solo en typ=temp
+    step: int | None = None            # solo en typ=temp
+    family_id: UUID | None = None      # solo en typ=refresh
+```
+
+Decision: el JWT contiene SOLO `sub` (user_id) como identificador. El
+email NO viaja en el token — JWT no es secreto (jwt.io lo decodifica) y
+filtrarlo via Referer/logs/history expondria PII. Los Lambdas que
+necesiten email hacen lookup a Neon.
+
+## Rolling temp JWT (entre pasos del flujo)
+
+Cada API del flujo:
+
+1. Recibe `temp_token` en el body.
+2. Verifica signature + exp + `typ='temp'` + NOT in blacklist.
+3. Blacklistea el `jti` viejo en DDB con `TTL=exp` original.
+4. Ejecuta el step (verificar code, set password, ...).
+5. Si NO es paso terminal: emite un nuevo `temp` con `now+5min` y
+   `step=step+1`. Lo devuelve en el body.
+6. Si ES terminal: emite `access` + `refresh` (NO temp). Frontend
+   borra el temp_token y persiste access/refresh.
+
+Beneficio: si el user esta inactivo 5 min, el JWT expira. Si intenta
+replay (reusar el viejo), falla por blacklist.
+
+## Access JWT
+
+- Stateless. El Lambda solo verifica signature + exp + aud + lookup
+  `jti` en `portfolio-jwt-blacklist-${stage}`.
+- Si el `jti` esta en blacklist con `revoked_at`: `401
+  TOKEN_BLACKLISTED`.
+- Logout pone el `jti` en blacklist.
+
+## Refresh JWT con `family_id` (token theft detection)
+
+Cada login emite un `family_id` nuevo (uuidv7). Cada uso del refresh
+ROTA: blacklistea el actual, emite uno nuevo con el MISMO `family_id`.
+
+Detection: si llega un refresh con `jti` ya blacklisteado (es decir, ya
+fue rotado), se considera **token theft**:
+
+1. Query GSI `by_family_id` con `KeyConditionExpression='family_id =
+   :fid'` (devuelve lista de `jti`).
+2. Blacklistea TODOS los `jti` de esa familia (BatchWriteItem paginando
+   de a 25).
+3. Devuelve `401 TOKEN_REUSE_DETECTED`.
+4. Audit log `session.refresh.reuse_detected`.
+
+Limite operativo: `MAX_FAMILY_SIZE = 10` (cap defensivo; en uso normal
+1-3 refresh activos). Si Query devuelve >10, log `family.oversized` y
+revoca igual.
+
+## Logout
+
+Recibe access JWT en el body. Opcionalmente refresh JWT:
+
+1. Verifica access -> obtiene `jti_access` + `sub` (user_id).
+2. Blacklistea `jti_access` con `reason='logout'`.
+3. Si llega refresh: blacklistea TODOS los `jti` de su `family_id`.
+4. Devuelve `204`.
+
+Idempotente: si el `jti` ya esta blacklisted, devuelve `204` sin error
+(AC-23).
+
+## Tabla DynamoDB `portfolio-jwt-blacklist-${stage}`
+
+```
+PK: jti (S)        -- UUID v7 string
+TTL: exp           -- unix; AWS borra el item
+GSI by_family_id:  -- KEYS_ONLY (solo necesitamos jti para revocar)
+  PK: family_id (S)
+```
+
+Schema del item:
+
+```jsonc
+{
+  "jti": "01H9X...uuid",
+  "user_id": "01H9V...",
+  "typ": "access",                // 'temp'|'access'|'refresh'
+  "family_id": "01H9W...",        // solo si typ=refresh
+  "revoked_at": 1717000000,       // unix
+  "reason": "logout",             // 'logout'|'rotation'|'reuse'|'forced'
+  "exp": 1717003600               // unix; TTL attribute
+}
+```
+
+## Errores tipados
+
+| Excepcion | Cuando | HTTP |
+|-----------|--------|------|
+| `JwtExpiredError` | exp < now | 401 |
+| `JwtInvalidError` | signature/aud/typ mismatch | 401 |
+| `JwtRevokedError` | jti en blacklist | 401 |
+
+Implementadas en `shared.auth.jwt`. Los services las propagan; los
+controllers las traducen a `{error: 'TEMP_TOKEN_EXPIRED'|'TOKEN_INVALID'|
+'TOKEN_BLACKLISTED'}`.

--- a/.claude/docs/auth-system/02-flows.md
+++ b/.claude/docs/auth-system/02-flows.md
@@ -1,0 +1,167 @@
+# Flujos de autenticacion
+
+> Diagrama ASCII por flujo. Mas detalle en los controllers correspondientes.
+
+## Register
+
+```text
+POST /auth {operation: register, action: start, data: {email, cf_turnstile_response}}
+  | turnstile + rate-limit
+  v
+[user no existe?] -- si -- crear auth_users (status=pending)
+  |                          generar code + magic_link_token
+  | si existe + status=active -> 409 EMAIL_ALREADY_REGISTERED
+  | si existe + status=pending -> re-emite (idempotente, AC-19)
+  | si existe + status=disabled/locked -> 404 EMAIL_NOT_FOUND (AC-20)
+  v
+persistir Neon: auth_email_codes(code_hash, kind=register, attempts=0, expires_at)
+                auth_magic_links(token_hash, kind=register, expires_at)
+                auth_audit_log(event=register.start, success=true)
+  |
+publicar SQS: {kind: register-magic-link, ...} + {kind: register-code, ...}
+  |
+emitir temp JWT (flow=register, step=1, ttl=300)
+  v
+200 {temp_token, user_id, expires_in: 300}
+
+
+--- Verificacion magic-link (GET, browser) ---
+
+GET /auth?operation=register&action=verify-magic-link&token=<X>
+  | turnstile NO (ya validamos en start)
+  | rate-limit
+  v
+verificar token_hash en auth_magic_links (consumed_at IS NULL, exp > now)
+  | si consumed -> 400 LINK_CONSUMED (AC-16)
+  | si expired  -> 400 LINK_EXPIRED  (AC-17)
+  v
+marcar consumed + auth_users.status='active'
+  |
+emitir access + refresh (family_id nuevo)
+  |
+audit log
+  v
+302 Location: https://admin.portfolio.{env}.the-full-stack.com/callback
+              #access=<JWT>&refresh=<JWT>&user_id=<X>&email=<Y>
+              Cache-Control: no-store, no-cache, must-revalidate
+
+
+--- Verificacion code (POST, dashboard) ---
+
+POST /auth {operation: register, action: verify-code, data: {code, temp_token}}
+  | verify temp JWT (typ=temp, flow=register, NOT blacklisted)
+  | rate-limit
+  v
+buscar auth_email_codes (user_id del JWT, kind=register, consumed_at IS NULL)
+  | si wrong -> increment attempts, 400 INVALID_CODE
+  | si >=5 attempts -> auth_users.status='locked', 423 ACCOUNT_LOCKED (AC-11)
+  | si expired -> 400 EXPIRED_CODE
+  v
+marcar consumed + status='active' + blacklist temp_token jti
+  |
+emitir access + refresh (family_id nuevo)
+  v
+200 {access_token, refresh_token, expires_in: 900, token_type: 'Bearer',
+     user: {id, email, status}}
+```
+
+## Login
+
+```text
+POST /auth {operation: login, action: start, data: {email, cf_turnstile_response}}
+  | turnstile + rate-limit
+  v
+buscar auth_users por email
+  | si NO existe -> 404 EMAIL_NOT_FOUND + suggest_register: true (AC-5)
+  | si disabled/locked -> 404 EMAIL_NOT_FOUND + suggest_register: false (AC-20)
+  | si pending -> 409 PENDING_VERIFICATION
+  v
+generar code + magic_link + emitir temp JWT (flow=login)
+publicar SQS
+  v
+200 {temp_token, methods: ['magic-link', 'email-code'], expires_in: 300}
+
+
+--- verify-magic-link / verify-code: identicos a register pero con
+flow='login'. Al exito: actualizar auth_users.last_login_at + reset
+failed_attempts (AC-22). ---
+```
+
+## Verify (set-password / resend-code)
+
+```text
+POST /auth {operation: verify, action: set-password, data: {password, temp_token}}
+  | verify temp JWT (typ=temp, NOT blacklisted)
+  | rate-limit
+  | password >= 12 chars
+  v
+hash_password(password, argon2id)
+INSERT INTO auth_credentials (user_id, password_hash, algo='argon2id')
+auth_users.password_set_at = now()
+blacklist temp_token jti
+  |
+emitir nuevo temp con step+1 (si flujo continua) o access+refresh (si terminal)
+
+
+POST /auth {operation: verify, action: resend-code, data: {temp_token}}
+  | verify temp JWT
+  | rate-limit RESEND (3/5min/IP) y throttle por user (60s desde el ultimo, AC-21)
+  v
+re-genera code + magic_link (invalida los anteriores con consumed_at=now)
+publica SQS
+emite nuevo temp_token (rolling)
+```
+
+## Session (refresh / logout)
+
+```text
+POST /auth {operation: session, action: refresh, data: {refresh_token}}
+  | verify refresh JWT (typ=refresh)
+  | NOT in blacklist
+  v
+[blacklisted?]
+  | si  -> reuse detected: Query GSI by_family_id, blacklist TODA la familia
+  |        401 TOKEN_REUSE_DETECTED + audit (AC-8)
+  | no  v
+blacklist refresh viejo (PutItem con reason='rotation', TTL=exp)
+emitir nuevo access + nuevo refresh (mismo family_id)
+audit log success
+  v
+200 {access_token, refresh_token, expires_in: 900}
+
+
+POST /auth {operation: session, action: logout, data: {access_token, refresh_token?}}
+  | verify access JWT
+  v
+blacklist jti_access con reason='logout'
+si refresh_token presente: blacklist TODOS los jti de su family_id
+  |
+audit log
+  v
+204 (idempotente: si ya blacklisted, devuelve 204 sin error, AC-23)
+```
+
+## Magic-link via email (worker async)
+
+```text
+Lambda auth publica a SQS portfolio-auth-email-${stage}:
+{
+  kind: 'register-magic-link' | 'register-code' | 'login-magic-link' |
+        'login-code' | 'password-reset',
+  to: 'user@example.com',
+  user_id, niche?, subject_id, data: {token | code, expires_in_min,
+  verify_url?}, audit_event_id
+}
+  |
+SQS trigger (batch_size=5) -> auth_email_worker
+  | router por kind -> controller especifico
+  v
+template_service renderiza plantilla {es,en}/<kind>.{txt,html}
+send_service llama shared.aws.send_email(from=ses_from_address,
+                                          to=[email],
+                                          subject, text, html)
+audit_service inserta auth_audit_log event='email.sent.<kind>'
+  |
+si SES throttle -> levanta excepcion (SQS reintenta, max=3 -> DLQ)
+si SES bounce permanente -> log + audit fail + return (no reintenta)
+```

--- a/.claude/docs/auth-system/03-rate-limit-rules.md
+++ b/.claude/docs/auth-system/03-rate-limit-rules.md
@@ -1,0 +1,85 @@
+# Reglas de rate-limit del Lambda `auth`
+
+> Seed manual via `serverless rate-limit set` 1 vez por stage. Reusa
+> `shared.rate_limit` (sliding window weighted) + tabla
+> `portfolio-rate-limit-rules-${stage}`.
+
+## Endpoint key
+
+Formato: `<operation>.<action>` literal. El controller llama
+`shared.rate_limit.check_or_raise(endpoint=f'{operation}.{action}')`.
+Matching exacto (NO prefix). Cada operation.action tiene su key propia.
+
+## Tabla de reglas activas
+
+| Endpoint | Limit | Window | Hard cap | Hard-cap action | Justificacion |
+|---|---|---|---|---|---|
+| `register.start` | 3 | 3600s | 10/h | blacklist-24h | Anti spam masivo de registros |
+| `login.start` | 5 | 60s | 20/min | blacklist-1h | Anti brute force email enumeration |
+| `register.verify-magic-link` | 10 | 60s | — | — | Generoso (un user normal hace 1) |
+| `register.verify-code` | 10 | 60s | — | — | Idem |
+| `login.verify-magic-link` | 10 | 60s | — | — | Idem |
+| `login.verify-code` | 10 | 60s | — | — | Idem |
+| `verify.set-password` | 5 | 60s | — | — | Operacion sensible |
+| `verify.resend-code` | 3 | 300s | — | — | Anti-spam de emails (5 min ventana) |
+| `session.refresh` | 30 | 60s | — | — | Token rotation frecuente OK |
+| `session.logout` | 30 | 60s | — | — | Idem |
+
+## Throttle adicional aplicado en el controller
+
+Independiente del rate-limit por IP:
+
+- `verify.resend-code`: 60s desde la ultima emision PARA EL MISMO user
+  (AC-21). Si NO paso, devuelve `429 RESEND_THROTTLED`.
+
+## Comandos seed (1 vez por stage)
+
+```bash
+# dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='register.start' --limit=3 --window=3600 \
+  --hard-cap=10 --hard-cap-action=blacklist-24h --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='login.start' --limit=5 --window=60 \
+  --hard-cap=20 --hard-cap-action=blacklist-1h --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='register.verify-magic-link' --limit=10 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='register.verify-code' --limit=10 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='login.verify-magic-link' --limit=10 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='login.verify-code' --limit=10 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='verify.set-password' --limit=5 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='verify.resend-code' --limit=3 --window=300 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='session.refresh' --limit=30 --window=60 --aws-profile=tfs-dev
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='session.logout' --limit=30 --window=60 --aws-profile=tfs-dev
+
+# Repetir 1 a 1 con --stage=stage y --stage=prod
+```
+
+Idempotente: ejecutar de nuevo sobrescribe los valores.
+
+Verificar:
+
+```bash
+python devtools/run.py serverless rate-limit list --stage=dev
+# debe mostrar las 10 reglas
+```
+
+## Response al exceder
+
+```jsonc
+HTTP/1.1 429 Too Many Requests
+{
+  "error": "RATE_LIMITED",
+  "retry_after": 42        // segundos hasta que el window se libere
+}
+```
+
+El header `Retry-After: 42` tambien se setea para clientes que lo
+respeten.

--- a/.claude/docs/auth-system/README.md
+++ b/.claude/docs/auth-system/README.md
@@ -1,0 +1,124 @@
+# Sistema de autenticacion del portfolio
+
+> Knowledge tree del dominio auth del backend serverless. Sobrevive al
+> merge del plan `docs/specs/01-auth-infra-basics/` (efimero). Fuente de
+> verdad para decisiones de arquitectura, JWT lifecycle, schema Neon,
+> flujos, rate-limit y operacion.
+
+## Componentes
+
+| Componente | Que es | Donde vive |
+|---|---|---|
+| Lambda `auth` | HTTP POST `/auth` — register, login, verify, session (refresh/logout) | `serverless/lambda/services/auth/` |
+| Lambda `auth_email_worker` | SQS consumer — renderiza y envia magic-link + code por SES | `serverless/lambda/services/auth_email_worker/` |
+| `shared.auth` | Portador unico de `pyjwt` + `argon2-cffi` + generador de codes/tokens | `serverless/lambda/shared/auth/` |
+| Schema Neon `auth_*` | 5 tablas: users, credentials, email_codes, magic_links, audit_log | `serverless/lambda/shared/db/models/auth/` |
+| DynamoDB `jwt-blacklist` | Blacklist de JWTs (temp/access/refresh) con TTL=exp + GSI `by_family_id` | `serverless/lambda/resources/dynamodb/jwt-blacklist.yaml` |
+| SQS `auth-email-queue` + DLQ | Cola de emails async | `serverless/lambda/resources/sqs/auth-email-{queue,dlq}.yaml` |
+| SSM `/portfolio/${stage}/jwt-secret` | HS256 secret para JWT signing | `serverless/lambda/resources/secrets/jwt-secret.yaml` |
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| JWT lifecycle (temp/access/refresh, rotation, blacklist, family detection) | [01-jwt-lifecycle.md](01-jwt-lifecycle.md) |
+| Flujos (diagrama ASCII de cada operacion) | [02-flows.md](02-flows.md) |
+| Reglas de rate-limit activas | [03-rate-limit-rules.md](03-rate-limit-rules.md) |
+
+## Decisiones clave (cerradas)
+
+1. **Split de lambdas**: `auth` (signup/signin/session) + futuro `users`
+   (profile/admin). Este dominio entrega `auth` solamente.
+2. **Persistencia hibrida**: estado relacional + codes + magic links en
+   Neon (`auth_*`), blacklist de JWTs en DynamoDB (lookup O(1) por `jti`
+   en cada request autenticada).
+3. **JWT HS256** firmado con secret de SSM. 3 tipos:
+   - `typ=temp` (5 min, rolling refresh entre pasos del flujo).
+   - `typ=access` (15 min, stateless con verificacion blacklist).
+   - `typ=refresh` (30 dias, rotacion + `family_id` para detectar reuso).
+4. **Codigo de 8 chars Crockford-like**: alfabeto `A-Z + 0-9` sin
+   `O/0/I/1/L` (30 chars, espacio = 30^8 ~ 6.5x10^11). Max 5 intentos
+   por code, TTL 15 min.
+5. **Magic link**: token opaco 32 bytes b64url (NO JWT). Hash SHA-256
+   guardado en Neon. Single-use, TTL 15 min.
+6. **Email async**: cola SQS `portfolio-auth-email-${stage}` + worker
+   `auth_email_worker` (NO se reusa `contact_worker` — aislamiento de
+   dominios).
+7. **Turnstile**: obligatorio en `register.start` y `login.start`. El
+   resto del flujo confia en el JWT temp + rate-limit.
+8. **Login UX (email no existe)**: 404 +
+   `{suggest_register: true, methods: []}`. Si existe + active sin
+   password: 200 + `{methods: ['magic-link', 'email-code']}`.
+9. **FK profile_id**: `auth_users.profile_id` -> `cv_profiles.id`
+   NULLABLE (ON DELETE SET NULL). Solo el row de Pablo apuntara.
+10. **Hash de password**: argon2id (defaults de argon2-cffi
+    `PasswordHasher()`: time_cost=3, memory_cost=64MiB, parallelism=4).
+11. **Rate-limit**: reusa `shared.rate_limit.check_or_raise` con reglas
+    nuevas seedeadas via `serverless rate-limit set`.
+12. **CI**: `change_detector.py` auto-detecta cambios en
+    `services/auth/` y `services/auth_email_worker/` — cero cambio en
+    `deploy-backend.yml`.
+
+## Reglas duras (SIEMPRE / NUNCA)
+
+- **SIEMPRE** los services importan paquetes externos via
+  `shared.<subpaquete>` (lambda-shared-imports).
+- **SIEMPRE** un controller por action; logica de negocio en
+  `core/services/`, NUNCA en controllers ni handler.
+- **SIEMPRE** `auth_users.email` se guarda lowercased
+  (`email.lower().strip()`).
+- **SIEMPRE** los logs NO incluyen email completo (solo hash truncado),
+  password, JWT, magic-link token, code. Auditoria en `auth_audit_log`.
+- **SIEMPRE** el JWT_SECRET se lee de SSM en cold start (cached con
+  `@cached_property` en AppConfig). NUNCA env var directa.
+- **NUNCA** devolver `404` con body distinto entre "email no existe" y
+  "email existe pero esta `disabled`/`locked`" — anti enumeration.
+- **NUNCA** loguear el valor de `JWT_SECRET`, Neon URL, code o magic
+  link token.
+- **NUNCA** firmar un JWT con un secret distinto del leido de SSM.
+
+## Operacion
+
+```bash
+# Aplicar migration nueva
+python devtools/run.py serverless run --stage=dev --lambda=db \
+  --event=events/migrate.json --aws-profile=tfs-dev
+
+# Provision recursos compartidos (DDB jwt-blacklist + SQS + SSM jwt-secret)
+python devtools/run.py serverless provision-infra --stage=dev \
+  --aws-profile=tfs-dev
+
+# Sync JWT_SECRET (categoria server)
+python devtools/run.py serverless sync-secrets --stage=dev \
+  --aws-profile=tfs-dev
+
+# Deploy lambdas
+python devtools/run.py serverless deploy --lambda=auth_email_worker \
+  --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless deploy --lambda=auth \
+  --stage=dev --aws-profile=tfs-dev
+
+# Seed de rate-limit (1 vez por stage)
+python devtools/run.py serverless rate-limit set --stage=dev \
+  --endpoint='register.start' --limit=3 --window=3600 \
+  --aws-profile=tfs-dev
+# ... otras reglas en 03-rate-limit-rules.md
+```
+
+## Referencias cruzadas
+
+- [.claude/rules/auth-system.md](../../rules/auth-system.md) — rule de
+  enforcement
+- [.claude/rules/lambda-controller.md](../../rules/lambda-controller.md)
+  — patron general de Lambdas
+- [.claude/rules/lambda-shared-imports.md](../../rules/lambda-shared-imports.md)
+  — catalogo de portadores
+- [.claude/rules/neon-management.md](../../rules/neon-management.md) —
+  operacion de Neon (DB_URL en SSM, migrations via la Lambda `db`)
+- [.claude/rules/serverless-secrets.md](../../rules/serverless-secrets.md)
+  — inventario SSM (incluye `jwt-secret`)
+- [.claude/docs/serverless-backend/README.md](../serverless-backend/README.md)
+  — arquitectura general del backend
+- [docs/diagrams/db-er.mmd](../../../docs/diagrams/db-er.mmd) — schema
+  Neon (incluye cluster `auth_*`)
+- Skill: `/auth-system`

--- a/.claude/rules/auth-system.md
+++ b/.claude/rules/auth-system.md
@@ -1,0 +1,189 @@
+# Sistema de autenticacion del portfolio
+
+> Reglas duras para trabajar con los Lambdas `auth` + `auth_email_worker`,
+> el subpackage `shared.auth`, el schema `auth_*` en Neon, la tabla DDB
+> `jwt-blacklist` y los flujos register/login/verify/session. Aplica al
+> backend serverless. NO aplica al frontend Astro ni al dashboard Next.
+
+## Activacion
+
+Aplica SIEMPRE que se trabaje con:
+
+- Cualquier archivo bajo `serverless/lambda/services/auth/`
+- Cualquier archivo bajo `serverless/lambda/services/auth_email_worker/`
+- Cualquier archivo bajo `serverless/lambda/shared/auth/`
+- Cualquier archivo bajo `serverless/lambda/shared/db/models/auth/`
+- `serverless/lambda/shared/db/repositories/auth.py`
+- `serverless/lambda/shared/db/alembic/versions/*auth*`
+- `serverless/lambda/resources/dynamodb/jwt-blacklist.yaml`
+- `serverless/lambda/resources/sqs/auth-email-{queue,dlq}.yaml`
+- `serverless/lambda/resources/secrets/jwt-secret.yaml`
+- Cualquier referencia a `/portfolio/${stage}/jwt-secret` en SSM
+- Decisiones sobre JWT (HS256, lifetimes, claims, family_id, rotation)
+- Decisiones sobre rate-limit de los endpoints `/auth?operation=...`
+
+## Reglas duras (SIEMPRE / NUNCA)
+
+### Estructura y patrones
+
+- **SIEMPRE** los services del Lambda `auth` siguen `lambda-controller`:
+  controller orquesta + service tiene la logica + Pydantic models
+  validan el payload. Logica de negocio NUNCA en handler ni controllers.
+- **SIEMPRE** un controller por action. Archivo en
+  `controllers/<operation>/<action_snake>.py` y clase `<ActionPascal>`.
+- **SIEMPRE** el handler delgado: `lambda_handler` -> `http_handler(
+  event, event_model=EVENT_MODEL, cors_origin='echo',
+  success_status=200, metric_names={...})`. Sin negocio.
+- **SIEMPRE** todos los paquetes externos (`pyjwt`, `argon2-cffi`) se
+  importan via `shared.auth` (NUNCA `import jwt` ni `import argon2` en
+  `core/`). Mismo patron para boto3 / sqlalchemy / aws-lambda-powertools.
+- **SIEMPRE** los services importan SQLAlchemy via `shared.db` y boto3
+  via `shared.aws`.
+
+### Secretos y datos sensibles
+
+- **SIEMPRE** el JWT_SECRET se lee de SSM en cold start usando
+  `AppConfig.jwt_secret` (`@cached_property` que llama
+  `get_secret_by_name('jwt-secret', local_env='JWT_SECRET')`).
+- **SIEMPRE** el `auth_users.email` se guarda lowercased
+  (`email.lower().strip()`).
+- **SIEMPRE** los codes se guardan como `bytea` (SHA-256 hash) en
+  `auth_email_codes.code_hash`. NUNCA en plain text.
+- **SIEMPRE** los magic-link tokens se guardan como `bytea` (SHA-256
+  hash) en `auth_magic_links.token_hash`. NUNCA en plain text.
+- **SIEMPRE** las passwords se hashean con argon2id via
+  `shared.auth.hash_password()`. NUNCA bcrypt ni SHA-256 ni plain text.
+- **NUNCA** loguear: JWT, magic-link token, code, password, email
+  completo, Neon URL, JWT_SECRET. El audit log va a `auth_audit_log`
+  (Neon), no a CloudWatch logs.
+- **NUNCA** firmar un JWT con un secret distinto del leido de SSM.
+
+### JWT lifecycle
+
+- **SIEMPRE** HS256.
+- **SIEMPRE** 3 tipos validos: `temp` (5 min, rolling), `access` (15
+  min), `refresh` (30 dias, rotation + `family_id`).
+- **SIEMPRE** cada API del flujo verifica el `temp_token` recibido,
+  blacklistea su `jti` y emite uno nuevo (rolling).
+- **SIEMPRE** cada login emite un `family_id` (uuidv7) nuevo. Cada uso
+  de refresh rota dentro de la misma familia.
+- **SIEMPRE** si llega un refresh con `jti` ya blacklisted (reuso
+  detectado): revocar TODA la familia via Query GSI `by_family_id` +
+  BatchWriteItem (max 25 por call, paginar). Devolver `401
+  TOKEN_REUSE_DETECTED` + audit `session.refresh.reuse_detected`.
+- **NUNCA** poner email u otros datos de perfil en los claims del JWT.
+  El JWT contiene SOLO `sub` (user_id) como identificador.
+- **NUNCA** reusar el mismo `family_id` entre logout y nuevo login.
+  Cada login = nuevo `family_id`.
+
+### Schema Neon
+
+- **SIEMPRE** las 5 tablas `auth_*` se crean con la migration
+  `00000002_auth_schema.py` (Alembic). Cambios futuros: migration nueva,
+  NUNCA editar la 00000002 aplicada.
+- **SIEMPRE** los enums `auth_user_status`, `auth_code_kind`,
+  `auth_link_kind` se crean con `op.execute('CREATE TYPE ...')` o
+  `postgresql.ENUM(...).create(op.get_bind())`. NUNCA `String` con
+  CHECK constraint.
+- **SIEMPRE** `auth_users.profile_id` es FK NULLABLE a `cv_profiles.id`
+  con ON DELETE SET NULL.
+- **SIEMPRE** `auth_users.email` es `CITEXT` UNIQUE.
+- **NUNCA** borrar las tablas `auth_*` en `prod` con `downgrade`.
+  Cualquier rollback se hace con migration forward que revierta.
+
+### Login UX (anti enumeration)
+
+- **SIEMPRE** `login.start` con email inexistente devuelve `404
+  {error: 'EMAIL_NOT_FOUND', suggest_register: true}`.
+- **SIEMPRE** `login.start` con email cuyo status es `disabled` o
+  `locked` devuelve EL MISMO `404 {error: 'EMAIL_NOT_FOUND',
+  suggest_register: false}` (anti-enumeration). Audit log registra el
+  intento con `error_code='ACCOUNT_DISABLED'` o `'ACCOUNT_LOCKED'`.
+- **SIEMPRE** `login.start` con email cuyo status es `pending` devuelve
+  `409 PENDING_VERIFICATION` para forzar que termine el flujo de register.
+- **NUNCA** devolver 404 con body distinto entre "no existe" y
+  "existe + disabled/locked". La diferencia visible al cliente es solo
+  `suggest_register`.
+
+### Turnstile y rate-limit
+
+- **SIEMPRE** Turnstile obligatorio en `register.start` y `login.start`
+  (AC-12). El resto del flujo NO valida Turnstile — confia en el JWT
+  temp + rate-limit.
+- **SIEMPRE** rate-limit per-IP via `shared.rate_limit.check_or_raise`
+  con las reglas seedeadas (ver
+  [.claude/docs/auth-system/03-rate-limit-rules.md](../docs/auth-system/03-rate-limit-rules.md)).
+- **SIEMPRE** la verificacion de Turnstile + rate-limit ocurre ANTES
+  de tocar Neon o SQS.
+
+### Email async (SQS + worker)
+
+- **SIEMPRE** el Lambda `auth` solo publica a la cola SQS
+  `portfolio-auth-email-${stage}`. NUNCA llama SES directo.
+- **SIEMPRE** el `auth_email_worker` consume la cola con
+  `ReportBatchItemFailures` (permite fallar un mensaje del batch y
+  reintentarlo sin afectar al resto).
+- **SIEMPRE** el worker tras enviar exitosamente inserta un row en
+  `auth_audit_log` con `event=email.sent.<kind>` (success=true).
+- **NUNCA** reusar `contact_worker` para emails de auth — aislamiento
+  de dominios.
+
+### IAM y costos
+
+- **SIEMPRE** el Lambda `auth` tiene IAM scoped: las 5 tablas DDB
+  declaradas en `manifest.yaml#uses.tables`, la cola SQS, los 5 secretos
+  SSM. NUNCA wildcard.
+- **SIEMPRE** el `auth_email_worker` tiene IAM scoped: SQS por ARN
+  exacto, SSM `ses-from-address` por ARN exacto, SES por **identity ARN
+  exacto** (`arn:aws:ses:us-east-1:<account-id>:identity/the-full-stack.com`).
+  NUNCA `Resource: *` ni `ses:*`.
+
+### Anti-patrones (correcciones criticas)
+
+| Anti-patron | Correccion |
+|---|---|
+| `import jwt` en el `core/` de auth | `from shared.auth import issue_temp_jwt, verify_jwt, ...` |
+| `import argon2` o `from passlib import ...` | `from shared.auth import hash_password, verify_password` |
+| Comparar codes con `==` (timing attack) | `from shared.auth import compare_code` (secrets.compare_digest) |
+| Generar code con `random.choice` | `secrets.choice` via `shared.auth.generate_code` (CSPRNG) |
+| Loggear JWT/code/token | log solo `jti`, `user_id`, `event`, NUNCA el valor |
+| Email distinto en respuesta a "no existe" vs "disabled" | Mismo 404, solo `suggest_register` cambia |
+| Token de magic-link como JWT | Opaco 32 bytes b64url; hash SHA-256 en `auth_magic_links.token_hash` |
+| Hardcodear secret en `manifest.yaml` | SSM SecureString + KMS; `@cached_property` en AppConfig |
+| Lambda `auth` enviando SES directo | Publicar a SQS; el worker es quien envia |
+| Reusar `family_id` entre sesiones | Cada login = `family_id` nuevo (uuidv7) |
+| Editar migration `00000002` ya aplicada | Migration nueva (forward fix) |
+| Rate-limit con prefix matching | Exacto `<operation>.<action>` literal |
+
+## Verificacion antes de commit (recordatorio)
+
+```bash
+# Tests del subpackage shared.auth
+python devtools/run.py serverless tests --type=unit --shared
+
+# Tests del Lambda auth
+python devtools/run.py serverless tests --type=unit --lambda=auth
+python devtools/run.py serverless tests --type=coverage --lambda=auth   # >=80% per-file
+
+# Lint deps (shared-only imports + dedup D-3)
+python devtools/run.py serverless lint-deps --lambda=auth
+python devtools/run.py serverless lint-deps --lambda=auth_email_worker
+python devtools/run.py serverless lint-deps --shared
+```
+
+## Referencias cruzadas
+
+- [.claude/docs/auth-system/README.md](../docs/auth-system/README.md) —
+  knowledge tree del dominio
+- [.claude/docs/auth-system/01-jwt-lifecycle.md](../docs/auth-system/01-jwt-lifecycle.md)
+- [.claude/docs/auth-system/02-flows.md](../docs/auth-system/02-flows.md)
+- [.claude/docs/auth-system/03-rate-limit-rules.md](../docs/auth-system/03-rate-limit-rules.md)
+- [.claude/rules/lambda-controller.md](lambda-controller.md) — patron
+  general
+- [.claude/rules/lambda-shared-imports.md](lambda-shared-imports.md) —
+  catalogo de portadores
+- [.claude/rules/neon-management.md](neon-management.md) — operacion de
+  Neon (migrations via la Lambda `db`, branches)
+- [.claude/rules/serverless-secrets.md](serverless-secrets.md) — SSM +
+  KMS + IAM scopes
+- Skill: `/auth-system`

--- a/.claude/skills/auth-system/SKILL.md
+++ b/.claude/skills/auth-system/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: auth-system
+description: >
+  Auth domain reference for the portfolio backend serverless: the Lambda
+  `auth` (HTTP POST `/auth` with operations register / login / verify /
+  session for refresh+logout), the Lambda `auth_email_worker` (SQS
+  consumer + SES sender for magic-link and 8-char email codes), the
+  shared subpackage `shared.auth` (pyjwt + argon2-cffi + Crockford-like
+  code generator), the Neon schema with 5 tables auth_users /
+  auth_credentials / auth_email_codes / auth_magic_links /
+  auth_audit_log, the DynamoDB table portfolio-jwt-blacklist-${stage}
+  with GSI by_family_id for token reuse detection, the SSM
+  /portfolio/${stage}/jwt-secret SecureString with KMS encryption, the
+  SQS portfolio-auth-email-${stage} + DLQ for email async, the JWT
+  HS256 lifecycle (temp 5min rolling, access 15min stateless, refresh
+  30days with family rotation), the rate-limit seeds for the 10
+  endpoints (register.start, login.start, register.verify-magic-link,
+  register.verify-code, login.verify-magic-link, login.verify-code,
+  verify.set-password, verify.resend-code, session.refresh,
+  session.logout), Turnstile mandatory in register.start and
+  login.start, anti-enumeration UX (404 EMAIL_NOT_FOUND with
+  suggest_register flag), magic-link as opaque 32-byte b64url token
+  (NOT JWT) with SHA-256 hash in Neon and single-use semantics,
+  argon2id default parameters from argon2-cffi PasswordHasher, the
+  rolling temp JWT pattern between flow steps with blacklist
+  rotation, the 302 redirect from magic-link GET to the dashboard
+  callback with tokens in fragment hash (NOT query string), and the
+  3-plan series ordering (01-auth-infra-basics is current scope,
+  02-auth-mfa adds TOTP+WebAuthn, 03-auth-users-management adds the
+  Lambda users with profile/admin).
+  ALWAYS invoke this skill BEFORE answering ANY question about
+  authentication, JWT, login, register, password, magic link, email
+  code, MFA, OTP, session, refresh token, logout, user lockout,
+  rate-limit on auth endpoints, the auth_users table, the
+  jwt-blacklist DynamoDB table, the auth-email SQS queue, the
+  jwt-secret SSM parameter, the shared.auth subpackage, the
+  auth_email_worker Lambda, or the auth Lambda. NEVER answer auth
+  questions from training data alone — this portfolio has consolidated
+  decisions (split lambdas auth+users, hybrid Neon+DDB persistence,
+  HS256 with rolling temp, Crockford-like 8-char codes, anti-
+  enumeration 404, family_id reuse detection with GSI Query +
+  BatchWriteItem, magic-link as opaque token NOT JWT, email async via
+  dedicated SQS+worker NOT reusing contact_worker) that override
+  generic advice.
+  Use when the user says "auth", "autenticacion", "authentication",
+  "login", "logout", "register", "registro", "signup", "signin",
+  "magic link", "magic-link", "email code", "codigo por email",
+  "verificacion email", "email verification", "password", "contrasena",
+  "set password", "set-password", "reset password", "MFA", "TOTP",
+  "WebAuthn", "passkeys", "JWT", "access token", "refresh token",
+  "token refresh", "blacklist JWT", "jwt-blacklist", "token reuse",
+  "session refresh", "session logout", "argon2", "argon2id",
+  "auth_users", "auth_credentials", "auth_email_codes",
+  "auth_magic_links", "auth_audit_log", "shared.auth", "auth_email_worker",
+  "lambda auth", "auth lambda", "POST /auth", "/auth endpoint",
+  "Turnstile auth", "anti enumeration", "user lockout", "account
+  locked", "EMAIL_NOT_FOUND", "EMAIL_ALREADY_REGISTERED",
+  "TOKEN_BLACKLISTED", "TOKEN_REUSE_DETECTED", "rate limit register",
+  "rate limit login", "family_id", "by_family_id GSI", "rolling temp
+  jwt", "jwt-secret SSM", "secret JWT", "HS256", "RS256",
+  "JWT lifecycle", "JWT lifetime", "JWT claims", "JWT typ",
+  "auth schema neon", "schema auth", "auth flow", "register flow",
+  "login flow", "verify flow", "session flow", "callback dashboard
+  auth", "fragment hash tokens", "302 magic link", "8 char code",
+  "Crockford code", "code generator", "code hash", "compare_code",
+  "verify_password", "hash_password", "issue_temp_jwt",
+  "issue_access_jwt", "issue_refresh_jwt", "verify_jwt", "auth
+  audit log", "audit auth", "auth security", "auth-system",
+  "/auth-system", "plan auth-infra-basics", "auth plan 01",
+  "auth plan 02", "auth plan 03", "auth-mfa", "auth-users-management",
+  "users lambda", "lambda users", "perfil de usuario", "user profile",
+  "auth deploy", "rotar jwt secret", "rotate jwt secret", "rotate
+  JWT_SECRET", "como funciona el auth del portfolio".
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: Read, Glob, Grep
+---
+
+# Auth system reference
+
+> Knowledge tree del dominio de autenticacion del backend del portfolio.
+> Detalle completo en [.claude/docs/auth-system/](../../docs/auth-system/)
+> + rule [.claude/rules/auth-system.md](../../rules/auth-system.md).
+
+## Componentes (snapshot)
+
+| Componente | Donde vive |
+|---|---|
+| Lambda `auth` (HTTP) | `serverless/lambda/services/auth/` |
+| Lambda `auth_email_worker` (SQS) | `serverless/lambda/services/auth_email_worker/` |
+| `shared.auth` (pyjwt + argon2 + codes) | `serverless/lambda/shared/auth/` |
+| Schema Neon `auth_*` (5 tablas) | `serverless/lambda/shared/db/models/auth/` |
+| Migration 00000002 | `serverless/lambda/shared/db/alembic/versions/00000002_auth_schema.py` |
+| DDB `jwt-blacklist` + GSI `by_family_id` | `serverless/lambda/resources/dynamodb/jwt-blacklist.yaml` |
+| SQS `auth-email-queue` + DLQ | `serverless/lambda/resources/sqs/auth-email-*.yaml` |
+| SSM `jwt-secret` (SecureString + KMS) | `serverless/lambda/resources/secrets/jwt-secret.yaml` |
+
+## Operations (Lambda `auth`)
+
+| operation | actions |
+|---|---|
+| `register` | `start`, `verify-magic-link`, `verify-code` |
+| `login` | `start`, `verify-magic-link`, `verify-code` |
+| `verify` | `set-password`, `resend-code` |
+| `session` | `refresh`, `logout` |
+
+## Decisiones cerradas (NO reabrir)
+
+1. **Split `auth` + futuro `users`**.
+2. **Persistencia hibrida**: Neon (relacional + codes + magic links) +
+   DDB (`jwt-blacklist` con TTL=exp + GSI `by_family_id`).
+3. **JWT HS256** con SSM secret. 3 tipos: `temp` (5 min rolling),
+   `access` (15 min stateless), `refresh` (30 dias, rotation +
+   `family_id`).
+4. **Codigo 8 chars Crockford-like** (alfabeto sin O/0/I/1/L). TTL 15
+   min. Max 5 attempts.
+5. **Magic link opaco** (NO JWT): 32 bytes b64url, hash SHA-256 en
+   Neon. Single-use, TTL 15 min.
+6. **Email async** via SQS dedicada + worker dedicado (NO reusa
+   `contact_worker`).
+7. **Turnstile solo en `register.start` y `login.start`**. El resto
+   confia en JWT temp + rate-limit.
+8. **Login UX anti-enumeration**: 404 EMAIL_NOT_FOUND con
+   `suggest_register` que diferencia "no existe" (true) vs
+   "disabled/locked" (false).
+9. **FK `auth_users.profile_id`** NULLABLE a `cv_profiles.id`,
+   ON DELETE SET NULL.
+10. **argon2id** con defaults de `PasswordHasher()`.
+11. **Rate-limit** reusa `shared.rate_limit` con seeds via
+    `serverless rate-limit set`.
+12. **CI** auto-detecta los Lambdas nuevos via `change_detector.py`.
+
+## JWT lifecycle (resumen)
+
+- `temp` (5 min): rolling. Cada paso del flujo blacklistea el `jti`
+  recibido y emite uno nuevo (`step+1`).
+- `access` (15 min): stateless. Lookup `jti` en DDB blacklist.
+- `refresh` (30 dias): rotation + `family_id` (uuidv7 por login). Si
+  llega un refresh ya blacklisted -> Query GSI by_family_id -> revoca
+  TODA la familia -> 401 TOKEN_REUSE_DETECTED.
+
+Claims: `sub` (user_id), `jti`, `typ`, `iat`, `exp`, `iss`, `aud`,
+`flow`/`step` (solo temp), `family_id` (solo refresh). **El email NUNCA
+viaja en el JWT**.
+
+## Rate-limit (snapshot)
+
+Detalle en
+[.claude/docs/auth-system/03-rate-limit-rules.md](../../docs/auth-system/03-rate-limit-rules.md).
+
+| Endpoint | Limit | Window |
+|---|---|---|
+| `register.start` | 3 | 3600s |
+| `login.start` | 5 | 60s |
+| `register.verify-*` / `login.verify-*` | 10 | 60s |
+| `verify.set-password` | 5 | 60s |
+| `verify.resend-code` | 3 | 300s |
+| `session.refresh` / `session.logout` | 30 | 60s |
+
+## Cuando NO usar esta skill
+
+- Preguntas sobre el dashboard Next.js (`admin.portfolio.*`) que NO
+  toquen el contrato del Lambda `auth`. Usar skill `dashboard-stack`.
+- Preguntas sobre el form de contacto (`contact_form` + `contact_worker`).
+- Preguntas generales sobre Lambda Python (manifest, deploy, testing)
+  que NO involucren auth. Usar skill `lambda-controller`.
+- Preguntas sobre Neon en general (operacion, migrations, branches).
+  Usar skill `neon` y rule `neon-management`.
+
+## Referencias cruzadas
+
+- [.claude/docs/auth-system/](../../docs/auth-system/) — knowledge tree
+- [.claude/rules/auth-system.md](../../rules/auth-system.md) — rule
+- [.claude/rules/lambda-controller.md](../../rules/lambda-controller.md)
+- [.claude/rules/lambda-shared-imports.md](../../rules/lambda-shared-imports.md)
+- [.claude/rules/neon-management.md](../../rules/neon-management.md)
+- [.claude/rules/serverless-secrets.md](../../rules/serverless-secrets.md)


### PR DESCRIPTION
## Problema

1. El plan `docs/specs/01-auth-infra-basics/` es efimero: se elimina
   cuando se mergea el PR final. Sin documentacion permanente, futuras
   modificaciones al sistema auth perderian el contexto de las
   decisiones de arquitectura.
2. No existe rule ni skill que enforce las convenciones del dominio auth
   (JWT lifecycle, anti-enumeration, shared.auth como portador unico de
   pyjwt+argon2, etc.).

## Solucion

1. Agrega knowledge tree permanente en `.claude/docs/auth-system/` con
   README + 3 capitulos (JWT lifecycle, flujos ASCII, reglas de
   rate-limit) que sobrevive al merge.
2. Agrega `.claude/rules/auth-system.md` con reglas duras
   SIEMPRE/NUNCA del dominio + `.claude/skills/auth-system/SKILL.md`
   invocable como `/auth-system` con keywords ES/EN.

## Como probar

```bash
# Validacion frontmatter de la skill (YAML)
python3 -c "
import yaml
with open('.claude/skills/auth-system/SKILL.md') as f:
    c = f.read()
fm = yaml.safe_load(c[3:c.index('---', 3)])
print(fm['name'], fm['user-invocable'])
"
# debe imprimir: auth-system True

# Verificar que la skill se carga al inicio de sesion: el listado de
# skills disponibles del proximo session start incluira 'auth-system'.
```

## TODO

(vacio — la implementacion del codigo arranca en PR 2)

---

Plan padre: `docs/specs/01-auth-infra-basics/` (commit 1.1 ya esta en
dev por `c382b35`).