### PR TITLE
feat(resources): DynamoDB jwt-blacklist + SQS auth-email + SSM jwt-secret

### DIFF
--- a/devtools/serverless/infra_provision.py
+++ b/devtools/serverless/infra_provision.py
@@ -390,19 +390,63 @@ def _build_create_table_args(rendered: RenderedResource) -> list[str]:
     hash_key = spec['hash_key']
     range_key = spec.get('range_key')
 
-    attribute_defs = [
-        {'AttributeName': hash_key['name'], 'AttributeType': hash_key['type']},
-    ]
+    # Acumulamos los attribute definitions con un dict para deduplicar:
+    # el GSI puede compartir attribute con la PK o agregar uno nuevo.
+    attribute_defs_by_name: dict[str, dict[str, str]] = {
+        hash_key['name']: {
+            'AttributeName': hash_key['name'],
+            'AttributeType': hash_key['type'],
+        },
+    }
     key_schema = [{'AttributeName': hash_key['name'], 'KeyType': 'HASH'}]
     if range_key:
-        attribute_defs.append(
-            {
-                'AttributeName': range_key['name'],
-                'AttributeType': range_key['type'],
-            },
-        )
+        attribute_defs_by_name[range_key['name']] = {
+            'AttributeName': range_key['name'],
+            'AttributeType': range_key['type'],
+        }
         key_schema.append(
             {'AttributeName': range_key['name'], 'KeyType': 'RANGE'},
+        )
+
+    # Global Secondary Indexes (opcional). Cada GSI declara su hash_key
+    # (+ range_key opcional) y la projection (KEYS_ONLY / ALL / INCLUDE).
+    # En PAY_PER_REQUEST no se declara ProvisionedThroughput.
+    gsis_input = spec.get('global_secondary_indexes') or []
+    gsis_aws: list[dict[str, object]] = []
+    for gsi in gsis_input:
+        gsi_hash = gsi['hash_key']
+        attribute_defs_by_name.setdefault(
+            gsi_hash['name'],
+            {
+                'AttributeName': gsi_hash['name'],
+                'AttributeType': gsi_hash['type'],
+            },
+        )
+        gsi_key_schema = [
+            {'AttributeName': gsi_hash['name'], 'KeyType': 'HASH'},
+        ]
+        gsi_range = gsi.get('range_key')
+        if gsi_range:
+            attribute_defs_by_name.setdefault(
+                gsi_range['name'],
+                {
+                    'AttributeName': gsi_range['name'],
+                    'AttributeType': gsi_range['type'],
+                },
+            )
+            gsi_key_schema.append(
+                {'AttributeName': gsi_range['name'], 'KeyType': 'RANGE'},
+            )
+        projection_type = gsi.get('projection', 'KEYS_ONLY')
+        projection: dict[str, object] = {'ProjectionType': projection_type}
+        if projection_type == 'INCLUDE':
+            projection['NonKeyAttributes'] = gsi.get('non_key_attributes', [])
+        gsis_aws.append(
+            {
+                'IndexName': gsi['name'],
+                'KeySchema': gsi_key_schema,
+                'Projection': projection,
+            },
         )
 
     import json as _json
@@ -415,10 +459,12 @@ def _build_create_table_args(rendered: RenderedResource) -> list[str]:
         '--billing-mode',
         spec.get('billing_mode', 'PAY_PER_REQUEST'),
         '--attribute-definitions',
-        _json.dumps(attribute_defs),
+        _json.dumps(list(attribute_defs_by_name.values())),
         '--key-schema',
         _json.dumps(key_schema),
     ]
+    if gsis_aws:
+        args += ['--global-secondary-indexes', _json.dumps(gsis_aws)]
     if spec.get('stream'):
         args += [
             '--stream-specification',

--- a/serverless/lambda/resources/dynamodb/jwt-blacklist.yaml
+++ b/serverless/lambda/resources/dynamodb/jwt-blacklist.yaml
@@ -1,0 +1,29 @@
+# Esquema devtools — NO CloudFormation: esquema plano, sin funciones
+# intrinsecas. devtools lo lee y emite las llamadas AWS CLI.
+#
+# DynamoDB jwt-blacklist: blacklist de JWTs (temp/access/refresh) con
+# TTL=exp para que AWS borre los items expirados sin WCU.
+#
+# El GSI by_family_id soporta el flujo de token-reuse detection del
+# Lambda auth: cuando llega un refresh con jti ya blacklisted, se
+# hace Query GSI con KeyConditionExpression='family_id = :fid' (returns
+# [jti, ...]) y se blacklisteam TODOS los jti de la familia con
+# BatchWriteItem. Projection=KEYS_ONLY: solo necesitamos jti para
+# revocar (no NonKeyAttributes).
+kind: dynamodb-table
+name: portfolio-jwt-blacklist-${stage}
+billing_mode: PAY_PER_REQUEST
+hash_key: { name: jti, type: S }
+range_key: null
+stream: null
+point_in_time_recovery: false
+encryption: true
+ttl_attribute: exp
+global_secondary_indexes:
+  - name: by_family_id
+    hash_key: { name: family_id, type: S }
+    projection: KEYS_ONLY
+publishes_ssm:
+  name: /portfolio/${stage}/dynamodb/jwt-blacklist/name
+  arn: /portfolio/${stage}/dynamodb/jwt-blacklist/arn
+tags: { Project: portfolio, Module: auth, ManagedBy: devtools }

--- a/serverless/lambda/resources/secrets/jwt-secret.yaml
+++ b/serverless/lambda/resources/secrets/jwt-secret.yaml
@@ -1,0 +1,39 @@
+# Esquema devtools — NO CloudFormation: esquema plano, sin funciones
+# intrinsecas. devtools lo lee y emite las llamadas AWS CLI necesarias.
+# SSM Parameter del JWT_SECRET (HS256) que firma los JWT del dominio
+# auth (temp/access/refresh). Generacion del valor:
+#   python -c "import secrets; print(secrets.token_urlsafe(64))"
+# Pegar en docker/env/server/.{dev,stage,prod} como JWT_SECRET=<valor>;
+# luego sincronizar a SSM con `serverless sync-secrets --stage=<X>`.
+kind: ssm-parameter
+
+name: jwt-secret
+description: HS256 secret para firmar JWTs del dominio auth (temp/access/refresh)
+
+path: /portfolio/${stage}/jwt-secret
+ssm_type: SecureString
+kms_key_alias: alias/portfolio-lambdas
+
+# Mapeo .env -> Lambda.
+# source_env_var: KEY que devtools busca en docker/env/server/.{stage}
+# target_env_var: env var del Lambda (path SSM en cloud, fallback en local)
+source_env_var: JWT_SECRET
+target_env_var: SSM_JWT_SECRET_PATH
+
+stages: [dev, stage, prod]
+required: true
+
+rotation:
+  interval_days: 90
+
+owners:
+  - pacg1991@gmail.com
+
+consumed_by:
+  - auth
+  # users (futuro plan 3)
+
+tags:
+  Project: portfolio
+  Module: auth
+  ManagedBy: devtools

--- a/serverless/lambda/resources/sqs/auth-email-dlq.yaml
+++ b/serverless/lambda/resources/sqs/auth-email-dlq.yaml
@@ -1,0 +1,11 @@
+# Esquema devtools — NO CloudFormation: esquema plano, sin funciones
+# intrinsecas. DLQ del worker auth_email_worker. SQS retiene los
+# mensajes 14 dias para inspeccion + reproceso manual.
+kind: sqs-queue
+name: portfolio-auth-email-dlq-${stage}
+message_retention_seconds: 1209600       # 14 dias (max SQS)
+visibility_timeout_seconds: 30
+publishes_ssm:
+  arn: /portfolio/${stage}/sqs/auth-email-dlq/arn
+  url: /portfolio/${stage}/sqs/auth-email-dlq/url
+tags: { Project: portfolio, Module: auth, ManagedBy: devtools }

--- a/serverless/lambda/resources/sqs/auth-email-queue.yaml
+++ b/serverless/lambda/resources/sqs/auth-email-queue.yaml
@@ -1,0 +1,16 @@
+# Cola principal del worker auth_email_worker. visibility_timeout = 180s
+# (6x el timeout del worker que es 30s) — recomendado AWS para evitar
+# duplicate processing por timeout antes de ack. El Lambda `auth`
+# publica magic-link / register-code / login-code / password-reset; el
+# worker renderiza la plantilla y manda via SES.
+kind: sqs-queue
+name: portfolio-auth-email-${stage}
+message_retention_seconds: 345600        # 4 dias (default SQS)
+visibility_timeout_seconds: 180
+redrive_policy:
+  target: portfolio-auth-email-dlq-${stage}
+  max_receive_count: 3
+publishes_ssm:
+  arn: /portfolio/${stage}/sqs/auth-email/arn
+  url: /portfolio/${stage}/sqs/auth-email/url
+tags: { Project: portfolio, Module: auth, ManagedBy: devtools }


### PR DESCRIPTION
## Problema

1. El Lambda `auth` necesita una tabla DDB `portfolio-jwt-blacklist-${stage}`
   con TTL=exp + GSI `by_family_id` (KEYS_ONLY) para revocar JWTs y
   detectar token reuse (AC-8).
2. El Lambda `auth` + `auth_email_worker` (PR 5) necesitan una cola SQS
   dedicada (no se reusa `contact-form-queue`).
3. Los JWTs (HS256) necesitan un secret en SSM `SecureString` con KMS.
4. `devtools/serverless/infra_provision.py` IGNORA SILENCIOSAMENTE
   `global_secondary_indexes` en los yamls de DDB — el GSI no se
   provisionaria.

## Solucion

1. `resources/dynamodb/jwt-blacklist.yaml`: PK `jti`, TTL `exp`,
   encryption, GSI `by_family_id` KEYS_ONLY.
2. `resources/sqs/auth-email-queue.yaml` + `auth-email-dlq.yaml`:
   visibility 180s, redrive a DLQ con max_receive_count=3, retencion
   14 dias en DLQ.
3. `resources/secrets/jwt-secret.yaml`: SecureString + KMS
   `alias/portfolio-lambdas`. consumed_by: `auth` (este plan) + `users`
   (plan 03 futuro).
4. Extiende `_build_create_table_args` en `infra_provision.py` para
   parsear `global_secondary_indexes`. Soporta projection KEYS_ONLY /
   ALL / INCLUDE, deduplica `attribute_definitions` cuando el GSI
   comparte atributo con la PK.

## Como probar

```bash
# Validacion del catalogo
python devtools/run.py serverless validate-catalog --stage=dev
# 7 secretos validos (jwt-secret nuevo aparece)

# Listado de recursos
python devtools/run.py serverless list-resources --stage=dev
# jwt-blacklist + auth-email* aparecen

# Sintaxis del cambio en devtools
python -m compileall -q devtools/serverless/infra_provision.py
```

## TODO

- [ ] Generar JWT_SECRET (`python -c 'import secrets; print(secrets.token_urlsafe(64))'`)
- [ ] Pegar como `JWT_SECRET=<valor>` en `docker/env/server/.{dev,stage,prod}`
- [ ] `python devtools/run.py serverless provision-infra --stage=dev --aws-profile=tfs-dev`
- [ ] `python devtools/run.py serverless sync-secrets --stage=dev --aws-profile=tfs-dev`
- [ ] `python devtools/run.py serverless secrets-status --stage=dev --aws-profile=tfs-dev` debe reportar `jwt-secret SKIP`

---

Plan padre: `docs/specs/01-auth-infra-basics/` (PR 4 del plan).