### PR TITLE
feat(auth): scaffold Lambda + 9 services + 10 models Pydantic

### DIFF
--- a/serverless/lambda/services/auth/.gitignore
+++ b/serverless/lambda/services/auth/.gitignore
@@ -1,0 +1,10 @@
+build/
+build.zip
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage*
+htmlcov/
+.ruff_cache/
+.mypy_cache/

--- a/serverless/lambda/services/auth/core/__init__.py
+++ b/serverless/lambda/services/auth/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core del Lambda `auth` (endpoint HTTP POST /auth)."""

--- a/serverless/lambda/services/auth/core/controllers/__init__.py
+++ b/serverless/lambda/services/auth/core/controllers/__init__.py
@@ -1,0 +1,6 @@
+"""Controllers del Lambda `auth`.
+
+Cada operation (`register`, `login`, `verify`, `session`) tiene su
+subcarpeta con un modulo por action. Los controllers concretos se
+agregan en PR 7 + PR 8.
+"""

--- a/serverless/lambda/services/auth/core/handler.py
+++ b/serverless/lambda/services/auth/core/handler.py
@@ -1,0 +1,77 @@
+"""Lambda `auth` — endpoint HTTP `POST /auth`.
+
+Entrypoint del Lambda. Router delgado que delega TODO el ciclo al
+`http_handler` generico de `shared.lambda_kit`. El cliente envia
+`operation` y `action` en el body JSON:
+
+    POST /auth
+    {
+      "operation": "register" | "login" | "verify" | "session",
+      "action": "start" | "verify-magic-link" | ...,
+      "data": { ... }
+    }
+
+El `http_handler` extrae `operation`/`action`/`data` del body, inyecta
+`data._meta` con la metadata de transporte (IP, country, user-agent,
+bypass-secret) y ejecuta el ciclo `preload -> validate -> execute` del
+controller resuelto por `OPERATIONS`.
+
+El Handler de la funcion AWS es `core.handler.lambda_handler`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# El handler vive dentro de core/. Agregamos core/ al sys.path para que
+# los imports absolutos (models., services., settings., shared.)
+# resuelvan en AWS y en invoke local. shared/ se vendoriza en core/shared/.
+_CORE_DIR = os.path.dirname(os.path.abspath(__file__))
+if _CORE_DIR not in sys.path:
+    sys.path.insert(0, _CORE_DIR)
+
+from typing import Any
+
+from models.event import EVENT_MODEL
+from settings.operations import OPERATIONS
+from shared.lambda_kit import http_handler
+from shared.observability.logger import logger
+from shared.observability.metrics import metrics
+from shared.observability.tracer import tracer
+
+__version__ = '0.1.0'
+
+
+@logger.inject_lambda_context(
+    log_event=False, correlation_id_path='requestContext.requestId'
+)
+@tracer.capture_lambda_handler
+@metrics.log_metrics(capture_cold_start_metric=True)
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Entrypoint Lambda auth (POST /auth).
+
+    Delega en `http_handler` con CORS echo (dashboard + niches con
+    auth) y las 3 metricas CloudWatch
+    (AuthRequestAccepted/Rejected/Error).
+
+    Status de exito: HTTP 200 para todos los flows. El cuerpo discrimina
+    entre temp_token (flow en curso) y access+refresh tokens (flow
+    terminal).
+    """
+    return http_handler(
+        event,
+        event_model=EVENT_MODEL,
+        cors_origin='echo',
+        success_status=200,
+        metric_names={
+            'submitted': 'AuthRequestAccepted',
+            'rejected': 'AuthRequestRejected',
+            'error': 'AuthRequestError',
+        },
+    )
+
+
+# OPERATIONS se importa para forzar el registro de las operations
+# (descubrimiento por convencion); referenciado para evitar F401.
+_ = OPERATIONS

--- a/serverless/lambda/services/auth/core/models/__init__.py
+++ b/serverless/lambda/services/auth/core/models/__init__.py
@@ -1,0 +1,6 @@
+"""Modelos Pydantic del Lambda `auth`.
+
+Un archivo por operation con sus actions. `_common.py` agrupa los tipos
+compartidos (`Niche`, `_Meta`). `event.py` construye el `EVENT_MODEL`
+agregado con `build_event_model` del kit.
+"""

--- a/serverless/lambda/services/auth/core/models/_common.py
+++ b/serverless/lambda/services/auth/core/models/_common.py
@@ -1,0 +1,46 @@
+"""Tipos compartidos entre los modelos del Lambda `auth`.
+
+`Niche` es una lista cerrada con los 6 niches del portfolio: cualquier
+otro valor en el payload del cliente -> `ValidationError` 400. Evita
+que un atacante meta strings arbitrarios (incluyendo HTML/script) en
+el audit log o en templates de email del worker.
+
+`_Meta` modela el bloque `_meta` que `http_handler` inyecta al `data`
+del request (ip, country, user_agent, bypass_secret, origin extraidos
+de los headers de API Gateway). Usa `populate_by_name=True` con
+`alias='_meta'` para que se acepte tanto en entrada como `_meta` como
+en codigo via `.meta`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from shared.core import BaseModel, ConfigDict, Field
+
+# 6 niches publicos del portfolio. Cualquier otro valor en payload ->
+# ValidationError 400 (defensa contra strings arbitrarios en audit /
+# emails).
+Niche = Literal['generic', 'hub', 'fintech', 'architect', 'leader', 'vibe']
+
+
+class _Meta(BaseModel):
+    """Metadata de transporte HTTP inyectada por `http_handler`.
+
+    `http_handler` la inyecta en `data['_meta']` desde los headers de
+    API Gateway (CF-Connecting-IP, CF-IPCountry, User-Agent,
+    X-Turnstile-Bypass-Secret, Origin). El service NO la conoce: solo
+    los controllers la usan para rate-limit + Turnstile + audit.
+    """
+
+    ip: str | None = None
+    country: str | None = None
+    user_agent: str | None = None
+    bypass_secret: str | None = None
+    origin: str | None = None
+    # Mapa raw de los headers cloudfront-* del request (Edge-Optimized
+    # API GW los expone). Mismo patron que contact_form para futuras
+    # decisiones de geolocation en el worker.
+    cloudfront_meta: dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra='ignore')

--- a/serverless/lambda/services/auth/core/models/event.py
+++ b/serverless/lambda/services/auth/core/models/event.py
@@ -1,0 +1,45 @@
+"""EventModel del Lambda `auth`.
+
+Construye `EVENT_MODEL` con `build_event_model(OPERATIONS)` del kit
+(`shared.lambda_kit`). El handler lo usa para validar la estructura
+`{operation, action, data}` del evento sintetico y resolver el
+controller correspondiente.
+
+Los modelos Pydantic concretos por action (`RegisterStartIn`,
+`LoginStartIn`, ...) se importan aqui para garantizar que sus
+modulos se cargan al cold start; los controllers los reutilizan para
+validar el payload concreto dentro de `validate()`.
+"""
+
+from __future__ import annotations
+
+from settings.operations import OPERATIONS
+from shared.lambda_kit import build_event_model
+
+# Side-effect: importar los modelos garantiza que se cargan en cold
+# start (algunos controllers los importan via `models.<operation>` y
+# nos beneficiamos del module caching de Python).
+from .login import LoginStartIn, LoginVerifyCodeIn, LoginVerifyMagicLinkIn
+from .register import (
+    RegisterStartIn,
+    RegisterVerifyCodeIn,
+    RegisterVerifyMagicLinkIn,
+)
+from .session import SessionLogoutIn, SessionRefreshIn
+from .verify import VerifyResendCodeIn, VerifySetPasswordIn
+
+# Eviten F401 (los imports estan para forzar la carga del modulo).
+_ = (
+    RegisterStartIn,
+    RegisterVerifyMagicLinkIn,
+    RegisterVerifyCodeIn,
+    LoginStartIn,
+    LoginVerifyMagicLinkIn,
+    LoginVerifyCodeIn,
+    VerifySetPasswordIn,
+    VerifyResendCodeIn,
+    SessionRefreshIn,
+    SessionLogoutIn,
+)
+
+EVENT_MODEL = build_event_model(OPERATIONS)

--- a/serverless/lambda/services/auth/core/models/login.py
+++ b/serverless/lambda/services/auth/core/models/login.py
@@ -1,0 +1,46 @@
+"""Modelos Pydantic de la operation `login`.
+
+3 actions, espejo de `register` (mismas shapes; el controller cambia el
+flujo de validacion / persistencia).
+"""
+
+from __future__ import annotations
+
+from shared.core import BaseModel, ConfigDict, EmailStr, Field
+
+from ._common import Niche, _Meta
+
+
+class LoginStartIn(BaseModel):
+    """POST /auth operation=login action=start."""
+
+    email: EmailStr
+    cf_turnstile_response: str = Field(..., min_length=1, max_length=2048)
+    niche: Niche | None = None
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
+class LoginVerifyMagicLinkIn(BaseModel):
+    """GET callback del magic-link de login (mismo shape que register)."""
+
+    token: str = Field(..., min_length=32, max_length=128)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
+class LoginVerifyCodeIn(BaseModel):
+    """POST /auth operation=login action=verify-code (mismo shape)."""
+
+    code: str = Field(
+        ...,
+        min_length=8,
+        max_length=8,
+        pattern=r'^[A-HJ-NP-Z2-9]{8}$',
+    )
+    temp_token: str = Field(..., min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')

--- a/serverless/lambda/services/auth/core/models/register.py
+++ b/serverless/lambda/services/auth/core/models/register.py
@@ -1,0 +1,59 @@
+"""Modelos Pydantic de la operation `register`.
+
+3 actions:
+- `start`: el visitante inicia el registro con su email + Turnstile.
+- `verify-magic-link`: el visitante clickea el link del email
+  (sin step intermedio).
+- `verify-code`: el visitante pega el code de 8 chars en el dashboard.
+"""
+
+from __future__ import annotations
+
+from shared.core import BaseModel, ConfigDict, EmailStr, Field
+
+from ._common import Niche, _Meta
+
+
+class RegisterStartIn(BaseModel):
+    """POST /auth operation=register action=start."""
+
+    email: EmailStr
+    cf_turnstile_response: str = Field(..., min_length=1, max_length=2048)
+    niche: Niche | None = None
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
+class RegisterVerifyMagicLinkIn(BaseModel):
+    """GET callback del magic-link (o POST si el dashboard re-hace la verify).
+
+    `token` es el opaque 32-byte b64url que viajo en la URL del email.
+    El controller resuelve el `user_id` por SHA-256(token) contra
+    `auth_magic_links.token_hash`.
+    """
+
+    token: str = Field(..., min_length=32, max_length=128)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
+class RegisterVerifyCodeIn(BaseModel):
+    """POST /auth operation=register action=verify-code.
+
+    `code`: 8 chars Crockford-like (alphabet `[A-HJ-NP-Z2-9]` —
+    excluye `O/0/I/1/L` para reducir confusion visual).
+    `temp_token`: rolling temp JWT emitido en `register.start`.
+    """
+
+    code: str = Field(
+        ...,
+        min_length=8,
+        max_length=8,
+        pattern=r'^[A-HJ-NP-Z2-9]{8}$',
+    )
+    temp_token: str = Field(..., min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')

--- a/serverless/lambda/services/auth/core/models/session.py
+++ b/serverless/lambda/services/auth/core/models/session.py
@@ -1,0 +1,43 @@
+"""Modelos Pydantic de la operation `session` (refresh + logout).
+
+2 actions:
+- `refresh`: el cliente intercambia un refresh JWT por un par
+  access+refresh nuevo (rotacion + family detection).
+- `logout`: el cliente revoca su access + (opcionalmente) refresh JWT
+  — el service blacklistea ambos en DDB.
+"""
+
+from __future__ import annotations
+
+from shared.core import BaseModel, ConfigDict, Field
+
+from ._common import _Meta
+
+
+class SessionRefreshIn(BaseModel):
+    """POST /auth operation=session action=refresh.
+
+    El refresh viaja en el body. El controller verifica typ='refresh',
+    chequea blacklist, y si OK -> rota la familia (blacklistea el
+    refresh viejo, emite refresh nuevo con el mismo family_id).
+    """
+
+    refresh_token: str = Field(..., min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
+class SessionLogoutIn(BaseModel):
+    """POST /auth operation=session action=logout.
+
+    `access_token` es obligatorio (lo necesitamos para identificar al
+    user y blacklistear su jti). `refresh_token` es opcional: si llega,
+    el service blacklistea la familia completa (Query GSI + BatchWrite).
+    """
+
+    access_token: str = Field(..., min_length=20)
+    refresh_token: str | None = Field(default=None, min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')

--- a/serverless/lambda/services/auth/core/models/verify.py
+++ b/serverless/lambda/services/auth/core/models/verify.py
@@ -1,0 +1,43 @@
+"""Modelos Pydantic de la operation `verify` (set password + resend code).
+
+2 actions:
+- `set-password`: el visitante define su password tras verify-magic-link
+  o verify-code (paso opcional en flujo register).
+- `resend-code`: re-emite un code/magic-link nuevo (en register o login).
+"""
+
+from __future__ import annotations
+
+from shared.core import BaseModel, ConfigDict, Field
+
+from ._common import _Meta
+
+
+class VerifySetPasswordIn(BaseModel):
+    """POST /auth operation=verify action=set-password.
+
+    `password`: min 12 chars (politica MVP). Hashing con argon2id en
+    el service.
+    `temp_token`: rolling temp JWT del flujo activo (typ=temp,
+    flow='register'|'login', step >=2 tras la verify del code/link).
+    """
+
+    password: str = Field(..., min_length=12, max_length=128)
+    temp_token: str = Field(..., min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
+class VerifyResendCodeIn(BaseModel):
+    """POST /auth operation=verify action=resend-code.
+
+    Re-emite code + magic-link nuevos. El service aplica rate-limit
+    propio (max 1 resend cada 60s, max 3 en 5min — seed declarado en
+    rate-limit-rules).
+    """
+
+    temp_token: str = Field(..., min_length=20)
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')

--- a/serverless/lambda/services/auth/core/services/__init__.py
+++ b/serverless/lambda/services/auth/core/services/__init__.py
@@ -1,0 +1,6 @@
+"""Services del Lambda `auth`.
+
+Clases con la logica de negocio. Cada controller instancia las que
+necesita pasandoles `app_config`; el service NO conoce el evento
+Lambda (solo data ya validada).
+"""

--- a/serverless/lambda/services/auth/core/services/audit_service.py
+++ b/serverless/lambda/services/auth/core/services/audit_service.py
@@ -1,0 +1,58 @@
+"""Audit service del Lambda `auth`.
+
+Inserta un row en `auth_audit_log` por cada evento de auth observable
+(register.start, login.start, verify.set-password, session.refresh,
+session.logout, ...). Es insert-only — nadie modifica los rows.
+
+Eventos canonicos: `<operation>.<action>`. `success=False` solo cuando
+el flujo falla por motivo de negocio (EMAIL_NOT_FOUND,
+INVALID_CODE, ...); errores 5xx no necesariamente quedan en este log
+(viven en CloudWatch).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from shared.db import db_session
+from shared.db.repositories.auth import insert_audit_event
+
+
+class AuditService:
+    """Wrapper de `insert_audit_event` con la signature del dominio."""
+
+    def __init__(self, app_config: object) -> None:
+        self.app_config = app_config
+
+    def log(
+        self,
+        *,
+        event: str,
+        success: bool,
+        user_id: UUID | str | None = None,
+        error_code: str | None = None,
+        ip: str | None = None,
+        user_agent: str | None = None,
+        niche: str | None = None,
+        meta_data: dict[str, Any] | None = None,
+    ) -> None:
+        """Inserta un row de auditoria. NO propaga si Neon falla.
+
+        Si Neon falla (rollback, DB caida), el audit insert se intenta
+        pero NO bloquea el flujo principal. El controller que falla
+        igual responde a tiempo; CloudWatch captura la excepcion via
+        logger.exception en este caller.
+        """
+        with db_session() as session:
+            insert_audit_event(
+                session,
+                event=event,
+                success=success,
+                user_id=str(user_id) if user_id is not None else None,
+                error_code=error_code,
+                ip=ip,
+                user_agent=user_agent,
+                niche=niche,
+                meta_data=meta_data,
+            )

--- a/serverless/lambda/services/auth/core/services/blacklist_service.py
+++ b/serverless/lambda/services/auth/core/services/blacklist_service.py
@@ -1,0 +1,106 @@
+"""JWT blacklist service del Lambda `auth`.
+
+Encapsula las operaciones DDB sobre `portfolio-jwt-blacklist-${stage}`:
+PutItem (blacklist un jti), GetItem (lookup), Query GSI by_family_id
+(devuelve todos los jti de una familia), BatchWriteItem (revoca la
+familia entera).
+
+El item shape:
+    {
+      jti: str (UUID),
+      exp: int (unix seconds) -> TTL (AWS borra el item al exp+48h),
+      user_id: str,
+      reason: str ('rotation' | 'logout' | 'reuse' | 'admin'),
+      family_id: str | None  (solo para refresh, alimenta el GSI),
+      blacklisted_at: int (unix seconds)
+    }
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from uuid import UUID
+
+from shared.aws import get_table
+
+
+class BlacklistService:
+    """Service de DDB jwt-blacklist (PutItem/GetItem/Query/BatchWrite)."""
+
+    def __init__(self, app_config: object) -> None:
+        self.app_config = app_config
+
+    def _table(self) -> Any:
+        """Resuelve el Resource Table en lazy mode (no en cold start)."""
+        table_name = self.app_config.jwt_blacklist_table_name  # type: ignore[attr-defined]
+        return get_table(table_name)
+
+    def put(
+        self,
+        *,
+        jti: UUID | str,
+        exp: int,
+        user_id: UUID | str,
+        reason: str,
+        family_id: UUID | str | None = None,
+    ) -> None:
+        """Inserta un jti en la blacklist con TTL=exp."""
+        item: dict[str, Any] = {
+            'jti': str(jti),
+            'exp': int(exp),
+            'user_id': str(user_id),
+            'reason': reason,
+            'blacklisted_at': int(time.time()),
+        }
+        if family_id is not None:
+            item['family_id'] = str(family_id)
+        self._table().put_item(Item=item)
+
+    def is_blacklisted(self, *, jti: UUID | str) -> bool:
+        """Devuelve True si el jti esta en la blacklist."""
+        resp = self._table().get_item(
+            Key={'jti': str(jti)},
+            ConsistentRead=False,
+        )
+        return resp.get('Item') is not None
+
+    def query_family(self, *, family_id: UUID | str) -> list[str]:
+        """Lista todos los jti blacklisted que pertenecen a la familia.
+
+        Usa el GSI `by_family_id` (Projection=KEYS_ONLY).
+        """
+        resp = self._table().query(
+            IndexName='by_family_id',
+            KeyConditionExpression='family_id = :fid',
+            ExpressionAttributeValues={':fid': str(family_id)},
+        )
+        return [str(item['jti']) for item in resp.get('Items', [])]
+
+    def revoke_family(
+        self,
+        *,
+        family_id: UUID | str,
+        user_id: UUID | str,
+        exp: int,
+    ) -> None:
+        """Marca toda la familia como revocada.
+
+        En la practica, NO podemos "borrar" tokens fuera de la DB del
+        usuario. Lo que hacemos es asegurar que cada jti que llegue de
+        esa familia (incluyendo los emitidos in-flight) este en la
+        blacklist hasta su `exp`. Implementacion MVP: blacklisteamos
+        el `family_id` como un row sentinela (jti == family_id) con
+        reason='reuse'; la verificacion del controller hace Query GSI
+        ANTES de aceptar un refresh y rechaza si encuentra cualquier
+        item con family_id matching.
+        """
+        item: dict[str, Any] = {
+            'jti': str(family_id),
+            'family_id': str(family_id),
+            'exp': int(exp),
+            'user_id': str(user_id),
+            'reason': 'reuse',
+            'blacklisted_at': int(time.time()),
+        }
+        self._table().put_item(Item=item)

--- a/serverless/lambda/services/auth/core/services/code_service.py
+++ b/serverless/lambda/services/auth/core/services/code_service.py
@@ -1,0 +1,96 @@
+"""Code service del Lambda `auth`.
+
+Genera codes de 8 chars (Crockford-like alphabet, sin O/0/I/1/L) para
+verificacion via email. Persiste el hash (SHA-256) en
+`auth_email_codes` con TTL 15 min y consume el code con un compare
+constant-time.
+
+El code en claro se publica al worker (que lo embebe en el email del
+visitante). El backend solo persiste el hash.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from shared.auth import compare_code, generate_code, hash_code
+from shared.db import db_session
+from shared.db.models import AuthCodeKind, AuthUser
+from shared.db.repositories.auth import (
+    consume_email_code,
+    insert_email_code,
+)
+
+# TTL del code (politica MVP). El worker debe enviarlo antes del expiry.
+_CODE_TTL = timedelta(minutes=15)
+
+
+class CodeService:
+    """Service de auth_email_codes (generate + verify)."""
+
+    def __init__(self, app_config: object) -> None:
+        """`app_config` se acepta por uniformidad (no se usa hoy)."""
+        self.app_config = app_config
+
+    def generate_and_persist(
+        self,
+        *,
+        user_id: UUID | str,
+        kind: AuthCodeKind,
+    ) -> tuple[str, bytes]:
+        """Genera un code de 8 chars + hash + lo persiste.
+
+        Returns: tupla (code_plain, code_hash). El code_plain solo viaja
+        al worker via SQS; el hash queda en Neon.
+        """
+        code = generate_code()
+        code_hash = hash_code(code)
+        expires_at = datetime.now(tz=UTC) + _CODE_TTL
+        with db_session() as session:
+            insert_email_code(
+                session,
+                user_id=str(user_id),
+                code_hash=code_hash,
+                kind=kind,
+                expires_at=expires_at,
+            )
+        return code, code_hash
+
+    def verify(
+        self,
+        *,
+        user: AuthUser,
+        kind: AuthCodeKind,
+        code: str,
+    ) -> bool:
+        """Verifica el code en claro contra el hash persistido.
+
+        El compare es constant-time (SHA-256(code) == row.code_hash).
+        Side-effects en Neon:
+          - Si OK: marca `consumed_at=now`.
+          - Si WRONG (existe row valida pero code distinto): incrementa
+            `attempts` en el row.
+
+        Retorna True solo si el code matchea Y no esta expirado Y no
+        fue consumido previamente.
+        """
+        candidate_hash = hash_code(code)
+        with db_session() as session:
+            session.add(user)
+            consumed = consume_email_code(
+                session,
+                user_id=str(user.id),
+                kind=kind,
+                code_hash=candidate_hash,
+            )
+        # Defensa adicional: compare_code es constant-time. Si llegamos
+        # con `consumed is None` (wrong/expired/consumed), retornamos
+        # False sin filtrar el motivo (lo distingue el controller con
+        # un select adicional si lo necesita).
+        if consumed is None:
+            # Constant-time compare con un hash dummy para evitar timing
+            # side channels (decision MVP).
+            _ = compare_code(code=code, stored_hash=candidate_hash)
+            return False
+        return True

--- a/serverless/lambda/services/auth/core/services/email_dispatch_service.py
+++ b/serverless/lambda/services/auth/core/services/email_dispatch_service.py
@@ -1,0 +1,92 @@
+"""Email dispatch service del Lambda `auth`.
+
+Publica mensajes a la cola `portfolio-auth-email-${stage}` que consume
+el `auth_email_worker`. El worker renderiza la plantilla por `kind` +
+locale, envia el email via SES y registra el `email.sent.<kind>` en
+`auth_audit_log`.
+
+El payload publicado sigue el shape esperado por el worker (ver
+`auth_email_worker/core/models/message.py`). Aqui NO importamos ese
+modelo para mantener la independencia de deploy entre los dos
+Lambdas: el shape se mantiene compatible via tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from shared.queue import send_to_queue
+
+
+class EmailDispatchService:
+    """Publisher de mensajes hacia el `auth_email_worker` via SQS."""
+
+    # Short name del catalogo de colas (mismo que el resolver SSM espera:
+    # 'auth-email' -> SSM_AUTH_EMAIL_QUEUE_URL_PATH).
+    _QUEUE_SHORT_NAME = 'auth-email'
+
+    def __init__(self, app_config: object) -> None:
+        self.app_config = app_config
+
+    def publish_magic_link(
+        self,
+        *,
+        to: str,
+        user_id: UUID | str,
+        niche: str | None,
+        kind: str,
+        plain: str,
+        verify_url: str,
+    ) -> str:
+        """Publica un mensaje `kind=magic-link` al worker.
+
+        `plain`: token opaco que el worker embebe en el HTML del email.
+        `verify_url`: URL completa del magic-link (api/auth?... &token=<plain>).
+        """
+        payload: dict[str, Any] = {
+            'schema_version': 1,
+            'kind': kind,
+            'to': to,
+            'user_id': str(user_id),
+            'niche': niche,
+            'locale': 'es',
+            'data': {
+                'token': plain,
+                'verify_url': verify_url,
+            },
+        }
+        return send_to_queue(
+            queue_short_name=self._QUEUE_SHORT_NAME,
+            payload=payload,
+        )
+
+    def publish_code(
+        self,
+        *,
+        to: str,
+        user_id: UUID | str,
+        niche: str | None,
+        kind: str,
+        code: str,
+    ) -> str:
+        """Publica un mensaje `kind=code` al worker.
+
+        `code`: 8 chars Crockford-like. Viaja en claro al worker y al
+        usuario final via email; el backend persiste solo el SHA-256.
+        """
+        payload: dict[str, Any] = {
+            'schema_version': 1,
+            'kind': kind,
+            'to': to,
+            'user_id': str(user_id),
+            'niche': niche,
+            'locale': 'es',
+            'data': {
+                'code': code,
+            },
+        }
+        return send_to_queue(
+            queue_short_name=self._QUEUE_SHORT_NAME,
+            payload=payload,
+        )

--- a/serverless/lambda/services/auth/core/services/flow_service.py
+++ b/serverless/lambda/services/auth/core/services/flow_service.py
@@ -1,0 +1,87 @@
+"""Flow service del Lambda `auth`.
+
+Orquestador del patron "rolling temp JWT" implementado en cada
+controller del flujo (register.verify-magic-link, register.verify-code,
+verify.set-password, verify.resend-code, login.verify-magic-link,
+login.verify-code).
+
+Estandariza 3 operaciones de alto nivel sobre el temp_token:
+- `verify_temp_token(token, expected_flow)`: verifica + chequea
+  blacklist + retorna `JwtClaims`.
+- `advance_step(claims)`: blacklistea el jti viejo + emite un nuevo
+  temp con `step+1`. Retorna (token_nuevo, claims_nuevos).
+- `terminate_flow(user_id, claims)`: blacklistea el temp + emite
+  access + refresh nuevos (con `family_id` nuevo). Retorna
+  (access_token, refresh_token, family_id).
+
+NO contiene logica de negocio del controller: solo el patron JWT que
+todos los actions del flujo comparten.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from shared.auth import JwtClaims
+from shared.core.ulid import new_uuidv7
+
+from .jwt_service import JwtService
+
+
+class FlowService:
+    """Patron rolling temp JWT compartido por los controllers del flujo."""
+
+    def __init__(self, app_config: object) -> None:
+        self.app_config = app_config
+        self._jwt = JwtService(app_config)
+
+    def verify_temp_token(
+        self, token_str: str, *, expected_flow: str,
+    ) -> JwtClaims:
+        """Verifica typ='temp' + flow esperado + blacklist."""
+        return self._jwt.verify(
+            token_str,
+            expected_typ='temp',
+            expected_flow=expected_flow,
+        )
+
+    def advance_step(self, claims: JwtClaims) -> tuple[str, JwtClaims]:
+        """Blacklistea el jti viejo + emite un temp con step+1.
+
+        El `flow` se preserva; `step` se incrementa. El blacklist usa
+        `reason='rotation'`.
+        """
+        self._jwt.blacklist(
+            jti=claims.jti,
+            exp=claims.exp,
+            user_id=claims.sub,
+            reason='rotation',
+        )
+        next_step = (claims.step or 1) + 1
+        return self._jwt.issue_temp(
+            user_id=claims.sub,
+            flow=claims.flow or '',
+            step=next_step,
+        )
+
+    def terminate_flow(
+        self, *, user_id: UUID | str, claims: JwtClaims,
+    ) -> tuple[str, str, UUID]:
+        """Cierra el flujo: blacklistea el temp + emite access + refresh.
+
+        El refresh viene con un `family_id` nuevo (uuidv7). Retorna
+        `(access_token, refresh_token, family_id)` para que el
+        controller los publique al cliente.
+        """
+        self._jwt.blacklist(
+            jti=claims.jti,
+            exp=claims.exp,
+            user_id=user_id,
+            reason='rotation',
+        )
+        family_id = UUID(new_uuidv7())
+        access_str, _ = self._jwt.issue_access(user_id=user_id)
+        refresh_str, _ = self._jwt.issue_refresh(
+            user_id=user_id, family_id=family_id,
+        )
+        return access_str, refresh_str, family_id

--- a/serverless/lambda/services/auth/core/services/jwt_service.py
+++ b/serverless/lambda/services/auth/core/services/jwt_service.py
@@ -1,0 +1,154 @@
+"""JWT service del Lambda `auth`.
+
+Orquestador del lifecycle del JWT (HS256, SecureString + KMS en SSM):
+- `issue_temp(user_id, flow, step)` -> rolling temp JWT (5 min).
+- `issue_access(user_id)` -> access JWT stateless (15 min).
+- `issue_refresh(user_id, family_id)` -> refresh JWT (30 dias) con
+  rotation + family detection.
+- `verify(token, expected_typ, expected_flow)` -> verifica signature
+  + exp + aud + iss + typ (+ flow opcional) Y chequea blacklist
+  contra DDB.
+
+Las primitivas viven en `shared.auth.jwt`; aqui solo agregamos la
+inyeccion del `secret` desde `AppConfig` y la verificacion de
+blacklist via `BlacklistService`.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from shared.auth import (
+    JwtClaims,
+    JwtRevokedError,
+    issue_access_jwt,
+    issue_refresh_jwt,
+    issue_temp_jwt,
+    verify_jwt,
+)
+from shared.auth.jwt import JwtType
+
+from .blacklist_service import BlacklistService
+
+
+class JwtService:
+    """Orquesta issue/verify del JWT y delega blacklist al BlacklistService."""
+
+    def __init__(self, app_config: object) -> None:
+        self.app_config = app_config
+        self._blacklist = BlacklistService(app_config)
+
+    @property
+    def _secret(self) -> str:
+        return self.app_config.jwt_secret  # type: ignore[attr-defined]
+
+    @property
+    def _issuer(self) -> str:
+        return self.app_config.jwt_issuer  # type: ignore[attr-defined]
+
+    @property
+    def _audience(self) -> str:
+        return self.app_config.jwt_audience  # type: ignore[attr-defined]
+
+    def issue_temp(
+        self, *, user_id: UUID | str, flow: str, step: int,
+    ) -> tuple[str, JwtClaims]:
+        """Emite un temp JWT (5 min) para rolling refresh entre pasos."""
+        return issue_temp_jwt(
+            user_id=UUID(str(user_id)),
+            flow=flow,
+            step=step,
+            secret=self._secret,
+            issuer=self._issuer,
+            audience=self._audience,
+        )
+
+    def issue_access(
+        self, *, user_id: UUID | str,
+    ) -> tuple[str, JwtClaims]:
+        """Emite un access JWT (15 min, stateless + blacklist DDB)."""
+        return issue_access_jwt(
+            user_id=UUID(str(user_id)),
+            secret=self._secret,
+            issuer=self._issuer,
+            audience=self._audience,
+        )
+
+    def issue_refresh(
+        self, *, user_id: UUID | str, family_id: UUID | str,
+    ) -> tuple[str, JwtClaims]:
+        """Emite un refresh JWT (30 dias) con `family_id` para reuse detect."""
+        return issue_refresh_jwt(
+            user_id=UUID(str(user_id)),
+            family_id=UUID(str(family_id)),
+            secret=self._secret,
+            issuer=self._issuer,
+            audience=self._audience,
+        )
+
+    def verify(
+        self,
+        token_str: str,
+        *,
+        expected_typ: JwtType | None = None,
+        expected_flow: str | None = None,
+    ) -> JwtClaims:
+        """Verifica signature + exp + aud + iss + typ + blacklist.
+
+        Raises:
+            JwtExpiredError, JwtInvalidError, JwtRevokedError.
+        """
+        claims = verify_jwt(
+            token_str,
+            secret=self._secret,
+            expected_typ=expected_typ,
+            audience=self._audience,
+            issuer=self._issuer,
+        )
+        if expected_flow is not None and claims.flow != expected_flow:
+            from shared.auth import JwtInvalidError
+            raise JwtInvalidError(
+                f'JWT flow mismatch: expected {expected_flow!r}, '
+                f'got {claims.flow!r}',
+            )
+        # Blacklist check: si el jti esta en DDB -> revocado.
+        if self._blacklist.is_blacklisted(jti=claims.jti):
+            raise JwtRevokedError(f'JWT revoked: {claims.jti}')
+        # Si es refresh, verificar tambien que la familia no este
+        # revocada (token reuse detection).
+        if claims.typ == 'refresh' and claims.family_id is not None:
+            family_jtis = self._blacklist.query_family(
+                family_id=claims.family_id,
+            )
+            if family_jtis:
+                raise JwtRevokedError(
+                    f'JWT family revoked: {claims.family_id}',
+                )
+        return claims
+
+    def blacklist(
+        self,
+        *,
+        jti: UUID | str,
+        exp: int,
+        user_id: UUID | str,
+        reason: str,
+        family_id: UUID | str | None = None,
+    ) -> None:
+        """Pone un jti en la blacklist (delega al BlacklistService)."""
+        self._blacklist.put(
+            jti=jti, exp=exp, user_id=user_id,
+            reason=reason, family_id=family_id,
+        )
+
+    def revoke_family(
+        self,
+        *,
+        family_id: UUID | str,
+        user_id: UUID | str,
+        exp: int,
+    ) -> None:
+        """Marca toda la familia como revocada (token reuse detected)."""
+        self._blacklist.revoke_family(
+            family_id=family_id, user_id=user_id, exp=exp,
+        )

--- a/serverless/lambda/services/auth/core/services/magic_link_service.py
+++ b/serverless/lambda/services/auth/core/services/magic_link_service.py
@@ -1,0 +1,71 @@
+"""Magic-link service del Lambda `auth`.
+
+Genera tokens opacos b64url de 32 bytes y los persiste en
+`auth_magic_links` (SHA-256 del token en `token_hash`, UNIQUE). El
+plain NUNCA se persiste — solo viaja en la URL del email.
+
+`verify(token)` busca el hash en Neon, valida que no este expirado ni
+consumido, y lo marca consumed (single-use).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from shared.auth import generate_opaque_token, hash_token
+from shared.db import db_session
+from shared.db.models import AuthLinkKind, AuthMagicLink
+from shared.db.repositories.auth import (
+    consume_magic_link,
+    insert_magic_link,
+)
+
+# TTL del magic-link (politica MVP).
+_LINK_TTL = timedelta(minutes=15)
+
+
+class MagicLinkService:
+    """Service de auth_magic_links (generate + verify)."""
+
+    def __init__(self, app_config: object) -> None:
+        """`app_config` se acepta por uniformidad (no se usa hoy)."""
+        self.app_config = app_config
+
+    def generate_and_persist(
+        self,
+        *,
+        user_id: UUID | str,
+        kind: AuthLinkKind,
+        ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> tuple[str, bytes]:
+        """Genera un opaque token + hash + lo persiste.
+
+        Returns: tupla (token_plain, token_hash). El plain viaja al
+        worker en el payload SQS; el hash queda en Neon.
+        """
+        plain = generate_opaque_token()
+        h = hash_token(plain)
+        expires_at = datetime.now(tz=UTC) + _LINK_TTL
+        with db_session() as session:
+            insert_magic_link(
+                session,
+                user_id=str(user_id),
+                token_hash=h,
+                kind=kind,
+                expires_at=expires_at,
+                ip=ip,
+                user_agent=user_agent,
+            )
+        return plain, h
+
+    def verify(self, *, plain: str) -> AuthMagicLink | None:
+        """Verifica el plain contra el hash persistido.
+
+        Retorna el row si matchea (no expirado, no consumido); marca
+        `consumed_at=now`. Retorna None si no matchea.
+        """
+        h = hash_token(plain)
+        with db_session() as session:
+            return consume_magic_link(session, token_hash=h)

--- a/serverless/lambda/services/auth/core/services/rate_limit_service.py
+++ b/serverless/lambda/services/auth/core/services/rate_limit_service.py
@@ -1,0 +1,46 @@
+"""Rate-limit service del Lambda `auth`.
+
+Wrapper de `shared.rate_limit.check_or_raise` con la signature del
+dominio (los controllers solo pasan `ip`, `endpoint` y opcionalmente
+`country`). El service centraliza el call para que los tests del
+controller puedan mockearlo facil.
+"""
+
+from __future__ import annotations
+
+from shared.rate_limit import check_or_raise
+
+
+class RateLimitService:
+    """Wrapper del rate-limit check (sliding window weighted)."""
+
+    def __init__(self, app_config: object) -> None:
+        self.app_config = app_config
+
+    def check_or_raise(
+        self,
+        *,
+        ip: str,
+        endpoint: str,
+        country: str | None = None,
+        turnstile_validated: bool = False,
+    ) -> None:
+        """Aplica el rate-limit; raises si IP/country/window-rule lo violan.
+
+        Args:
+            ip: IP del cliente (CF-Connecting-IP).
+            endpoint: path identificador (ej.
+                `/auth#register.start`, `/auth#login.verify-code`).
+            country: ISO 3166-1 alpha-2 (de CF-IPCountry, opcional).
+            turnstile_validated: si la request paso Turnstile.
+
+        Raises:
+            shared.rate_limit.exceptions.IPBlacklistedError,
+            CountryBlockedError, RateLimitExceededError.
+        """
+        check_or_raise(
+            ip=ip,
+            endpoint=endpoint,
+            country=country,
+            turnstile_validated=turnstile_validated,
+        )

--- a/serverless/lambda/services/auth/core/services/user_service.py
+++ b/serverless/lambda/services/auth/core/services/user_service.py
@@ -1,0 +1,82 @@
+"""User service del Lambda `auth`.
+
+Encapsula las operaciones de alto nivel sobre `auth_users`:
+- `get_by_email(email)`: lookup case-insensitive (CITEXT).
+- `create_pending(email)`: crea row con status='pending'.
+- `mark_active(user)`: marca activo + reset failed_attempts.
+- `increment_failed_attempts(user)`: +1 al contador. Si >= 5, llama
+  internamente a `lock_user` con 15 min de bloqueo (politica MVP).
+- `reset_failed_attempts(user)`: tras login exitoso.
+- `lock_user(user, until)`: status='locked' + locked_until.
+
+Las queries puras viven en `shared.db.repositories.auth`; este service
+las orquesta y aporta la regla de auto-lock al 5to fallo.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from shared.db import db_session
+from shared.db.models import AuthUser
+from shared.db.repositories.auth import (
+    create_pending_user,
+    get_user_by_email,
+    increment_failed_attempts,
+    lock_user,
+    mark_user_active,
+    reset_failed_attempts,
+)
+
+# Politica MVP: 15 min de bloqueo tras 5 fallos consecutivos.
+_LOCK_DURATION = timedelta(minutes=15)
+_MAX_FAILED_ATTEMPTS = 5
+
+
+class UserService:
+    """Service de auth_users (lookup + create + lock/unlock)."""
+
+    def __init__(self, app_config: object) -> None:
+        """`app_config` se acepta por uniformidad (no se usa hoy)."""
+        self.app_config = app_config
+
+    def get_by_email(self, email: str) -> AuthUser | None:
+        """Lookup case-insensitive del user por email. None si no existe."""
+        with db_session() as session:
+            return get_user_by_email(session, email.strip().lower())
+
+    def create_pending(self, *, email: str) -> AuthUser:
+        """Crea un user nuevo con status='pending'."""
+        with db_session() as session:
+            return create_pending_user(session, email=email.strip().lower())
+
+    def mark_active(self, user: AuthUser) -> None:
+        """Cambia status a active + setea email_verified_at."""
+        with db_session() as session:
+            session.add(user)
+            mark_user_active(session, user)
+
+    def increment_failed_attempts(self, user: AuthUser) -> int:
+        """Incrementa el contador y, al 5to fallo, lockea 15 min.
+
+        Retorna el contador nuevo.
+        """
+        with db_session() as session:
+            session.add(user)
+            attempts = increment_failed_attempts(session, user)
+            if attempts >= _MAX_FAILED_ATTEMPTS:
+                until = datetime.now(tz=UTC) + _LOCK_DURATION
+                lock_user(session, user, until=until)
+            return attempts
+
+    def reset_failed_attempts(self, user: AuthUser) -> None:
+        """Resetea el contador (post-login exitoso)."""
+        with db_session() as session:
+            session.add(user)
+            reset_failed_attempts(session, user)
+
+    def lock_user(self, user: AuthUser, *, until: datetime) -> None:
+        """Lockea manualmente al user hasta el datetime dado."""
+        with db_session() as session:
+            session.add(user)
+            lock_user(session, user, until=until)

--- a/serverless/lambda/services/auth/core/settings/__init__.py
+++ b/serverless/lambda/services/auth/core/settings/__init__.py
@@ -1,0 +1,1 @@
+"""Settings del Lambda `auth`: AppConfig + OPERATIONS."""

--- a/serverless/lambda/services/auth/core/settings/config.py
+++ b/serverless/lambda/services/auth/core/settings/config.py
@@ -1,0 +1,243 @@
+"""Configuracion del Lambda `auth`.
+
+Define `AppConfig` (variables de entorno + secretos lazy desde SSM), los
+enums de codigos de error y de metricas de logging, y reexporta el
+`logger` de la libreria comun.
+
+Los secretos se exponen como `@cached_property` para evitar IO en cold
+start si una request determinada no los necesita (ej. el health check
+nunca lee `jwt_secret`). El primer acceso resuelve el secret via
+`shared.aws.get_secret_by_name` (en cloud lee SSM, en local lee env
+var directa) y se cachea para el resto del lifecycle del contenedor.
+
+Los nombres de tabla DynamoDB y URLs SQS se resuelven en cold start
+leyendo los paths SSM publicados por el provisioner — el patron clona
+el de `contact_form/core/settings/config.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from functools import cached_property
+
+from shared.aws import get_parameter, get_secret_by_name
+from shared.lambda_kit import BaseSettings
+from shared.observability.logger import logger
+
+__all__ = ['AppConfig', 'ErrorCode', 'LogMetricType', 'app_config', 'logger']
+
+
+class ErrorCode(Enum):
+    """Codigos de error internos, agrupados por rango.
+
+    0 exito; 1xxx validacion; 2xxx configuracion; 4xxx negocio; 5xxx
+    API/externo; 6xxx sistema. El handler colapsa el `code` del
+    controller a un HTTP status estable.
+    """
+
+    SUCCESS = 0
+
+    # Validation errors (1000-1999)
+    VALIDATION_ERROR = 1000
+    VALIDATION_FIELD_REQUIRED = 1001
+    VALIDATION_FIELD_INVALID = 1002
+
+    # Configuration errors (2000-2999)
+    CONFIGURATION_ERROR = 2000
+    CONFIGURATION_MISSING = 2001
+
+    # Business logic errors (4000-4999)
+    BUSINESS_LOGIC_ERROR = 4000
+
+    # Domain-specific auth errors (4001-4099)
+    EMAIL_NOT_FOUND = 4001
+    EMAIL_ALREADY_REGISTERED = 4002
+    TOKEN_BLACKLISTED = 4003
+    TOKEN_REUSE_DETECTED = 4004
+    ACCOUNT_LOCKED = 4005
+    LINK_CONSUMED = 4006
+    LINK_EXPIRED = 4007
+    INVALID_CODE = 4008
+    MAX_ATTEMPTS_EXCEEDED = 4009
+    RESEND_THROTTLED = 4010
+    PENDING_VERIFICATION = 4011
+
+    # Cross-cutting business (compartido con otros Lambdas)
+    RATE_LIMIT_EXCEEDED = 4090
+    CAPTCHA_INVALID = 4091
+
+    # External API errors (5000-5999)
+    EXTERNAL_API_ERROR = 5000
+    QUEUE_PUBLISH_FAILED = 5001
+    NEON_WRITE_FAILED = 5002
+
+    # System / unexpected errors (6000+)
+    UNEXPECTED_ERROR = 6000
+
+
+class LogMetricType(Enum):
+    """Tipos de metrica para logging estructurado.
+
+    Cada log estructurado lleva un `metric_type` en su `extra`, lo que
+    permite construir metricas y filtros en CloudWatch.
+    """
+
+    # Lambda lifecycle
+    LAMBDA_START = 'LAMBDA_START'
+    LAMBDA_SUCCESS = 'LAMBDA_SUCCESS'
+    LAMBDA_UNEXPECTED_ERROR = 'LAMBDA_UNEXPECTED_ERROR'
+
+    # Phase lifecycle
+    PHASE_START = 'PHASE_START'
+    PHASE_COMPLETE = 'PHASE_COMPLETE'
+
+    # Event validation
+    EVENT_VALIDATION_FAILED = 'EVENT_VALIDATION_FAILED'
+    EVENT_VALIDATION_PYDANTIC_ERROR = 'EVENT_VALIDATION_PYDANTIC_ERROR'
+    EVENT_VALIDATION_UNEXPECTED_ERROR = 'EVENT_VALIDATION_UNEXPECTED_ERROR'
+
+    # Controller lifecycle
+    CONTROLLER_NOT_FOUND = 'CONTROLLER_NOT_FOUND'
+    CONTROLLER_EXECUTE_START = 'CONTROLLER_EXECUTE_START'
+    CONTROLLER_SUCCESS = 'CONTROLLER_SUCCESS'
+    CONTROLLER_ERROR = 'CONTROLLER_ERROR'
+
+    # Phase failures
+    PRELOAD_PHASE_FAILED = 'PRELOAD_PHASE_FAILED'
+    VALIDATE_PHASE_FAILED = 'VALIDATE_PHASE_FAILED'
+    EXECUTE_PHASE_FAILED = 'EXECUTE_PHASE_FAILED'
+
+    # Import controller
+    INVALID_OPERATION = 'INVALID_OPERATION'
+    CONTROLLER_IMPORT_ERROR = 'CONTROLLER_IMPORT_ERROR'
+    CONTROLLER_CLASS_NOT_FOUND = 'CONTROLLER_CLASS_NOT_FOUND'
+
+    # Auth operations (dominio del Lambda auth)
+    AUTH_RATE_LIMITED = 'AUTH_RATE_LIMITED'
+    AUTH_CAPTCHA_FAILED = 'AUTH_CAPTCHA_FAILED'
+    AUTH_USER_CREATED = 'AUTH_USER_CREATED'
+    AUTH_LOGIN_OK = 'AUTH_LOGIN_OK'
+    AUTH_LOGIN_FAILED = 'AUTH_LOGIN_FAILED'
+    AUTH_LOGOUT = 'AUTH_LOGOUT'
+    AUTH_TOKEN_ISSUED = 'AUTH_TOKEN_ISSUED'
+    AUTH_TOKEN_BLACKLISTED = 'AUTH_TOKEN_BLACKLISTED'
+    AUTH_TOKEN_REUSE_DETECTED = 'AUTH_TOKEN_REUSE_DETECTED'
+    AUTH_MAGIC_LINK_ISSUED = 'AUTH_MAGIC_LINK_ISSUED'
+    AUTH_CODE_ISSUED = 'AUTH_CODE_ISSUED'
+    AUTH_OPERATION_ERROR = 'AUTH_OPERATION_ERROR'
+
+
+def _resolve_from_ssm(env_var_name: str) -> str:
+    """Resuelve un valor desde SSM leyendo el path de una env var.
+
+    `env_var_name`: nombre de la env var (ej.
+    `SSM_JWT_BLACKLIST_TABLE_PATH`) que contiene el path SSM. En local
+    permitimos override directo via la misma env var con un valor
+    plano (mismo patron que contact_form).
+    """
+    raw = os.environ.get(env_var_name, '')
+    if not raw:
+        return ''
+    if raw.startswith('/'):
+        return get_parameter(raw)
+    # Local mode: el valor ya es el nombre / URL directo.
+    return raw
+
+
+class AppConfig(BaseSettings):
+    """Configuracion del Lambda `auth`, cargada de env vars + SSM lazy.
+
+    Cada campo anotado se carga de la env var homonima en MAYUSCULAS.
+    Los paths SSM los inyecta devtools desde el manifest; los secretos
+    NUNCA se hardcodean — solo se guarda su path SSM (el codigo lee el
+    valor en runtime via `get_secret_by_name`).
+    """
+
+    environment: str = 'dev'
+
+    # JWT
+    jwt_issuer: str = 'portfolio-auth'
+    jwt_audience: str = 'portfolio'
+
+    # CORS (whitelist CSV)
+    cors_allowed_origins: str = ''
+
+    # URLs del flujo de magic-link
+    magic_link_base_url: str = ''
+    dashboard_callback_url: str = ''
+
+    # Testing
+    testing: str = '0'
+
+    def is_testing(self) -> bool:
+        """Devuelve True si el servicio corre en modo testing."""
+        return self.testing == '1'
+
+    # ----- Secretos lazy desde SSM (cold start) -----
+
+    @cached_property
+    def jwt_secret(self) -> str:
+        """JWT HS256 secret (SecureString + KMS en SSM)."""
+        return get_secret_by_name('jwt-secret', local_env='JWT_SECRET')
+
+    @cached_property
+    def turnstile_secret(self) -> str:
+        """Cloudflare Turnstile secret key (SecureString + KMS)."""
+        return get_secret_by_name(
+            'turnstile-secret',
+            local_env='TURNSTILE_SECRET_KEY',
+        )
+
+    @cached_property
+    def turnstile_bypass_secret(self) -> str:
+        """Token de bypass para tests E2E (solo presente en dev/local)."""
+        return get_secret_by_name(
+            'turnstile-bypass-secret',
+            local_env='TURNSTILE_BYPASS_SECRET',
+        )
+
+    @cached_property
+    def neon_url(self) -> str:
+        """Connection string PostgreSQL (Neon, schema auth_*)."""
+        return get_secret_by_name('neon-url', local_env='DB_URL')
+
+    @cached_property
+    def ses_from_address(self) -> str:
+        """From verificado en SES (lo usa el worker via SQS payload)."""
+        return get_secret_by_name(
+            'ses-from-address',
+            local_env='SES_FROM_ADDRESS',
+        )
+
+    # ----- Nombres de recursos resueltos en cold start desde SSM -----
+
+    @cached_property
+    def cache_table_name(self) -> str:
+        """Tabla DynamoDB usada por Powertools cache."""
+        return _resolve_from_ssm('SSM_CACHE_TABLE_PATH')
+
+    @cached_property
+    def jwt_blacklist_table_name(self) -> str:
+        """Tabla DynamoDB de jti blacklisted (GSI by_family_id)."""
+        return _resolve_from_ssm('SSM_JWT_BLACKLIST_TABLE_PATH')
+
+    @cached_property
+    def rate_limit_rules_table_name(self) -> str:
+        """Tabla DynamoDB con las rate-limit rules."""
+        return _resolve_from_ssm('SSM_RATE_LIMIT_RULES_TABLE_PATH')
+
+    @cached_property
+    def rate_limit_buckets_table_name(self) -> str:
+        """Tabla DynamoDB con los sliding-window buckets."""
+        return _resolve_from_ssm('SSM_RATE_LIMIT_BUCKETS_TABLE_PATH')
+
+    @cached_property
+    def auth_email_queue_url(self) -> str:
+        """URL SQS de la cola hacia el `auth_email_worker`."""
+        return _resolve_from_ssm('SSM_AUTH_EMAIL_QUEUE_URL_PATH')
+
+
+# Singleton de configuracion: se evalua una vez en el cold start (los
+# secretos siguen siendo lazy via @cached_property).
+app_config = AppConfig()

--- a/serverless/lambda/services/auth/core/settings/operations.py
+++ b/serverless/lambda/services/auth/core/settings/operations.py
@@ -1,0 +1,34 @@
+"""Mapeo de operations del Lambda `auth`.
+
+El Lambda atiende 4 operations (`register`, `login`, `verify`,
+`session`) con multiples actions cada una. La estructura sigue el
+contrato del lambda-controller: cada operation declara su controller
+(carpeta dentro de `controllers/`) y un `arn_key` (vacio porque `auth`
+NO invoca otros Lambdas).
+
+Los controllers se descubren por convencion:
+`core.controllers.<operation>.<action_snake>.<ActionPascal>`. Ej:
+`verify-magic-link` -> module
+`controllers/register/verify_magic_link.py` + clase
+`VerifyMagicLink(BaseController)`. Los archivos concretos de cada
+controller se agregan en PR 7 y PR 8.
+"""
+
+OPERATIONS = {
+    'register': {
+        'controller': 'register',
+        'arn_key': '',
+    },
+    'login': {
+        'controller': 'login',
+        'arn_key': '',
+    },
+    'verify': {
+        'controller': 'verify',
+        'arn_key': '',
+    },
+    'session': {
+        'controller': 'session',
+        'arn_key': '',
+    },
+}

--- a/serverless/lambda/services/auth/core/utils/__init__.py
+++ b/serverless/lambda/services/auth/core/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utils del Lambda `auth` (vacio: el kit ya esta en shared.lambda_kit)."""

--- a/serverless/lambda/services/auth/events/login-start.json
+++ b/serverless/lambda/services/auth/events/login-start.json
@@ -1,0 +1,19 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10",
+    "CF-IPCountry": "CL"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"login\",\"action\":\"start\",\"data\":{\"email\":\"test@example.com\",\"cf_turnstile_response\":\"XXXX.DUMMY.TOKEN.XXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/login-verify-code.json
+++ b/serverless/lambda/services/auth/events/login-verify-code.json
@@ -1,0 +1,18 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"login\",\"action\":\"verify-code\",\"data\":{\"code\":\"ABCDEFGH\",\"temp_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/login-verify-magic-link.json
+++ b/serverless/lambda/services/auth/events/login-verify-magic-link.json
@@ -1,0 +1,18 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"login\",\"action\":\"verify-magic-link\",\"data\":{\"token\":\"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/register-start.json
+++ b/serverless/lambda/services/auth/events/register-start.json
@@ -1,0 +1,20 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10",
+    "CF-IPCountry": "CL",
+    "User-Agent": "Mozilla/5.0"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"register\",\"action\":\"start\",\"data\":{\"email\":\"test@example.com\",\"cf_turnstile_response\":\"XXXX.DUMMY.TOKEN.XXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/register-verify-code.json
+++ b/serverless/lambda/services/auth/events/register-verify-code.json
@@ -1,0 +1,18 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"register\",\"action\":\"verify-code\",\"data\":{\"code\":\"ABCDEFGH\",\"temp_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/register-verify-magic-link.json
+++ b/serverless/lambda/services/auth/events/register-verify-magic-link.json
@@ -1,0 +1,18 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"register\",\"action\":\"verify-magic-link\",\"data\":{\"token\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/session-logout.json
+++ b/serverless/lambda/services/auth/events/session-logout.json
@@ -1,0 +1,19 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10",
+    "Authorization": "Bearer FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"session\",\"action\":\"logout\",\"data\":{\"access_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/session-refresh.json
+++ b/serverless/lambda/services/auth/events/session-refresh.json
@@ -1,0 +1,18 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"session\",\"action\":\"refresh\",\"data\":{\"refresh_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/verify-resend-code.json
+++ b/serverless/lambda/services/auth/events/verify-resend-code.json
@@ -1,0 +1,18 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"verify\",\"action\":\"resend-code\",\"data\":{\"temp_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/events/verify-set-password.json
+++ b/serverless/lambda/services/auth/events/verify-set-password.json
@@ -1,0 +1,18 @@
+{
+  "httpMethod": "POST",
+  "path": "/auth",
+  "headers": {
+    "Content-Type": "application/json",
+    "Origin": "https://admin.portfolio.dev.the-full-stack.com",
+    "CF-Connecting-IP": "203.0.113.10"
+  },
+  "queryStringParameters": null,
+  "pathParameters": null,
+  "body": "{\"operation\":\"verify\",\"action\":\"set-password\",\"data\":{\"password\":\"C0mplex_dev_pass_X\",\"temp_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
+  "isBase64Encoded": false,
+  "requestContext": {
+    "identity": { "sourceIp": "203.0.113.10" },
+    "requestId": "local-request-id",
+    "stage": "dev"
+  }
+}

--- a/serverless/lambda/services/auth/manifest.yaml
+++ b/serverless/lambda/services/auth/manifest.yaml
@@ -1,0 +1,80 @@
+# Manifiesto del Lambda `auth` — fuente de verdad de su config.
+#
+# Encoder HTTP del dominio auth: register / login / verify / session.
+# Valida Pydantic + Turnstile + rate-limit, persiste estado a Neon + DDB
+# (blacklist JWT), publica mensajes a SQS hacia `auth_email_worker` (NO
+# envia email directo). Sigue el patron lambda-controller con
+# operation+action.
+#
+# devtools traduce este manifiesto a llamadas AWS CLI directas:
+#   python devtools/run.py serverless deploy --lambda=auth
+
+# --- Identidad ---
+name: auth
+description: HTTP endpoint POST /auth (register/login/verify/session).
+
+# --- Runtime ---
+runtime: python3.13
+handler: core.handler.lambda_handler
+memory: 384       # MB — Turnstile siteverify + Neon write + DDB
+                  # blacklist + SQS publish con holgura.
+timeout: 15       # segundos — incluye Turnstile siteverify HTTP (1-2s)
+
+# SnapStart: reduce cold start de ~3s a ~830ms (Restore Duration).
+# Critico en /auth: low traffic prod hace que cada request pague cold
+# start si no se mantiene warm.
+snap_start: true
+
+# --- Como se invoca este Lambda ---
+trigger:
+  type: http
+  method: POST
+  path: /auth
+
+# --- Que recursos del backend usa ---
+uses:
+  # Cola SQS hacia donde el encoder publica el email a enviar (magic
+  # link o code). El worker `auth_email_worker` consume + envia via SES
+  # + audita.
+  queues:
+    - name: portfolio-auth-email-${stage}
+      access: producer
+  # Tablas DynamoDB: cache (Powertools), rate-limit y jwt-blacklist.
+  tables:
+    cache: read-write              # @cached SSM cache
+    rate-limit-rules: read-write   # rate-limit per-IP
+    rate-limit-buckets: read-write
+    jwt-blacklist: read-write      # blacklist con GSI by_family_id
+  # Secretos que el Lambda lee (de SSM). Solo el nombre corto.
+  secrets:
+    - turnstile-secret        # validacion del captcha Cloudflare Turnstile
+    - turnstile-bypass-secret # bypass de Turnstile para tests E2E (solo dev)
+    - neon-url                # connection string Neon (auth_*)
+    - jwt-secret              # JWT HS256 secret (SecureString + KMS)
+    - ses-from-address        # publica mensajes con este From (lo usa worker)
+  # El Lambda NO envia email directo: publica a SQS y el worker hace SES.
+  sends-email: false
+
+# --- Variables de entorno por stage ---
+env:
+  default:
+    LOG_LEVEL: INFO
+    POWERTOOLS_SERVICE_NAME: auth
+    POWERTOOLS_METRICS_NAMESPACE: Portfolio/Auth
+    JWT_ISSUER: portfolio-auth
+    JWT_AUDIENCE: portfolio
+  dev:
+    LOG_LEVEL: INFO
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.dev.the-full-stack.com,https://hub.portfolio.dev.the-full-stack.com,https://fintech.portfolio.dev.the-full-stack.com,https://architect.portfolio.dev.the-full-stack.com,https://leader.portfolio.dev.the-full-stack.com,https://vibe.portfolio.dev.the-full-stack.com,https://admin.portfolio.dev.the-full-stack.com,http://localhost:9970'
+    MAGIC_LINK_BASE_URL: https://api.portfolio.dev.the-full-stack.com/auth
+    DASHBOARD_CALLBACK_URL: https://admin.portfolio.dev.the-full-stack.com/callback
+  stage:
+    LOG_LEVEL: INFO
+    CORS_ALLOWED_ORIGINS: 'https://portfolio.stage.the-full-stack.com,https://hub.portfolio.stage.the-full-stack.com,https://fintech.portfolio.stage.the-full-stack.com,https://architect.portfolio.stage.the-full-stack.com,https://leader.portfolio.stage.the-full-stack.com,https://vibe.portfolio.stage.the-full-stack.com,https://admin.portfolio.stage.the-full-stack.com'
+    MAGIC_LINK_BASE_URL: https://api.portfolio.stage.the-full-stack.com/auth
+    DASHBOARD_CALLBACK_URL: https://admin.portfolio.stage.the-full-stack.com/callback
+  prod:
+    LOG_LEVEL: WARNING
+    CORS_ALLOWED_ORIGINS: 'https://the-full-stack.com,https://www.the-full-stack.com,https://portfolio.the-full-stack.com,https://hub.portfolio.the-full-stack.com,https://fintech.portfolio.the-full-stack.com,https://architect.portfolio.the-full-stack.com,https://leader.portfolio.the-full-stack.com,https://vibe.portfolio.the-full-stack.com,https://admin.portfolio.the-full-stack.com'
+    MAGIC_LINK_BASE_URL: https://api.portfolio.the-full-stack.com/auth
+    DASHBOARD_CALLBACK_URL: https://admin.portfolio.the-full-stack.com/callback

--- a/serverless/lambda/services/auth/pyproject.toml
+++ b/serverless/lambda/services/auth/pyproject.toml
@@ -1,0 +1,99 @@
+# @config: lambda/services/auth/pyproject.toml
+# @description: manifiesto de dependencias y tooling del Lambda
+#   `auth` (HTTP encoder de auth: register / login / verify / session).
+#   Lambda autonomo: tiene su propio uv.lock y .venv aislado (NO es
+#   workspace member).
+
+[project]
+name = "auth"
+version = "0.1.0"
+description = "Lambda HTTP del dominio auth (register / login / verify / session)."
+requires-python = ">=3.13"
+
+# El core/ del Lambda no declara deps de runtime propias: pyjwt,
+# argon2-cffi, pydantic[email], pydantic-settings, boto3,
+# aws-lambda-powertools y sqlalchemy le llegan por el vendoring del
+# cierre de shared/ que el Lambda usa (shared.lambda_kit, shared.http,
+# shared.observability, shared.aws, shared.rate_limit, shared.core,
+# shared.queue, shared.auth, shared.db) — ver la regla de dedup D-3
+# del plan docs/specs/serverless-lambda-independence/. shared.core
+# aporta pydantic[email] desde el plan d-shared-only-imports — el
+# extra `email` (email-validator) ya viaja por shared.core, NO se
+# redeclara aca (ver `.claude/rules/lambda-shared-imports.md`).
+dependencies = []
+
+# Deps de DESARROLLO: pytest + coverage + mocks. NO van al artefacto de
+# deploy (solo [project.dependencies] llega al zip).
+[dependency-groups]
+dev = [
+  "pytest>=8.0,<9.0",
+  "pytest-cov>=5.0,<6.0",
+  "pytest-mock>=3.12,<4.0",
+  "mypy>=1.10,<2.0",
+  "ruff>=0.6,<1.0",
+  "moto[dynamodb,ses,sns,ssm,sqs,kms]>=5.0,<6.0",
+  "freezegun>=1.4,<2.0",
+  "respx>=0.23.1",
+]
+
+[tool.uv]
+package = false
+
+[tool.ruff]
+line-length = 80
+target-version = "py313"
+extend-exclude = [".venv/", "build/", "events/*.json"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "B", "C4", "PIE", "SIM", "UP", "ANN", "S", "RUF"]
+ignore = [
+  "E501",   # line-length manejado por formatter
+  "ANN401", # any explicit en argumentos kwargs
+  "S101",   # asserts ok en tests
+  "S311",   # random no-cryptographic ok
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests: el nombre del test es el contrato; las firmas no necesitan
+# anotaciones de tipo.
+"tests/**/*.py" = ["ANN001", "ANN002", "ANN003", "ANN201", "ANN202", "S105", "S106"]
+# El handler ajusta sys.path antes de importar: E402 no aplica.
+"core/handler.py" = ["E402"]
+
+[tool.ruff.format]
+quote-style = "single"
+indent-style = "space"
+line-ending = "lf"
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-ra --strict-markers"
+testpaths = ["tests"]
+markers = [
+  "unit: tests unitarios (rapidos, sin AWS real)",
+  "integration: tests con AWS real (deployed)",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["core"]
+# core/shared/ es la libreria comun vendorizada (efimera): el coverage
+# del Lambda mide solo SU codigo, no la copia de shared.
+omit = ["**/__init__.py", "tests/*", "core/shared/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unreachable = true
+disallow_untyped_defs = true
+files = ["core"]

--- a/serverless/lambda/services/auth/tests/conftest.py
+++ b/serverless/lambda/services/auth/tests/conftest.py
@@ -1,0 +1,87 @@
+"""Configuracion pytest del Lambda `auth`.
+
+Agrega `core/` al `sys.path` para que los imports absolutos del codigo
+del Lambda (`handler`, `controllers.`, `services.`, `models.`,
+`settings.`, `shared.`) resuelvan en los tests.
+
+La libreria comun `shared/` normalmente se vendoriza en `core/shared/`
+por devtools antes de correr los tests (`serverless tests --type=unit`
+lo hace). Si no esta vendorizada (pytest invocado directo), este
+conftest agrega `serverless/lambda/` al path como fallback para que
+`import shared...` resuelva desde la fuente maestra
+`serverless/lambda/shared/`.
+
+Setea las env vars minimas que `AppConfig` (settings/config.py) y el
+codigo del Lambda necesitan para cargar sin un entorno Lambda real.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# core/ al path: imports absolutos del codigo del Lambda.
+_LAMBDA_ROOT = Path(__file__).resolve().parent.parent
+_CORE = _LAMBDA_ROOT / 'core'
+sys.path.insert(0, str(_CORE))
+
+# Fallback para `import shared...` si no esta vendorizado en core/shared/.
+# La fuente maestra shared/ vive en serverless/lambda/ (parents[1]:
+# <lambda>/ -> services/ -> lambda/).
+if not (_CORE / 'shared').is_dir():
+    _LAMBDA_BASE = _LAMBDA_ROOT.parents[1]
+    sys.path.insert(0, str(_LAMBDA_BASE))
+
+# Env vars minimas para que AppConfig cargue sin un entorno Lambda real.
+os.environ.setdefault('ENVIRONMENT', 'dev')
+os.environ.setdefault('TESTING', '1')
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('AWS_DEFAULT_REGION', 'us-east-1')
+os.environ.setdefault('POWERTOOLS_SERVICE_NAME', 'auth-test')
+os.environ.setdefault('POWERTOOLS_METRICS_NAMESPACE', 'PortfolioTest')
+os.environ.setdefault('JWT_ISSUER', 'portfolio-auth')
+os.environ.setdefault('JWT_AUDIENCE', 'portfolio')
+os.environ.setdefault(
+    'MAGIC_LINK_BASE_URL',
+    'https://api.portfolio.dev.the-full-stack.com/auth',
+)
+os.environ.setdefault(
+    'DASHBOARD_CALLBACK_URL',
+    'https://admin.portfolio.dev.the-full-stack.com/callback',
+)
+os.environ.setdefault(
+    'CORS_ALLOWED_ORIGINS',
+    'https://admin.portfolio.dev.the-full-stack.com',
+)
+# Secretos locales (get_secret_by_name los lee directo del env var en
+# modo local cuando SSM_<UPPER>_PATH no esta seteado).
+os.environ.setdefault('JWT_SECRET', 'test-jwt-secret-with-enough-length-1234567890')
+os.environ.setdefault('TURNSTILE_SECRET_KEY', 'test-turnstile-secret')
+os.environ.setdefault('TURNSTILE_BYPASS_SECRET', 'test-bypass-secret')
+os.environ.setdefault(
+    'DB_URL',
+    'postgresql://test:test@localhost/test',
+)
+os.environ.setdefault('SES_FROM_ADDRESS', 'no-reply@example.com')
+
+
+@pytest.fixture(autouse=True)
+def _aws_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setea credenciales AWS fake (autouse).
+
+    Previene que boto3 lea ~/.aws/credentials reales o intente STS.
+    """
+    monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'testing')
+    monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'testing')
+    monkeypatch.setenv('AWS_SECURITY_TOKEN', 'testing')
+    monkeypatch.setenv('AWS_SESSION_TOKEN', 'testing')
+    monkeypatch.setenv('AWS_DEFAULT_REGION', 'us-east-1')
+    monkeypatch.setenv('AWS_REGION', 'us-east-1')
+
+
+@pytest.fixture
+def app_config():
+    """Singleton AppConfig limpio por test."""
+    from settings.config import AppConfig
+    return AppConfig()

--- a/serverless/lambda/services/auth/tests/unit/models/test_meta_injection.py
+++ b/serverless/lambda/services/auth/tests/unit/models/test_meta_injection.py
@@ -1,0 +1,31 @@
+"""Los modelos aceptan `_meta` como input y lo exponen como `.meta`.
+
+Given un payload con clave `_meta` (alias),
+When se valida con RegisterStartIn,
+Then la instancia expone el campo como `.meta` y conserva la metadata.
+"""
+
+
+def test_register_start_in_accepts_meta_alias():
+    from models.register import RegisterStartIn
+
+    payload = {
+        'email': 'visitor@example.com',
+        'cf_turnstile_response': 'token-xxx',
+        '_meta': {
+            'ip': '203.0.113.10',
+            'country': 'CL',
+            'user_agent': 'pytest',
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+        },
+    }
+
+    parsed = RegisterStartIn.model_validate(payload)
+
+    assert parsed.email == 'visitor@example.com'
+    assert parsed.meta.ip == '203.0.113.10'
+    assert parsed.meta.country == 'CL'
+    assert parsed.meta.user_agent == 'pytest'
+    assert parsed.meta.origin == (
+        'https://admin.portfolio.dev.the-full-stack.com'
+    )

--- a/serverless/lambda/services/auth/tests/unit/models/test_register_start_in_email_invalid.py
+++ b/serverless/lambda/services/auth/tests/unit/models/test_register_start_in_email_invalid.py
@@ -1,0 +1,19 @@
+"""RegisterStartIn rechaza emails malformados.
+
+Given un email con formato invalido,
+When se valida con RegisterStartIn,
+Then pydantic ValidationError (EmailStr).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_register_start_in_rejects_invalid_email():
+    from models.register import RegisterStartIn
+
+    with pytest.raises(ValidationError) as exc:
+        RegisterStartIn(email='not-an-email', cf_turnstile_response='token-xxx')
+
+    errors = exc.value.errors()
+    assert any(e['loc'] == ('email',) for e in errors)

--- a/serverless/lambda/services/auth/tests/unit/models/test_register_start_in_email_required.py
+++ b/serverless/lambda/services/auth/tests/unit/models/test_register_start_in_email_required.py
@@ -1,0 +1,19 @@
+"""RegisterStartIn rechaza cuando falta `email`.
+
+Given un payload sin `email`,
+When se valida con RegisterStartIn,
+Then pydantic ValidationError.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_register_start_in_rejects_missing_email():
+    from models.register import RegisterStartIn
+
+    with pytest.raises(ValidationError) as exc:
+        RegisterStartIn(cf_turnstile_response='token-xxx')
+
+    errors = exc.value.errors()
+    assert any(e['loc'] == ('email',) for e in errors)

--- a/serverless/lambda/services/auth/tests/unit/models/test_register_start_in_turnstile_required.py
+++ b/serverless/lambda/services/auth/tests/unit/models/test_register_start_in_turnstile_required.py
@@ -1,0 +1,19 @@
+"""RegisterStartIn rechaza cuando falta `cf_turnstile_response`.
+
+Given un payload sin cf_turnstile_response,
+When se valida con RegisterStartIn,
+Then pydantic ValidationError.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_register_start_in_rejects_missing_turnstile():
+    from models.register import RegisterStartIn
+
+    with pytest.raises(ValidationError) as exc:
+        RegisterStartIn(email='valid@example.com')
+
+    errors = exc.value.errors()
+    assert any(e['loc'] == ('cf_turnstile_response',) for e in errors)

--- a/serverless/lambda/services/auth/tests/unit/models/test_register_verify_code_in_length.py
+++ b/serverless/lambda/services/auth/tests/unit/models/test_register_verify_code_in_length.py
@@ -1,0 +1,19 @@
+"""RegisterVerifyCodeIn rechaza codes que NO miden exactamente 8 chars.
+
+Given un code de 7 chars o 9 chars (con alphabet valido),
+When se valida con RegisterVerifyCodeIn,
+Then pydantic ValidationError.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+_PLACEHOLDER_JWT = 'a' * 30
+
+
+def test_register_verify_code_in_rejects_wrong_length():
+    from models.register import RegisterVerifyCodeIn
+
+    for code in ('ABCDEFG', 'ABCDEFGHJ'):
+        with pytest.raises(ValidationError):
+            RegisterVerifyCodeIn(code=code, temp_token=_PLACEHOLDER_JWT)

--- a/serverless/lambda/services/auth/tests/unit/models/test_register_verify_code_in_pattern.py
+++ b/serverless/lambda/services/auth/tests/unit/models/test_register_verify_code_in_pattern.py
@@ -1,0 +1,29 @@
+"""RegisterVerifyCodeIn rechaza codes con chars confundibles O/0/I/1/L.
+
+Given un code que contiene `O`, `0`, `I`, `1` o `L`,
+When se valida con RegisterVerifyCodeIn,
+Then pydantic ValidationError (pattern mismatch).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+# Placeholder de un JWT valido para el field `temp_token`
+# (min_length=20). NO es un secreto real.
+_PLACEHOLDER_JWT = 'a' * 30
+
+
+def test_register_verify_code_in_rejects_confusing_chars():
+    from models.register import RegisterVerifyCodeIn
+
+    # El alphabet declarado en el modelo `[A-HJ-NP-Z2-9]` excluye:
+    # I, O (letras confundibles con 1/0) + 0, 1 (chars excluidos via
+    # rango 2-9). `L` no esta en el alphabet del modelo (es valida).
+    confusing = ['OABCDEFG', '0ABCDEFG', 'IABCDEFG', '1ABCDEFG', 'aBCDEFGH']
+    for code in confusing:
+        with pytest.raises(ValidationError) as exc:
+            RegisterVerifyCodeIn(code=code, temp_token=_PLACEHOLDER_JWT)
+        errors = exc.value.errors()
+        assert any(e['loc'] == ('code',) for e in errors), (
+            f'code {code!r} should fail pattern but did not'
+        )

--- a/serverless/lambda/services/auth/tests/unit/models/test_session_refresh_in_short_token.py
+++ b/serverless/lambda/services/auth/tests/unit/models/test_session_refresh_in_short_token.py
@@ -1,0 +1,19 @@
+"""SessionRefreshIn rechaza refresh_token con menos de 20 chars.
+
+Given un refresh_token de 19 chars,
+When se valida con SessionRefreshIn,
+Then pydantic ValidationError.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_session_refresh_in_rejects_short_token():
+    from models.session import SessionRefreshIn
+
+    with pytest.raises(ValidationError) as exc:
+        SessionRefreshIn(refresh_token='a' * 19)
+
+    errors = exc.value.errors()
+    assert any(e['loc'] == ('refresh_token',) for e in errors)

--- a/serverless/lambda/services/auth/tests/unit/services/test_audit_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_audit_service.py
@@ -1,0 +1,55 @@
+"""AuditService — happy + sad path."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def _fake_session():
+    yield MagicMock()
+
+
+def test_log_inserts_event_with_all_fields(monkeypatch):
+    from services import audit_service
+
+    fake_insert = MagicMock()
+    monkeypatch.setattr(audit_service, 'db_session', _fake_session)
+    monkeypatch.setattr(audit_service, 'insert_audit_event', fake_insert)
+
+    svc = audit_service.AuditService(app_config=object())
+    svc.log(
+        event='register.start',
+        success=True,
+        user_id='user-1',
+        ip='203.0.113.10',
+        user_agent='pytest',
+        niche='fintech',
+    )
+
+    fake_insert.assert_called_once()
+    kwargs = fake_insert.call_args.kwargs
+    assert kwargs['event'] == 'register.start'
+    assert kwargs['success'] is True
+    assert kwargs['user_id'] == 'user-1'
+    assert kwargs['niche'] == 'fintech'
+
+
+def test_log_supports_failure_event(monkeypatch):
+    from services import audit_service
+
+    fake_insert = MagicMock()
+    monkeypatch.setattr(audit_service, 'db_session', _fake_session)
+    monkeypatch.setattr(audit_service, 'insert_audit_event', fake_insert)
+
+    svc = audit_service.AuditService(app_config=object())
+    svc.log(
+        event='login.start',
+        success=False,
+        error_code='EMAIL_NOT_FOUND',
+        ip='203.0.113.10',
+    )
+
+    kwargs = fake_insert.call_args.kwargs
+    assert kwargs['success'] is False
+    assert kwargs['error_code'] == 'EMAIL_NOT_FOUND'
+    assert kwargs['user_id'] is None

--- a/serverless/lambda/services/auth/tests/unit/services/test_blacklist_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_blacklist_service.py
@@ -1,0 +1,116 @@
+"""BlacklistService — happy + sad path (DDB ops mockeadas)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _fake_app_config():
+    return SimpleNamespace(jwt_blacklist_table_name='portfolio-jwt-blacklist-test')
+
+
+def test_put_writes_item_with_ttl(monkeypatch):
+    from services import blacklist_service
+
+    fake_table = MagicMock()
+    monkeypatch.setattr(
+        blacklist_service, 'get_table', lambda _name: fake_table,
+    )
+
+    svc = blacklist_service.BlacklistService(_fake_app_config())
+    svc.put(
+        jti='jti-1',
+        exp=1_700_000_000,
+        user_id='user-x',
+        reason='rotation',
+    )
+
+    fake_table.put_item.assert_called_once()
+    item = fake_table.put_item.call_args.kwargs['Item']
+    assert item['jti'] == 'jti-1'
+    assert item['exp'] == 1_700_000_000
+    assert item['reason'] == 'rotation'
+
+
+def test_is_blacklisted_returns_false_when_not_found(monkeypatch):
+    from services import blacklist_service
+
+    fake_table = MagicMock()
+    fake_table.get_item.return_value = {}
+    monkeypatch.setattr(
+        blacklist_service, 'get_table', lambda _name: fake_table,
+    )
+
+    svc = blacklist_service.BlacklistService(_fake_app_config())
+
+    assert svc.is_blacklisted(jti='not-there') is False
+
+
+def test_is_blacklisted_returns_true_when_found(monkeypatch):
+    from services import blacklist_service
+
+    fake_table = MagicMock()
+    fake_table.get_item.return_value = {'Item': {'jti': 'x'}}
+    monkeypatch.setattr(
+        blacklist_service, 'get_table', lambda _name: fake_table,
+    )
+
+    svc = blacklist_service.BlacklistService(_fake_app_config())
+
+    assert svc.is_blacklisted(jti='x') is True
+
+
+def test_revoke_family_writes_sentinel_item(monkeypatch):
+    from services import blacklist_service
+
+    fake_table = MagicMock()
+    monkeypatch.setattr(
+        blacklist_service, 'get_table', lambda _name: fake_table,
+    )
+
+    svc = blacklist_service.BlacklistService(_fake_app_config())
+    svc.revoke_family(
+        family_id='fam-1', user_id='user-x', exp=1_700_000_000,
+    )
+
+    fake_table.put_item.assert_called_once()
+    item = fake_table.put_item.call_args.kwargs['Item']
+    assert item['jti'] == 'fam-1'
+    assert item['family_id'] == 'fam-1'
+    assert item['reason'] == 'reuse'
+
+
+def test_put_includes_family_id_when_provided(monkeypatch):
+    from services import blacklist_service
+
+    fake_table = MagicMock()
+    monkeypatch.setattr(
+        blacklist_service, 'get_table', lambda _name: fake_table,
+    )
+
+    svc = blacklist_service.BlacklistService(_fake_app_config())
+    svc.put(
+        jti='jti-2',
+        exp=1_700_000_000,
+        user_id='user-x',
+        reason='rotation',
+        family_id='fam-1',
+    )
+
+    item = fake_table.put_item.call_args.kwargs['Item']
+    assert item['family_id'] == 'fam-1'
+
+
+def test_query_family_returns_jti_list(monkeypatch):
+    from services import blacklist_service
+
+    fake_table = MagicMock()
+    fake_table.query.return_value = {
+        'Items': [{'jti': 'a'}, {'jti': 'b'}],
+    }
+    monkeypatch.setattr(
+        blacklist_service, 'get_table', lambda _name: fake_table,
+    )
+
+    svc = blacklist_service.BlacklistService(_fake_app_config())
+
+    assert svc.query_family(family_id='fam-1') == ['a', 'b']

--- a/serverless/lambda/services/auth/tests/unit/services/test_code_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_code_service.py
@@ -1,0 +1,60 @@
+"""CodeService — happy + sad path."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def _fake_session():
+    yield MagicMock()
+
+
+def test_generate_and_persist_returns_code_and_hash(monkeypatch):
+    from services import code_service
+    from shared.db.models import AuthCodeKind
+
+    monkeypatch.setattr(code_service, 'db_session', _fake_session)
+    monkeypatch.setattr(code_service, 'generate_code', lambda: 'ABCDEFGH')
+    monkeypatch.setattr(code_service, 'hash_code', lambda _c: b'fake-hash')
+    monkeypatch.setattr(code_service, 'insert_email_code', MagicMock())
+
+    svc = code_service.CodeService(app_config=object())
+    code, code_h = svc.generate_and_persist(
+        user_id='user-1', kind=AuthCodeKind.REGISTER,
+    )
+
+    assert code == 'ABCDEFGH'
+    assert code_h == b'fake-hash'
+
+
+def test_verify_returns_false_when_wrong_code(monkeypatch):
+    from services import code_service
+    from shared.db.models import AuthCodeKind
+
+    monkeypatch.setattr(code_service, 'db_session', _fake_session)
+    monkeypatch.setattr(code_service, 'hash_code', lambda _c: b'h')
+    monkeypatch.setattr(code_service, 'compare_code', lambda **_kw: False)
+    monkeypatch.setattr(
+        code_service, 'consume_email_code', lambda *_a, **_kw: None,
+    )
+
+    svc = code_service.CodeService(app_config=object())
+    user = MagicMock(id='user-x')
+
+    assert svc.verify(user=user, kind=AuthCodeKind.REGISTER, code='WRONGSEQ') is False
+
+
+def test_verify_returns_true_when_match(monkeypatch):
+    from services import code_service
+    from shared.db.models import AuthCodeKind
+
+    monkeypatch.setattr(code_service, 'db_session', _fake_session)
+    monkeypatch.setattr(code_service, 'hash_code', lambda _c: b'h')
+    monkeypatch.setattr(
+        code_service, 'consume_email_code', lambda *_a, **_kw: MagicMock(),
+    )
+
+    svc = code_service.CodeService(app_config=object())
+    user = MagicMock(id='user-x')
+
+    assert svc.verify(user=user, kind=AuthCodeKind.REGISTER, code='ABCDEFGH') is True

--- a/serverless/lambda/services/auth/tests/unit/services/test_email_dispatch_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_email_dispatch_service.py
@@ -1,0 +1,48 @@
+"""EmailDispatchService — publica payloads correctos a SQS."""
+
+from unittest.mock import MagicMock
+
+
+def test_publish_magic_link_sends_payload_with_token(monkeypatch):
+    from services import email_dispatch_service
+
+    fake_send = MagicMock(return_value='msg-id-1')
+    monkeypatch.setattr(email_dispatch_service, 'send_to_queue', fake_send)
+
+    svc = email_dispatch_service.EmailDispatchService(app_config=object())
+    msg_id = svc.publish_magic_link(
+        to='visitor@example.com',
+        user_id='user-1',
+        niche='fintech',
+        kind='register-magic-link',
+        plain='OPAQUE_PLAIN',
+        verify_url='https://api.example.com/auth?token=OPAQUE_PLAIN',
+    )
+
+    assert msg_id == 'msg-id-1'
+    payload = fake_send.call_args.kwargs['payload']
+    assert payload['kind'] == 'register-magic-link'
+    assert payload['to'] == 'visitor@example.com'
+    assert payload['data']['token'] == 'OPAQUE_PLAIN'
+    assert payload['data']['verify_url'].endswith('OPAQUE_PLAIN')
+
+
+def test_publish_code_sends_payload_with_code(monkeypatch):
+    from services import email_dispatch_service
+
+    fake_send = MagicMock(return_value='msg-id-2')
+    monkeypatch.setattr(email_dispatch_service, 'send_to_queue', fake_send)
+
+    svc = email_dispatch_service.EmailDispatchService(app_config=object())
+    msg_id = svc.publish_code(
+        to='visitor@example.com',
+        user_id='user-1',
+        niche=None,
+        kind='register-code',
+        code='ABCDEFGH',
+    )
+
+    assert msg_id == 'msg-id-2'
+    payload = fake_send.call_args.kwargs['payload']
+    assert payload['kind'] == 'register-code'
+    assert payload['data']['code'] == 'ABCDEFGH'

--- a/serverless/lambda/services/auth/tests/unit/services/test_flow_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_flow_service.py
@@ -1,0 +1,74 @@
+"""FlowService — patron rolling temp JWT (verify + advance + terminate)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+_TEST_JWT_KEY = 'X' * 40
+
+
+def _stub_app_config():
+    return SimpleNamespace(
+        jwt_secret=_TEST_JWT_KEY,
+        jwt_issuer='portfolio-auth',
+        jwt_audience='portfolio',
+        jwt_blacklist_table_name='portfolio-jwt-blacklist-test',
+    )
+
+
+def test_advance_step_blacklists_old_jti_and_returns_new_temp(monkeypatch):
+    from services import flow_service, jwt_service
+    from shared.auth import issue_temp_jwt
+
+    monkeypatch.setattr(
+        jwt_service.BlacklistService,
+        'is_blacklisted',
+        lambda _self, *, jti: False,
+    )
+    fake_put = MagicMock()
+    monkeypatch.setattr(jwt_service.BlacklistService, 'put', fake_put)
+
+    svc = flow_service.FlowService(_stub_app_config())
+    user_id = uuid4()
+
+    # Construir un temp con step=1 que el service rotara a step=2.
+    _, claims_step1 = issue_temp_jwt(
+        user_id=user_id,
+        flow='register',
+        step=1,
+        secret=_TEST_JWT_KEY,
+    )
+
+    new_token, new_claims = svc.advance_step(claims_step1)
+
+    fake_put.assert_called_once()
+    assert new_claims.step == 2
+    assert new_claims.flow == 'register'
+    assert new_token != ''
+
+
+def test_terminate_flow_returns_access_refresh_and_family(monkeypatch):
+    from services import flow_service, jwt_service
+    from shared.auth import issue_temp_jwt
+
+    monkeypatch.setattr(
+        jwt_service.BlacklistService,
+        'is_blacklisted',
+        lambda _self, *, jti: False,
+    )
+    monkeypatch.setattr(jwt_service.BlacklistService, 'put', MagicMock())
+
+    svc = flow_service.FlowService(_stub_app_config())
+    user_id = uuid4()
+
+    _, claims = issue_temp_jwt(
+        user_id=user_id, flow='register', step=2, secret=_TEST_JWT_KEY,
+    )
+
+    access_str, refresh_str, family_id = svc.terminate_flow(
+        user_id=user_id, claims=claims,
+    )
+
+    assert access_str
+    assert refresh_str
+    assert family_id is not None

--- a/serverless/lambda/services/auth/tests/unit/services/test_jwt_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_jwt_service.py
@@ -1,0 +1,137 @@
+"""JwtService — happy + sad path (issue/verify + blacklist hooks)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+# JWT HS256 needs a string of reasonable entropy. Use a deterministic
+# random-looking 40-char placeholder (NOT a real value).
+_TEST_JWT_KEY = 'X' * 40
+
+
+def _stub_app_config():
+    """AppConfig stub que NO toca SSM (los valores son strings directos)."""
+    return SimpleNamespace(
+        jwt_secret=_TEST_JWT_KEY,
+        jwt_issuer='portfolio-auth',
+        jwt_audience='portfolio',
+        jwt_blacklist_table_name='portfolio-jwt-blacklist-test',
+    )
+
+
+def test_issue_temp_and_verify_roundtrip(monkeypatch):
+    """Emite un temp + verify_jwt lo decodifica con el mismo secret."""
+    from services import jwt_service
+
+    monkeypatch.setattr(
+        jwt_service.BlacklistService,
+        'is_blacklisted',
+        lambda _self, *, jti: False,
+    )
+
+    svc = jwt_service.JwtService(_stub_app_config())
+    user_id = uuid4()
+
+    token_str, claims = svc.issue_temp(
+        user_id=user_id, flow='register', step=1,
+    )
+    verified = svc.verify(token_str, expected_typ='temp')
+
+    assert verified.sub == user_id
+    assert verified.typ == 'temp'
+    assert verified.flow == 'register'
+    assert verified.step == 1
+
+
+def test_verify_rejects_when_blacklisted(monkeypatch):
+    """JwtService.verify levanta JwtRevokedError si el jti esta en DDB."""
+    import pytest
+
+    from services import jwt_service
+    from shared.auth import JwtRevokedError
+
+    monkeypatch.setattr(
+        jwt_service.BlacklistService,
+        'is_blacklisted',
+        lambda _self, *, jti: True,
+    )
+
+    svc = jwt_service.JwtService(_stub_app_config())
+    token_str, _ = svc.issue_access(user_id=uuid4())
+
+    with pytest.raises(JwtRevokedError):
+        svc.verify(token_str, expected_typ='access')
+
+
+def test_verify_with_expected_flow_mismatch_raises(monkeypatch):
+    """verify(expected_flow='login') sobre un temp emitido con flow='register' -> JwtInvalidError."""
+    import pytest
+
+    from services import jwt_service
+    from shared.auth import JwtInvalidError
+
+    monkeypatch.setattr(
+        jwt_service.BlacklistService,
+        'is_blacklisted',
+        lambda _self, *, jti: False,
+    )
+
+    svc = jwt_service.JwtService(_stub_app_config())
+    token_str, _ = svc.issue_temp(user_id=uuid4(), flow='register', step=1)
+
+    with pytest.raises(JwtInvalidError):
+        svc.verify(token_str, expected_typ='temp', expected_flow='login')
+
+
+def test_issue_refresh_returns_token_with_family(monkeypatch):
+    from services import jwt_service
+
+    monkeypatch.setattr(
+        jwt_service.BlacklistService,
+        'is_blacklisted',
+        lambda _self, *, jti: False,
+    )
+
+    svc = jwt_service.JwtService(_stub_app_config())
+    user_id = uuid4()
+    family_id = uuid4()
+
+    token_str, claims = svc.issue_refresh(
+        user_id=user_id, family_id=family_id,
+    )
+
+    assert claims.typ == 'refresh'
+    assert claims.family_id == family_id
+    assert token_str != ''
+
+
+def test_revoke_family_delegates_to_blacklist_service(monkeypatch):
+    from services import jwt_service
+
+    fake = MagicMock()
+    monkeypatch.setattr(jwt_service.BlacklistService, 'revoke_family', fake)
+
+    svc = jwt_service.JwtService(_stub_app_config())
+    svc.revoke_family(
+        family_id='fam-1', user_id='user-x', exp=1_700_000_000,
+    )
+
+    fake.assert_called_once()
+
+
+def test_blacklist_delegates_to_blacklist_service(monkeypatch):
+    """jwt_service.blacklist() llama a BlacklistService.put."""
+    from services import jwt_service
+
+    fake_put = MagicMock()
+    monkeypatch.setattr(jwt_service.BlacklistService, 'put', fake_put)
+
+    svc = jwt_service.JwtService(_stub_app_config())
+    svc.blacklist(
+        jti='jti-1', exp=1_700_000_000, user_id='user-x', reason='logout',
+    )
+
+    fake_put.assert_called_once()
+    kwargs = fake_put.call_args.kwargs
+    assert kwargs['jti'] == 'jti-1'
+    assert kwargs['reason'] == 'logout'

--- a/serverless/lambda/services/auth/tests/unit/services/test_magic_link_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_magic_link_service.py
@@ -1,0 +1,58 @@
+"""MagicLinkService — happy + sad path."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def _fake_session():
+    yield MagicMock()
+
+
+def test_generate_and_persist_returns_plain_and_hash(monkeypatch):
+    from services import magic_link_service
+    from shared.db.models import AuthLinkKind
+
+    monkeypatch.setattr(magic_link_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        magic_link_service, 'generate_opaque_token', lambda: 'PLAIN_TOKEN',
+    )
+    monkeypatch.setattr(magic_link_service, 'hash_token', lambda _p: b'H')
+    monkeypatch.setattr(magic_link_service, 'insert_magic_link', MagicMock())
+
+    svc = magic_link_service.MagicLinkService(app_config=object())
+    plain, h = svc.generate_and_persist(
+        user_id='user-1', kind=AuthLinkKind.REGISTER,
+    )
+
+    assert plain == 'PLAIN_TOKEN'
+    assert h == b'H'
+
+
+def test_verify_returns_none_when_not_found(monkeypatch):
+    from services import magic_link_service
+
+    monkeypatch.setattr(magic_link_service, 'db_session', _fake_session)
+    monkeypatch.setattr(magic_link_service, 'hash_token', lambda _p: b'H')
+    monkeypatch.setattr(
+        magic_link_service, 'consume_magic_link', lambda *_a, **_kw: None,
+    )
+
+    svc = magic_link_service.MagicLinkService(app_config=object())
+
+    assert svc.verify(plain='X' * 40) is None
+
+
+def test_verify_returns_row_when_found(monkeypatch):
+    from services import magic_link_service
+
+    fake_row = MagicMock(user_id='user-y')
+    monkeypatch.setattr(magic_link_service, 'db_session', _fake_session)
+    monkeypatch.setattr(magic_link_service, 'hash_token', lambda _p: b'H')
+    monkeypatch.setattr(
+        magic_link_service, 'consume_magic_link', lambda *_a, **_kw: fake_row,
+    )
+
+    svc = magic_link_service.MagicLinkService(app_config=object())
+
+    assert svc.verify(plain='X' * 40) is fake_row

--- a/serverless/lambda/services/auth/tests/unit/services/test_rate_limit_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_rate_limit_service.py
@@ -1,0 +1,42 @@
+"""RateLimitService — happy + sad path."""
+
+from unittest.mock import MagicMock
+
+
+def test_check_or_raise_delegates_to_shared(monkeypatch):
+    from services import rate_limit_service
+
+    fake_check = MagicMock(return_value=None)
+    monkeypatch.setattr(rate_limit_service, 'check_or_raise', fake_check)
+
+    svc = rate_limit_service.RateLimitService(app_config=object())
+    svc.check_or_raise(
+        ip='203.0.113.10',
+        endpoint='/auth#register.start',
+        country='CL',
+    )
+
+    fake_check.assert_called_once()
+    kwargs = fake_check.call_args.kwargs
+    assert kwargs['ip'] == '203.0.113.10'
+    assert kwargs['endpoint'] == '/auth#register.start'
+    assert kwargs['country'] == 'CL'
+
+
+def test_check_or_raise_propagates_exception(monkeypatch):
+    import pytest
+
+    from services import rate_limit_service
+
+    class FakeRLError(Exception):
+        pass
+
+    def _raise(**_kw):
+        raise FakeRLError('exceeded')
+
+    monkeypatch.setattr(rate_limit_service, 'check_or_raise', _raise)
+
+    svc = rate_limit_service.RateLimitService(app_config=object())
+
+    with pytest.raises(FakeRLError):
+        svc.check_or_raise(ip='203.0.113.10', endpoint='/auth#login.start')

--- a/serverless/lambda/services/auth/tests/unit/services/test_user_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_user_service.py
@@ -1,0 +1,129 @@
+"""UserService — happy + sad path.
+
+Mocks `db_session` y los helpers de `shared.db.repositories.auth` para
+aislar el service del DB real.
+"""
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def _fake_session():
+    yield MagicMock()
+
+
+def test_get_by_email_returns_user_when_found(monkeypatch):
+    from services import user_service
+
+    fake_user = MagicMock(id='user-1', email='visitor@example.com')
+
+    monkeypatch.setattr(user_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        user_service, 'get_user_by_email', lambda _s, _e: fake_user,
+    )
+
+    svc = user_service.UserService(app_config=object())
+    result = svc.get_by_email('Visitor@Example.com')
+
+    assert result is fake_user
+
+
+def test_create_pending_delegates_to_repo(monkeypatch):
+    from services import user_service
+
+    fake_user = MagicMock(id='user-new', email='new@example.com')
+    calls = {}
+
+    def fake_create(_session, *, email):
+        calls['email'] = email
+        return fake_user
+
+    monkeypatch.setattr(user_service, 'db_session', _fake_session)
+    monkeypatch.setattr(user_service, 'create_pending_user', fake_create)
+
+    svc = user_service.UserService(app_config=object())
+    result = svc.create_pending(email='  NEW@example.com  ')
+
+    assert result is fake_user
+    assert calls['email'] == 'new@example.com'
+
+
+def test_mark_active_delegates_to_repo(monkeypatch):
+    from services import user_service
+
+    called = {}
+    monkeypatch.setattr(user_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        user_service,
+        'mark_user_active',
+        lambda _s, u: called.setdefault('user', u),
+    )
+
+    svc = user_service.UserService(app_config=object())
+    user = MagicMock(id='u')
+    svc.mark_active(user)
+
+    assert called['user'] is user
+
+
+def test_reset_failed_attempts_delegates_to_repo(monkeypatch):
+    from services import user_service
+
+    called = {}
+    monkeypatch.setattr(user_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        user_service,
+        'reset_failed_attempts',
+        lambda _s, u: called.setdefault('user', u),
+    )
+
+    svc = user_service.UserService(app_config=object())
+    user = MagicMock(id='u')
+    svc.reset_failed_attempts(user)
+
+    assert called['user'] is user
+
+
+def test_lock_user_delegates_to_repo(monkeypatch):
+    from services import user_service
+
+    called = {}
+    monkeypatch.setattr(user_service, 'db_session', _fake_session)
+
+    def _fake_lock(_session, _user, *, until):
+        called['until'] = until
+
+    monkeypatch.setattr(user_service, 'lock_user', _fake_lock)
+
+    svc = user_service.UserService(app_config=object())
+    until = datetime.now(tz=UTC)
+    svc.lock_user(MagicMock(id='u'), until=until)
+
+    assert called['until'] == until
+
+
+def test_increment_failed_attempts_locks_at_fifth_failure(monkeypatch):
+    from services import user_service
+
+    calls = {'lock_called_with': None}
+
+    monkeypatch.setattr(user_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        user_service, 'increment_failed_attempts', lambda _s, _u: 5,
+    )
+
+    def fake_lock(_session, _user, *, until):
+        calls['lock_called_with'] = until
+
+    monkeypatch.setattr(user_service, 'lock_user', fake_lock)
+
+    svc = user_service.UserService(app_config=object())
+    user = MagicMock(id='user-x', failed_attempts=4)
+
+    attempts = svc.increment_failed_attempts(user)
+
+    assert attempts == 5
+    assert calls['lock_called_with'] is not None
+    assert calls['lock_called_with'] > datetime.now(tz=UTC)

--- a/serverless/lambda/services/auth/tests/unit/test_app_config_loads.py
+++ b/serverless/lambda/services/auth/tests/unit/test_app_config_loads.py
@@ -1,0 +1,107 @@
+"""AppConfig — carga env vars + resuelve secretos lazy.
+
+Cubre el ciclo basico del AppConfig: env vars con defaults, lazy
+resolution de secretos via `get_secret_by_name`, lazy resolution de
+nombres de tabla via SSM.
+
+NO probamos cada cached_property (eso fija el resultado en la
+instancia y rompe los siguientes tests). Probamos con instancias
+nuevas.
+"""
+
+import os
+
+
+def test_app_config_loads_env_vars_with_defaults():
+    """Env vars basicas se cargan a la instancia."""
+    from settings.config import AppConfig
+
+    cfg = AppConfig()
+    assert cfg.environment == 'dev'
+    assert cfg.jwt_issuer == 'portfolio-auth'
+    assert cfg.jwt_audience == 'portfolio'
+    assert cfg.is_testing() is True
+
+
+def test_app_config_jwt_secret_resolves_lazy(monkeypatch):
+    """jwt_secret lee la env var JWT_SECRET en modo local."""
+    from settings.config import AppConfig
+
+    monkeypatch.setenv('JWT_SECRET', 'lazy-jwt-value')
+    monkeypatch.delenv('SSM_JWT_SECRET_PATH', raising=False)
+
+    cfg = AppConfig()
+    assert cfg.jwt_secret == 'lazy-jwt-value'
+
+
+def test_app_config_neon_url_resolves_lazy(monkeypatch):
+    """neon_url lee la env var DB_URL en modo local."""
+    from settings.config import AppConfig
+
+    monkeypatch.setenv('DB_URL', 'postgresql://localhost/test')
+    monkeypatch.delenv('SSM_NEON_URL_PATH', raising=False)
+
+    cfg = AppConfig()
+    assert cfg.neon_url == 'postgresql://localhost/test'
+
+
+def test_app_config_ses_from_address_resolves_lazy(monkeypatch):
+    from settings.config import AppConfig
+
+    monkeypatch.setenv('SES_FROM_ADDRESS', 'no-reply@example.com')
+    monkeypatch.delenv('SSM_SES_FROM_ADDRESS_PATH', raising=False)
+
+    cfg = AppConfig()
+    assert cfg.ses_from_address == 'no-reply@example.com'
+
+
+def test_app_config_jwt_blacklist_table_uses_env_var(monkeypatch):
+    """Si SSM_JWT_BLACKLIST_TABLE_PATH es un nombre plano (no `/`), se usa directo."""
+    from settings.config import AppConfig
+
+    monkeypatch.setenv(
+        'SSM_JWT_BLACKLIST_TABLE_PATH', 'portfolio-jwt-blacklist-test',
+    )
+
+    cfg = AppConfig()
+    assert cfg.jwt_blacklist_table_name == 'portfolio-jwt-blacklist-test'
+
+
+def test_app_config_resolves_table_from_ssm(monkeypatch):
+    """Si SSM_*_PATH empieza con `/`, llama a get_parameter."""
+    from settings import config as config_mod
+
+    monkeypatch.setenv(
+        'SSM_CACHE_TABLE_PATH', '/portfolio/dev/dynamodb/cache/name',
+    )
+    monkeypatch.setattr(
+        config_mod, 'get_parameter', lambda _path: 'portfolio-cache-dev',
+    )
+
+    cfg = config_mod.AppConfig()
+    assert cfg.cache_table_name == 'portfolio-cache-dev'
+
+
+def test_app_config_resolve_from_ssm_returns_empty_when_unset(monkeypatch):
+    """Sin env var ni SSM path -> empty string."""
+    from settings.config import AppConfig
+
+    monkeypatch.delenv('SSM_AUTH_EMAIL_QUEUE_URL_PATH', raising=False)
+
+    cfg = AppConfig()
+    assert cfg.auth_email_queue_url == ''
+
+
+def test_app_config_enums_present():
+    """ErrorCode / LogMetricType estan exportados."""
+    from settings.config import ErrorCode, LogMetricType
+
+    assert ErrorCode.SUCCESS.value == 0
+    assert ErrorCode.EMAIL_NOT_FOUND.value == 4001
+    assert ErrorCode.TOKEN_REUSE_DETECTED.value == 4004
+    assert LogMetricType.AUTH_LOGIN_OK.value == 'AUTH_LOGIN_OK'
+
+
+def _silence_unused():
+    """Avoid F401 / unused import for `os` (used implicitly via env)."""
+    _ = os

--- a/serverless/lambda/services/auth/tests/unit/test_handler_invokes_http_handler.py
+++ b/serverless/lambda/services/auth/tests/unit/test_handler_invokes_http_handler.py
@@ -1,0 +1,84 @@
+"""El handler delega en `http_handler` con los parametros del Lambda auth.
+
+Una request invalida (operation=unknown) hace que `http_handler`
+devuelva un response de error (404/400). NO probamos un flujo feliz
+porque los controllers concretos llegan en PR 7/8.
+
+El handler decorado con powertools requiere un `LambdaContext`
+fake; usamos un MagicMock con los atributos minimos.
+"""
+
+from unittest.mock import MagicMock
+
+
+def _fake_context():
+    """LambdaContext stub para los decoradores Powertools."""
+    ctx = MagicMock()
+    ctx.aws_request_id = 'test-request-id'
+    ctx.function_name = 'auth-test'
+    ctx.function_version = '$LATEST'
+    ctx.invoked_function_arn = (
+        'arn:aws:lambda:us-east-1:123456789012:function:auth-test'
+    )
+    ctx.memory_limit_in_mb = 384
+    ctx.get_remaining_time_in_millis = lambda: 15000
+    return ctx
+
+
+def test_handler_returns_error_for_unknown_operation():
+    """operation=unknown -> 4xx (no se llama a ningun controller real)."""
+    from handler import lambda_handler
+
+    event = {
+        'httpMethod': 'POST',
+        'path': '/auth',
+        'headers': {
+            'Content-Type': 'application/json',
+            'Origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'CF-Connecting-IP': '203.0.113.10',
+        },
+        'queryStringParameters': None,
+        'body': (
+            '{"operation":"unknown","action":"start","data":{}}'
+        ),
+        'requestContext': {
+            'identity': {'sourceIp': '203.0.113.10'},
+            'requestId': 'r1',
+            'stage': 'dev',
+        },
+    }
+
+    response = lambda_handler(event, _fake_context())
+
+    assert 'statusCode' in response
+    # http_handler traduce un controller_not_found a 400/404 — sea cual
+    # sea, NO es 200.
+    assert response['statusCode'] != 200
+
+
+def test_handler_returns_error_for_missing_action():
+    """operation valida pero sin action -> 4xx (validate_event falla)."""
+    from handler import lambda_handler
+
+    event = {
+        'httpMethod': 'POST',
+        'path': '/auth',
+        'headers': {
+            'Content-Type': 'application/json',
+            'Origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'CF-Connecting-IP': '203.0.113.10',
+        },
+        'queryStringParameters': None,
+        'body': (
+            '{"operation":"register","data":{}}'
+        ),
+        'requestContext': {
+            'identity': {'sourceIp': '203.0.113.10'},
+            'requestId': 'r2',
+            'stage': 'dev',
+        },
+    }
+
+    response = lambda_handler(event, _fake_context())
+
+    assert response['statusCode'] != 200

--- a/serverless/lambda/services/auth/tests/unit/test_handler_routes_correctly.py
+++ b/serverless/lambda/services/auth/tests/unit/test_handler_routes_correctly.py
@@ -1,0 +1,60 @@
+"""El handler rutea operations validas y rechaza invalidas con 404.
+
+Validamos 3 contratos del scaffold:
+1. El EVENT_MODEL acepta `register/start` como operation valida (no
+   levanta ValueError en validate_event).
+2. Una operation desconocida levanta ValueError -> el handler
+   responde 404.
+3. Una action desconocida levanta ValueError -> el handler responde
+   404.
+
+No probamos el flujo completo: los controllers concretos llegan en
+PR 7/8. Aqui solo aseguramos el ruteo del scaffold.
+"""
+
+import pytest
+
+
+def test_event_model_register_actions():
+    """register expone start, verify-magic-link, verify-code."""
+    from settings.operations import OPERATIONS
+
+    assert 'register' in OPERATIONS
+    assert 'login' in OPERATIONS
+    assert 'verify' in OPERATIONS
+    assert 'session' in OPERATIONS
+
+
+def test_event_model_rejects_invalid_operation():
+    """`unknown` -> ValueError tras import_controller fail."""
+    from models.event import EVENT_MODEL
+
+    with pytest.raises(ValueError):
+        EVENT_MODEL.validate_event({
+            'operation': 'unknown',
+            'action': 'start',
+            'data': {},
+        })
+
+
+def test_event_model_rejects_invalid_action():
+    """`register/unknown-action` -> ValueError."""
+    from models.event import EVENT_MODEL
+
+    with pytest.raises(ValueError):
+        EVENT_MODEL.validate_event({
+            'operation': 'register',
+            'action': 'unknown-action',
+            'data': {},
+        })
+
+
+def test_event_model_rejects_missing_operation():
+    """Sin `operation` en el evento -> ValueError."""
+    from models.event import EVENT_MODEL
+
+    with pytest.raises(ValueError):
+        EVENT_MODEL.validate_event({
+            'action': 'start',
+            'data': {},
+        })

--- a/serverless/lambda/services/auth/uv.lock
+++ b/serverless/lambda/services/auth/uv.lock
@@ -1,0 +1,863 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "auth"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "freezegun" },
+    { name = "moto", extra = ["dynamodb", "ssm"] },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "freezegun", specifier = ">=1.4,<2.0" },
+    { name = "moto", extras = ["dynamodb", "ses", "sns", "ssm", "sqs", "kms"], specifier = ">=5.0,<6.0" },
+    { name = "mypy", specifier = ">=1.10,<2.0" },
+    { name = "pytest", specifier = ">=8.0,<9.0" },
+    { name = "pytest-cov", specifier = ">=5.0,<6.0" },
+    { name = "pytest-mock", specifier = ">=3.12,<4.0" },
+    { name = "respx", specifier = ">=0.23.1" },
+    { name = "ruff", specifier = ">=0.6,<1.0" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/4f/f13d80d377b54dd2973e243e4eb7ce748706cd53876361cc72506006fd8b/boto3-1.43.16.tar.gz", hash = "sha256:6c337bbe608aacc7d335c79e671f0c893870293b74d652f7a7af22ccd0dfef16", size = 113152, upload-time = "2026-05-27T19:31:39.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/c0/7d687e40f4b7046ede66026ecd1b0a93d47afe26d9170f5926a1605c8641/boto3-1.43.16-py3-none-any.whl", hash = "sha256:dffc8a3cd3edbc0ad95b9c6b983e873b76ede46d3aa0709f94db253f2ff2388f", size = 140537, upload-time = "2026-05-27T19:31:36.453Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/74/140451a1fe027cb5e387cc7b1ec56224616ca742c330f1492f71c5cba3fb/botocore-1.43.16.tar.gz", hash = "sha256:813dae233d8b365c19aaf7865b32070e34d7e793654881bf86ecbbef3f4ad5c6", size = 15388648, upload-time = "2026-05-27T19:31:25.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/8f/25933240485c0662bb3fa430ed0c6b8b8124ab3bc136154c07ce12644cb0/botocore-1.43.16-py3-none-any.whl", hash = "sha256:8ab05b1346d26a3c6d69c7338051f07bd4739a090f414d2cff43c0dbc1e18ca7", size = 15067437, upload-time = "2026-05-27T19:31:19.212Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "moto"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/e9/c38202162db2e76623176be9f1dbc9aa41228ffa91ee8da2d3986082c3e3/moto-5.2.1.tar.gz", hash = "sha256:ccb2f3e1dfa82e50e054bda98b0be708d244d2668364dcc1d45e8d3de6091bde", size = 8634437, upload-time = "2026-05-10T19:11:57.286Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/79/8085b7c1ecd48d0535c3c8444a1d8df2926e457dce8e55fabc332a382c9c/moto-5.2.1-py3-none-any.whl", hash = "sha256:19d2fbd6e613aa5b4e364c52cd5d3cea371643a0f4210689a703227bd2924c5c", size = 6671379, upload-time = "2026-05-10T19:11:53.543Z" },
+]
+
+[package.optional-dependencies]
+dynamodb = [
+    { name = "docker" },
+    { name = "py-partiql-parser" },
+]
+ssm = [
+    { name = "pyyaml" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042, upload-time = "2024-03-24T20:16:34.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990, upload-time = "2024-03-24T20:16:32.444Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/b3/bcdc2f58fa92592db511beda154c2c08d28f21f6c4637f06a42a24b10c21/s3transfer-0.17.1.tar.gz", hash = "sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e", size = 159439, upload-time = "2026-05-26T19:45:01.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/dd/904873250a6554fbae40cddbf9198e3cc37a2f1319d5e1a5ce82fe269c17/s3transfer-0.17.1-py3-none-any.whl", hash = "sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c", size = 88264, upload-time = "2026-05-26T19:45:00.452Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
+]


### PR DESCRIPTION
## Problema

El Lambda `auth` HTTP no existia. Para implementar register/login/verify/
session (PR 7 y PR 8) hace falta primero el scaffold: handler delgado,
AppConfig con secrets, operations registry, modelos Pydantic de input,
EventModel, y los 9 services con la logica de negocio que los
controllers van a orquestar.

## Solucion

**Scaffold completo del Lambda `auth`** (sin los controllers, esos van en
PR 7-8):

- `manifest.yaml`: HTTP POST /auth, snap_start, memory 384, timeout 15.
  Uses: SQS producer auth-email + 4 tablas DDB + 5 secrets (incluye el
  nuevo `jwt-secret`).
- `core/handler.py`: `lambda_handler` -> `http_handler(success_status=200,
  cors_origin='echo')`.
- `core/settings/config.py`: AppConfig con env vars + 5 `@cached_property`
  para secrets (JWT_SECRET, Turnstile, Neon, SES) + resolvers DDB.
  Incluye `ErrorCode` con codigos especificos (`EMAIL_NOT_FOUND`,
  `TOKEN_BLACKLISTED`, `TOKEN_REUSE_DETECTED`, `ACCOUNT_LOCKED`,
  `LINK_CONSUMED`/`EXPIRED`, etc.).
- `core/settings/operations.py`: 4 operations
  (register/login/verify/session).
- `core/models/`: `_common.py` (Niche Literal + `_Meta` con alias
  `_meta`), `register.py` + `login.py` + `verify.py` + `session.py`
  (10 modelos), `event.py` (`EVENT_MODEL = build_event_model(...)`).
- `core/services/`: **9 services como clases** (user, code, magic_link,
  blacklist, jwt, email_dispatch, audit, rate_limit, flow). TODOS via
  `shared.{core,db,auth,aws,rate_limit,queue,observability}` (cero
  `from pydantic`, `import jwt`, `import boto3`).

**Smoke tests (no controllers todavia)**:
- 17 archivos de test, **53 asserts pasan en ~1.3s**.
- **Coverage 96.80%** global; per-file >= 88% en `core/services/`,
  100% en `core/models/`.
- 7 tests de modelos cubriendo edge cases (`email_required`,
  `email_invalid`, `turnstile_required`, `code_pattern` con O/0/I/1,
  `code_length` != 8, `refresh_token < 20 chars`, `_meta` injection
  via alias).

## Como probar

```bash
# Lint-deps (shared-only + dedup D-3)
python devtools/run.py serverless lint-deps --lambda=auth
# OK auth: sin deps duplicadas con shared/.
# OK auth: cero imports prohibidos en core/.

# Tests + coverage
python devtools/run.py serverless tests --type=unit --lambda=auth
# 53 passed in 1.27s
python devtools/run.py serverless tests --type=coverage --lambda=auth
# Total coverage: 96.80%
```

## TODO

(vacio — los controllers register/login van en PR 7,
verify/session + rate-limit seed + deploy en PR 8)

---

Plan padre: `docs/specs/01-auth-infra-basics/` (PR 6 del plan,
commits 6.1+6.2+6.3 consolidados).