### PR TITLE
fix(db): carga FK-targets cross-domain en cada __init__ de dominio

### DIFF
--- a/.claude/rules/lambda-config.md
+++ b/.claude/rules/lambda-config.md
@@ -70,8 +70,20 @@ pesada (fido2 -> cryptography) cuesta segundos. Reglas:
   son los imports concretos, dejando los imports en el top del modulo.
 - Los modelos SQLAlchemy se importan POR DOMINIO
   (`from shared.db.models.auth import AuthUser`), NUNCA del barrel
-  `shared.db.models` (vacio): auth registra ~12 clases, no las 43 ->
-  menos `configure_mappers()` en el cold.
+  `shared.db.models.registry` (que carga las 43) salvo Alembic/seed:
+  cargar un dominio paga solo su closure (su dominio + sus FK-targets
+  cross-domain, ver abajo), no las 43 clases.
+- **Cross-domain FK targets**: si una tabla de un dominio tiene una
+  `ForeignKey()` a una tabla de OTRO dominio, ese dominio target DEBE
+  cargarse o la FK no resuelve en INSERT/UPDATE (`NoReferencedTableError`
+  -> 500). Cada `__init__.py` de dominio carga sus FK-targets:
+  `auth -> cv` (`auth_users.profile_id -> cv_profiles.id`),
+  `cv -> taxonomy`, `visitor -> taxonomy`. Costo medido: cargar cv en
+  auth = +~24 ms (negligible vs el resume de Neon). Un SELECT no resuelve
+  la FK (por eso `login.start` 404 no fallaba), pero un INSERT si: el bug
+  de PR #199 fue exactamente esto (register/login/users 500, tracking_worker
+  a DLQ). Lo enforza el guard
+  `shared/tests/unit/shared/db/test_domain_load_resolves_cross_domain_fks.py`.
 - Que NO se carga fido2 al importar jwt se cubre con un test en subproceso
   (`shared/tests/unit/shared/auth/test_lazy_no_eager_fido2.py`).
 

--- a/serverless/lambda/shared/db/models/auth/__init__.py
+++ b/serverless/lambda/shared/db/models/auth/__init__.py
@@ -1,5 +1,11 @@
 """Subpaquete `auth/`: schema relacional del dominio auth (11 tablas)."""
 
+# Cross-domain FK target: `auth_users.profile_id -> cv_profiles.id`. La
+# carga per-dominio debe registrar `cv_profiles` en el MetaData o la FK no
+# resuelve en INSERT/UPDATE de `auth_users` (NoReferencedTableError -> 500
+# en register/login/users). Ver `.claude/rules/lambda-config.md`.
+import shared.db.models.cv  # noqa: F401
+
 from .admin_action import AuthUserAdminAction
 from .audit_log import AuthAuditLog
 from .consent_log import AuthUserConsentLog

--- a/serverless/lambda/shared/db/models/cv/__init__.py
+++ b/serverless/lambda/shared/db/models/cv/__init__.py
@@ -8,6 +8,12 @@ Renames respecto al schema previo:
 - `ReferenceNiche` -> `EndorsementNiche`
 """
 
+# Cross-domain FK targets: `cv_*` referencian `tax_niches.id` y
+# `tax_tech_tags.id`. La carga per-dominio debe registrar el dominio
+# taxonomy o esas FK no resuelven (NoReferencedTableError). Ver
+# `.claude/rules/lambda-config.md`.
+import shared.db.models.taxonomy  # noqa: F401
+
 from .cv_entity import (
     Award,
     AwardNiche,

--- a/serverless/lambda/shared/db/models/visitor/__init__.py
+++ b/serverless/lambda/shared/db/models/visitor/__init__.py
@@ -1,5 +1,12 @@
 """Re-exports planos del dominio visitor."""
 
+# Cross-domain FK target: `vis_tracking_events.event_type_id ->
+# tax_event_types.id`. La carga per-dominio debe registrar el dominio
+# taxonomy o la FK no resuelve en INSERT de `vis_tracking_events`
+# (NoReferencedTableError -> el tracking_worker falla y reintenta hasta DLQ).
+# Ver `.claude/rules/lambda-config.md`.
+import shared.db.models.taxonomy  # noqa: F401
+
 from .contact import Contact
 from .session import Session
 from .session_visit import SessionVisit

--- a/serverless/lambda/shared/tests/unit/shared/db/test_domain_load_resolves_cross_domain_fks.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/test_domain_load_resolves_cross_domain_fks.py
@@ -1,0 +1,88 @@
+"""
+Given un dominio de `shared.db.models` importado en AISLAMIENTO (como hace
+     el handler de un lambda: `import shared.db.models.<dominio>`),
+When se resuelven todas las ForeignKey de las tablas registradas,
+Then ninguna lanza `NoReferencedTableError`: el dominio carga sus propios
+     FK-targets cross-domain (auth->cv_profiles, cv/visitor->taxonomy).
+
+Guard de regresion del bug de PR #199 (carga per-dominio): `auth_users.
+profile_id -> cv_profiles.id` es una FK cross-domain. Cargar solo
+`shared.db.models.auth` dejaba `cv_profiles` fuera del MetaData -> la FK no
+resolvia en el INSERT de `auth_users` -> `NoReferencedTableError` ->
+HTTP 500 en register/login/users (y data-loss async en el tracking_worker
+por `vis_tracking_events.event_type_id -> tax_event_types.id`).
+
+El fix encapsula los FK-targets en el `__init__` de cada dominio. Este test
+protege contra que alguien (a) agregue una FK cross-domain nueva sin cargar
+su dominio target, o (b) quite el load encapsulado. Ver
+`.claude/rules/lambda-config.md`.
+
+Se ejecuta en un SUBPROCESO por dominio: el MetaData de SQLAlchemy es global
+por proceso, asi que cargar un dominio in-process contaminaria a los demas
+(todos compartirian el mismo `Base.metadata`) y ocultaria el aislamiento
+real que tiene un lambda en su cold start.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+import shared
+
+pytestmark = pytest.mark.unit
+
+# Dir que contiene el paquete `shared` (.../serverless/lambda). Unico entry
+# del PYTHONPATH del subproceso: poner `.../shared` directo haria que
+# `shared/http` shadowee el `http` de la stdlib.
+_LAMBDA_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(shared.__file__)))
+
+# Los 5 dominios del schema unificado. Cada uno se importa en aislamiento.
+_DOMAINS = ['auth', 'cv', 'visitor', 'taxonomy', 'i18n']
+
+_CHECK = """
+import importlib
+import sys
+
+domain = sys.argv[1]
+importlib.import_module('shared.db.models.' + domain)
+
+from shared.db.base import Base
+
+errors = []
+for table in Base.metadata.tables.values():
+    for fk in table.foreign_keys:
+        try:
+            _ = fk.column  # fuerza la resolucion de la FK contra el MetaData
+        except Exception as exc:  # noqa: BLE001 -- reportamos cualquier fallo
+            errors.append(
+                table.name + '.' + fk.parent.name
+                + ' -> ' + str(fk._colspec)
+                + ' (' + type(exc).__name__ + ')'
+            )
+
+if errors:
+    print('FK_ERRORS: ' + '; '.join(errors))
+    sys.exit(1)
+print('OK')
+"""
+
+
+@pytest.mark.parametrize('domain', _DOMAINS)
+def test_domain_load_resolves_all_foreign_keys(domain: str) -> None:
+    # Arrange: subproceso con SOLO el lambda root en PYTHONPATH para que
+    # `import shared.db.models.<domain>` cargue ese dominio aislado.
+    env = {**os.environ, 'PYTHONPATH': _LAMBDA_ROOT}
+
+    # Act
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, '-c', _CHECK, domain],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    # Assert
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == 'OK'


### PR DESCRIPTION
## Problema

`register/login/users` devolvian **HTTP 500 INTERNAL_ERROR** en dev. La carga
per-dominio de modelos (`import shared.db.models.auth`) dejaba `cv_profiles`
fuera del `MetaData`, y la FK `auth_users.profile_id -> cv_profiles.id` no
resolvia en el INSERT/UPDATE de `auth_users`:

```
NoReferencedTableError: Foreign key associated with column
'auth_users.profile_id' could not find table 'cv_profiles'
```

Un SELECT no resuelve la FK (por eso `login.start` 404 funcionaba y el test
de eficiencia no lo detecto), pero un INSERT si. Mismo bug latente en el
`tracking_worker`: `vis_tracking_events.event_type_id -> tax_event_types.id`
(visitor no cargaba taxonomy) -> el INSERT fallaba y reintentaba hasta la DLQ
(data-loss async silencioso).

3 FKs cross-domain afectadas: `auth -> cv_profiles`, `cv -> tax_*`,
`visitor -> tax_event_types`.

## Solucion

Cada `__init__.py` de dominio carga sus FK-targets cross-domain (encapsulado,
no parche por handler — fue justamente la fragilidad de parchear handler por
handler la que causo el bug):

- `auth/__init__` -> `import shared.db.models.cv`
- `cv/__init__` -> `import shared.db.models.taxonomy`
- `visitor/__init__` -> `import shared.db.models.taxonomy`

Costo medido de cargar cv en auth: **+~24 ms** (negligible vs el resume de
Neon, que domina el cold con segundos). Guard test (subproceso por dominio)
que verifica que importar un dominio aislado resuelve TODAS sus ForeignKey.
Doc del contrato en `lambda-config.md`.

## Como probar

```bash
# Repro del bug (metadata solo-auth): NoReferencedTableError
cd serverless/lambda
PYTHONPATH=. services/auth/.venv/bin/python -c "import shared.db.models.auth; from shared.db.base import Base; [fk.column for t in Base.metadata.tables.values() for fk in t.foreign_keys]"

# Tras el fix: 0 errores en los 5 dominios
python devtools/run.py serverless tests --type=unit --shared    # 485 passed (incl. guard)
python devtools/run.py serverless tests --type=unit --lambda=auth   # 198 passed
python devtools/run.py serverless tests --type=unit --lambda=users  # 83 passed
python devtools/run.py serverless lint-deps                          # OK

# E2E real (tras deploy a dev): register.start -> seed code_hash -> verify-code -> /users
#   register.start debe responder 200 (antes 500); /users profile.get 200 con el access JWT.
```

## TODO

- Validar el cambio de `lambda-config.md` con `claude -p` (5 angulos) — diferido
  porque `claude -p` cambia la cuenta activa de gh durante el flujo del PR.
- Evaluar mover el contrato cross-domain FK a un check de `serverless lint-deps`
  (hoy lo cubre el guard pytest).
- Perf aparte (no en este PR): `/cv?action=get` ~7.8s warm (query del CV
  completo, 58 KB) — candidato a cache / query optimizada.