### PR TITLE
fix(auth): cold-start de auth/users + IP INET en list-sessions + ADMIN_EMAILS en CI

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -75,6 +75,7 @@ jobs:
       TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
       TURNSTILE_BYPASS_SECRET: ${{ secrets.TURNSTILE_BYPASS_SECRET }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
       DB_URL: ${{ secrets.DB_URL }}
       OWNER_EMAIL: ${{ secrets.OWNER_EMAIL }}
       EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
@@ -231,6 +232,7 @@ jobs:
       TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
       TURNSTILE_BYPASS_SECRET: ${{ secrets.TURNSTILE_BYPASS_SECRET }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
       DB_URL: ${{ secrets.DB_URL }}
       OWNER_EMAIL: ${{ secrets.OWNER_EMAIL }}
       EMAIL_FROM: ${{ secrets.EMAIL_FROM }}

--- a/serverless/lambda/services/auth/manifest.yaml
+++ b/serverless/lambda/services/auth/manifest.yaml
@@ -16,9 +16,11 @@ description: HTTP endpoint POST /auth (register/login/verify/session).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 384       # MB — Turnstile siteverify + Neon write + DDB
-                  # blacklist + SQS publish con holgura.
-timeout: 15       # segundos — incluye Turnstile siteverify HTTP (1-2s)
+memory: 1024      # MB — imports pesados (sqlalchemy + fido2 + pyjwt +
+                  # argon2 + boto3) requieren CPU para cold start <10s.
+                  # A 384 MB el cold init era ~13.8s y excedia el timeout.
+timeout: 30       # segundos — cold init + SSM/DDB/Neon frio + Turnstile
+                  # siteverify HTTP. Margen sobre el cold de ~8.6s a 1024 MB.
 
 # SnapStart: reduce cold start de ~3s a ~830ms (Restore Duration).
 # Critico en /auth: low traffic prod hace que cada request pague cold

--- a/serverless/lambda/services/users/core/services/audit_admin_service.py
+++ b/serverless/lambda/services/users/core/services/audit_admin_service.py
@@ -102,7 +102,10 @@ class AuditAdminService:
                     ),
                     'action': row.action,
                     'metadata': row.meta_data,
-                    'ip': row.ip,
+                    # row.ip es INET -> psycopg3 lo devuelve como
+                    # ipaddress.IPv4Address/IPv6Address, NO serializable a
+                    # JSON. str() lo normaliza; None se preserva.
+                    'ip': str(row.ip) if row.ip is not None else None,
                     'created_at': row.created_at.isoformat(),
                 }
                 for row in rows

--- a/serverless/lambda/services/users/core/services/session_service.py
+++ b/serverless/lambda/services/users/core/services/session_service.py
@@ -44,7 +44,10 @@ class SessionService:
                 {
                     'session_id': str(row.id),
                     'device_info': _device_summary(row.device_info),
-                    'ip': row.ip,
+                    # row.ip es INET -> psycopg3 lo devuelve como
+                    # ipaddress.IPv4Address/IPv6Address, NO serializable a
+                    # JSON. str() lo normaliza; None se preserva.
+                    'ip': str(row.ip) if row.ip is not None else None,
                     'country': row.country,
                     'created_at': row.created_at.isoformat(),
                     'last_active_at': row.last_active_at.isoformat(),

--- a/serverless/lambda/services/users/manifest.yaml
+++ b/serverless/lambda/services/users/manifest.yaml
@@ -17,9 +17,10 @@ description: HTTP endpoint POST /users (profile/status/admin).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 384       # MB — verify JWT + Neon read/write + DDB blacklist
-                  # + SQS publish con holgura.
-timeout: 15       # segundos
+memory: 1024      # MB — comparte los imports pesados de auth (shared.auth
+                  # con fido2 + argon2 + pyjwt + sqlalchemy). A 384 MB el
+                  # cold init excedia el timeout; 1024 MB lo deja en ~8.6s.
+timeout: 30       # segundos — cold init + SSM/DDB/Neon frio con margen.
 
 # SnapStart: reduce cold start (~830ms Restore). Mismo criterio que auth:
 # low traffic prod hace que cada request pague cold start.

--- a/serverless/lambda/services/users/tests/unit/services/test_audit_admin_list_actions_inet_ip.py
+++ b/serverless/lambda/services/users/tests/unit/services/test_audit_admin_list_actions_inet_ip.py
@@ -1,0 +1,67 @@
+"""AuditAdminService.list_actions — la IP INET sale como str serializable.
+
+Given un row de admin action cuyo `row.ip` es un ipaddress.IPv4Address (lo
+     que devuelve psycopg3 para la columna INET `auth_user_admin_actions.ip`),
+When se invoca list_actions,
+Then el dict trae `ip` como str y el payload es json.dumps-eable.
+
+Guard de regresion: mismo bug que status.list-sessions. `'ip': row.ip` crudo
+metia un IPv4Address al dict -> json.dumps reventaba con TypeError.
+"""
+
+import json
+from contextlib import contextmanager
+from ipaddress import IPv4Address
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def _ctx(session):
+    yield session
+
+
+def test_audit_admin_list_actions_serializes_inet_ip(monkeypatch):
+    from services import audit_admin_service
+
+    fake_session = MagicMock()
+    rows = [
+        SimpleNamespace(
+            id='action-1',
+            admin_user_id='admin-1',
+            target_user_id='user-2',
+            action='admin.disable',
+            meta_data={'reason': 'spam'},
+            ip=IPv4Address('203.0.113.9'),
+            created_at=SimpleNamespace(
+                isoformat=lambda: '2026-01-01T00:00:00',
+            ),
+        ),
+        SimpleNamespace(
+            id='action-2',
+            admin_user_id='admin-1',
+            target_user_id=None,
+            action='admin.list-users',
+            meta_data={},
+            ip=None,
+            created_at=SimpleNamespace(
+                isoformat=lambda: '2026-01-01T00:01:00',
+            ),
+        ),
+    ]
+
+    monkeypatch.setattr(
+        audit_admin_service, 'db_session', lambda: _ctx(fake_session),
+    )
+    monkeypatch.setattr(
+        audit_admin_service,
+        'list_admin_actions',
+        lambda _s, *, from_date, to_date, page_size, cursor: rows,
+    )
+
+    svc = audit_admin_service.AuditAdminService(app_config=object())
+    result = svc.list_actions()
+
+    assert result[0]['ip'] == '203.0.113.9'
+    assert result[1]['ip'] is None
+    assert json.dumps(result) is not None

--- a/serverless/lambda/services/users/tests/unit/services/test_session_list_serializes_inet_ip.py
+++ b/serverless/lambda/services/users/tests/unit/services/test_session_list_serializes_inet_ip.py
@@ -1,0 +1,64 @@
+"""SessionService.list_for_user — la IP INET sale como str serializable.
+
+Given una sesion cuyo `row.ip` es un ipaddress.IPv4Address (lo que devuelve
+     psycopg3 para una columna INET),
+When se invoca list_for_user,
+Then el dict resultante trae `ip` como str y es json.dumps-eable.
+
+Guard de regresion: `'ip': row.ip` (crudo) metia un IPv4Address al dict y
+`json.dumps` reventaba con `TypeError: Object of type IPv4Address is not JSON
+serializable` -> status.list-sessions devolvia HTTP 500.
+"""
+
+import json
+from contextlib import contextmanager
+from ipaddress import IPv4Address, IPv6Address
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def _ctx(session):
+    yield session
+
+
+def _row(*, sid, ip):
+    return SimpleNamespace(
+        id=sid,
+        device_info={'os': 'linux'},
+        ip=ip,
+        country='CL',
+        family_id='fam-1',
+        created_at=SimpleNamespace(isoformat=lambda: '2026-01-01T00:00:00'),
+        last_active_at=SimpleNamespace(
+            isoformat=lambda: '2026-01-02T00:00:00',
+        ),
+    )
+
+
+def test_session_list_for_user_serializes_inet_ip(monkeypatch):
+    from services import session_service
+
+    fake_session = MagicMock()
+    rows = [
+        _row(sid='sess-v4', ip=IPv4Address('203.0.113.5')),
+        _row(sid='sess-v6', ip=IPv6Address('2001:db8::1')),
+        _row(sid='sess-null', ip=None),
+    ]
+
+    monkeypatch.setattr(
+        session_service, 'db_session', lambda: _ctx(fake_session),
+    )
+    monkeypatch.setattr(
+        session_service, 'list_user_sessions', lambda _s, *, user_id: rows,
+    )
+
+    svc = session_service.SessionService(app_config=object())
+    result = svc.list_for_user(user_id='user-1', current_family_id='fam-1')
+
+    assert result[0]['ip'] == '203.0.113.5'
+    assert result[1]['ip'] == '2001:db8::1'
+    assert result[2]['ip'] is None
+
+    # El payload completo debe ser JSON-serializable (lo que fallaba en prod).
+    assert json.dumps(result) is not None


### PR DESCRIPTION
## Problema

Al probar todas las APIs del backend en dev (tras mergear PR #195) se detectaron 3 fallas:

1. **`auth` y `users` devolvian 502 en TODA request.** Timeout de 15s: el cold init a 384 MB tardaba ~13.8s (imports pesados `sqlalchemy + fido2 + pyjwt + argon2 + boto3` via `shared.auth` + resolucion cold de SSM/DynamoDB/Neon). Cada retry reciclaba container frio -> nunca calentaba. `cv` (512 MB / 30s) si funcionaba; `auth`/`users` quedaron en 384 MB / 15s pese a ser mas pesados.
2. **`status.list-sessions` devolvia HTTP 500.** `auth_user_sessions.ip` y `auth_user_admin_actions.ip` son columnas `INET`: psycopg3 las devuelve como `ipaddress.IPv4Address` y el serializer las metia crudas al dict -> `json.dumps` lanzaba `TypeError: Object of type IPv4Address is not JSON serializable`.
3. **El deploy de `users` en CI fallaba** en `secrets-sync`: `ADMIN_EMAILS ausente o vacio en os.environ`. El secreto `admin-emails` (plan 03, consumido por `users`) no estaba mapeado en el bloque `env:` de `deploy-backend.yml`.

## Solucion

1. `auth` y `users`: `memory 384 -> 1024 MB` (cold ~8.6s) y `timeout 15 -> 30s` con margen. Fix de config, sin cambio de comportamiento.
2. `session_service.list_for_user` y `audit_admin_service.list_actions`: normalizan `str(row.ip)` preservando `None`. + 2 tests de regresion con `IPv4Address`/`IPv6Address` reales que verifican el str y que el payload es `json.dumps`-eable.
3. `deploy-backend.yml`: agrega `ADMIN_EMAILS: \${{ secrets.ADMIN_EMAILS }}` a los jobs `migrate-db` y `deploy-lambdas`. GitHub Environment Secret `ADMIN_EMAILS` ya seteado en el env `dev`.

## Como probar

Contra `https://api.portfolio.dev.the-full-stack.com` (las 3 lambdas ya deployadas a dev con estos cambios y verificadas):

- `GET /cv?operation=cv&action=get&niche=fintech` -> 200 (10/10 secciones OK).
- `POST /contact` (Turnstile bypass) -> 202.
- `POST /track` (operation=tracking, action=track) -> 202.
- `POST /auth` register.start -> 200; verify-code -> 200 (access+refresh); login.start inexistente -> 404 `suggest_register:true`; login.start activo -> 200; session.refresh -> 200 rotacion; logout+refresh -> 204 + 401 `TOKEN_REUSE_DETECTED`.
- `POST /users` profile.get/status.get/profile.update -> 200; status.list-sessions -> 200 (IP como str); admin.* no-admin -> 404; sin token -> 401.

Unit: \`serverless tests --type=unit --lambda=users\` -> 83 passed (incluye los 2 guards INET).

## TODO

- Setear el GitHub Environment Secret \`ADMIN_EMAILS\` en \`stage\` y \`prod\` antes de deployar \`users\` a esos envs.
- Optimizacion futura: \`shared/auth/__init__.py\` hace imports eager de fido2/argon2/pyotp aunque el path no los use; hacerlo lazy (PEP 562 \`__getattr__\`) bajaria el cold start sin necesitar 1024 MB (se podria volver a 512 MB).