### PR TITLE
fix(auth): revoca el refresh vigente cuando la familia ya fue revocada (AC-8)

### DIFF
--- a/serverless/lambda/services/auth/core/controllers/session/refresh.py
+++ b/serverless/lambda/services/auth/core/controllers/session/refresh.py
@@ -99,9 +99,21 @@ class Refresh(BaseController):
                 'data': {'error': 'TOKEN_INVALID'},
             }
 
-        # Reuso detectado: el refresh ya fue rotado (su jti esta en la
-        # blacklist). Revoca TODA la familia y rechaza (AC-8).
-        if jwt_svc.is_blacklisted(jti=claims.jti):
+        # Reuso detectado en 2 casos (AC-8 — "revocar TODA la familia"):
+        #  a) el jti de ESTE refresh ya esta blacklisted (fue rotado y se
+        #     re-presenta): reuso clasico de un token viejo.
+        #  b) la FAMILIA ya fue revocada por un reuso previo: el centinela
+        #     (jti == family_id, escrito por revoke_family con reason='reuse')
+        #     esta presente. Sin este chequeo, el refresh AUN VIGENTE de una
+        #     familia ya comprometida sobreviviria a la revocacion — el gap
+        #     que rompe la garantia de AC-8. El centinela usa jti==family_id,
+        #     asi que un GetItem por family_id lo detecta (no hay colision:
+        #     jti y family_id son uuidv7 independientes en cada emision).
+        family_revoked = (
+            claims.family_id is not None
+            and jwt_svc.is_blacklisted(jti=claims.family_id)
+        )
+        if jwt_svc.is_blacklisted(jti=claims.jti) or family_revoked:
             if claims.family_id is not None:
                 jwt_svc.revoke_family(
                     family_id=claims.family_id,

--- a/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_family_revoked.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/session/test_session_refresh_family_revoked.py
@@ -1,0 +1,50 @@
+"""AC-8: refresh VIGENTE de una familia ya revocada -> 401 (no rota).
+
+Given un refresh JWT valido cuyo jti propio NO esta blacklisted, pero
+  cuya familia ya fue revocada por un reuso previo (existe el centinela
+  jti == family_id en la blacklist),
+When se invoca session.refresh,
+Then revoca (re-asegura) la familia y devuelve 401 TOKEN_REUSE_DETECTED,
+  SIN emitir tokens nuevos.
+
+Regresion: antes el controller solo miraba is_blacklisted(jti) propio,
+asi el refresh aun vigente de una familia comprometida sobrevivia a la
+revocacion — rompiendo la garantia de AC-8 ("revocar TODA la familia").
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_event_refresh, _make_session_claims
+
+
+def test_session_refresh_family_revoked(monkeypatch):
+    """AC-8: familia revocada (centinela) -> 401 aunque el jti no lo este."""
+    from controllers.session import refresh
+
+    uid = uuid4()
+    fid = uuid4()
+    claims = _make_session_claims(typ='refresh', user_id=uid, family_id=fid)
+
+    jwt_svc = MagicMock()
+    jwt_svc.verify_allow_revoked.return_value = claims
+    # El jti propio NO esta blacklisted; el centinela de la familia SI
+    # (jti == family_id, escrito por revoke_family en el reuso previo).
+    jwt_svc.is_blacklisted.side_effect = lambda *, jti: str(jti) == str(fid)
+
+    monkeypatch.setattr(refresh, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(refresh, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(refresh, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_refresh()
+    result = refresh.Refresh(event=event).run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4004
+    assert result['status'] == 401
+    assert result['data']['error'] == 'TOKEN_REUSE_DETECTED'
+    jwt_svc.revoke_family.assert_called_once_with(
+        family_id=fid, user_id=uid, exp=claims.exp,
+    )
+    jwt_svc.issue_access.assert_not_called()
+    jwt_svc.issue_refresh.assert_not_called()


### PR DESCRIPTION
A continuacion el problema, la solucion y como reproducir.

## Problema

Probando la API de auth desplegada en dev con una bateria E2E (36 casos sobre las 10 actions), un caso fallo: tras detectar reuso de un refresh token y revocar la familia, el refresh **aun vigente** de esa familia seguia funcionando.

Secuencia: login -> refresh R1 (familia F) -> rota a R2 (R1 blacklisted) -> se reusa R1 -> reuso detectado, `revoke_family(F)` escribe el centinela -> **pero** un refresh con R2 devolvia 200 y seguia rotando.

Causa raiz: `session.refresh.execute()` solo evaluaba `is_blacklisted(jti=claims.jti)` (el jti propio del token). El centinela de familia que escribe `revoke_family` usa `jti == family_id` y nunca se consultaba en el path de refresh (`verify_allow_revoked` no chequea blacklist/familia). El token reusado R1 si se rechazaba (su jti estaba blacklisted), pero R2 sobrevivia. Esto rompe la garantia de AC-8: "revocar TODA la familia".

## Solucion

`session.refresh` ahora detecta reuso en 2 casos:
1. el jti propio del refresh esta blacklisted (reuso clasico, ya cubierto), o
2. la familia ya fue revocada: el centinela `jti == family_id` esta presente (`is_blacklisted(jti=claims.family_id)`).

No hay falsos positivos: `jti` y `family_id` son uuidv7 independientes por emision, asi que en rotacion normal `is_blacklisted(family_id)` es False (solo `revoke_family` escribe esa clave). Se agrega un test unit del caso familia-revocada-con-jti-propio-no-blacklisted.

## Como probar

Unit (auth, coverage):

```
python devtools/run.py serverless tests --type=coverage --lambda=auth
# 84 passed; core/controllers/session/refresh.py 90%; total 88%
python devtools/run.py serverless lint-deps --lambda=auth   # OK
```

E2E contra dev (ya verificado tras `serverless deploy --lambda=auth --stage=dev`, alias live -> v6): bateria de 36 casos sobre register/login/verify/session + validacion + Turnstile + rate-limit -> **36/36 PASS**. El caso de regresion (familia revocada -> refresh vigente) devuelve ahora `401 TOKEN_REUSE_DETECTED`.

## TODO

- El Lambda auth en dev ya corre v6 con el fix (deploy manual durante la verificacion). El merge a dev mantiene la rama y el codigo alineados; el deploy de CI re-aplica el mismo artefacto (idempotente).
- Sin cambios de frontend (pre-commit/pre-push omiten gates de apps/packages).