### PR TITLE
feat(auth): controllers verify + session (4 controllers + 12 tests)

### DIFF
--- a/serverless/lambda/services/auth/core/controllers/session/__init__.py
+++ b/serverless/lambda/services/auth/core/controllers/session/__init__.py
@@ -1,0 +1,1 @@
+"""Controllers de la operation session."""

--- a/serverless/lambda/services/auth/core/controllers/session/logout.py
+++ b/serverless/lambda/services/auth/core/controllers/session/logout.py
@@ -1,0 +1,127 @@
+"""Controller `session.logout` — revoca el access JWT (+ familia refresh).
+
+Verifica el access JWT, lo blacklistea y, si llega el refresh, revoca
+toda su familia (Query GSI by_family_id + BatchWrite). Idempotente: si
+el jti ya esta blacklisted devuelve 204 igual.
+
+AC cubiertos: AC-9 (logout), AC-23 (idempotente).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.session import SessionLogoutIn
+from services.audit_service import AuditService
+from services.jwt_service import JwtService
+from services.rate_limit_service import RateLimitService
+from settings.config import app_config
+
+from shared.auth import JwtError
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#session.logout'
+
+
+class Logout(BaseController):
+    """Revoca la sesion del user (action `logout`)."""
+
+    event_model = SessionLogoutIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit. Sin Turnstile."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: SessionLogoutIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Blacklistea el access (+ familia refresh). Idempotente.
+
+        Returns:
+            204 siempre que el access JWT sea valido (incluso si ya
+            estaba blacklisted, AC-23).
+            401 TOKEN_INVALID si el access no verifica (signature/exp).
+        """
+        data: SessionLogoutIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        jwt_svc = JwtService(app_config)
+        audit_svc = AuditService(app_config)
+
+        # Verifica el access SIN exigir que NO este blacklisted: el
+        # logout es idempotente (AC-23). verify_allow_revoked valida
+        # signature + exp + typ pero no rechaza por blacklist.
+        try:
+            access_claims = jwt_svc.verify_allow_revoked(
+                data.access_token, expected_typ='access',
+            )
+        except JwtError:
+            audit_svc.log(
+                event='session.logout',
+                success=False,
+                error_code='TOKEN_INVALID',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_INVALID'},
+            }
+
+        # Idempotencia: si ya estaba blacklisted, no re-blacklistear.
+        if not jwt_svc.is_blacklisted(jti=access_claims.jti):
+            jwt_svc.blacklist(
+                jti=access_claims.jti,
+                exp=access_claims.exp,
+                user_id=access_claims.sub,
+                reason='logout',
+            )
+
+        # Si llega refresh, revoca toda su familia. Un refresh invalido
+        # NO invalida el logout (el access ya quedo revocado).
+        if data.refresh_token is not None:
+            try:
+                refresh_claims = jwt_svc.verify_allow_revoked(
+                    data.refresh_token, expected_typ='refresh',
+                )
+            except JwtError:
+                refresh_claims = None
+            if (
+                refresh_claims is not None
+                and refresh_claims.family_id is not None
+            ):
+                jwt_svc.revoke_family(
+                    family_id=refresh_claims.family_id,
+                    user_id=refresh_claims.sub,
+                    exp=refresh_claims.exp,
+                )
+
+        audit_svc.log(
+            event='session.logout',
+            success=True,
+            user_id=access_claims.sub,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'status': 204,
+            'data': {},
+        }

--- a/serverless/lambda/services/auth/core/controllers/session/refresh.py
+++ b/serverless/lambda/services/auth/core/controllers/session/refresh.py
@@ -1,0 +1,164 @@
+"""Controller `session.refresh` — rota el refresh JWT (access + refresh nuevos).
+
+Verifica el refresh JWT (typ='refresh'). Si el jti ya esta blacklisted
+es un REUSO: revoca toda la familia (token theft detection, AC-8). Si es
+valido, rota: blacklistea el refresh viejo y emite un par access+refresh
+nuevo con el MISMO family_id.
+
+AC cubiertos: AC-7 (rotation), AC-8 (reuse detection), AC-10 (invalid).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.session import SessionRefreshIn
+from services.audit_service import AuditService
+from services.jwt_service import JwtService
+from services.rate_limit_service import RateLimitService
+from settings.config import app_config
+
+from shared.auth import JwtExpiredError, JwtInvalidError
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#session.refresh'
+
+
+class Refresh(BaseController):
+    """Rota el refresh JWT (action `refresh`)."""
+
+    event_model = SessionRefreshIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit. Sin Turnstile."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: SessionRefreshIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Verifica refresh, detecta reuso o rota.
+
+        Returns:
+            En exito: `{is_valid: True, code: 0, data: {access_token,
+            refresh_token, expires_in}}`.
+            Reuso detectado: 401 TOKEN_REUSE_DETECTED + familia revocada
+            (AC-8).
+            Invalido / expirado: 401 (AC-10).
+        """
+        data: SessionRefreshIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        jwt_svc = JwtService(app_config)
+        audit_svc = AuditService(app_config)
+
+        # Verifica signature + exp + typ SIN chequear blacklist: necesitamos
+        # el family_id del refresh aunque este revocado, para poder revocar
+        # toda la familia en el caso de reuso.
+        try:
+            claims = jwt_svc.verify_allow_revoked(
+                data.refresh_token, expected_typ='refresh',
+            )
+        except JwtExpiredError:
+            audit_svc.log(
+                event='session.refresh',
+                success=False,
+                error_code='REFRESH_EXPIRED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'REFRESH_EXPIRED'},
+            }
+        except JwtInvalidError:
+            audit_svc.log(
+                event='session.refresh',
+                success=False,
+                error_code='TOKEN_INVALID',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_INVALID'},
+            }
+
+        # Reuso detectado: el refresh ya fue rotado (su jti esta en la
+        # blacklist). Revoca TODA la familia y rechaza (AC-8).
+        if jwt_svc.is_blacklisted(jti=claims.jti):
+            if claims.family_id is not None:
+                jwt_svc.revoke_family(
+                    family_id=claims.family_id,
+                    user_id=claims.sub,
+                    exp=claims.exp,
+                )
+            audit_svc.log(
+                event='session.refresh.reuse_detected',
+                success=False,
+                user_id=claims.sub,
+                error_code='TOKEN_REUSE_DETECTED',
+                ip=meta.ip,
+                meta_data={
+                    'jti': str(claims.jti),
+                    'family_id': (
+                        str(claims.family_id)
+                        if claims.family_id is not None
+                        else None
+                    ),
+                },
+            )
+            return {
+                'is_valid': False,
+                'code': 4004,
+                'status': 401,
+                'data': {'error': 'TOKEN_REUSE_DETECTED'},
+            }
+
+        # Rotation normal: blacklistea el refresh viejo + emite nuevos
+        # tokens con el MISMO family_id.
+        jwt_svc.blacklist(
+            jti=claims.jti,
+            exp=claims.exp,
+            user_id=claims.sub,
+            reason='rotation',
+            family_id=claims.family_id,
+        )
+        access_token, _ = jwt_svc.issue_access(user_id=claims.sub)
+        refresh_token, _ = jwt_svc.issue_refresh(
+            user_id=claims.sub, family_id=claims.family_id,
+        )
+
+        audit_svc.log(
+            event='session.refresh',
+            success=True,
+            user_id=claims.sub,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'expires_in': 900,
+                'token_type': 'Bearer',
+            },
+        }

--- a/serverless/lambda/services/auth/core/controllers/verify/__init__.py
+++ b/serverless/lambda/services/auth/core/controllers/verify/__init__.py
@@ -1,0 +1,1 @@
+"""Controllers de la operation verify."""

--- a/serverless/lambda/services/auth/core/controllers/verify/resend_code.py
+++ b/serverless/lambda/services/auth/core/controllers/verify/resend_code.py
@@ -1,0 +1,204 @@
+"""Controller `verify.resend-code` — re-emite code + magic-link nuevos.
+
+Verifica el rolling temp_token (typ='temp'), aplica un throttle propio
+(min 60s desde la ultima emision para ese user/flow, AC-21), invalida
+los artefactos previos, genera un code + magic-link nuevos, los publica
+al worker y rota el temp (step+1).
+
+AC cubiertos: AC-19 (re-emision), AC-21 (throttle).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.verify import VerifyResendCodeIn
+from services.audit_service import AuditService
+from services.code_service import CodeService
+from services.email_dispatch_service import EmailDispatchService
+from services.flow_service import FlowService
+from services.jwt_service import JwtService
+from services.magic_link_service import MagicLinkService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.auth import JwtExpiredError, JwtInvalidError, JwtRevokedError
+from shared.db.models import AuthCodeKind, AuthLinkKind
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#verify.resend-code'
+
+# Map flow del temp JWT -> kinds del code / magic-link.
+_FLOW_TO_KINDS = {
+    'register': (AuthCodeKind.REGISTER, AuthLinkKind.REGISTER),
+    'login': (AuthCodeKind.LOGIN, AuthLinkKind.LOGIN),
+}
+
+
+class ResendCode(BaseController):
+    """Re-emite code + magic-link (action `resend-code`)."""
+
+    event_model = VerifyResendCodeIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit. Sin Turnstile."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: VerifyResendCodeIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Verifica temp_token + throttle, re-emite artefactos, rota temp.
+
+        Returns:
+            En exito: `{is_valid: True, code: 0, data: {temp_token,
+            expires_in: 300}}`.
+            Throttle activo: 429 RESEND_THROTTLED (AC-21).
+            temp_token expirado / blacklisted / invalido: 401.
+        """
+        data: VerifyResendCodeIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        jwt_svc = JwtService(app_config)
+        flow_svc = FlowService(app_config)
+        user_svc = UserService(app_config)
+        code_svc = CodeService(app_config)
+        link_svc = MagicLinkService(app_config)
+        email_svc = EmailDispatchService(app_config)
+        audit_svc = AuditService(app_config)
+
+        try:
+            claims = jwt_svc.verify(data.temp_token, expected_typ='temp')
+        except JwtExpiredError:
+            audit_svc.log(
+                event='verify.resend-code',
+                success=False,
+                error_code='TEMP_TOKEN_EXPIRED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4018,
+                'status': 401,
+                'data': {'error': 'TEMP_TOKEN_EXPIRED'},
+            }
+        except JwtRevokedError:
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_BLACKLISTED'},
+            }
+        except JwtInvalidError:
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_INVALID'},
+            }
+
+        user = user_svc.get_by_id(str(claims.sub))
+        if user is None:
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {'error': 'EMAIL_NOT_FOUND'},
+            }
+
+        kind_code, kind_link = _FLOW_TO_KINDS.get(
+            claims.flow or 'register',
+            (AuthCodeKind.REGISTER, AuthLinkKind.REGISTER),
+        )
+
+        # Throttle: minimo 60s desde el ultimo code (AC-21).
+        retry_after = code_svc.seconds_until_resend_allowed(
+            user_id=user.id, kind=kind_code,
+        )
+        if retry_after > 0:
+            audit_svc.log(
+                event='verify.resend-code',
+                success=False,
+                user_id=user.id,
+                error_code='RESEND_THROTTLED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4010,
+                'status': 429,
+                'data': {
+                    'error': 'RESEND_THROTTLED',
+                    'retry_after': retry_after,
+                },
+            }
+
+        # Invalida artefactos previos + genera nuevos.
+        user_svc.invalidate_active_codes_and_links(
+            user_id=str(user.id),
+            kind_code=kind_code,
+            kind_link=kind_link,
+        )
+        code, _ = code_svc.generate_and_persist(
+            user_id=user.id, kind=kind_code,
+        )
+        token, _ = link_svc.generate_and_persist(
+            user_id=user.id,
+            kind=kind_link,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        verify_url = (
+            f'{app_config.magic_link_base_url}'
+            f'?operation={claims.flow}&action=verify-magic-link&token={token}'
+        )
+        email_svc.publish_magic_link(
+            to=user.email,
+            user_id=user.id,
+            niche=None,
+            kind=f'{claims.flow}-magic-link',
+            plain=token,
+            verify_url=verify_url,
+        )
+        email_svc.publish_code(
+            to=user.email,
+            user_id=user.id,
+            niche=None,
+            kind=f'{claims.flow}-code',
+            code=code,
+        )
+
+        # Rota el temp (blacklistea el viejo + step+1).
+        new_temp, _ = flow_svc.advance_step(claims)
+
+        audit_svc.log(
+            event='verify.resend-code',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'temp_token': new_temp,
+                'expires_in': 300,
+            },
+        }

--- a/serverless/lambda/services/auth/core/controllers/verify/set_password.py
+++ b/serverless/lambda/services/auth/core/controllers/verify/set_password.py
@@ -1,0 +1,163 @@
+"""Controller `verify.set-password` — define la password tras verificar email.
+
+El visitante (ya con el email verificado via magic-link o code) define
+su password. Verifica el rolling temp_token (typ='temp'), hashea la
+password con argon2id, la persiste en `auth_credentials`, blacklistea el
+temp y emite access + refresh JWTs (cierra el flujo).
+
+AC cubiertos: AC-4.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.verify import VerifySetPasswordIn
+from services.audit_service import AuditService
+from services.flow_service import FlowService
+from services.jwt_service import JwtService
+from services.rate_limit_service import RateLimitService
+from services.user_service import UserService
+from settings.config import app_config
+
+from shared.auth import (
+    JwtExpiredError,
+    JwtInvalidError,
+    JwtRevokedError,
+    hash_password,
+)
+from shared.lambda_kit import BaseController
+
+_ENDPOINT = '/auth#verify.set-password'
+
+
+class SetPassword(BaseController):
+    """Define la password del user (action `set-password`)."""
+
+    event_model = VerifySetPasswordIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic (password min 12) + rate-limit. Sin Turnstile."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: VerifySetPasswordIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Verifica temp_token, hashea + persiste password, emite tokens.
+
+        Returns:
+            En exito: `{is_valid: True, code: 0, data: {access_token,
+            refresh_token, user, ...}}`.
+            temp_token expirado: 401 TEMP_TOKEN_EXPIRED (AC-18).
+            temp_token blacklisted: 401 TOKEN_BLACKLISTED (AC-10).
+        """
+        data: VerifySetPasswordIn = (
+            self.validated_data  # type: ignore[assignment]
+        )
+        meta = data.meta
+
+        jwt_svc = JwtService(app_config)
+        flow_svc = FlowService(app_config)
+        user_svc = UserService(app_config)
+        audit_svc = AuditService(app_config)
+
+        # El set-password puede venir de register o login: no fijamos
+        # expected_flow, solo exigimos typ='temp' + no blacklisted.
+        try:
+            claims = jwt_svc.verify(data.temp_token, expected_typ='temp')
+        except JwtExpiredError:
+            audit_svc.log(
+                event='verify.set-password',
+                success=False,
+                error_code='TEMP_TOKEN_EXPIRED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4018,
+                'status': 401,
+                'data': {'error': 'TEMP_TOKEN_EXPIRED'},
+            }
+        except JwtRevokedError:
+            audit_svc.log(
+                event='verify.set-password',
+                success=False,
+                error_code='TOKEN_BLACKLISTED',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_BLACKLISTED'},
+            }
+        except JwtInvalidError:
+            audit_svc.log(
+                event='verify.set-password',
+                success=False,
+                error_code='TOKEN_INVALID',
+                ip=meta.ip,
+            )
+            return {
+                'is_valid': False,
+                'code': 4003,
+                'status': 401,
+                'data': {'error': 'TOKEN_INVALID'},
+            }
+
+        user = user_svc.get_by_id(str(claims.sub))
+        if user is None:
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {'error': 'EMAIL_NOT_FOUND'},
+            }
+
+        # Hashea + persiste la password (argon2id). El hashing ocurre en
+        # el controller (CPU-bound, sin I/O); el service solo upserta.
+        password_hash = hash_password(data.password)
+        user_svc.set_password_hash(
+            user_id=str(user.id), password_hash=password_hash,
+        )
+
+        # Cierra el flujo: blacklistea el temp + emite access + refresh.
+        access_token, refresh_token, _ = flow_svc.terminate_flow(
+            user_id=user.id, claims=claims,
+        )
+
+        audit_svc.log(
+            event='verify.set-password',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'data': {
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'expires_in': 900,
+                'token_type': 'Bearer',
+                'user': {
+                    'id': str(user.id),
+                    'email': user.email,
+                    'status': user.status.value,
+                },
+            },
+        }

--- a/serverless/lambda/services/auth/core/services/code_service.py
+++ b/serverless/lambda/services/auth/core/services/code_service.py
@@ -19,6 +19,7 @@ from shared.db import db_session
 from shared.db.models import AuthCodeKind, AuthUser
 from shared.db.repositories.auth import (
     consume_email_code,
+    get_last_email_code,
     insert_email_code,
 )
 
@@ -56,6 +57,30 @@ class CodeService:
                 expires_at=expires_at,
             )
         return code, code_hash
+
+    def seconds_until_resend_allowed(
+        self,
+        *,
+        user_id: UUID | str,
+        kind: AuthCodeKind,
+        min_interval: timedelta = timedelta(seconds=60),
+    ) -> int:
+        """Segundos que faltan para permitir un resend (AC-21).
+
+        Mira el ultimo code emitido para (user, kind) — consumed o no —
+        y compara `now - created_at` contra `min_interval`. Retorna 0 si
+        ya se puede reenviar (no hay code previo o paso el intervalo), o
+        los segundos restantes (> 0) si todavia esta throttled.
+        """
+        with db_session() as session:
+            last = get_last_email_code(
+                session, user_id=str(user_id), kind=kind,
+            )
+            if last is None:
+                return 0
+            elapsed = datetime.now(tz=last.created_at.tzinfo) - last.created_at
+            remaining = min_interval - elapsed
+        return max(int(remaining.total_seconds()), 0)
 
     def verify(
         self,

--- a/serverless/lambda/services/auth/core/services/jwt_service.py
+++ b/serverless/lambda/services/auth/core/services/jwt_service.py
@@ -126,6 +126,35 @@ class JwtService:
                 )
         return claims
 
+    def verify_allow_revoked(
+        self,
+        token_str: str,
+        *,
+        expected_typ: JwtType | None = None,
+    ) -> JwtClaims:
+        """Verifica signature + exp + aud + iss + typ, SIN chequear blacklist.
+
+        Devuelve los claims aunque el jti (o su familia) esten revocados.
+        Lo usa `session.refresh` para detectar token reuse: necesita el
+        `family_id` del refresh recibido ANTES de decidir si revocar la
+        familia completa (AC-8). El caller consulta `is_blacklisted` por
+        separado.
+
+        Raises:
+            JwtExpiredError, JwtInvalidError (NUNCA JwtRevokedError).
+        """
+        return verify_jwt(
+            token_str,
+            secret=self._secret,
+            expected_typ=expected_typ,
+            audience=self._audience,
+            issuer=self._issuer,
+        )
+
+    def is_blacklisted(self, *, jti: UUID | str) -> bool:
+        """True si el jti esta en la blacklist DDB (delega al service)."""
+        return self._blacklist.is_blacklisted(jti=jti)
+
     def blacklist(
         self,
         *,

--- a/serverless/lambda/services/auth/core/services/user_service.py
+++ b/serverless/lambda/services/auth/core/services/user_service.py
@@ -27,6 +27,7 @@ from shared.db.repositories.auth import (
     lock_user,
     mark_user_active,
     reset_failed_attempts,
+    set_password_hash,
     update_last_login,
 )
 
@@ -87,6 +88,28 @@ class UserService:
         with db_session() as session:
             session.add(user)
             lock_user(session, user, until=until)
+
+    def set_password_hash(
+        self,
+        *,
+        user_id: str,
+        password_hash: str,
+        algo: str = 'argon2id',
+    ) -> None:
+        """Upsert del password_hash del user (AC-4).
+
+        Delega al repository `shared.db.repositories.auth.set_password_hash`
+        que upserta el row en `auth_credentials` (1-to-0..1 con `auth_users`).
+        Lo invoca el controller `verify.set-password` tras validar el
+        rolling temp JWT del flujo y antes de emitir access+refresh.
+        """
+        with db_session() as session:
+            set_password_hash(
+                session,
+                user_id=user_id,
+                password_hash=password_hash,
+                algo=algo,
+            )
 
     def update_last_login(self, user: AuthUser) -> None:
         """Setea last_login_at=now + resetea failed_attempts (AC-22).

--- a/serverless/lambda/services/auth/tests/unit/controllers/_helpers.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/_helpers.py
@@ -84,6 +84,116 @@ def _make_event_with_code(
     }
 
 
+def _make_event_set_password(
+    *,
+    password: str = 'a-very-strong-passphrase-1',  # noqa: S107
+    temp_token: str = 'FAKE-TEMP-TOKEN-FOR-TEST-XXXXXXXXXXX',
+    ip: str = '203.0.113.10',
+    country: str = 'CL',
+    user_agent: str = 'pytest',
+) -> dict[str, Any]:
+    """Evento de verify/set-password."""
+    return {
+        'password': password,
+        'temp_token': temp_token,
+        '_meta': {
+            'ip': ip,
+            'country': country,
+            'user_agent': user_agent,
+            'bypass_secret': None,
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'cloudfront_meta': {},
+        },
+    }
+
+
+def _make_event_resend_code(
+    *,
+    temp_token: str = 'FAKE-TEMP-TOKEN-FOR-TEST-XXXXXXXXXXX',
+    ip: str = '203.0.113.10',
+    country: str = 'CL',
+    user_agent: str = 'pytest',
+) -> dict[str, Any]:
+    """Evento de verify/resend-code."""
+    return {
+        'temp_token': temp_token,
+        '_meta': {
+            'ip': ip,
+            'country': country,
+            'user_agent': user_agent,
+            'bypass_secret': None,
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'cloudfront_meta': {},
+        },
+    }
+
+
+def _make_event_refresh(
+    *,
+    refresh_token: str = 'FAKE-REFRESH-TOKEN-FOR-TEST-XXXXXXXX',
+    ip: str = '203.0.113.10',
+    country: str = 'CL',
+    user_agent: str = 'pytest',
+) -> dict[str, Any]:
+    """Evento de session/refresh."""
+    return {
+        'refresh_token': refresh_token,
+        '_meta': {
+            'ip': ip,
+            'country': country,
+            'user_agent': user_agent,
+            'bypass_secret': None,
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'cloudfront_meta': {},
+        },
+    }
+
+
+def _make_event_logout(
+    *,
+    access_token: str = 'FAKE-ACCESS-TOKEN-FOR-TEST-XXXXXXXXX',
+    refresh_token: str | None = None,
+    ip: str = '203.0.113.10',
+    country: str = 'CL',
+    user_agent: str = 'pytest',
+) -> dict[str, Any]:
+    """Evento de session/logout."""
+    event: dict[str, Any] = {
+        'access_token': access_token,
+        '_meta': {
+            'ip': ip,
+            'country': country,
+            'user_agent': user_agent,
+            'bypass_secret': None,
+            'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'cloudfront_meta': {},
+        },
+    }
+    if refresh_token is not None:
+        event['refresh_token'] = refresh_token
+    return event
+
+
+def _make_session_claims(
+    *,
+    user_id: UUID | None = None,
+    typ: str = 'refresh',
+    jti: UUID | None = None,
+    family_id: UUID | None = None,
+    exp: int = 9999999999,
+) -> Any:
+    """Mock de JwtClaims para access/refresh (session)."""
+    return SimpleNamespace(
+        sub=user_id or uuid4(),
+        jti=jti or uuid4(),
+        flow=None,
+        step=None,
+        exp=exp,
+        typ=typ,
+        family_id=family_id if family_id is not None else uuid4(),
+    )
+
+
 def _make_user(
     *,
     user_id: UUID | None = None,

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/__init__.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/__init__.py
@@ -1,0 +1,1 @@
+"""Tests de controllers session."""

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_logout_access_and_refresh.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_logout_access_and_refresh.py
@@ -1,0 +1,46 @@
+"""AC-9: logout con access + refresh -> blacklistea jti + revoca familia.
+
+Given un access JWT valido y un refresh JWT con family_id,
+When se invoca session.logout con ambos,
+Then blacklistea el access y revoca toda la familia del refresh, 204.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_logout, _make_session_claims
+
+_FAKE_REFRESH = 'FAKE-REFRESH-' + ('X' * 16)
+
+
+def test_session_logout_access_and_refresh(monkeypatch):
+    """AC-9: logout con ambos tokens -> familia revocada."""
+    from controllers.session import logout
+
+    uid = uuid4()
+    fid = uuid4()
+    access_claims = _make_session_claims(typ='access', user_id=uid)
+    refresh_claims = _make_session_claims(
+        typ='refresh', user_id=uid, family_id=fid,
+    )
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify_allow_revoked.side_effect = [access_claims, refresh_claims]
+    jwt_svc.is_blacklisted.return_value = False
+
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(logout, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(logout, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(logout, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_logout(refresh_token=_FAKE_REFRESH)
+    controller = logout.Logout(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['status'] == 204
+    jwt_svc.blacklist.assert_called_once()
+    jwt_svc.revoke_family.assert_called_once_with(
+        family_id=fid, user_id=uid, exp=refresh_claims.exp,
+    )

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_logout_access_ok.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_logout_access_ok.py
@@ -1,0 +1,38 @@
+"""AC-9: logout con access valido -> blacklistea jti + 204.
+
+Given un access JWT valido no blacklisted,
+When se invoca session.logout (sin refresh),
+Then blacklistea el jti del access y devuelve 204.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_logout, _make_session_claims
+
+
+def test_session_logout_access_ok(monkeypatch):
+    """AC-9: logout solo access -> 204."""
+    from controllers.session import logout
+
+    jti = uuid4()
+    claims = _make_session_claims(typ='access', jti=jti)
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify_allow_revoked.return_value = claims
+    jwt_svc.is_blacklisted.return_value = False
+
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(logout, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(logout, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(logout, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_logout()
+    controller = logout.Logout(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['status'] == 204
+    jwt_svc.blacklist.assert_called_once()
+    jwt_svc.revoke_family.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_logout_already_blacklisted.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_logout_already_blacklisted.py
@@ -1,0 +1,37 @@
+"""AC-23: logout con access ya blacklisted -> 204 idempotente.
+
+Given un access JWT valido cuyo jti YA esta blacklisted,
+When se invoca session.logout,
+Then devuelve 204 sin re-blacklistear (idempotencia).
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_logout, _make_session_claims
+
+
+def test_session_logout_already_blacklisted(monkeypatch):
+    """AC-23: logout idempotente -> 204 sin re-blacklistear."""
+    from controllers.session import logout
+
+    jti = uuid4()
+    claims = _make_session_claims(typ='access', jti=jti)
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify_allow_revoked.return_value = claims
+    jwt_svc.is_blacklisted.return_value = True
+
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(logout, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(logout, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(logout, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_logout()
+    controller = logout.Logout(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['status'] == 204
+    jwt_svc.blacklist.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_invalid_signature.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_invalid_signature.py
@@ -1,0 +1,37 @@
+"""AC-10: refresh con signature invalida -> 401 TOKEN_INVALID.
+
+Given un refresh JWT cuya verificacion lanza JwtInvalidError,
+When se invoca session.refresh,
+Then devuelve 401 TOKEN_INVALID sin emitir tokens.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_refresh
+
+
+def test_session_refresh_invalid_signature(monkeypatch):
+    """AC-10: signature invalida -> 401."""
+    from controllers.session import refresh
+
+    from shared.auth import JwtInvalidError
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify_allow_revoked.side_effect = JwtInvalidError('bad sig')
+
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(refresh, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(refresh, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(refresh, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_refresh()
+    controller = refresh.Refresh(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4003
+    assert result['status'] == 401
+    assert result['data']['error'] == 'TOKEN_INVALID'
+    jwt_svc.issue_access.assert_not_called()
+    jwt_svc.revoke_family.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_ok.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_ok.py
@@ -1,0 +1,43 @@
+"""AC-7: refresh valido (no blacklisted) -> rota y emite par nuevo.
+
+Given un refresh JWT valido cuyo jti NO esta blacklisted,
+When se invoca session.refresh,
+Then blacklistea el viejo y emite access+refresh nuevos (mismo family_id).
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_refresh, _make_session_claims
+
+
+def test_session_refresh_ok(monkeypatch):
+    """AC-7: rotation OK."""
+    from controllers.session import refresh
+
+    fid = uuid4()
+    claims = _make_session_claims(typ='refresh', family_id=fid)
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify_allow_revoked.return_value = claims
+    jwt_svc.is_blacklisted.return_value = False
+    jwt_svc.issue_access.return_value = ('ACCESS-JWT', MagicMock())
+    jwt_svc.issue_refresh.return_value = ('REFRESH-JWT', MagicMock())
+
+    audit_svc = MagicMock()
+    rl_svc = MagicMock()
+
+    monkeypatch.setattr(refresh, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(refresh, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(refresh, 'RateLimitService', lambda _c: rl_svc)
+
+    event = _make_event_refresh()
+    controller = refresh.Refresh(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['access_token'] == 'ACCESS-JWT'
+    assert result['data']['refresh_token'] == 'REFRESH-JWT'
+    jwt_svc.blacklist.assert_called_once()
+    jwt_svc.revoke_family.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_reuse_detected.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_reuse_detected.py
@@ -1,0 +1,43 @@
+"""AC-8: refresh ya consumido (jti blacklisted) -> revoca familia + 401.
+
+Given un refresh JWT cuyo jti YA esta blacklisted (reuso),
+When se invoca session.refresh,
+Then revoca toda la familia y devuelve 401 TOKEN_REUSE_DETECTED.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_refresh, _make_session_claims
+
+
+def test_session_refresh_reuse_detected(monkeypatch):
+    """AC-8: reuso -> familia revocada + 401."""
+    from controllers.session import refresh
+
+    uid = uuid4()
+    fid = uuid4()
+    claims = _make_session_claims(typ='refresh', user_id=uid, family_id=fid)
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify_allow_revoked.return_value = claims
+    jwt_svc.is_blacklisted.return_value = True
+
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(refresh, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(refresh, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(refresh, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_refresh()
+    controller = refresh.Refresh(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4004
+    assert result['status'] == 401
+    assert result['data']['error'] == 'TOKEN_REUSE_DETECTED'
+    jwt_svc.revoke_family.assert_called_once_with(
+        family_id=fid, user_id=uid, exp=claims.exp,
+    )
+    jwt_svc.issue_access.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/verify/__init__.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/verify/__init__.py
@@ -1,0 +1,1 @@
+"""Tests de controllers verify."""

--- a/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_resend_code_ok.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_resend_code_ok.py
@@ -1,0 +1,62 @@
+"""AC-19: temp_token valido + sin throttle -> re-emite code + magic-link.
+
+Given un temp_token valido y la ultima emision hace > 60s,
+When se invoca verify.resend-code,
+Then invalida los previos, publica code + magic-link nuevos y rota el temp.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_resend_code, _make_jwt_claims, _make_user
+
+
+def test_verify_resend_code_ok(monkeypatch):
+    """AC-19: resend OK -> nuevo temp_token."""
+    from controllers.verify import resend_code
+
+    uid = uuid4()
+    claims = _make_jwt_claims(user_id=uid, flow='register')
+    user = _make_user(user_id=uid, status='pending')
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify.return_value = claims
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+
+    code_svc = MagicMock()
+    code_svc.seconds_until_resend_allowed.return_value = 0
+    code_svc.generate_and_persist.return_value = ('ABCDEFGH', b'hash')
+
+    link_svc = MagicMock()
+    link_svc.generate_and_persist.return_value = ('TOKEN', b'thash')
+
+    email_svc = MagicMock()
+    flow_svc = MagicMock()
+    flow_svc.advance_step.return_value = ('NEW-TEMP-JWT', MagicMock())
+    audit_svc = MagicMock()
+    rl_svc = MagicMock()
+
+    monkeypatch.setattr(resend_code, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(resend_code, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(resend_code, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(resend_code, 'MagicLinkService', lambda _c: link_svc)
+    monkeypatch.setattr(
+        resend_code, 'EmailDispatchService', lambda _c: email_svc,
+    )
+    monkeypatch.setattr(resend_code, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(resend_code, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(resend_code, 'RateLimitService', lambda _c: rl_svc)
+
+    event = _make_event_resend_code()
+    controller = resend_code.ResendCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['temp_token'] == 'NEW-TEMP-JWT'
+    assert result['data']['expires_in'] == 300
+    user_svc.invalidate_active_codes_and_links.assert_called_once()
+    assert email_svc.publish_magic_link.call_count == 1
+    assert email_svc.publish_code.call_count == 1

--- a/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_resend_code_throttled.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_resend_code_throttled.py
@@ -1,0 +1,54 @@
+"""AC-21: resend con < 60s desde el ultimo -> 429 RESEND_THROTTLED.
+
+Given un temp_token valido pero la ultima emision hace 25s,
+When se invoca verify.resend-code,
+Then devuelve 429 RESEND_THROTTLED con retry_after y NO publica emails.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_resend_code, _make_jwt_claims, _make_user
+
+
+def test_verify_resend_code_throttled(monkeypatch):
+    """AC-21: throttle activo -> 429."""
+    from controllers.verify import resend_code
+
+    uid = uuid4()
+    claims = _make_jwt_claims(user_id=uid, flow='register')
+    user = _make_user(user_id=uid, status='pending')
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify.return_value = claims
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+
+    code_svc = MagicMock()
+    code_svc.seconds_until_resend_allowed.return_value = 35
+
+    email_svc = MagicMock()
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(resend_code, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(resend_code, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(resend_code, 'CodeService', lambda _c: code_svc)
+    monkeypatch.setattr(resend_code, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(
+        resend_code, 'EmailDispatchService', lambda _c: email_svc,
+    )
+    monkeypatch.setattr(resend_code, 'FlowService', lambda _c: MagicMock())
+    monkeypatch.setattr(resend_code, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(resend_code, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_resend_code()
+    controller = resend_code.ResendCode(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4010
+    assert result['status'] == 429
+    assert result['data']['error'] == 'RESEND_THROTTLED'
+    assert result['data']['retry_after'] == 35
+    email_svc.publish_code.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_ok.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_ok.py
@@ -1,0 +1,51 @@
+"""AC-4: temp_token valido + password >= 12 -> persiste hash + emite tokens.
+
+Given un temp_token valido y una password de 12+ chars,
+When se invoca verify.set-password,
+Then upserta el hash, cierra el flujo y devuelve access+refresh.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_set_password, _make_jwt_claims, _make_user
+
+
+def test_verify_set_password_ok(monkeypatch):
+    """AC-4: set-password OK -> tokens."""
+    from controllers.verify import set_password
+
+    uid = uuid4()
+    claims = _make_jwt_claims(user_id=uid, flow='register')
+    user = _make_user(user_id=uid, status='active')
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify.return_value = claims
+
+    user_svc = MagicMock()
+    user_svc.get_by_id.return_value = user
+
+    flow_svc = MagicMock()
+    flow_svc.terminate_flow.return_value = ('ACCESS-JWT', 'REFRESH-JWT', uuid4())
+
+    audit_svc = MagicMock()
+    rl_svc = MagicMock()
+
+    monkeypatch.setattr(set_password, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(set_password, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(set_password, 'FlowService', lambda _c: flow_svc)
+    monkeypatch.setattr(set_password, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(set_password, 'RateLimitService', lambda _c: rl_svc)
+    monkeypatch.setattr(set_password, 'hash_password', lambda _p: 'HASH')
+
+    event = _make_event_set_password(password='a-very-strong-pass-1')
+    controller = set_password.SetPassword(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['access_token'] == 'ACCESS-JWT'
+    assert result['data']['refresh_token'] == 'REFRESH-JWT'
+    user_svc.set_password_hash.assert_called_once_with(
+        user_id=str(uid), password_hash='HASH',
+    )

--- a/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_temp_blacklisted.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_temp_blacklisted.py
@@ -1,0 +1,39 @@
+"""AC-10: set-password con temp_token blacklisted -> 401 TOKEN_BLACKLISTED.
+
+Given un temp_token cuyo jti ya esta en la blacklist,
+When se invoca verify.set-password,
+Then jwt.verify lanza JwtRevokedError y el controller devuelve 401.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_set_password
+
+
+def test_verify_set_password_temp_blacklisted(monkeypatch):
+    """AC-10: temp revocado -> 401 sin persistir password."""
+    from controllers.verify import set_password
+
+    from shared.auth import JwtRevokedError
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify.side_effect = JwtRevokedError('revoked')
+
+    user_svc = MagicMock()
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(set_password, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(set_password, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(set_password, 'FlowService', lambda _c: MagicMock())
+    monkeypatch.setattr(set_password, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(set_password, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_set_password(password='a-very-strong-pass-1')
+    controller = set_password.SetPassword(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4003
+    assert result['status'] == 401
+    assert result['data']['error'] == 'TOKEN_BLACKLISTED'
+    user_svc.set_password_hash.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_temp_expired.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_temp_expired.py
@@ -1,0 +1,39 @@
+"""AC-18: set-password con temp_token expirado -> 401 TEMP_TOKEN_EXPIRED.
+
+Given un temp_token cuyo exp ya paso,
+When se invoca verify.set-password,
+Then jwt.verify lanza JwtExpiredError y el controller devuelve 401.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_set_password
+
+
+def test_verify_set_password_temp_expired(monkeypatch):
+    """AC-18: temp expirado -> 401 sin persistir password."""
+    from controllers.verify import set_password
+
+    from shared.auth import JwtExpiredError
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify.side_effect = JwtExpiredError('expired')
+
+    user_svc = MagicMock()
+    audit_svc = MagicMock()
+
+    monkeypatch.setattr(set_password, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(set_password, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(set_password, 'FlowService', lambda _c: MagicMock())
+    monkeypatch.setattr(set_password, 'AuditService', lambda _c: audit_svc)
+    monkeypatch.setattr(set_password, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_set_password(password='a-very-strong-pass-1')
+    controller = set_password.SetPassword(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4018
+    assert result['status'] == 401
+    assert result['data']['error'] == 'TEMP_TOKEN_EXPIRED'
+    user_svc.set_password_hash.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_too_short.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/verify/test_verify_set_password_too_short.py
@@ -1,0 +1,30 @@
+"""AC-4: password < 12 chars -> ValidationError (400) sin tocar negocio.
+
+Given una password de menos de 12 chars,
+When se invoca verify.set-password,
+Then el modelo Pydantic la rechaza y el controller devuelve is_valid=False
+     antes de hashear o persistir nada.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_set_password
+
+
+def test_verify_set_password_too_short(monkeypatch):
+    """Password corta -> validacion falla, no se persiste."""
+    from controllers.verify import set_password
+
+    user_svc = MagicMock()
+    monkeypatch.setattr(set_password, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(set_password, 'RateLimitService', lambda _c: MagicMock())
+
+    # 11 chars (< 12 min).
+    event = _make_event_set_password(password='short-pass1')
+    controller = set_password.SetPassword(event=event)
+    result = controller.run()
+
+    assert result['is_valid'] is False
+    # ErrorCode.VALIDATION_ERROR — no llega al negocio.
+    assert result['code'] == 1000
+    user_svc.set_password_hash.assert_not_called()

--- a/serverless/lambda/shared/db/repositories/auth.py
+++ b/serverless/lambda/shared/db/repositories/auth.py
@@ -36,6 +36,7 @@ __all__ = [
     'consume_email_code',
     'consume_magic_link',
     'create_pending_user',
+    'get_last_email_code',
     'get_magic_link_state',
     'get_user_by_email',
     'increment_failed_attempts',
@@ -201,6 +202,30 @@ def insert_email_code(
     session.add(code)
     session.flush()
     return code
+
+
+def get_last_email_code(
+    session: Session,
+    *,
+    user_id: str,
+    kind: AuthCodeKind,
+) -> AuthEmailCode | None:
+    """Devuelve el ultimo `auth_email_codes` emitido para (user, kind).
+
+    NO filtra por `consumed_at`: lo usa el throttle de
+    `verify.resend-code` que mide `now - created_at` del ultimo code
+    (consumed o no) para evitar abuso del endpoint (AC-21).
+    """
+    stmt = (
+        select(AuthEmailCode)
+        .where(
+            AuthEmailCode.user_id == user_id,
+            AuthEmailCode.kind == kind,
+        )
+        .order_by(AuthEmailCode.created_at.desc())
+        .limit(1)
+    )
+    return session.execute(stmt).scalar_one_or_none()
 
 
 def consume_email_code(


### PR DESCRIPTION
## Problema

Faltaban los ultimos 4 controllers del Lambda `auth`:
`verify/{set-password,resend-code}` y `session/{refresh,logout}`. Sin
ellos el flujo no cierra (no se puede setear password, reenviar code,
renovar la sesion ni cerrar sesion).

## Solucion

**4 controllers** que cubren AC-4, AC-7, AC-8, AC-9, AC-10, AC-18,
AC-19, AC-21, AC-23:

- `verify/set_password.py`: verifica temp JWT, hashea con argon2id,
  upserta `auth_credentials`, cierra el flujo.
- `verify/resend_code.py`: throttle 60s (AC-21), invalida artefactos
  previos, re-emite code + magic-link, rota el temp.
- `session/refresh.py`: rotation + **family detection** (si el jti del
  refresh ya esta blacklisted → revoca toda la familia via Query GSI
  `by_family_id` + BatchWrite → 401 TOKEN_REUSE_DETECTED).
- `session/logout.py`: blacklistea el access + revoca familia del
  refresh. Idempotente (204 aunque ya este blacklisted).

**Services**: nuevo `jwt_service.verify_allow_revoked` (verifica
firma+exp+typ SIN chequear blacklist — necesario para obtener el
`family_id` de un token revocado) + `is_blacklisted` passthrough;
`code_service.seconds_until_resend_allowed` (throttle AC-21);
`set_password_hash` wiring.

**Repository** (`shared/db/repositories/auth.py`): `get_last_email_code`,
`update_last_login`, `invalidate_active_codes_and_links`,
`set_password_hash`.

## Como probar

```bash
python devtools/run.py serverless lint-deps --lambda=auth
# OK: cero deps duplicadas + cero imports prohibidos

python devtools/run.py serverless tests --type=unit --lambda=auth
# 83 passed (+12 nuevos vs PR 7)

python devtools/run.py serverless tests --type=coverage --lambda=auth
# TOTAL 88%; per-file >=84% en los 4 controllers nuevos
```

## TODO

- [ ] Commit 8.3 operativo: seed de rate-limit rules en dev/stage/prod
      (`serverless rate-limit set` x10 reglas x3 envs)
- [ ] Commit 8.4 operativo: deploy auth a dev (CI auto-detecta) +
      sync JWT_SECRET a SSM + smoke E2E
- [ ] PR 9: integration tests + ER + cleanup spec

---

Plan padre: `docs/specs/01-auth-infra-basics/` (PR 8).