### PR TITLE
fix(tracking): cold-start de tracking_pixel (256/10) y contact_form (384/15)

### DIFF
--- a/serverless/lambda/services/contact_form/manifest.yaml
+++ b/serverless/lambda/services/contact_form/manifest.yaml
@@ -16,10 +16,11 @@ description: Encoder del form de contacto (valida + Turnstile + encola SQS).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 384       # MB — 256 daba poca CPU al handler (INIT ~200MB).
-                  # 384 sostiene Turnstile siteverify + DDB rate-limit
-                  # + SQS publish con holgura.
-timeout: 15       # segundos — incluye Turnstile siteverify HTTP (1-2s)
+memory: 512       # MB — 384 quedaba justo: el cold init (Turnstile +
+                  # DDB rate-limit + SQS + imports) podia rozar el timeout
+                  # cuando SnapStart no restauraba. 512 MB baja el cold.
+timeout: 30       # segundos — margen sobre el cold init + Turnstile
+                  # siteverify HTTP cuando el SnapStart restore no aplica.
 
 # SnapStart: reduce cold start de 3.4s a ~830ms (Restore Duration).
 # Cuando true, cada deploy hace publish-version + update-alias `live`,

--- a/serverless/lambda/services/tracking_pixel/manifest.yaml
+++ b/serverless/lambda/services/tracking_pixel/manifest.yaml
@@ -16,10 +16,11 @@ description: Encoder de eventos de tracking (valida + rate-limit + encola SQS).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 256       # MB — 128 era insuficiente: INIT ya usa 118MB y queda
-                  # sin RAM libre para el handler. Resultado: handler cuelga
-                  # sin loguear hasta el timeout. Mantenemos 256MB.
-timeout: 10       # segundos — primer call cold paga SSM + boto3 init
+memory: 512       # MB — 256 daba poca CPU: el cold init (boto3 + SSM +
+                  # imports) tardaba ~12s y con timeout 10s devolvia 502
+                  # cuando SnapStart no restauraba. 512 MB baja el cold a ~6s.
+timeout: 30       # segundos — margen sobre el cold init cuando el SnapStart
+                  # restore no aplica (alineado con cv: 512 MB / 30s).
 
 # --- Como se invoca este Lambda ---
 # http: expone un endpoint en la API del backend. devtools conecta la


### PR DESCRIPTION
## Problema

Probando dev tras el PR #196, el smoke de `/track` devolvio **HTTP 502** en un container cold: `tracking_pixel` estaba en **256 MB / timeout 10s** y su cold init (boto3 + SSM + imports) tardaba ~12-14s, asi que cuando SnapStart no restauraba, el handler superaba el timeout. `contact_form` (384 MB / 15s) tenia el mismo riesgo marginal. `cv` (512 MB / 30s) nunca tropezaba.

## Solucion

Ambos HTTP encoders a **512 MB / timeout 30s** (perfil robusto de `cv`):
- cold baja a ~6-9s, con margen amplio aunque el SnapStart restore no aplique;
- warm sigue en <1s.

Mismo patron que el fix de auth/users (PR #196). Solo config, sin cambio de codigo.

## Como probar

Contra `https://api.portfolio.dev.the-full-stack.com` (ya deployado a dev):

- `POST /track` (operation=tracking, action=track, payload completo) -> 202 (cold ~8.7s, warm 0.5s).
- `POST /contact` (Turnstile bypass, payload valido) -> 202 (warm ~0.8s).

Nota operativa: tras un redeploy con SnapStart, el alias `:live` puede devolver 500 unos segundos mientras el snapshot de la nueva version pasa de `InProgress` a `On`; es transitorio y se resuelve solo.

## TODO

- Optimizacion transversal (todas las lambdas auth/users/contact/tracking): el cold start alto viene de imports pesados; evaluar lazy-imports en `shared.auth` y revisar si `shared/` se puede aligerar para volver a memorias menores.