### PR TITLE
feat(auth): 6 controllers register + login + fix import_controller para actions con guion

### DIFF
--- a/serverless/lambda/services/auth/core/controllers/login/__init__.py
+++ b/serverless/lambda/services/auth/core/controllers/login/__init__.py
@@ -1,0 +1,7 @@
+"""Controllers de la operation `login` del Lambda `auth`.
+
+3 actions, espejo de register:
+- `start` -> `start.py` + `Start`
+- `verify-magic-link` -> `verify_magic_link.py` + `VerifyMagicLink`
+- `verify-code` -> `verify_code.py` + `VerifyCode`
+"""

--- a/serverless/lambda/services/auth/core/controllers/login/start.py
+++ b/serverless/lambda/services/auth/core/controllers/login/start.py
@@ -1,0 +1,203 @@
+"""Controller `login.start` — inicia el flujo de login passwordless.
+
+Espejo de `register.start`. El visitante existente pide login: el
+controller verifica Turnstile + rate-limit, valida que el email exista
+y este activo, genera code + magic-link nuevos, publica los 2 mensajes
+SQS al worker, y devuelve un temp_token (rolling JWT, 5 min) con
+flow='login'.
+
+AC cubiertos: AC-5, AC-6, AC-20.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.login import LoginStartIn
+from services.audit_service import AuditService
+from services.code_service import CodeService
+from services.email_dispatch_service import EmailDispatchService
+from services.jwt_service import JwtService
+from services.magic_link_service import MagicLinkService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.db.models import AuthCodeKind, AuthLinkKind, AuthUserStatus
+from shared.http import verify_turnstile_token
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#login.start'
+_TEMP_TTL_SECONDS = 300
+
+
+class Start(BaseController):
+    """Inicia el flujo de login (action `start`)."""
+
+    event_model = LoginStartIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit + Turnstile."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: LoginStartIn = self.validated_data  # type: ignore[assignment]
+        meta = data.meta
+
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=False,
+        )
+        verify_turnstile_token(
+            data.cf_turnstile_response,
+            remote_ip=meta.ip,
+            bypass_secret=meta.bypass_secret,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Verifica que el email exista/active, publica code + magic-link.
+
+        Returns:
+            Exito: `{is_valid: True, code: 0, data: {temp_token,
+            methods, expires_in}}` (HTTP 200).
+            Email no existe: 404 EMAIL_NOT_FOUND con suggest_register=True
+            (AC-5).
+            Email pending: 409 PENDING_VERIFICATION.
+            Email disabled/locked: 404 EMAIL_NOT_FOUND, suggest_register
+            =False (AC-20, anti-enumeration).
+        """
+        data: LoginStartIn = self.validated_data  # type: ignore[assignment]
+        meta = data.meta
+        email = data.email.lower()
+        niche = data.niche
+
+        user_svc = UserService(app_config)
+        code_svc = CodeService(app_config)
+        link_svc = MagicLinkService(app_config)
+        jwt_svc = JwtService(app_config)
+        email_svc = EmailDispatchService(app_config)
+        audit_svc = AuditService(app_config)
+
+        existing = user_svc.get_by_email(email)
+
+        if existing is None:
+            audit_svc.log(
+                event='login.start',
+                success=False,
+                error_code='EMAIL_NOT_FOUND',
+                ip=meta.ip,
+                user_agent=meta.user_agent,
+                niche=niche,
+            )
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {
+                    'error': 'EMAIL_NOT_FOUND',
+                    'suggest_register': True,
+                    'methods': [],
+                },
+            }
+
+        if existing.status == AuthUserStatus.PENDING:
+            audit_svc.log(
+                event='login.start',
+                success=False,
+                user_id=existing.id,
+                error_code='PENDING_VERIFICATION',
+                ip=meta.ip,
+                niche=niche,
+            )
+            return {
+                'is_valid': False,
+                'code': 4011,
+                'status': 409,
+                'data': {'error': 'PENDING_VERIFICATION'},
+            }
+
+        if existing.status in (
+            AuthUserStatus.DISABLED, AuthUserStatus.LOCKED,
+        ):
+            audit_svc.log(
+                event='login.start',
+                success=False,
+                user_id=existing.id,
+                error_code='EMAIL_NOT_FOUND',
+                ip=meta.ip,
+                niche=niche,
+            )
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {
+                    'error': 'EMAIL_NOT_FOUND',
+                    'suggest_register': False,
+                    'methods': [],
+                },
+            }
+
+        # status active: invalidar codes + links previos + generar nuevos.
+        user_svc.invalidate_active_codes_and_links(
+            user_id=str(existing.id),
+            kind_code=AuthCodeKind.LOGIN,
+            kind_link=AuthLinkKind.LOGIN,
+        )
+
+        code, _ = code_svc.generate_and_persist(
+            user_id=existing.id, kind=AuthCodeKind.LOGIN,
+        )
+        token, _ = link_svc.generate_and_persist(
+            user_id=existing.id,
+            kind=AuthLinkKind.LOGIN,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        verify_url = (
+            f'{app_config.magic_link_base_url}'
+            f'?operation=login&action=verify-magic-link&token={token}'
+        )
+        email_svc.publish_magic_link(
+            to=existing.email,
+            user_id=existing.id,
+            niche=niche,
+            kind='login-magic-link',
+            plain=token,
+            verify_url=verify_url,
+        )
+        email_svc.publish_code(
+            to=existing.email,
+            user_id=existing.id,
+            niche=niche,
+            kind='login-code',
+            code=code,
+        )
+
+        temp_token, _ = jwt_svc.issue_temp(
+            user_id=existing.id, flow='login', step=1,
+        )
+
+        audit_svc.log(
+            event='login.start',
+            success=True,
+            user_id=existing.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+            niche=niche,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'temp_token': temp_token,
+                'methods': ['magic-link', 'email-code'],
+                'expires_in': _TEMP_TTL_SECONDS,
+            },
+        }

--- a/serverless/lambda/services/auth/core/controllers/login/verify_code.py
+++ b/serverless/lambda/services/auth/core/controllers/login/verify_code.py
@@ -1,0 +1,204 @@
+"""Controller `login.verify-code` — login passwordless via code 8 chars.
+
+Espejo de `register.verify-code` pero con `expected_flow='login'` y
+sin marcar al user como `active` (ya lo esta). Actualiza
+`last_login_at` (AC-22) y emite access + refresh.
+
+AC cubiertos: AC-22.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from models.login import LoginVerifyCodeIn
+from services.audit_service import AuditService
+from services.code_service import CodeService
+from services.flow_service import FlowService
+from services.jwt_service import JwtService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.auth import JwtExpiredError, JwtInvalidError, JwtRevokedError
+from shared.core.ulid import new_uuidv7
+from shared.db.models import AuthCodeKind
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#login.verify-code'
+_LOCK_DURATION = timedelta(hours=1)
+_MAX_FAILED_ATTEMPTS = 5
+
+
+class VerifyCode(BaseController):
+    """Verifica el code de login (action `verify-code`)."""
+
+    event_model = LoginVerifyCodeIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: LoginVerifyCodeIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Verifica temp_token (flow='login') + code, emite access+refresh."""
+        data: LoginVerifyCodeIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        flow_svc = FlowService(app_config)
+        user_svc = UserService(app_config)
+        code_svc = CodeService(app_config)
+        jwt_svc = JwtService(app_config)
+        audit_svc = AuditService(app_config)
+
+        try:
+            claims = flow_svc.verify_temp_token(
+                data.temp_token, expected_flow='login',
+            )
+        except JwtExpiredError:
+            audit_svc.log(
+                event='login.verify-code',
+                success=False,
+                error_code='TEMP_TOKEN_EXPIRED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4018,
+                'status': 401,
+                'data': {'error': 'TEMP_TOKEN_EXPIRED'},
+            }
+        except JwtRevokedError:
+            audit_svc.log(
+                event='login.verify-code',
+                success=False,
+                error_code='TOKEN_BLACKLISTED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_BLACKLISTED'},
+            }
+        except JwtInvalidError:
+            audit_svc.log(
+                event='login.verify-code',
+                success=False,
+                error_code='TOKEN_INVALID',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_INVALID'},
+            }
+
+        user = user_svc.get_by_id(str(claims.sub))
+        if user is None:
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {'error': 'EMAIL_NOT_FOUND'},
+            }
+
+        matched = code_svc.verify(
+            user=user, kind=AuthCodeKind.LOGIN, code=data.code,
+        )
+        if not matched:
+            attempts = user_svc.increment_failed_attempts(user)
+            if attempts >= _MAX_FAILED_ATTEMPTS:
+                until = datetime.now(tz=UTC) + _LOCK_DURATION
+                user_svc.lock_user(user, until=until)
+                audit_svc.log(
+                    event='login.verify-code',
+                    success=False,
+                    user_id=user.id,
+                    error_code='ACCOUNT_LOCKED',
+                    ip=meta.ip,
+                )
+                return {
+                    'is_valid': False,
+                    'code': 4005,
+                    'status': 423,
+                    'data': {
+                        'error': 'ACCOUNT_LOCKED',
+                        'retry_after_seconds': int(
+                            _LOCK_DURATION.total_seconds(),
+                        ),
+                    },
+                }
+            audit_svc.log(
+                event='login.verify-code',
+                success=False,
+                user_id=user.id,
+                error_code='INVALID_CODE',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4008,
+                'status': 400,
+                'data': {
+                    'error': 'INVALID_CODE',
+                    'attempts': attempts,
+                },
+            }
+
+        # Code OK: actualiza last_login + blacklistea el temp + tokens.
+        user_svc.update_last_login(user)
+        jwt_svc.blacklist(
+            jti=claims.jti,
+            exp=claims.exp,
+            user_id=user.id,
+            reason='rotation',
+        )
+
+        access_token, _ = jwt_svc.issue_access(user_id=user.id)
+        family_id = UUID(new_uuidv7())
+        refresh_token, _ = jwt_svc.issue_refresh(
+            user_id=user.id, family_id=family_id,
+        )
+
+        audit_svc.log(
+            event='login.verify-code',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'expires_in': 900,
+                'token_type': 'Bearer',
+                'user': {
+                    'id': str(user.id),
+                    'email': user.email,
+                    'status': user.status.value,
+                },
+            },
+        }

--- a/serverless/lambda/services/auth/core/controllers/login/verify_magic_link.py
+++ b/serverless/lambda/services/auth/core/controllers/login/verify_magic_link.py
@@ -1,0 +1,141 @@
+"""Controller `login.verify-magic-link` — login passwordless via link.
+
+Espejo de `register.verify-magic-link` pero para usuarios ya activos.
+Tras consumir el link emite access + refresh JWTs y ACTUALIZA
+`last_login_at` (AC-22). No marca el user como active (ya lo esta).
+
+AC cubiertos: AC-22.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from models.login import LoginVerifyMagicLinkIn
+from services.audit_service import AuditService
+from services.jwt_service import JwtService
+from services.magic_link_service import MagicLinkService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.core.ulid import new_uuidv7
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#login.verify-magic-link'
+
+
+class VerifyMagicLink(BaseController):
+    """Verifica el magic-link de login (action `verify-magic-link`)."""
+
+    event_model = LoginVerifyMagicLinkIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: LoginVerifyMagicLinkIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Consume el link + emite access/refresh + update last_login."""
+        data: LoginVerifyMagicLinkIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        link_svc = MagicLinkService(app_config)
+        user_svc = UserService(app_config)
+        jwt_svc = JwtService(app_config)
+        audit_svc = AuditService(app_config)
+
+        consumed = link_svc.verify(plain=data.token)
+        if consumed is None:
+            state = link_svc.get_state(plain=data.token)
+            if state is not None and state.consumed_at is not None:
+                audit_svc.log(
+                    event='login.verify-magic-link',
+                    success=False,
+                    error_code='LINK_CONSUMED',
+                    ip=meta.ip,
+                )
+                return {
+                    'is_valid': False,
+                    'code': 4006,
+                    'status': 400,
+                    'data': {'error': 'LINK_CONSUMED'},
+                }
+            audit_svc.log(
+                event='login.verify-magic-link',
+                success=False,
+                error_code='LINK_EXPIRED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4007,
+                'status': 400,
+                'data': {'error': 'LINK_EXPIRED'},
+            }
+
+        user = user_svc.get_by_id(str(consumed.user_id))
+        if user is None:
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {'error': 'EMAIL_NOT_FOUND'},
+            }
+
+        # AC-22: actualiza last_login_at + resetea failed_attempts.
+        user_svc.update_last_login(user)
+
+        access_token, _ = jwt_svc.issue_access(user_id=user.id)
+        family_id = UUID(new_uuidv7())
+        refresh_token, _ = jwt_svc.issue_refresh(
+            user_id=user.id, family_id=family_id,
+        )
+
+        audit_svc.log(
+            event='login.verify-magic-link',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        redirect_url = (
+            f'{app_config.dashboard_callback_url}'
+            f'#access={access_token}'
+            f'&refresh={refresh_token}'
+            f'&user_id={user.id}'
+            f'&email={user.email}'
+        )
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'redirect_url': redirect_url,
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'expires_in': 900,
+                'token_type': 'Bearer',
+                'user': {
+                    'id': str(user.id),
+                    'email': user.email,
+                    'status': user.status.value,
+                },
+            },
+        }

--- a/serverless/lambda/services/auth/core/controllers/register/__init__.py
+++ b/serverless/lambda/services/auth/core/controllers/register/__init__.py
@@ -1,0 +1,10 @@
+"""Controllers de la operation `register` del Lambda `auth`.
+
+3 actions:
+- `start` -> `start.py` + `Start`
+- `verify-magic-link` -> `verify_magic_link.py` + `VerifyMagicLink`
+- `verify-code` -> `verify_code.py` + `VerifyCode`
+
+El import_controller del kit resuelve el modulo y la clase a partir
+del nombre del action sent por el cliente (con guiones).
+"""

--- a/serverless/lambda/services/auth/core/controllers/register/start.py
+++ b/serverless/lambda/services/auth/core/controllers/register/start.py
@@ -1,0 +1,204 @@
+"""Controller `register.start` — inicia el flujo de registro.
+
+Orquestador del primer paso del flujo de registro. Verifica Turnstile,
+rate-limit per-IP, idempotencia (email existente), crea/upserta el user
+en `pending`, genera code de 8 chars + magic-link opaco, publica 2
+mensajes SQS al `auth_email_worker` y devuelve un temp_token (rolling
+JWT, 5 min) para continuar al paso siguiente.
+
+AC cubiertos: AC-1, AC-2, AC-12, AC-13, AC-19, AC-20.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.register import RegisterStartIn
+from services.audit_service import AuditService
+from services.code_service import CodeService
+from services.email_dispatch_service import EmailDispatchService
+from services.jwt_service import JwtService
+from services.magic_link_service import MagicLinkService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.db.models import AuthCodeKind, AuthLinkKind, AuthUserStatus
+from shared.http import verify_turnstile_token
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#register.start'
+_TEMP_TTL_SECONDS = 300
+
+
+class Start(BaseController):
+    """Inicia el flujo de registro (action `start`).
+
+    Flujo:
+      1. validate(): rate-limit + Turnstile.
+      2. execute(): idempotencia + genera artefactos + publica emails.
+    """
+
+    event_model = RegisterStartIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit + Turnstile.
+
+        El rate-limit puede levantar `RateLimitExceededError` (HTTP 429)
+        o `IPBlacklistedError`/`CountryBlockedError` (HTTP 403). El
+        Turnstile puede levantar `TurnstileError` (HTTP 403). Ambas
+        excepciones las traduce `http_handler` al status correcto.
+        """
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: RegisterStartIn = self.validated_data  # type: ignore[assignment]
+        meta = data.meta
+
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=False,
+        )
+
+        verify_turnstile_token(
+            data.cf_turnstile_response,
+            remote_ip=meta.ip,
+            bypass_secret=meta.bypass_secret,
+        )
+
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Idempotencia + genera artefactos + publica emails.
+
+        Returns:
+            En exito: `{is_valid: True, code: 0, data: {temp_token,
+            user_id, expires_in}}` (HTTP 200).
+            Email already registered: `{is_valid: False, code: 4002,
+            data: {error}, status: 409}`.
+            Email disabled/locked: `{is_valid: False, code: 4001, data:
+            {error, suggest_register: False}, status: 404}` (anti-
+            enumeration, AC-20).
+        """
+        data: RegisterStartIn = self.validated_data  # type: ignore[assignment]
+        meta = data.meta
+        email = data.email.lower()
+        niche = data.niche
+
+        user_svc = UserService(app_config)
+        code_svc = CodeService(app_config)
+        link_svc = MagicLinkService(app_config)
+        jwt_svc = JwtService(app_config)
+        email_svc = EmailDispatchService(app_config)
+        audit_svc = AuditService(app_config)
+
+        existing = user_svc.get_by_email(email)
+
+        if existing is not None:
+            if existing.status == AuthUserStatus.ACTIVE:
+                audit_svc.log(
+                    event='register.start',
+                    success=False,
+                    user_id=existing.id,
+                    error_code='EMAIL_ALREADY_REGISTERED',
+                    ip=meta.ip,
+                    user_agent=meta.user_agent,
+                    niche=niche,
+                )
+                return {
+                    'is_valid': False,
+                    'code': 4002,
+                    'data': {'error': 'EMAIL_ALREADY_REGISTERED'},
+                    'status': 409,
+                }
+            if existing.status in (
+                AuthUserStatus.DISABLED,
+                AuthUserStatus.LOCKED,
+            ):
+                audit_svc.log(
+                    event='register.start',
+                    success=False,
+                    user_id=existing.id,
+                    error_code='EMAIL_NOT_FOUND',
+                    ip=meta.ip,
+                    user_agent=meta.user_agent,
+                    niche=niche,
+                )
+                return {
+                    'is_valid': False,
+                    'code': 4001,
+                    'data': {
+                        'error': 'EMAIL_NOT_FOUND',
+                        'suggest_register': False,
+                    },
+                    'status': 404,
+                }
+            # status pending: invalidar codes + links previos (AC-19),
+            # reutiliza el mismo user.
+            user_svc.invalidate_active_codes_and_links(
+                user_id=str(existing.id),
+                kind_code=AuthCodeKind.REGISTER,
+                kind_link=AuthLinkKind.REGISTER,
+            )
+            user = existing
+        else:
+            user = user_svc.create_pending(email=email)
+
+        code, _ = code_svc.generate_and_persist(
+            user_id=user.id,
+            kind=AuthCodeKind.REGISTER,
+        )
+        token, _ = link_svc.generate_and_persist(
+            user_id=user.id,
+            kind=AuthLinkKind.REGISTER,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        verify_url = (
+            f'{app_config.magic_link_base_url}'
+            f'?operation=register&action=verify-magic-link&token={token}'
+        )
+        email_svc.publish_magic_link(
+            to=user.email,
+            user_id=user.id,
+            niche=niche,
+            kind='register-magic-link',
+            plain=token,
+            verify_url=verify_url,
+        )
+        email_svc.publish_code(
+            to=user.email,
+            user_id=user.id,
+            niche=niche,
+            kind='register-code',
+            code=code,
+        )
+
+        temp_token, _ = jwt_svc.issue_temp(
+            user_id=user.id,
+            flow='register',
+            step=1,
+        )
+
+        audit_svc.log(
+            event='register.start',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+            niche=niche,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'temp_token': temp_token,
+                'user_id': str(user.id),
+                'expires_in': _TEMP_TTL_SECONDS,
+            },
+        }

--- a/serverless/lambda/services/auth/core/controllers/register/verify_code.py
+++ b/serverless/lambda/services/auth/core/controllers/register/verify_code.py
@@ -1,0 +1,218 @@
+"""Controller `register.verify-code` — confirma con code 8 chars + temp_token.
+
+El visitante pega el code que recibio por email. Verifica el rolling
+temp_token (typ='temp', flow='register'), valida el code (constant-time
+compare contra el hash en Neon, incrementa attempts, autobloquea al 5to
+fallo) y, en exito, blacklistea el temp, activa al user y emite
+access + refresh JWTs.
+
+AC cubiertos: AC-4, AC-10, AC-11, AC-18.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from models.register import RegisterVerifyCodeIn
+from services.audit_service import AuditService
+from services.code_service import CodeService
+from services.flow_service import FlowService
+from services.jwt_service import JwtService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.auth import JwtExpiredError, JwtInvalidError, JwtRevokedError
+from shared.core.ulid import new_uuidv7
+from shared.db.models import AuthCodeKind
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#register.verify-code'
+_LOCK_DURATION = timedelta(hours=1)
+_MAX_FAILED_ATTEMPTS = 5
+
+
+class VerifyCode(BaseController):
+    """Verifica el code de registro (action `verify-code`)."""
+
+    event_model = RegisterVerifyCodeIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit (sin Turnstile, ya valido en start)."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: RegisterVerifyCodeIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Verifica temp_token + code, emite access+refresh.
+
+        Returns:
+            En exito: `{is_valid: True, code: 0, data: {access_token,
+            refresh_token, user, ...}}`.
+            temp_token expirado: 401 TEMP_TOKEN_EXPIRED (AC-18).
+            temp_token blacklisted: 401 TOKEN_BLACKLISTED (AC-10).
+            code invalido: 400 INVALID_CODE (AC-11) o 423 ACCOUNT_LOCKED
+            (>=5 fallos, AC-11).
+        """
+        data: RegisterVerifyCodeIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        flow_svc = FlowService(app_config)
+        user_svc = UserService(app_config)
+        code_svc = CodeService(app_config)
+        jwt_svc = JwtService(app_config)
+        audit_svc = AuditService(app_config)
+
+        try:
+            claims = flow_svc.verify_temp_token(
+                data.temp_token, expected_flow='register',
+            )
+        except JwtExpiredError:
+            audit_svc.log(
+                event='register.verify-code',
+                success=False,
+                error_code='TEMP_TOKEN_EXPIRED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4018,
+                'status': 401,
+                'data': {'error': 'TEMP_TOKEN_EXPIRED'},
+            }
+        except JwtRevokedError:
+            audit_svc.log(
+                event='register.verify-code',
+                success=False,
+                error_code='TOKEN_BLACKLISTED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_BLACKLISTED'},
+            }
+        except JwtInvalidError:
+            audit_svc.log(
+                event='register.verify-code',
+                success=False,
+                error_code='TOKEN_INVALID',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_INVALID'},
+            }
+
+        user = user_svc.get_by_id(str(claims.sub))
+        if user is None:
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {'error': 'EMAIL_NOT_FOUND'},
+            }
+
+        # Verifica el code; si wrong, code_svc / repository incrementan
+        # `attempts` en el row. El controller chequea failed_attempts
+        # del USER (no del code) para decidir el lock — politica AC-11.
+        matched = code_svc.verify(
+            user=user, kind=AuthCodeKind.REGISTER, code=data.code,
+        )
+        if not matched:
+            attempts = user_svc.increment_failed_attempts(user)
+            if attempts >= _MAX_FAILED_ATTEMPTS:
+                until = datetime.now(tz=UTC) + _LOCK_DURATION
+                user_svc.lock_user(user, until=until)
+                audit_svc.log(
+                    event='register.verify-code',
+                    success=False,
+                    user_id=user.id,
+                    error_code='ACCOUNT_LOCKED',
+                    ip=meta.ip,
+                )
+                return {
+                    'is_valid': False,
+                    'code': 4005,
+                    'status': 423,
+                    'data': {
+                        'error': 'ACCOUNT_LOCKED',
+                        'retry_after_seconds': int(
+                            _LOCK_DURATION.total_seconds(),
+                        ),
+                    },
+                }
+            audit_svc.log(
+                event='register.verify-code',
+                success=False,
+                user_id=user.id,
+                error_code='INVALID_CODE',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4008,
+                'status': 400,
+                'data': {
+                    'error': 'INVALID_CODE',
+                    'attempts': attempts,
+                },
+            }
+
+        # Code OK: activa el user + blacklistea el temp + emite tokens.
+        user_svc.mark_active(user)
+        jwt_svc.blacklist(
+            jti=claims.jti,
+            exp=claims.exp,
+            user_id=user.id,
+            reason='rotation',
+        )
+
+        access_token, _ = jwt_svc.issue_access(user_id=user.id)
+        family_id = UUID(new_uuidv7())
+        refresh_token, _ = jwt_svc.issue_refresh(
+            user_id=user.id, family_id=family_id,
+        )
+
+        audit_svc.log(
+            event='register.verify-code',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'expires_in': 900,
+                'token_type': 'Bearer',
+                'user': {
+                    'id': str(user.id),
+                    'email': user.email,
+                    'status': user.status.value,
+                },
+            },
+        }

--- a/serverless/lambda/services/auth/core/controllers/register/verify_magic_link.py
+++ b/serverless/lambda/services/auth/core/controllers/register/verify_magic_link.py
@@ -1,0 +1,164 @@
+"""Controller `register.verify-magic-link` — confirma el email via link.
+
+El visitante clickea el link recibido por email. El controller resuelve
+el token opaco (SHA-256 del plain) contra `auth_magic_links`, consume
+single-use, activa al user y emite access + refresh JWTs.
+
+http_handler NO soporta HTTP 302 nativamente: la respuesta es un JSON
+200 con `redirect_url` en el body. El frontend (dashboard) hace el
+redirect del lado cliente al `dashboard_callback_url#access=...&...`.
+
+AC cubiertos: AC-3, AC-16, AC-17.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from models.register import RegisterVerifyMagicLinkIn
+from services.audit_service import AuditService
+from services.jwt_service import JwtService
+from services.magic_link_service import MagicLinkService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.core.ulid import new_uuidv7
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#register.verify-magic-link'
+
+
+class VerifyMagicLink(BaseController):
+    """Verifica el magic-link del registro (action `verify-magic-link`)."""
+
+    event_model = RegisterVerifyMagicLinkIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit. Sin Turnstile (ya valido en start)."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: RegisterVerifyMagicLinkIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Consume el link + emite access/refresh + redirect al dashboard.
+
+        Returns:
+            En exito: `{is_valid: True, code: 0, data: {redirect_url,
+            access_token, refresh_token, user: {...}}}` (HTTP 200).
+            link consumido (`LINK_CONSUMED`): `{is_valid: False, code:
+            4006, status: 400, data: {error}}`.
+            link expirado o inexistente (`LINK_EXPIRED`): `{is_valid:
+            False, code: 4007, status: 400, data: {error}}`.
+        """
+        data: RegisterVerifyMagicLinkIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        link_svc = MagicLinkService(app_config)
+        user_svc = UserService(app_config)
+        jwt_svc = JwtService(app_config)
+        audit_svc = AuditService(app_config)
+
+        consumed = link_svc.verify(plain=data.token)
+        if consumed is None:
+            # Distinguir el motivo del fallo.
+            state = link_svc.get_state(plain=data.token)
+            if state is not None and state.consumed_at is not None:
+                audit_svc.log(
+                    event='register.verify-magic-link',
+                    success=False,
+                    error_code='LINK_CONSUMED',
+                    ip=meta.ip,
+                    user_agent=meta.user_agent,
+                )
+                return {
+                    'is_valid': False,
+                    'code': 4006,
+                    'status': 400,
+                    'data': {'error': 'LINK_CONSUMED'},
+                }
+            # state is None o expirado: agrupado bajo LINK_EXPIRED (anti
+            # enumeration: no revelamos si el link existia o no).
+            audit_svc.log(
+                event='register.verify-magic-link',
+                success=False,
+                error_code='LINK_EXPIRED',
+                ip=meta.ip,
+                user_agent=meta.user_agent,
+            )
+            return {
+                'is_valid': False,
+                'code': 4007,
+                'status': 400,
+                'data': {'error': 'LINK_EXPIRED'},
+            }
+
+        user = user_svc.get_by_id(str(consumed.user_id))
+        if user is None:
+            audit_svc.log(
+                event='register.verify-magic-link',
+                success=False,
+                error_code='USER_NOT_FOUND',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {'error': 'EMAIL_NOT_FOUND'},
+            }
+
+        user_svc.mark_active(user)
+
+        access_token, _ = jwt_svc.issue_access(user_id=user.id)
+        family_id = UUID(new_uuidv7())
+        refresh_token, _ = jwt_svc.issue_refresh(
+            user_id=user.id, family_id=family_id,
+        )
+
+        audit_svc.log(
+            event='register.verify-magic-link',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        redirect_url = (
+            f'{app_config.dashboard_callback_url}'
+            f'#access={access_token}'
+            f'&refresh={refresh_token}'
+            f'&user_id={user.id}'
+            f'&email={user.email}'
+        )
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'redirect_url': redirect_url,
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'expires_in': 900,
+                'token_type': 'Bearer',
+                'user': {
+                    'id': str(user.id),
+                    'email': user.email,
+                    'status': user.status.value,
+                },
+            },
+        }

--- a/serverless/lambda/services/auth/core/services/magic_link_service.py
+++ b/serverless/lambda/services/auth/core/services/magic_link_service.py
@@ -18,6 +18,7 @@ from shared.db import db_session
 from shared.db.models import AuthLinkKind, AuthMagicLink
 from shared.db.repositories.auth import (
     consume_magic_link,
+    get_magic_link_state,
     insert_magic_link,
 )
 
@@ -69,3 +70,15 @@ class MagicLinkService:
         h = hash_token(plain)
         with db_session() as session:
             return consume_magic_link(session, token_hash=h)
+
+    def get_state(self, *, plain: str) -> AuthMagicLink | None:
+        """Devuelve el row SIN consumirlo, para distinguir errores.
+
+        Lo usan los controllers `verify_magic_link` cuando `verify`
+        retorna `None`, para diferenciar `LINK_CONSUMED` (consumed_at
+        is not None) vs `LINK_EXPIRED` (expires_at <= now) vs no
+        existe (None).
+        """
+        h = hash_token(plain)
+        with db_session() as session:
+            return get_magic_link_state(session, token_hash=h)

--- a/serverless/lambda/services/auth/core/services/user_service.py
+++ b/serverless/lambda/services/auth/core/services/user_service.py
@@ -18,14 +18,16 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from shared.db import db_session
-from shared.db.models import AuthUser
+from shared.db.models import AuthCodeKind, AuthLinkKind, AuthUser
 from shared.db.repositories.auth import (
     create_pending_user,
     get_user_by_email,
     increment_failed_attempts,
+    invalidate_active_codes_and_links,
     lock_user,
     mark_user_active,
     reset_failed_attempts,
+    update_last_login,
 )
 
 # Politica MVP: 15 min de bloqueo tras 5 fallos consecutivos.
@@ -44,6 +46,11 @@ class UserService:
         """Lookup case-insensitive del user por email. None si no existe."""
         with db_session() as session:
             return get_user_by_email(session, email.strip().lower())
+
+    def get_by_id(self, user_id: str) -> AuthUser | None:
+        """Lookup por UUID. None si no existe."""
+        with db_session() as session:
+            return session.get(AuthUser, user_id)
 
     def create_pending(self, *, email: str) -> AuthUser:
         """Crea un user nuevo con status='pending'."""
@@ -80,3 +87,32 @@ class UserService:
         with db_session() as session:
             session.add(user)
             lock_user(session, user, until=until)
+
+    def update_last_login(self, user: AuthUser) -> None:
+        """Setea last_login_at=now + resetea failed_attempts (AC-22).
+
+        Lo llaman los controllers `login/verify_magic_link` y
+        `login/verify_code` tras un login exitoso.
+        """
+        with db_session() as session:
+            session.add(user)
+            update_last_login(session, user)
+
+    def invalidate_active_codes_and_links(
+        self,
+        *,
+        user_id: str,
+        kind_code: AuthCodeKind = AuthCodeKind.REGISTER,
+        kind_link: AuthLinkKind = AuthLinkKind.REGISTER,
+    ) -> None:
+        """Invalida codes + magic_links activos del user (AC-19).
+
+        Usado por `register.start` cuando el visitante reinicia el flow.
+        """
+        with db_session() as session:
+            invalidate_active_codes_and_links(
+                session,
+                user_id=user_id,
+                kind_code=kind_code,
+                kind_link=kind_link,
+            )

--- a/serverless/lambda/services/auth/events/verify-set-password.json
+++ b/serverless/lambda/services/auth/events/verify-set-password.json
@@ -8,7 +8,7 @@
   },
   "queryStringParameters": null,
   "pathParameters": null,
-  "body": "{\"operation\":\"verify\",\"action\":\"set-password\",\"data\":{\"password\":\"C0mplex_dev_pass_X\",\"temp_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
+  "body": "{\"operation\":\"verify\",\"action\":\"set-password\",\"data\":{\"password\":\"PLACEHOLDER-NOT-A-REAL-PASSWORD\",\"temp_token\":\"FAKE-TOKEN-FOR-LOCAL-RUN-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX\"}}",
   "isBase64Encoded": false,
   "requestContext": {
     "identity": { "sourceIp": "203.0.113.10" },

--- a/serverless/lambda/services/auth/tests/conftest.py
+++ b/serverless/lambda/services/auth/tests/conftest.py
@@ -55,10 +55,15 @@ os.environ.setdefault(
     'https://admin.portfolio.dev.the-full-stack.com',
 )
 # Secretos locales (get_secret_by_name los lee directo del env var en
-# modo local cuando SSM_<UPPER>_PATH no esta seteado).
-os.environ.setdefault('JWT_SECRET', 'test-jwt-secret-with-enough-length-1234567890')
-os.environ.setdefault('TURNSTILE_SECRET_KEY', 'test-turnstile-secret')
-os.environ.setdefault('TURNSTILE_BYPASS_SECRET', 'test-bypass-secret')
+# modo local cuando SSM_<UPPER>_PATH no esta seteado). Valores fake
+# para los tests — generados con `secrets.token_urlsafe(32)` en runtime
+# para evitar falsos positivos de scanners (GitGuardian) sobre los
+# placeholders literales.
+import secrets as _secrets  # noqa: E402
+
+os.environ.setdefault('JWT_SECRET', _secrets.token_urlsafe(48))
+os.environ.setdefault('TURNSTILE_SECRET_KEY', _secrets.token_urlsafe(16))
+os.environ.setdefault('TURNSTILE_BYPASS_SECRET', _secrets.token_urlsafe(16))
 os.environ.setdefault(
     'DB_URL',
     'postgresql://test:test@localhost/test',

--- a/serverless/lambda/services/auth/tests/unit/controllers/_helpers.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/_helpers.py
@@ -1,0 +1,164 @@
+"""Helpers compartidos por los tests de controllers de auth.
+
+Prefijo `_` para que pytest no recolecte el modulo. Cada helper es una
+funcion pura que arma un fixture minimo para un test (mock de service
+con valor o evento sintetico).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+
+def _make_event_register_start(
+    *,
+    email: str = 'visitor@example.com',
+    cf_token: str = 'TURNSTILE-OK',
+    niche: str | None = None,
+    ip: str = '203.0.113.10',
+    country: str = 'CL',
+    user_agent: str = 'pytest',
+    bypass_secret: str | None = None,
+) -> dict[str, Any]:
+    """Arma el `controller_event` (data) tipico de register/start."""
+    return {
+        'email': email,
+        'cf_turnstile_response': cf_token,
+        'niche': niche,
+        '_meta': {
+            'ip': ip,
+            'country': country,
+            'user_agent': user_agent,
+            'bypass_secret': bypass_secret,
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'cloudfront_meta': {},
+        },
+    }
+
+
+def _make_event_with_token(
+    *,
+    token: str = 'A' * 32,
+    ip: str = '203.0.113.10',
+    country: str = 'CL',
+    user_agent: str = 'pytest',
+) -> dict[str, Any]:
+    """Evento de verify-magic-link (register o login)."""
+    return {
+        'token': token,
+        '_meta': {
+            'ip': ip,
+            'country': country,
+            'user_agent': user_agent,
+            'bypass_secret': None,
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'cloudfront_meta': {},
+        },
+    }
+
+
+def _make_event_with_code(
+    *,
+    code: str = 'ABCDEFGH',
+    temp_token: str = 'FAKE-TEMP-TOKEN-FOR-TEST-XXXXXXXXXXX',
+    ip: str = '203.0.113.10',
+    country: str = 'CL',
+    user_agent: str = 'pytest',
+) -> dict[str, Any]:
+    """Evento de verify-code (register o login)."""
+    return {
+        'code': code,
+        'temp_token': temp_token,
+        '_meta': {
+            'ip': ip,
+            'country': country,
+            'user_agent': user_agent,
+            'bypass_secret': None,
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'cloudfront_meta': {},
+        },
+    }
+
+
+def _make_user(
+    *,
+    user_id: UUID | None = None,
+    email: str = 'visitor@example.com',
+    status: str = 'pending',
+    failed_attempts: int = 0,
+) -> Any:
+    """Mock de AuthUser con los campos minimos que usan los controllers."""
+    from shared.db.models import AuthUserStatus
+    user = MagicMock()
+    user.id = user_id or uuid4()
+    user.email = email
+    # Map del string al enum para que el controller use .value y matchee.
+    user.status = AuthUserStatus(status)
+    user.failed_attempts = failed_attempts
+    return user
+
+
+def _make_jwt_claims(
+    *,
+    user_id: UUID | None = None,
+    flow: str = 'register',
+    step: int = 1,
+    jti: UUID | None = None,
+    exp: int = 9999999999,
+) -> Any:
+    """Mock de JwtClaims minimo."""
+    return SimpleNamespace(
+        sub=user_id or uuid4(),
+        jti=jti or uuid4(),
+        flow=flow,
+        step=step,
+        exp=exp,
+        typ='temp',
+        family_id=None,
+    )
+
+
+def _make_magic_link(
+    *,
+    user_id: UUID | None = None,
+    consumed: bool = False,
+    expired: bool = False,
+) -> Any:
+    """Mock de AuthMagicLink."""
+    link = MagicMock()
+    link.user_id = user_id or uuid4()
+    link.consumed_at = datetime.now(tz=UTC) if consumed else None
+    link.expires_at = (
+        datetime(2020, 1, 1, tzinfo=UTC)
+        if expired else datetime(2099, 1, 1, tzinfo=UTC)
+    )
+    return link
+
+
+def _patch_services(monkeypatch: Any, controller_module: Any) -> dict[str, Any]:
+    """Patchea los services importados por el modulo del controller.
+
+    Devuelve un dict {nombre_service: mock} para que el test seleccione
+    el comportamiento (return_value, side_effect, ...).
+    """
+    mocks = {
+        'UserService': MagicMock(),
+        'CodeService': MagicMock(),
+        'MagicLinkService': MagicMock(),
+        'JwtService': MagicMock(),
+        'EmailDispatchService': MagicMock(),
+        'AuditService': MagicMock(),
+        'RateLimitService': MagicMock(),
+        'FlowService': MagicMock(),
+    }
+    for name, m in mocks.items():
+        if hasattr(controller_module, name):
+            instance = MagicMock()
+            m.return_value = instance
+            monkeypatch.setattr(controller_module, name, m)
+            mocks[name] = instance  # the instance is what tests use
+    return mocks

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_active_no_password.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_active_no_password.py
@@ -1,0 +1,51 @@
+"""AC-6: email activo -> 200 con temp_token + methods (sin password).
+
+Given un email con user.status='active',
+When se invoca login.start,
+Then publica code + magic-link + devuelve temp_token con methods.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_register_start, _make_user
+
+
+def test_login_start_email_active_no_password(monkeypatch):
+    """AC-6: email activo -> 200 con temp_token y methods."""
+    from controllers.login import start
+
+    user = _make_user(email='visitor@example.com', status='active')
+
+    user_svc = MagicMock()
+    user_svc.get_by_email.return_value = user
+    code_svc = MagicMock()
+    code_svc.generate_and_persist.return_value = ('ABCDEFGH', b'\x00' * 32)
+    link_svc = MagicMock()
+    link_svc.generate_and_persist.return_value = ('T' + 'X' * 31, b'\x01' * 32)
+    jwt_svc = MagicMock()
+    jwt_svc.issue_temp.return_value = ('TEMP-LOGIN-JWT', MagicMock())
+    email_svc = MagicMock()
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: link_svc)
+    monkeypatch.setattr(start, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        start, 'verify_turnstile_token',
+        lambda *_a, **_k: {'success': True},
+    )
+
+    event = _make_event_register_start(email='visitor@example.com')
+    controller = start.Start(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['temp_token'] == 'TEMP-LOGIN-JWT'
+    assert result['data']['methods'] == ['magic-link', 'email-code']
+    assert result['data']['expires_in'] == 300
+    email_svc.publish_magic_link.assert_called_once()
+    email_svc.publish_code.assert_called_once()

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_locked_404.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_locked_404.py
@@ -1,0 +1,45 @@
+"""AC-20: email locked/disabled -> 404 EMAIL_NOT_FOUND, suggest_register=False.
+
+Given un email con status='locked' (mismo flujo para 'disabled'),
+When se invoca login.start,
+Then anti-enumeration: 404 EMAIL_NOT_FOUND con suggest_register=False
+(NO revela que el user existe).
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_register_start, _make_user
+
+
+def test_login_start_email_locked_404(monkeypatch):
+    """AC-20: locked -> 404 anti-enumeration."""
+    from controllers.login import start
+
+    user = _make_user(email='visitor@example.com', status='locked')
+
+    user_svc = MagicMock()
+    user_svc.get_by_email.return_value = user
+
+    email_svc = MagicMock()
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        start, 'verify_turnstile_token',
+        lambda *_a, **_k: {'success': True},
+    )
+
+    event = _make_event_register_start(email='visitor@example.com')
+    controller = start.Start(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4001
+    assert result['status'] == 404
+    assert result['data']['error'] == 'EMAIL_NOT_FOUND'
+    assert result['data']['suggest_register'] is False
+    email_svc.publish_magic_link.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_not_found_404.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_not_found_404.py
@@ -1,0 +1,40 @@
+"""AC-5: email no existe -> 404 EMAIL_NOT_FOUND con suggest_register=True.
+
+Given un email que no esta en auth_users,
+When se invoca login.start,
+Then devuelve is_valid=False, code 4001, status 404, suggest_register=True.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_register_start
+
+
+def test_login_start_email_not_found_404(monkeypatch):
+    """AC-5: email no existe -> 404 con suggest_register=True."""
+    from controllers.login import start
+
+    user_svc = MagicMock()
+    user_svc.get_by_email.return_value = None
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        start, 'verify_turnstile_token',
+        lambda *_a, **_k: {'success': True},
+    )
+
+    event = _make_event_register_start(email='unknown@example.com')
+    controller = start.Start(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4001
+    assert result['status'] == 404
+    assert result['data']['error'] == 'EMAIL_NOT_FOUND'
+    assert result['data']['suggest_register'] is True

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_pending_409.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_pending_409.py
@@ -1,0 +1,42 @@
+"""Login con email pending -> 409 PENDING_VERIFICATION.
+
+Given un email con status='pending' (registro no completado),
+When se invoca login.start,
+Then devuelve 409 para empujar al user a completar el registro
+(en vez de pretender login y mandar otro code).
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_register_start, _make_user
+
+
+def test_login_start_email_pending_409(monkeypatch):
+    """Email pending -> 409 PENDING_VERIFICATION."""
+    from controllers.login import start
+
+    user = _make_user(email='visitor@example.com', status='pending')
+
+    user_svc = MagicMock()
+    user_svc.get_by_email.return_value = user
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        start, 'verify_turnstile_token',
+        lambda *_a, **_k: {'success': True},
+    )
+
+    event = _make_event_register_start(email='visitor@example.com')
+    controller = start.Start(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4011
+    assert result['status'] == 409
+    assert result['data']['error'] == 'PENDING_VERIFICATION'

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_verify_code_ok_updates_last_login.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_verify_code_ok_updates_last_login.py
@@ -1,0 +1,57 @@
+"""AC-22: login.verify-code OK -> emite tokens + update_last_login.
+
+Given un temp_token de login valido + code correcto,
+When se invoca login.verify-code,
+Then update_last_login (NO mark_active) + blacklistea temp + emite
+access+refresh.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import (
+    _make_event_with_code,
+    _make_jwt_claims,
+    _make_user,
+)
+
+
+def test_login_verify_code_ok_updates_last_login(monkeypatch):
+    """AC-22: login code OK -> update_last_login + tokens."""
+    from controllers.login import verify_code
+
+    uid = uuid4()
+    claims = _make_jwt_claims(user_id=uid, flow='login')
+    user = _make_user(user_id=uid, status='active')
+
+    flow_svc = MagicMock()
+    flow_svc.verify_temp_token.return_value = claims
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+
+    code_svc = MagicMock()
+    code_svc.verify.return_value = True
+
+    jwt_svc = MagicMock()
+    jwt_svc.issue_access.return_value = ('LOGIN-ACC', MagicMock())
+    jwt_svc.issue_refresh.return_value = ('LOGIN-REF', MagicMock())
+
+    monkeypatch.setattr(verify_code, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(verify_code, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(verify_code, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(verify_code, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(verify_code, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_with_code(code='ABCDEFGH')
+    controller = verify_code.VerifyCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['access_token'] == 'LOGIN-ACC'
+    assert result['data']['refresh_token'] == 'LOGIN-REF'
+    user_svc.update_last_login.assert_called_once_with(user)
+    user_svc.mark_active.assert_not_called()
+    jwt_svc.blacklist.assert_called_once()

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_verify_magic_link_ok_updates_last_login.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_verify_magic_link_ok_updates_last_login.py
@@ -1,0 +1,50 @@
+"""AC-22: login.verify-magic-link OK -> emite tokens + update_last_login.
+
+Given un magic-link de login valido,
+When se invoca login.verify-magic-link,
+Then consume el link + update_last_login (NO mark_active porque user
+ya es active) + emite access+refresh.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_with_token, _make_magic_link, _make_user
+
+
+def test_login_verify_magic_link_ok_updates_last_login(monkeypatch):
+    """AC-22: login magic-link OK -> update_last_login + tokens."""
+    from controllers.login import verify_magic_link
+
+    link = _make_magic_link()
+    user = _make_user(user_id=link.user_id, status='active')
+
+    link_svc = MagicMock()
+    link_svc.verify.return_value = link
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+
+    jwt_svc = MagicMock()
+    jwt_svc.issue_access.return_value = ('LOGIN-ACCESS-JWT', MagicMock())
+    jwt_svc.issue_refresh.return_value = ('LOGIN-REFRESH-JWT', MagicMock())
+
+    monkeypatch.setattr(
+        verify_magic_link, 'MagicLinkService', lambda _c: link_svc,
+    )
+    monkeypatch.setattr(verify_magic_link, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(verify_magic_link, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(verify_magic_link, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        verify_magic_link, 'RateLimitService', lambda _c: MagicMock(),
+    )
+
+    event = _make_event_with_token(token='L' * 32)
+    controller = verify_magic_link.VerifyMagicLink(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['access_token'] == 'LOGIN-ACCESS-JWT'
+    assert result['data']['refresh_token'] == 'LOGIN-REFRESH-JWT'
+    user_svc.update_last_login.assert_called_once_with(user)
+    user_svc.mark_active.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_email_active_409.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_email_active_409.py
@@ -1,0 +1,47 @@
+"""AC-2: email ya registrado activo -> 409 EMAIL_ALREADY_REGISTERED.
+
+Given un email con user.status='active',
+When se invoca register.start,
+Then NO se publica email + responde is_valid=False con code 4002.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_register_start, _make_user
+
+
+def test_register_start_email_active_409(monkeypatch):
+    """AC-2: email activo -> 409 sin publicar."""
+    from controllers.register import start
+
+    existing = _make_user(email='visitor@example.com', status='active')
+
+    user_svc = MagicMock()
+    user_svc.get_by_email.return_value = existing
+
+    email_svc = MagicMock()
+    audit_svc = MagicMock()
+    rl_svc = MagicMock()
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
+    monkeypatch.setattr(start, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: rl_svc)
+    monkeypatch.setattr(
+        start, 'verify_turnstile_token',
+        lambda *_a, **_k: {'success': True},
+    )
+
+    event = _make_event_register_start(email='visitor@example.com')
+    controller = start.Start(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4002
+    assert result['status'] == 409
+    assert result['data']['error'] == 'EMAIL_ALREADY_REGISTERED'
+    email_svc.publish_magic_link.assert_not_called()
+    email_svc.publish_code.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_new_email_ok.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_new_email_ok.py
@@ -1,0 +1,60 @@
+"""AC-1: nuevo email -> 200 con temp_token y user_id (registro happy path).
+
+Given un email que no existe en `auth_users`,
+When se invoca register.start con Turnstile valido,
+Then crea user pending + genera code + magic-link + publica 2 SQS +
+emite temp_token (5 min) y devuelve `is_valid=True`.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_register_start, _make_user
+
+
+def test_register_start_new_email_ok(monkeypatch):
+    """AC-1: email nuevo -> 200 con temp_token."""
+    from controllers.register import start
+
+    new_user = _make_user(email='visitor@example.com', status='pending')
+
+    user_svc = MagicMock()
+    user_svc.get_by_email.return_value = None
+    user_svc.create_pending.return_value = new_user
+
+    code_svc = MagicMock()
+    code_svc.generate_and_persist.return_value = ('ABCDEFGH', b'\x00' * 32)
+
+    link_svc = MagicMock()
+    link_svc.generate_and_persist.return_value = ('TOKEN' + 'A' * 27, b'\x01' * 32)
+
+    jwt_svc = MagicMock()
+    jwt_svc.issue_temp.return_value = ('TEMP-JWT-FAKE', MagicMock())
+
+    email_svc = MagicMock()
+    audit_svc = MagicMock()
+    rl_svc = MagicMock()
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: link_svc)
+    monkeypatch.setattr(start, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
+    monkeypatch.setattr(start, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: rl_svc)
+    monkeypatch.setattr(
+        start, 'verify_turnstile_token',
+        lambda *_a, **_k: {'success': True},
+    )
+
+    event = _make_event_register_start(email='visitor@example.com')
+    controller = start.Start(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['temp_token'] == 'TEMP-JWT-FAKE'
+    assert result['data']['user_id'] == str(new_user.id)
+    assert result['data']['expires_in'] == 300
+    user_svc.create_pending.assert_called_once()
+    email_svc.publish_magic_link.assert_called_once()
+    email_svc.publish_code.assert_called_once()

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_rate_limited_429.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_rate_limited_429.py
@@ -1,0 +1,42 @@
+"""AC-13: rate-limit excedido -> levanta RateLimitExceededError (HTTP 429).
+
+Given una IP que paso el limite del endpoint register.start,
+When se invoca register.start,
+Then RateLimitService.check_or_raise levanta RateLimitExceededError.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from .._helpers import _make_event_register_start
+
+
+def test_register_start_rate_limited_429(monkeypatch):
+    """AC-13: rate-limit fail -> propaga RateLimitExceededError."""
+    from controllers.register import start
+    from shared.core.exceptions import RateLimitExceededError
+
+    rl_svc = MagicMock()
+    rl_svc.check_or_raise.side_effect = RateLimitExceededError(
+        'limit hit', retry_after_seconds=60,
+    )
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: rl_svc)
+    monkeypatch.setattr(
+        start, 'verify_turnstile_token',
+        lambda *_a, **_k: {'success': True},
+    )
+
+    event = _make_event_register_start()
+    controller = start.Start(event=event)
+
+    with pytest.raises(RateLimitExceededError) as exc_info:
+        controller.run()
+    assert exc_info.value.status_code == 429

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_turnstile_invalid_403.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_start_turnstile_invalid_403.py
@@ -1,0 +1,40 @@
+"""AC-12: Turnstile invalido -> levanta TurnstileError (HTTP 403).
+
+Given un cf_turnstile_response invalido,
+When se invoca register.start,
+Then verify_turnstile_token levanta TurnstileError; http_handler la
+mapea a 403.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from .._helpers import _make_event_register_start
+
+
+def test_register_start_turnstile_invalid_403(monkeypatch):
+    """AC-12: Turnstile fail -> propaga TurnstileError."""
+    from controllers.register import start
+    from shared.core.exceptions import TurnstileError
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
+
+    def _fail_turnstile(*_a, **_k):
+        raise TurnstileError('invalid', code='CAPTCHA_INVALID')
+
+    monkeypatch.setattr(start, 'verify_turnstile_token', _fail_turnstile)
+
+    event = _make_event_register_start()
+    controller = start.Start(event=event)
+
+    with pytest.raises(TurnstileError) as exc_info:
+        controller.run()
+    assert exc_info.value.code == 'CAPTCHA_INVALID'
+    assert exc_info.value.status_code == 403

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_locks_after_5_fail.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_locks_after_5_fail.py
@@ -1,0 +1,51 @@
+"""AC-11: failed_attempts >= 5 -> lock_user + 423 ACCOUNT_LOCKED.
+
+Given un user con failed_attempts=4 + code wrong (lleva a 5),
+When se invoca register.verify-code,
+Then increment lleva a 5, dispara lock_user(until), devuelve 423.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import (
+    _make_event_with_code,
+    _make_jwt_claims,
+    _make_user,
+)
+
+
+def test_register_verify_code_locks_after_5_fail(monkeypatch):
+    """AC-11: 5to fallo -> lock + 423 ACCOUNT_LOCKED."""
+    from controllers.register import verify_code
+
+    uid = uuid4()
+    claims = _make_jwt_claims(user_id=uid, flow='register')
+    user = _make_user(user_id=uid, status='pending', failed_attempts=4)
+
+    flow_svc = MagicMock()
+    flow_svc.verify_temp_token.return_value = claims
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+    user_svc.increment_failed_attempts.return_value = 5
+
+    code_svc = MagicMock()
+    code_svc.verify.return_value = False
+
+    monkeypatch.setattr(verify_code, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(verify_code, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(verify_code, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(verify_code, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_with_code(code='WRNGABCD')
+    controller = verify_code.VerifyCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4005
+    assert result['status'] == 423
+    assert result['data']['error'] == 'ACCOUNT_LOCKED'
+    user_svc.lock_user.assert_called_once()

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_ok.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_ok.py
@@ -1,0 +1,58 @@
+"""AC-4: code valido + temp_token valido -> exito (access+refresh tokens).
+
+Given un temp_token register-flow valido y el code correcto,
+When se invoca register.verify-code,
+Then activa user + blacklistea temp + emite access+refresh.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import (
+    _make_event_with_code,
+    _make_jwt_claims,
+    _make_user,
+)
+
+
+def test_register_verify_code_ok(monkeypatch):
+    """AC-4: code OK -> exito + tokens."""
+    from controllers.register import verify_code
+
+    uid = uuid4()
+    claims = _make_jwt_claims(user_id=uid, flow='register')
+    user = _make_user(user_id=uid, status='pending')
+
+    flow_svc = MagicMock()
+    flow_svc.verify_temp_token.return_value = claims
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+
+    code_svc = MagicMock()
+    code_svc.verify.return_value = True
+
+    jwt_svc = MagicMock()
+    jwt_svc.issue_access.return_value = ('ACCESS-JWT', MagicMock())
+    jwt_svc.issue_refresh.return_value = ('REFRESH-JWT', MagicMock())
+
+    audit_svc = MagicMock()
+    rl_svc = MagicMock()
+
+    monkeypatch.setattr(verify_code, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(verify_code, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(verify_code, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(verify_code, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(verify_code, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(verify_code, 'RateLimitService', lambda _c: rl_svc)
+
+    event = _make_event_with_code(code='ABCDEFGH')
+    controller = verify_code.VerifyCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['access_token'] == 'ACCESS-JWT'
+    assert result['data']['refresh_token'] == 'REFRESH-JWT'
+    user_svc.mark_active.assert_called_once_with(user)
+    jwt_svc.blacklist.assert_called_once()

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_temp_token_blacklisted.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_temp_token_blacklisted.py
@@ -1,0 +1,36 @@
+"""AC-10: temp_token blacklisted -> 401 TOKEN_BLACKLISTED.
+
+Given un temp_token cuyo jti esta en DDB jwt-blacklist,
+When se invoca register.verify-code,
+Then flow_svc.verify_temp_token levanta JwtRevokedError; controller
+devuelve 401 TOKEN_BLACKLISTED.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_with_code
+
+
+def test_register_verify_code_temp_token_blacklisted(monkeypatch):
+    """AC-10: temp blacklisted -> 401 TOKEN_BLACKLISTED."""
+    from controllers.register import verify_code
+    from shared.auth import JwtRevokedError
+
+    flow_svc = MagicMock()
+    flow_svc.verify_temp_token.side_effect = JwtRevokedError('revoked')
+
+    monkeypatch.setattr(verify_code, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(verify_code, 'UserService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_with_code()
+    controller = verify_code.VerifyCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4003
+    assert result['status'] == 401
+    assert result['data']['error'] == 'TOKEN_BLACKLISTED'

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_temp_token_expired.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_temp_token_expired.py
@@ -1,0 +1,36 @@
+"""AC-18: temp_token expirado -> 401 TEMP_TOKEN_EXPIRED.
+
+Given un temp_token cuya signature OK pero exp<now,
+When se invoca register.verify-code,
+Then flow_svc.verify_temp_token levanta JwtExpiredError; el controller
+captura y devuelve 401.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_with_code
+
+
+def test_register_verify_code_temp_token_expired(monkeypatch):
+    """AC-18: temp expirado -> 401 TEMP_TOKEN_EXPIRED."""
+    from controllers.register import verify_code
+    from shared.auth import JwtExpiredError
+
+    flow_svc = MagicMock()
+    flow_svc.verify_temp_token.side_effect = JwtExpiredError('exp')
+
+    monkeypatch.setattr(verify_code, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(verify_code, 'UserService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_with_code()
+    controller = verify_code.VerifyCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4018
+    assert result['status'] == 401
+    assert result['data']['error'] == 'TEMP_TOKEN_EXPIRED'

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_wrong_increments.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_code_wrong_increments.py
@@ -1,0 +1,54 @@
+"""AC-11: code WRONG (no llega al 5to) -> 400 INVALID_CODE + attempts++.
+
+Given un code que no matchea + failed_attempts=1 -> 2,
+When se invoca register.verify-code,
+Then incrementa failed_attempts y devuelve 400 INVALID_CODE con
+attempts.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import (
+    _make_event_with_code,
+    _make_jwt_claims,
+    _make_user,
+)
+
+
+def test_register_verify_code_wrong_increments(monkeypatch):
+    """AC-11: code wrong -> increment attempts + 400."""
+    from controllers.register import verify_code
+
+    uid = uuid4()
+    claims = _make_jwt_claims(user_id=uid, flow='register')
+    user = _make_user(user_id=uid, status='pending', failed_attempts=1)
+
+    flow_svc = MagicMock()
+    flow_svc.verify_temp_token.return_value = claims
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+    user_svc.increment_failed_attempts.return_value = 2
+
+    code_svc = MagicMock()
+    code_svc.verify.return_value = False
+
+    monkeypatch.setattr(verify_code, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(verify_code, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(verify_code, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(verify_code, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_code, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_with_code(code='WRNGABCD')
+    controller = verify_code.VerifyCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4008
+    assert result['status'] == 400
+    assert result['data']['error'] == 'INVALID_CODE'
+    assert result['data']['attempts'] == 2
+    user_svc.increment_failed_attempts.assert_called_once_with(user)
+    user_svc.lock_user.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_magic_link_consumed.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_magic_link_consumed.py
@@ -1,0 +1,40 @@
+"""AC-16: link ya consumido -> 400 LINK_CONSUMED.
+
+Given un token cuyo row tiene consumed_at != None,
+When se invoca register.verify-magic-link,
+Then devuelve is_valid=False, code 4006, status 400.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_with_token, _make_magic_link
+
+
+def test_register_verify_magic_link_consumed(monkeypatch):
+    """AC-16: link consumido -> 400 LINK_CONSUMED."""
+    from controllers.register import verify_magic_link
+
+    consumed_link = _make_magic_link(consumed=True)
+
+    link_svc = MagicMock()
+    link_svc.verify.return_value = None
+    link_svc.get_state.return_value = consumed_link
+
+    monkeypatch.setattr(
+        verify_magic_link, 'MagicLinkService', lambda _c: link_svc,
+    )
+    monkeypatch.setattr(verify_magic_link, 'UserService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_magic_link, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_magic_link, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        verify_magic_link, 'RateLimitService', lambda _c: MagicMock(),
+    )
+
+    event = _make_event_with_token(token='C' * 32)
+    controller = verify_magic_link.VerifyMagicLink(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4006
+    assert result['status'] == 400
+    assert result['data']['error'] == 'LINK_CONSUMED'

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_magic_link_expired.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_magic_link_expired.py
@@ -1,0 +1,38 @@
+"""AC-17: link expirado o inexistente -> 400 LINK_EXPIRED.
+
+Given un token sin row activo (no existe o expires_at < now),
+When se invoca register.verify-magic-link,
+Then devuelve is_valid=False, code 4007, status 400.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_with_token
+
+
+def test_register_verify_magic_link_expired(monkeypatch):
+    """AC-17: link expirado/inexistente -> 400 LINK_EXPIRED."""
+    from controllers.register import verify_magic_link
+
+    link_svc = MagicMock()
+    link_svc.verify.return_value = None
+    link_svc.get_state.return_value = None  # no existe
+
+    monkeypatch.setattr(
+        verify_magic_link, 'MagicLinkService', lambda _c: link_svc,
+    )
+    monkeypatch.setattr(verify_magic_link, 'UserService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_magic_link, 'JwtService', lambda _c: MagicMock())
+    monkeypatch.setattr(verify_magic_link, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        verify_magic_link, 'RateLimitService', lambda _c: MagicMock(),
+    )
+
+    event = _make_event_with_token(token='D' * 32)
+    controller = verify_magic_link.VerifyMagicLink(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4007
+    assert result['status'] == 400
+    assert result['data']['error'] == 'LINK_EXPIRED'

--- a/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_magic_link_ok.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/register/test_register_verify_magic_link_ok.py
@@ -1,0 +1,50 @@
+"""AC-3: link valido -> consume + activa user + emite access+refresh.
+
+Given un token de magic-link no consumido y no expirado,
+When se invoca register.verify-magic-link,
+Then consume el link + mark_active + emite access/refresh + devuelve
+redirect_url al dashboard.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_with_token, _make_magic_link, _make_user
+
+
+def test_register_verify_magic_link_ok(monkeypatch):
+    """AC-3: magic-link valido -> exito con redirect_url."""
+    from controllers.register import verify_magic_link
+
+    link = _make_magic_link()
+    user = _make_user(user_id=link.user_id, status='pending')
+
+    link_svc = MagicMock()
+    link_svc.verify.return_value = link
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+
+    jwt_svc = MagicMock()
+    jwt_svc.issue_access.return_value = ('ACCESS-JWT', MagicMock())
+    jwt_svc.issue_refresh.return_value = ('REFRESH-JWT', MagicMock())
+
+    audit_svc = MagicMock()
+    rl_svc = MagicMock()
+
+    monkeypatch.setattr(verify_magic_link, 'MagicLinkService', lambda _c: link_svc)
+    monkeypatch.setattr(verify_magic_link, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(verify_magic_link, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(verify_magic_link, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(verify_magic_link, 'RateLimitService', lambda _c: rl_svc)
+
+    event = _make_event_with_token(token='B' * 32)
+    controller = verify_magic_link.VerifyMagicLink(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['access_token'] == 'ACCESS-JWT'
+    assert result['data']['refresh_token'] == 'REFRESH-JWT'
+    assert 'redirect_url' in result['data']
+    assert '#access=ACCESS-JWT' in result['data']['redirect_url']
+    user_svc.mark_active.assert_called_once_with(user)

--- a/serverless/lambda/services/db/core/controllers/db/show_migrations.py
+++ b/serverless/lambda/services/db/core/controllers/db/show_migrations.py
@@ -3,9 +3,10 @@
 Orquestador delgado: delega al service y normaliza el resultado. NO
 contiene logica de negocio.
 
-El command de invocacion es `show-migrations` (con guion); el handler lo
-mapea a la action `show_migrations` (con underscore) para que el nombre
-del modulo y de la clase sean identificadores Python validos.
+El command de invocacion es `show-migrations` (con guion). El kit
+`import_controller` normaliza la action a snake_case para el modulo
+(`show_migrations.py`) y a PascalCase para la clase (`ShowMigrations`),
+siguiendo el estandar lambda-controller.
 """
 
 from __future__ import annotations
@@ -15,12 +16,8 @@ from services.db_service import ServiceError, run_show_migrations
 from shared.lambda_kit import BaseController
 
 
-class Show_migrations(BaseController):  # noqa: N801 - action.capitalize()
-    """Controller para la accion 'show_migrations' de la operacion 'db'.
-
-    El estandar exige que la clase se llame action.capitalize(); para la
-    action 'show_migrations' eso es 'Show_migrations'.
-    """
+class ShowMigrations(BaseController):
+    """Controller para la accion 'show-migrations' de la operacion 'db'."""
 
     event_model = ShowMigrationsModel
 

--- a/serverless/lambda/services/db/tests/integration/test_show_migrations_command_e2e.py
+++ b/serverless/lambda/services/db/tests/integration/test_show_migrations_command_e2e.py
@@ -3,7 +3,7 @@
 Given un evento crudo {command: 'show-migrations'} (con guion),
 When se invoca lambda_handler real,
 Then el handler mapea el command 'show-migrations' a la action
-     'show_migrations', el flujo controller Show_migrations ->
+     'show_migrations', el flujo controller ShowMigrations ->
      run_show_migrations consulta el historial de Alembic y devuelve
      {command: 'show-migrations', status: 'ok'} con la lista de lineas.
 """

--- a/serverless/lambda/services/db/tests/unit/test_handler_maps_show_migrations_command_to_action.py
+++ b/serverless/lambda/services/db/tests/unit/test_handler_maps_show_migrations_command_to_action.py
@@ -3,7 +3,7 @@
 
 Given un payload {command: 'show-migrations'},
 When lambda_handler lo procesa,
-Then resuelve el controller Show_migrations y devuelve su resultado.
+Then resuelve el controller ShowMigrations y devuelve su resultado.
 """
 
 from unittest.mock import patch

--- a/serverless/lambda/services/db/tests/unit/test_show_migrations_controller_maps_service_error.py
+++ b/serverless/lambda/services/db/tests/unit/test_show_migrations_controller_maps_service_error.py
@@ -1,7 +1,7 @@
 """Controller db/show_migrations.
 
 Given el service run_show_migrations que lanza un ServiceError,
-When el controller Show_migrations ejecuta su ciclo run(),
+When el controller ShowMigrations ejecuta su ciclo run(),
 Then captura la excepcion y devuelve {is_valid: False} con el error_code,
      message y code del ServiceError.
 """
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.unit
 
 
 def test_show_migrations_controller_maps_service_error():
-    from controllers.db.show_migrations import Show_migrations
+    from controllers.db.show_migrations import ShowMigrations
     from services.db_service import ServiceError
 
     # Arrange
@@ -27,7 +27,7 @@ def test_show_migrations_controller_maps_service_error():
         'controllers.db.show_migrations.run_show_migrations',
         side_effect=error,
     ):
-        controller = Show_migrations(event={})
+        controller = ShowMigrations(event={})
 
         # Act
         result = controller.run()

--- a/serverless/lambda/shared/db/repositories/auth.py
+++ b/serverless/lambda/shared/db/repositories/auth.py
@@ -15,7 +15,7 @@ Convencion de retorno:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -36,15 +36,18 @@ __all__ = [
     'consume_email_code',
     'consume_magic_link',
     'create_pending_user',
+    'get_magic_link_state',
     'get_user_by_email',
     'increment_failed_attempts',
     'insert_audit_event',
     'insert_email_code',
     'insert_magic_link',
+    'invalidate_active_codes_and_links',
     'lock_user',
     'mark_user_active',
     'reset_failed_attempts',
     'set_password_hash',
+    'update_last_login',
 ]
 
 
@@ -102,6 +105,56 @@ def lock_user(
     """Cambia status a `locked` y setea `locked_until`."""
     user.status = AuthUserStatus.LOCKED
     user.locked_until = until
+    session.flush()
+
+
+def update_last_login(
+    session: Session,
+    user: AuthUser,
+    *,
+    when: datetime | None = None,
+) -> None:
+    """Setea `last_login_at` + resetea `failed_attempts` (AC-22).
+
+    Lo llaman los controllers `login/verify_magic_link` y
+    `login/verify_code` tras un login exitoso.
+    """
+    user.last_login_at = when or datetime.now(tz=user.created_at.tzinfo)
+    user.failed_attempts = 0
+    session.flush()
+
+
+def invalidate_active_codes_and_links(
+    session: Session,
+    *,
+    user_id: str,
+    kind_code: AuthCodeKind,
+    kind_link: AuthLinkKind,
+    when: datetime | None = None,
+) -> None:
+    """Marca consumed_at=now en codes y magic_links activos del user (AC-19).
+
+    Usado por `register.start` cuando el visitante reinicia el flow:
+    invalida los artefactos pendientes para que solo el ultimo par
+    code+link sea valido. NO toca rows consumed_at!=None.
+    """
+    now = when or datetime.now(tz=UTC)
+    # Codes activos
+    codes_stmt = select(AuthEmailCode).where(
+        AuthEmailCode.user_id == user_id,
+        AuthEmailCode.kind == kind_code,
+        AuthEmailCode.consumed_at.is_(None),
+    )
+    for row in session.execute(codes_stmt).scalars():
+        row.consumed_at = now
+    # Magic links activos
+    links_stmt = select(AuthMagicLink).where(
+        AuthMagicLink.user_id == user_id,
+        AuthMagicLink.kind == kind_link,
+        AuthMagicLink.consumed_at.is_(None),
+    )
+    for row in session.execute(links_stmt).scalars():
+        row.consumed_at = now
     session.flush()
 
 
@@ -220,6 +273,19 @@ def insert_magic_link(
     session.add(link)
     session.flush()
     return link
+
+
+def get_magic_link_state(
+    session: Session, *, token_hash: bytes,
+) -> AuthMagicLink | None:
+    """Devuelve el row sin consumirlo. Para distinguir consumed/expired.
+
+    Usado por los controllers `verify_magic_link` para devolver el codigo
+    de error correcto (LINK_CONSUMED vs LINK_EXPIRED) cuando
+    `consume_magic_link` retorna `None`.
+    """
+    stmt = select(AuthMagicLink).where(AuthMagicLink.token_hash == token_hash)
+    return session.execute(stmt).scalar_one_or_none()
 
 
 def consume_magic_link(

--- a/serverless/lambda/shared/lambda_kit/import_controller.py
+++ b/serverless/lambda/shared/lambda_kit/import_controller.py
@@ -97,8 +97,14 @@ def import_controller(
         }
 
     resolved_operation = resolve_operation(operation, operations)
-    class_name = action.capitalize()
-    module_path = f'controllers.{resolved_operation}.{action}'
+    # Normalizar el action a la convencion del estandar lambda-controller:
+    # `verify-magic-link` -> module `verify_magic_link.py` + clase
+    # `VerifyMagicLink`. El action puede llegar con guiones (URL/JSON),
+    # underscores o ya en PascalCase; se resuelve en ambas variantes.
+    action_snake = action.replace('-', '_')
+    action_segments = [s for s in action.replace('_', '-').split('-') if s]
+    class_name = ''.join(seg[:1].upper() + seg[1:] for seg in action_segments)
+    module_path = f'controllers.{resolved_operation}.{action_snake}'
 
     try:
         module = import_module(module_path)


### PR DESCRIPTION
## Problema

El Lambda `auth` (mergeado en PR 6) tenia el scaffold pero ningun
controller para procesar requests reales. Los flujos
`register/{start,verify-magic-link,verify-code}` y
`login/{start,verify-magic-link,verify-code}` quedaron pendientes
(commits 7.1+7.2 del plan).

Bonus: `shared.lambda_kit.import_controller` hacia `action.capitalize()`,
lo que NO sirve para actions multi-palabra con guion como
`verify-magic-link`. Habia un workaround feo en `db` lambda
(`class Show_migrations` con `# noqa: N801`).

## Solucion

**6 controllers** (`controllers/{register,login}/*.py`) que cubren 13
AC del plan. Patron: `BaseController` orquesta — Pydantic valida
input, services tienen la logica. Cero `from pydantic` / `import jwt`
/ `import boto3` en `core/`.

**Helpers nuevos**:
- `shared/db/repositories/auth.py`: `update_last_login`,
  `get_magic_link_state`, `invalidate_active_codes_and_links`.
- `core/services/`: metodos para soportar los nuevos flujos.

**Fix en `import_controller`** (5 lineas): `'verify-magic-link'` ahora
resuelve a `verify_magic_link.py` + `VerifyMagicLink` (PascalCase por
segmento), no `Verify-magic-link`. Mantiene compat con actions de una
sola palabra (`start` -> `Start`). Renombra `Show_migrations` ->
`ShowMigrations` en el `db` lambda + tests para alinear con el
standard.

**Sanitizacion de placeholders** en events JSON / conftest para evitar
falsos positivos de GitGuardian (lecciones aprendidas en PR 6):
- `verify-set-password.json`: password literal -> `PLACEHOLDER-NOT-A-REAL-PASSWORD`
- `tests/conftest.py`: JWT_SECRET literal -> `secrets.token_urlsafe(48)`
  en runtime

**Decision sobre redirect 302**: el plan describe redirect 302 desde
verify-magic-link al dashboard callback con tokens en fragment hash.
`http_handler` aun no soporta 302 nativo, asi que retornamos
`JSON 200 {redirect_url}` y el frontend hace el redirect. Documentado
en docstring de cada `verify_magic_link.py`.

## Como probar

```bash
# Lint-deps verde
python devtools/run.py serverless lint-deps --lambda=auth

# Tests del Lambda auth (71/71 pasan, +18 nuevos vs PR 6)
python devtools/run.py serverless tests --type=unit --lambda=auth
# 71 passed

# Coverage Lambda auth (89.95% global)
python devtools/run.py serverless tests --type=coverage --lambda=auth

# Verificar que el cambio en lambda_kit no rompe otros lambdas
for L in contact_form contact_worker tracking_pixel tracking_worker cv db auth_email_worker; do
  python devtools/run.py serverless tests --type=unit --lambda=$L
done
# Todos verdes
```

## TODO

- [ ] PR 8: verify + session controllers + rate-limit seed + deploy
- [ ] PR 9: integration tests + ER + cleanup

---

Plan padre: `docs/specs/01-auth-infra-basics/` (PR 7).