### PR TITLE
feat(db): schema auth_* + models SQLAlchemy + migration 00000002 + repository

### DIFF
--- a/serverless/lambda/shared/db/alembic/versions/00000002_auth_schema.py
+++ b/serverless/lambda/shared/db/alembic/versions/00000002_auth_schema.py
@@ -1,0 +1,266 @@
+"""auth_schema
+
+Revision ID: 00000002
+Revises: 00000001
+Create Date: 2026-05-28
+
+Schema del dominio de autenticacion: 5 tablas + 3 enums PG.
+
+- auth_users         (pk uuid, email citext UK, status enum, ...)
+- auth_credentials   (pk user_id, password_hash, algo)
+- auth_email_codes   (pk uuid, user_id FK, code_hash bytea, kind enum, ...)
+- auth_magic_links   (pk uuid, user_id FK, token_hash bytea UK, kind enum, ...)
+- auth_audit_log     (pk uuid, user_id FK NULL, event, success, metadata jsonb, ...)
+
+Decisiones:
+- `email` es CITEXT (no STRING) para lookup case-insensitive sin LOWER().
+  El service guarda lowercased igual; CITEXT garantiza que un user
+  registrado como `Foo@x.com` no se duplique como `foo@x.com`.
+- `auth_users.profile_id` FK NULLABLE a `cv_profiles.id` con ON DELETE
+  SET NULL — solo el row de Pablo apuntara (manual).
+- `auth_email_codes.code_hash` y `auth_magic_links.token_hash` son
+  SHA-256 (32 bytes BYTEA). El code/token en plain text NUNCA se guarda.
+- `auth_magic_links.token_hash` UNIQUE para que la query
+  `WHERE token_hash = ?` use el index.
+- 3 ENUMs PG creados con `op.execute('CREATE TYPE ...')` para asegurar
+  el orden exacto de valores (necesario para downgrade reproducible).
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '00000002'
+down_revision: str | None = '00000001'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- ENUMs ---
+    op.execute(
+        "CREATE TYPE auth_user_status AS ENUM ("
+        "'pending', 'active', 'disabled', 'locked', 'deleted')",
+    )
+    op.execute(
+        "CREATE TYPE auth_code_kind AS ENUM ("
+        "'register', 'login', 'password_reset')",
+    )
+    op.execute(
+        "CREATE TYPE auth_link_kind AS ENUM ("
+        "'register', 'login', 'password_reset')",
+    )
+
+    auth_user_status_enum = postgresql.ENUM(
+        'pending', 'active', 'disabled', 'locked', 'deleted',
+        name='auth_user_status', create_type=False,
+    )
+    auth_code_kind_enum = postgresql.ENUM(
+        'register', 'login', 'password_reset',
+        name='auth_code_kind', create_type=False,
+    )
+    auth_link_kind_enum = postgresql.ENUM(
+        'register', 'login', 'password_reset',
+        name='auth_link_kind', create_type=False,
+    )
+
+    # --- auth_users ---
+    op.create_table(
+        'auth_users',
+        sa.Column(
+            'id', sa.UUID(as_uuid=False),
+            server_default=sa.text('uuidv7()'), nullable=False,
+        ),
+        sa.Column('email', postgresql.CITEXT(), nullable=False),
+        sa.Column(
+            'status', auth_user_status_enum,
+            server_default=sa.text("'pending'::auth_user_status"),
+            nullable=False,
+        ),
+        sa.Column('profile_id', sa.UUID(as_uuid=False), nullable=True),
+        sa.Column(
+            'email_verified_at', sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            'password_set_at', sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            'locked_until', sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            'last_login_at', sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            'failed_attempts', sa.Integer(),
+            server_default=sa.text('0'), nullable=False,
+        ),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False,
+        ),
+        sa.Column(
+            'updated_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ['profile_id'], ['cv_profiles.id'],
+            name=op.f('fk_auth_users_profile_id_cv_profiles'),
+            ondelete='SET NULL',
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_auth_users')),
+        sa.UniqueConstraint('email', name=op.f('uq_auth_users_email')),
+    )
+
+    # --- auth_credentials ---
+    op.create_table(
+        'auth_credentials',
+        sa.Column('user_id', sa.UUID(as_uuid=False), nullable=False),
+        sa.Column('password_hash', sa.Text(), nullable=False),
+        sa.Column(
+            'algo', sa.String(length=32),
+            server_default=sa.text("'argon2id'"), nullable=False,
+        ),
+        sa.Column(
+            'password_set_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False,
+        ),
+        sa.Column(
+            'last_change_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_id'], ['auth_users.id'],
+            name=op.f('fk_auth_credentials_user_id_auth_users'),
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint(
+            'user_id', name=op.f('pk_auth_credentials'),
+        ),
+    )
+
+    # --- auth_email_codes ---
+    op.create_table(
+        'auth_email_codes',
+        sa.Column(
+            'id', sa.UUID(as_uuid=False),
+            server_default=sa.text('uuidv7()'), nullable=False,
+        ),
+        sa.Column('user_id', sa.UUID(as_uuid=False), nullable=False),
+        sa.Column('code_hash', postgresql.BYTEA(), nullable=False),
+        sa.Column('kind', auth_code_kind_enum, nullable=False),
+        sa.Column(
+            'attempts', sa.Integer(),
+            server_default=sa.text('0'), nullable=False,
+        ),
+        sa.Column(
+            'expires_at', sa.DateTime(timezone=True), nullable=False,
+        ),
+        sa.Column(
+            'consumed_at', sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_id'], ['auth_users.id'],
+            name=op.f('fk_auth_email_codes_user_id_auth_users'),
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_auth_email_codes')),
+    )
+    op.create_index(
+        'ix_auth_email_codes_user_kind',
+        'auth_email_codes',
+        ['user_id', 'kind', 'consumed_at'],
+    )
+
+    # --- auth_magic_links ---
+    op.create_table(
+        'auth_magic_links',
+        sa.Column(
+            'id', sa.UUID(as_uuid=False),
+            server_default=sa.text('uuidv7()'), nullable=False,
+        ),
+        sa.Column('user_id', sa.UUID(as_uuid=False), nullable=False),
+        sa.Column('token_hash', postgresql.BYTEA(), nullable=False),
+        sa.Column('kind', auth_link_kind_enum, nullable=False),
+        sa.Column(
+            'expires_at', sa.DateTime(timezone=True), nullable=False,
+        ),
+        sa.Column(
+            'consumed_at', sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False,
+        ),
+        sa.Column('ip', postgresql.INET(), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['user_id'], ['auth_users.id'],
+            name=op.f('fk_auth_magic_links_user_id_auth_users'),
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_auth_magic_links')),
+        sa.UniqueConstraint(
+            'token_hash', name=op.f('uq_auth_magic_links_token_hash'),
+        ),
+    )
+
+    # --- auth_audit_log ---
+    op.create_table(
+        'auth_audit_log',
+        sa.Column(
+            'id', sa.UUID(as_uuid=False),
+            server_default=sa.text('uuidv7()'), nullable=False,
+        ),
+        sa.Column('user_id', sa.UUID(as_uuid=False), nullable=True),
+        sa.Column('event', sa.String(length=64), nullable=False),
+        sa.Column('success', sa.Boolean(), nullable=False),
+        sa.Column('error_code', sa.String(length=64), nullable=True),
+        sa.Column('ip', postgresql.INET(), nullable=True),
+        sa.Column('user_agent', sa.Text(), nullable=True),
+        sa.Column('niche', sa.String(length=32), nullable=True),
+        sa.Column('metadata', postgresql.JSONB(), nullable=True),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True),
+            server_default=sa.text('now()'), nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_id'], ['auth_users.id'],
+            name=op.f('fk_auth_audit_log_user_id_auth_users'),
+            ondelete='SET NULL',
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_auth_audit_log')),
+    )
+    op.create_index(
+        'ix_auth_audit_log_user_event_ts',
+        'auth_audit_log',
+        ['user_id', 'event', 'created_at'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'ix_auth_audit_log_user_event_ts', table_name='auth_audit_log',
+    )
+    op.drop_table('auth_audit_log')
+
+    op.drop_table('auth_magic_links')
+
+    op.drop_index(
+        'ix_auth_email_codes_user_kind', table_name='auth_email_codes',
+    )
+    op.drop_table('auth_email_codes')
+
+    op.drop_table('auth_credentials')
+    op.drop_table('auth_users')
+
+    op.execute('DROP TYPE IF EXISTS auth_link_kind')
+    op.execute('DROP TYPE IF EXISTS auth_code_kind')
+    op.execute('DROP TYPE IF EXISTS auth_user_status')

--- a/serverless/lambda/shared/db/models/__init__.py
+++ b/serverless/lambda/shared/db/models/__init__.py
@@ -11,6 +11,16 @@ API publica: `from shared.db.models import Profile, Contact, ...` sigue
 funcionando para todas las clases sin rename.
 """
 
+from .auth import (
+    AuthAuditLog,
+    AuthCodeKind,
+    AuthCredentials,
+    AuthEmailCode,
+    AuthLinkKind,
+    AuthMagicLink,
+    AuthUser,
+    AuthUserStatus,
+)
 from .cv import (
     Award,
     AwardNiche,
@@ -46,6 +56,15 @@ from .taxonomy import EventType, Niche, NichePriority, TechTag
 from .visitor import Contact, Session, SessionVisit, TrackingEvent
 
 __all__ = [  # noqa: RUF022
+    # Sistema auth (auth_)
+    'AuthAuditLog',
+    'AuthCodeKind',
+    'AuthCredentials',
+    'AuthEmailCode',
+    'AuthLinkKind',
+    'AuthMagicLink',
+    'AuthUser',
+    'AuthUserStatus',
     # Datos del visitante (vis_)
     'Contact',
     'EventType',

--- a/serverless/lambda/shared/db/models/auth/__init__.py
+++ b/serverless/lambda/shared/db/models/auth/__init__.py
@@ -1,0 +1,19 @@
+"""Subpaquete `auth/`: schema relacional del dominio auth (5 tablas)."""
+
+from .audit_log import AuthAuditLog
+from .credentials import AuthCredentials
+from .email_code import AuthEmailCode
+from .enums import AuthCodeKind, AuthLinkKind, AuthUserStatus
+from .magic_link import AuthMagicLink
+from .user import AuthUser
+
+__all__ = [
+    'AuthAuditLog',
+    'AuthCodeKind',
+    'AuthCredentials',
+    'AuthEmailCode',
+    'AuthLinkKind',
+    'AuthMagicLink',
+    'AuthUser',
+    'AuthUserStatus',
+]

--- a/serverless/lambda/shared/db/models/auth/audit_log.py
+++ b/serverless/lambda/shared/db/models/auth/audit_log.py
@@ -1,0 +1,82 @@
+"""@module auth.audit_log — tabla `auth_audit_log` (eventos de auditoria)."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import INET, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ...base import Base
+
+
+class AuthAuditLog(Base):
+    """Bitacora insert-only de eventos del dominio auth.
+
+    Cada accion del Lambda `auth` (login.start, register.verify-code,
+    session.refresh, ...) inserta un row aqui — exitoso (success=true)
+    o fallido (success=false + error_code).
+
+    `user_id` puede ser NULL: en `login.start` con email inexistente o
+    en `register.start` antes de crear el row, no hay user todavia.
+
+    `metadata` es JSONB libre para detalles no estructurados (ej.
+    `{'jti': '...', 'family_id': '...'}` en session.refresh.reuse_detected).
+
+    Indice `(user_id, event, created_at)` cubre las queries comunes:
+    "lista de events de un user" y "ultimos eventos de un type".
+
+    Retencion: insert-only. La estrategia de retencion / particionado
+    se evaluara cuando el volumen lo justifique (no en este plan).
+    """
+
+    __tablename__ = 'auth_audit_log'
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text('uuidv7()'),
+    )
+
+    user_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey('auth_users.id', ondelete='SET NULL'),
+        nullable=True,
+    )
+
+    event: Mapped[str] = mapped_column(String(64), nullable=False)
+    success: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    error_code: Mapped[str | None] = mapped_column(
+        String(64), nullable=True,
+    )
+
+    ip: Mapped[str | None] = mapped_column(INET(), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    niche: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+    meta_data: Mapped[dict[str, Any] | None] = mapped_column(
+        # En la DB la columna se llama `metadata` (no `meta_data`); SQLAlchemy
+        # reserva `metadata` en la clase Base, asi que mapeamos al nombre
+        # `meta_data` en Python pero la DDL la mantiene como `metadata`.
+        JSONB(), name='metadata', nullable=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            'ix_auth_audit_log_user_event_ts',
+            'user_id', 'event', 'created_at',
+        ),
+    )

--- a/serverless/lambda/shared/db/models/auth/credentials.py
+++ b/serverless/lambda/shared/db/models/auth/credentials.py
@@ -1,0 +1,56 @@
+"""@module auth.credentials — tabla `auth_credentials` (password hashes)."""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ...base import Base
+
+
+class AuthCredentials(Base):
+    """Credenciales (password hash) de un usuario.
+
+    Relacion 1-to-0..1 con `auth_users` (PK = user_id, FK). Esta tabla
+    NO existe para users que solo se autentican via magic-link o code
+    — solo se popula cuando el user llama `verify.set-password`.
+
+    `algo` es `'argon2id'` siempre por ahora. Existe la columna para
+    futuras migraciones (ej. cambio a Argon2.next o derivacion).
+
+    `password_hash` contiene el hash en formato argon2 completo
+    (`$argon2id$v=19$m=65536,t=3,p=4$<salt>$<hash>`) — incluye salt y
+    parametros, asi que NO hace falta tabla aparte.
+    """
+
+    __tablename__ = 'auth_credentials'
+
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey('auth_users.id', ondelete='CASCADE'),
+        primary_key=True,
+    )
+
+    password_hash: Mapped[str] = mapped_column(Text, nullable=False)
+
+    algo: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default=text("'argon2id'"),
+    )
+
+    password_set_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+    last_change_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/serverless/lambda/shared/db/models/auth/email_code.py
+++ b/serverless/lambda/shared/db/models/auth/email_code.py
@@ -1,0 +1,88 @@
+"""@module auth.email_code — tabla `auth_email_codes` (codes de 8 chars)."""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Index,
+    Integer,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import BYTEA, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ...base import Base
+from .enums import AuthCodeKind
+
+
+class AuthEmailCode(Base):
+    """Code de 8 chars enviado por email para verificar un flujo.
+
+    `code_hash` es SHA-256 (32 bytes) del code generado — el code en
+    plain text NO se guarda en la DB (defensa contra read access).
+
+    `attempts` se incrementa en cada `verify.code` que NO coincide.
+    Tras 5 fallos, el service `lock_user` cambia `auth_users.status` a
+    `locked` (AC-11).
+
+    `expires_at` es `now + 15 min` al insertar. La query de verify
+    descarta expirados (`expires_at < now`).
+
+    `consumed_at` se setea cuando el code se usa exitosamente. Despues
+    del consumo el row NO se borra — sirve para auditoria.
+
+    Indice compuesto `(user_id, kind, consumed_at)`: la query mas
+    comun es "el ultimo code activo del user para este flujo" — esta
+    forma cubre el filtro + sort.
+    """
+
+    __tablename__ = 'auth_email_codes'
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text('uuidv7()'),
+    )
+
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey('auth_users.id', ondelete='CASCADE'),
+        nullable=False,
+    )
+
+    code_hash: Mapped[bytes] = mapped_column(BYTEA(), nullable=False)
+
+    kind: Mapped[AuthCodeKind] = mapped_column(
+        SAEnum(
+            AuthCodeKind,
+            name='auth_code_kind',
+            create_type=False,
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
+        nullable=False,
+    )
+
+    attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text('0'),
+    )
+
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+
+    __table_args__ = (
+        Index(
+            'ix_auth_email_codes_user_kind',
+            'user_id', 'kind', 'consumed_at',
+        ),
+    )

--- a/serverless/lambda/shared/db/models/auth/enums.py
+++ b/serverless/lambda/shared/db/models/auth/enums.py
@@ -1,0 +1,47 @@
+"""Enums Python del dominio auth.
+
+Mapean 1-a-1 con los tipos PostgreSQL declarados en la migration
+00000002:
+- `auth_user_status`     -> AuthUserStatus
+- `auth_code_kind`       -> AuthCodeKind
+- `auth_link_kind`       -> AuthLinkKind
+"""
+
+from enum import StrEnum
+
+
+class AuthUserStatus(StrEnum):
+    """Estados del usuario en `auth_users.status`.
+
+    - `pending`: registro iniciado pero magic-link / code no verificado.
+    - `active`: validado y operativo.
+    - `disabled`: deshabilitado por admin (plan 3).
+    - `locked`: bloqueo automatico tras 5+ fallos en 5 min.
+    - `deleted`: soft-delete (futuro plan 3).
+    """
+
+    PENDING = 'pending'
+    ACTIVE = 'active'
+    DISABLED = 'disabled'
+    LOCKED = 'locked'
+    DELETED = 'deleted'
+
+
+class AuthCodeKind(StrEnum):
+    """Kind del `auth_email_codes.kind` (tipo de flujo del code).
+
+    Identico a `AuthLinkKind` por convencion; viven separados porque sus
+    semánticas pueden divergir (ej. plan 02 agrega `mfa_setup`).
+    """
+
+    REGISTER = 'register'
+    LOGIN = 'login'
+    PASSWORD_RESET = 'password_reset'
+
+
+class AuthLinkKind(StrEnum):
+    """Kind del `auth_magic_links.kind` (tipo de flujo del magic-link)."""
+
+    REGISTER = 'register'
+    LOGIN = 'login'
+    PASSWORD_RESET = 'password_reset'

--- a/serverless/lambda/shared/db/models/auth/magic_link.py
+++ b/serverless/lambda/shared/db/models/auth/magic_link.py
@@ -1,0 +1,74 @@
+"""@module auth.magic_link — tabla `auth_magic_links` (URLs single-use)."""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import BYTEA, INET, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ...base import Base
+from .enums import AuthLinkKind
+
+
+class AuthMagicLink(Base):
+    """Token opaco de magic-link (NO JWT).
+
+    El token (32 bytes b64url) se envia en el email; en la DB se guarda
+    SOLO el hash SHA-256 (`token_hash`, BYTEA UNIQUE) — el lookup es
+    O(log n) por el indice unique.
+
+    Single-use: tras consumir, `consumed_at = now()`. Re-clicks devuelven
+    400 LINK_CONSUMED.
+
+    `ip` + `user_agent` se guardan SOLO si el GET del magic-link los
+    trae — sirven para auditoria (detectar uso fuera del rango esperado
+    del user).
+    """
+
+    __tablename__ = 'auth_magic_links'
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text('uuidv7()'),
+    )
+
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey('auth_users.id', ondelete='CASCADE'),
+        nullable=False,
+    )
+
+    token_hash: Mapped[bytes] = mapped_column(
+        BYTEA(), nullable=False, unique=True,
+    )
+
+    kind: Mapped[AuthLinkKind] = mapped_column(
+        SAEnum(
+            AuthLinkKind,
+            name='auth_link_kind',
+            create_type=False,
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
+        nullable=False,
+    )
+
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+    ip: Mapped[str | None] = mapped_column(INET(), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/serverless/lambda/shared/db/models/auth/user.py
+++ b/serverless/lambda/shared/db/models/auth/user.py
@@ -1,0 +1,98 @@
+"""@module auth.user — tabla `auth_users` (cuentas del sistema auth)."""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Integer,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import CITEXT, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ...base import Base
+from .enums import AuthUserStatus
+
+
+class AuthUser(Base):
+    """Usuario del sistema auth.
+
+    `id` se autogenera con `uuidv7()` server-side (PG18). NO usa
+    UUIDPKMixin porque agrega `created_at`/`updated_at` con onupdate y
+    aqui los queremos explicitos junto a `last_login_at` y similares.
+
+    `email` es CITEXT UNIQUE: el lookup es case-insensitive. El service
+    lo guarda lowercased (`email.lower().strip()`) para que el index
+    funcione optimo.
+
+    `profile_id` FK NULLABLE a `cv_profiles.id` con ON DELETE SET NULL.
+    Solo el row de Pablo apuntara (manual). El resto de users (visitantes
+    autenticados, futuro plan 3) tiene `profile_id=NULL`.
+
+    `status` enum PG `auth_user_status`. Default `pending`.
+    `failed_attempts` se incrementa en cada verify wrong (code/password).
+    Tras 5 fallos en 5 min: status -> `locked`, locked_until = now + 1h.
+    """
+
+    __tablename__ = 'auth_users'
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        server_default=text('uuidv7()'),
+    )
+
+    email: Mapped[str] = mapped_column(
+        CITEXT(), nullable=False, unique=True,
+    )
+
+    # ENUM nativo PG. El `name` DEBE coincidir con el `name` del tipo
+    # creado en la migration ('auth_user_status'). `create_type=False`
+    # evita que el autogenerate intente recrear el tipo en cada revision.
+    # `values_callable` fuerza que SQLAlchemy serialize el value del
+    # StrEnum (`'pending'`, `'active'`, ...) en lugar de el name.
+    status: Mapped[AuthUserStatus] = mapped_column(
+        SAEnum(
+            AuthUserStatus,
+            name='auth_user_status',
+            create_type=False,
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
+        nullable=False,
+        server_default=text("'pending'::auth_user_status"),
+    )
+
+    profile_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey('cv_profiles.id', ondelete='SET NULL'),
+        nullable=True,
+    )
+
+    email_verified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    password_set_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    locked_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_login_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    failed_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text('0'),
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/serverless/lambda/shared/db/repositories/__init__.py
+++ b/serverless/lambda/shared/db/repositories/__init__.py
@@ -1,0 +1,6 @@
+"""Subpaquete `repositories/`: helpers de queries por dominio.
+
+Cada dominio (auth, cv, ...) tiene su modulo aqui. Los services del
+Lambda consumen estos helpers (NO importan `sqlalchemy` directo —
+contrato `lambda-shared-imports`).
+"""

--- a/serverless/lambda/shared/db/repositories/auth.py
+++ b/serverless/lambda/shared/db/repositories/auth.py
@@ -1,0 +1,285 @@
+"""@module repositories.auth — helpers de queries del dominio auth.
+
+Funciones puras sobre `Session` (no abren transactions, eso lo controla
+el caller). Los services del Lambda `auth` y `auth_email_worker` los
+consumen via `from shared.db.repositories.auth import ...`.
+
+Convencion de retorno:
+- `get_user_by_email`, `consume_email_code`, `consume_magic_link`
+  retornan el modelo o `None` si no existe / expired / consumed.
+- `create_pending_user`, `insert_email_code`, `insert_magic_link`
+  retornan el modelo recien insertado.
+- Mutaciones (`mark_user_active`, `lock_user`, ...) retornan `None` —
+  modifican el modelo in-place.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from shared.db.models import (
+    AuthAuditLog,
+    AuthCodeKind,
+    AuthCredentials,
+    AuthEmailCode,
+    AuthLinkKind,
+    AuthMagicLink,
+    AuthUser,
+    AuthUserStatus,
+)
+
+__all__ = [
+    'consume_email_code',
+    'consume_magic_link',
+    'create_pending_user',
+    'get_user_by_email',
+    'increment_failed_attempts',
+    'insert_audit_event',
+    'insert_email_code',
+    'insert_magic_link',
+    'lock_user',
+    'mark_user_active',
+    'reset_failed_attempts',
+    'set_password_hash',
+]
+
+
+# ----- Users -----
+
+
+def get_user_by_email(session: Session, email: str) -> AuthUser | None:
+    """Lookup case-insensitive (la columna es CITEXT).
+
+    El caller deberia normalizar el email a lower() + strip() antes,
+    pero CITEXT garantiza la insensibilidad incluso si no lo hace.
+    """
+    stmt = select(AuthUser).where(AuthUser.email == email)
+    return session.execute(stmt).scalar_one_or_none()
+
+
+def create_pending_user(session: Session, *, email: str) -> AuthUser:
+    """Crea un row con status=pending. El caller llama session.flush()
+    (o session.commit()) para que el `id` autogenerado este disponible.
+    """
+    user = AuthUser(email=email, status=AuthUserStatus.PENDING)
+    session.add(user)
+    session.flush()
+    return user
+
+
+def mark_user_active(
+    session: Session, user: AuthUser, *, when: datetime | None = None,
+) -> None:
+    """Cambia status a `active` y setea `email_verified_at`."""
+    user.status = AuthUserStatus.ACTIVE
+    user.email_verified_at = when or datetime.now(tz=user.created_at.tzinfo)
+    user.failed_attempts = 0
+    session.flush()
+
+
+def increment_failed_attempts(
+    session: Session, user: AuthUser,
+) -> int:
+    """Incrementa el contador. Retorna el valor nuevo."""
+    user.failed_attempts = (user.failed_attempts or 0) + 1
+    session.flush()
+    return user.failed_attempts
+
+
+def reset_failed_attempts(session: Session, user: AuthUser) -> None:
+    """Resetea a 0 (tras login exitoso)."""
+    user.failed_attempts = 0
+    session.flush()
+
+
+def lock_user(
+    session: Session, user: AuthUser, *, until: datetime,
+) -> None:
+    """Cambia status a `locked` y setea `locked_until`."""
+    user.status = AuthUserStatus.LOCKED
+    user.locked_until = until
+    session.flush()
+
+
+# ----- Credentials -----
+
+
+def set_password_hash(
+    session: Session, *, user_id: str, password_hash: str,
+    algo: str = 'argon2id',
+) -> AuthCredentials:
+    """Upsert del hash de password (1-to-0..1)."""
+    existing = session.get(AuthCredentials, user_id)
+    if existing is None:
+        cred = AuthCredentials(
+            user_id=user_id, password_hash=password_hash, algo=algo,
+        )
+        session.add(cred)
+        session.flush()
+        return cred
+    existing.password_hash = password_hash
+    existing.algo = algo
+    session.flush()
+    return existing
+
+
+# ----- Email codes -----
+
+
+def insert_email_code(
+    session: Session,
+    *,
+    user_id: str,
+    code_hash: bytes,
+    kind: AuthCodeKind,
+    expires_at: datetime,
+) -> AuthEmailCode:
+    """Inserta un code nuevo. NO consume codes anteriores."""
+    code = AuthEmailCode(
+        user_id=user_id,
+        code_hash=code_hash,
+        kind=kind,
+        expires_at=expires_at,
+    )
+    session.add(code)
+    session.flush()
+    return code
+
+
+def consume_email_code(
+    session: Session,
+    *,
+    user_id: str,
+    kind: AuthCodeKind,
+    code_hash: bytes,
+) -> AuthEmailCode | None:
+    """Busca el code activo (`consumed_at IS NULL`) que matchea.
+
+    Retorna el row si:
+    - hay un row activo para `(user_id, kind)`,
+    - el `code_hash` coincide,
+    - `expires_at > now`.
+
+    En caso afirmativo, marca `consumed_at = now` y retorna el row.
+
+    Si hay un row activo pero el code es WRONG, incrementa
+    `attempts` y retorna None. El caller debe decidir si llamar
+    `lock_user` cuando attempts >= 5.
+    """
+    stmt = (
+        select(AuthEmailCode)
+        .where(
+            AuthEmailCode.user_id == user_id,
+            AuthEmailCode.kind == kind,
+            AuthEmailCode.consumed_at.is_(None),
+        )
+        .order_by(AuthEmailCode.created_at.desc())
+        .limit(1)
+    )
+    row = session.execute(stmt).scalar_one_or_none()
+    if row is None:
+        return None
+    now = datetime.now(tz=row.created_at.tzinfo)
+    if row.expires_at <= now:
+        return None
+    if row.code_hash != code_hash:
+        row.attempts += 1
+        session.flush()
+        return None
+    row.consumed_at = now
+    session.flush()
+    return row
+
+
+# ----- Magic links -----
+
+
+def insert_magic_link(
+    session: Session,
+    *,
+    user_id: str,
+    token_hash: bytes,
+    kind: AuthLinkKind,
+    expires_at: datetime,
+    ip: str | None = None,
+    user_agent: str | None = None,
+) -> AuthMagicLink:
+    """Inserta un magic-link nuevo."""
+    link = AuthMagicLink(
+        user_id=user_id,
+        token_hash=token_hash,
+        kind=kind,
+        expires_at=expires_at,
+        ip=ip,
+        user_agent=user_agent,
+    )
+    session.add(link)
+    session.flush()
+    return link
+
+
+def consume_magic_link(
+    session: Session, *, token_hash: bytes,
+) -> AuthMagicLink | None:
+    """Busca por `token_hash` (UNIQUE).
+
+    Retorna el row si:
+    - existe,
+    - `consumed_at IS NULL`,
+    - `expires_at > now`.
+
+    Marca `consumed_at = now` y retorna. En cualquier otro caso (no
+    existe, ya consumido, expirado), retorna None — el caller distingue
+    el error consultando con `_get_magic_link_state` si necesita
+    diferenciar.
+
+    Para diferenciar "consumed" vs "expired" vs "no existe" el caller
+    debe hacer un segundo select sin filtros antes de consumir.
+    """
+    stmt = select(AuthMagicLink).where(AuthMagicLink.token_hash == token_hash)
+    row = session.execute(stmt).scalar_one_or_none()
+    if row is None:
+        return None
+    if row.consumed_at is not None:
+        return None
+    now = datetime.now(tz=row.created_at.tzinfo)
+    if row.expires_at <= now:
+        return None
+    row.consumed_at = now
+    session.flush()
+    return row
+
+
+# ----- Audit log -----
+
+
+def insert_audit_event(
+    session: Session,
+    *,
+    event: str,
+    success: bool,
+    user_id: str | None = None,
+    error_code: str | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+    niche: str | None = None,
+    meta_data: dict[str, Any] | None = None,
+) -> AuthAuditLog:
+    """Inserta un row de auditoria. NO devuelve por default (insert-only)."""
+    row = AuthAuditLog(
+        event=event,
+        success=success,
+        user_id=user_id,
+        error_code=error_code,
+        ip=ip,
+        user_agent=user_agent,
+        niche=niche,
+        meta_data=meta_data,
+    )
+    session.add(row)
+    session.flush()
+    return row

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/__init__.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Tests unit de los repositories de shared.db."""

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_create_pending_user.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_create_pending_user.py
@@ -1,0 +1,29 @@
+"""
+Given un email lowercased,
+When se llama create_pending_user,
+Then se inserta un AuthUser con status=pending y se hace flush().
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.db.models import AuthUserStatus
+from shared.db.repositories.auth import create_pending_user
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_create_pending_user_adds_and_flushes():
+    # Arrange
+    session = MagicMock()
+
+    # Act
+    user = create_pending_user(session, email='new@x.com')
+
+    # Assert
+    assert user.email == 'new@x.com'
+    assert user.status == AuthUserStatus.PENDING
+    session.add.assert_called_once_with(user)
+    session.flush.assert_called_once()

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_get_user_by_email_found.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_get_user_by_email_found.py
@@ -1,0 +1,38 @@
+"""
+Given un row AuthUser con email='user@x.com' en la DB,
+When se llama get_user_by_email('user@x.com'),
+Then retorna ese AuthUser.
+
+Test usa un Mock de Session porque shared.db usa SQLAlchemy 2.x con
+postgres-specific types (CITEXT, ENUM nativo) — SQLite in-memory no es
+suficiente. El Mock garantiza que el repo construye la query correcta
+y propaga el resultado.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.db.models import AuthUser, AuthUserStatus
+from shared.db.repositories.auth import get_user_by_email
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_user_by_email_returns_user_when_found():
+    # Arrange
+    session = MagicMock()
+    expected = AuthUser(
+        id='01900000-0000-7000-8000-000000000001',
+        email='user@x.com',
+        status=AuthUserStatus.ACTIVE,
+    )
+    session.execute.return_value.scalar_one_or_none.return_value = expected
+
+    # Act
+    result = get_user_by_email(session, 'user@x.com')
+
+    # Assert
+    assert result is expected
+    session.execute.assert_called_once()

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_get_user_by_email_not_found.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_get_user_by_email_not_found.py
@@ -1,0 +1,26 @@
+"""
+Given una DB sin row para email='missing@x.com',
+When se llama get_user_by_email('missing@x.com'),
+Then retorna None (sin levantar excepcion).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.db.repositories.auth import get_user_by_email
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_user_by_email_returns_none_when_not_found():
+    # Arrange
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = None
+
+    # Act
+    result = get_user_by_email(session, 'missing@x.com')
+
+    # Assert
+    assert result is None

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_increment_failed_attempts.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_increment_failed_attempts.py
@@ -1,0 +1,34 @@
+"""
+Given un AuthUser con failed_attempts=4,
+When se llama increment_failed_attempts,
+Then el contador queda en 5 y se retorna 5.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.db.models import AuthUser, AuthUserStatus
+from shared.db.repositories.auth import increment_failed_attempts
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_increment_failed_attempts_returns_new_value():
+    # Arrange
+    session = MagicMock()
+    user = AuthUser(
+        id='01900000-0000-7000-8000-000000000001',
+        email='u@x.com',
+        status=AuthUserStatus.ACTIVE,
+        failed_attempts=4,
+    )
+
+    # Act
+    result = increment_failed_attempts(session, user)
+
+    # Assert
+    assert result == 5
+    assert user.failed_attempts == 5
+    session.flush.assert_called_once()

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_insert_audit_event.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_insert_audit_event.py
@@ -1,0 +1,42 @@
+"""
+Given parametros validos,
+When se llama insert_audit_event con event='register.start' success=True,
+Then se inserta un AuthAuditLog con esos campos.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.db.repositories.auth import insert_audit_event
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_insert_audit_event_creates_row_with_all_fields():
+    # Arrange
+    session = MagicMock()
+
+    # Act
+    row = insert_audit_event(
+        session,
+        event='register.start',
+        success=True,
+        user_id='01900000-0000-7000-8000-000000000001',
+        error_code=None,
+        ip='203.0.113.10',
+        user_agent='curl/8.0',
+        niche='fintech',
+        meta_data={'turnstile': 'valid'},
+    )
+
+    # Assert
+    assert row.event == 'register.start'
+    assert row.success is True
+    assert row.user_id == '01900000-0000-7000-8000-000000000001'
+    assert row.ip == '203.0.113.10'
+    assert row.niche == 'fintech'
+    assert row.meta_data == {'turnstile': 'valid'}
+    session.add.assert_called_once_with(row)
+    session.flush.assert_called_once()

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mark_user_active.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mark_user_active.py
@@ -1,0 +1,38 @@
+"""
+Given un AuthUser pending,
+When se llama mark_user_active,
+Then status=active, email_verified_at se setea, failed_attempts=0.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.db.models import AuthUser, AuthUserStatus
+from shared.db.repositories.auth import mark_user_active
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_mark_user_active_updates_status_and_resets_attempts():
+    # Arrange
+    session = MagicMock()
+    user = AuthUser(
+        id='01900000-0000-7000-8000-000000000001',
+        email='u@x.com',
+        status=AuthUserStatus.PENDING,
+        failed_attempts=3,
+    )
+    user.created_at = datetime.now(UTC)
+    when = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+
+    # Act
+    mark_user_active(session, user, when=when)
+
+    # Assert
+    assert user.status == AuthUserStatus.ACTIVE
+    assert user.email_verified_at == when
+    assert user.failed_attempts == 0
+    session.flush.assert_called_once()


### PR DESCRIPTION
## Problema

1. El backend no tiene tablas para usuarios autenticados, codes de
   email, magic-links ni audit log de eventos auth.
2. La Lambda `auth` (que viene en PR 6+) necesita un repository
   `shared.db.repositories.auth` para no importar SQLAlchemy directo
   (regla `lambda-shared-imports`).
3. Alembic todavia no tiene la migration que crea las 5 tablas
   `auth_*`.

## Solucion

1. 5 modelos SQLAlchemy 2.x en `serverless/lambda/shared/db/models/auth/`:
   `AuthUser`, `AuthCredentials`, `AuthEmailCode`, `AuthMagicLink`,
   `AuthAuditLog`. 3 enums Python (`AuthUserStatus`, `AuthCodeKind`,
   `AuthLinkKind`) que mapean a tipos PG nativos.
2. Repository `shared/db/repositories/auth.py` con 11 helpers puros
   sobre `Session`. Tests unit con 6 escenarios criticos.
3. Migration `00000002_auth_schema.py` con `CREATE TYPE` enums + 5
   `create_table` + indices + `downgrade` simetrico.

## Como probar

```bash
# Sintaxis Python
python -m compileall -q serverless/lambda/shared/db/models/auth \
                       serverless/lambda/shared/db/repositories \
                       serverless/lambda/shared/db/alembic/versions/00000002_auth_schema.py

# Alembic detecta la cadena 00000001 -> 00000002
cd serverless/lambda
serverless/.venv/bin/alembic -c shared/db/alembic.ini history
# debe mostrar: 00000001 -> 00000002 (head), auth_schema

# Imports OK + tabla names
python -c "from shared.db.models import AuthUser, AuthAuditLog; print(AuthUser.__tablename__, AuthAuditLog.__tablename__)"
# auth_users auth_audit_log

# Lint-deps + tests (406 verdes, +6 nuevos)
python devtools/run.py serverless lint-deps --shared
python devtools/run.py serverless tests --type=unit --shared
```

## TODO

- [ ] Aplicar la migration a `dev` tras merge:
      `python devtools/run.py serverless run --stage=dev --lambda=db --event=events/migrate.json --aws-profile=tfs-dev`
- [ ] Verificar con `events/current.json` que dev queda en revision
      `00000002`

---

Plan padre: `docs/specs/01-auth-infra-basics/` (PR 3 del plan).