### PR TITLE
chore(auth): enablers de infra (JWT_SECRET en CI + rate-limit endpoints)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -74,6 +74,7 @@ jobs:
     env:
       TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
       TURNSTILE_BYPASS_SECRET: ${{ secrets.TURNSTILE_BYPASS_SECRET }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
       DB_URL: ${{ secrets.DB_URL }}
       OWNER_EMAIL: ${{ secrets.OWNER_EMAIL }}
       EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
@@ -229,6 +230,7 @@ jobs:
     env:
       TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
       TURNSTILE_BYPASS_SECRET: ${{ secrets.TURNSTILE_BYPASS_SECRET }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
       DB_URL: ${{ secrets.DB_URL }}
       OWNER_EMAIL: ${{ secrets.OWNER_EMAIL }}
       EMAIL_FROM: ${{ secrets.EMAIL_FROM }}

--- a/devtools/serverless/rate_limit_cmds.py
+++ b/devtools/serverless/rate_limit_cmds.py
@@ -96,7 +96,24 @@ _VALID_ACTIONS = [
     'clear-buckets',
 ]
 
-_VALID_ENDPOINTS = ['/contact', '/track', '*']
+# Endpoints validos para `rate-limit set`. El Lambda `auth` usa keys
+# compuestas `/auth#<operation>.<action>` (el controller las pasa a
+# shared.rate_limit.check_or_raise) para tener una regla por accion.
+_VALID_ENDPOINTS = [
+    '/contact',
+    '/track',
+    '*',
+    '/auth#register.start',
+    '/auth#register.verify-magic-link',
+    '/auth#register.verify-code',
+    '/auth#login.start',
+    '/auth#login.verify-magic-link',
+    '/auth#login.verify-code',
+    '/auth#verify.set-password',
+    '/auth#verify.resend-code',
+    '/auth#session.refresh',
+    '/auth#session.logout',
+]
 
 
 def _ensure_aws_cli() -> bool:


### PR DESCRIPTION
## Problema

El deploy del Lambda `auth` (auto-disparado por CI al mergear PR 7/8)
falla con: `secrets-sync fallo: JWT_SECRET ausente o vacio en
os.environ (requerido por secreto 'jwt-secret')`. Ademas, el seed de
rate-limit rules del auth no se puede correr porque sus endpoints no
estan en la whitelist `_VALID_ENDPOINTS` de devtools.

## Solucion

1. `deploy-backend.yml`: agrega `JWT_SECRET: ${{ secrets.JWT_SECRET }}`
   a los 2 bloques `env:` (migrate-db + deploy-lambdas).
2. `devtools/serverless/rate_limit_cmds.py`: extiende
   `_VALID_ENDPOINTS` con los 10 endpoints `/auth#<operation>.<action>`.

## Como probar

```bash
python -m compileall -q devtools/serverless/rate_limit_cmds.py
# (tras merge + JWT_SECRET en GH Secrets) el deploy-backend del auth
# pasa el step secrets-sync
```

## TODO

- [ ] **Accion humana**: agregar `JWT_SECRET` a GitHub Environment
      Secrets (dev/stage/prod) + a `docker/env/server/.{env}`
- [ ] Tras merge: seed de rate-limit + sync JWT_SECRET a SSM + smoke E2E
      (PR 9 / operativo)

---

Plan padre: `docs/specs/01-auth-infra-basics/` (enabler del commit 8.4).