### PR TITLE
docs(rules): orquestacion (workflow/subagents/agents/worktree)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -8,9 +8,9 @@ description: >
   "review my code", "revisar mi codigo", "is this correct", "esta bien esto",
   "review branch", "revisar rama".
 tools: Read, Write, Grep, Glob, Bash(git:*)
-model: sonnet
+model: opus
 memory: project
-permissionMode: plan
+permissionMode: bypassPermissions
 ---
 
 You are a code review specialist for this portfolio/CV project (Astro 6 + TypeScript). You review changes against project conventions, patterns, and quality standards.

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -6,9 +6,9 @@ description: >
   "evaluar opciones", "alternativas a", "que opciones hay para", or any research-related
   request about technologies, libraries, tools, or solutions.
 tools: Read, Write, Grep, Glob, WebSearch, WebFetch
-model: haiku
+model: opus
 memory: project
-permissionMode: plan
+permissionMode: bypassPermissions
 ---
 
 You are a technology research specialist for this portfolio/CV project. You conduct systematic, comparative research with verifiable sources.

--- a/.claude/rules/orchestration.md
+++ b/.claude/rules/orchestration.md
@@ -1,0 +1,182 @@
+# Orquestacion: workflow / subagents / agents / worktree
+
+> Como Claude Code elige y opera las primitivas de orquestacion en este
+> repo: la herramienta `Workflow` (script JS determinístico en background),
+> los subagentes (Agent/Task tool), los agent types (`.claude/agents/*.md`),
+> los git worktrees (`isolation`) y las tareas en background. Incluye los
+> CAPS de concurrencia para NO pegar el rate-limit "Server is temporarily
+> limiting requests" y la politica de modelos (Opus 4.8 por defecto,
+> Sonnet 4.6 acotado).
+
+## Activacion
+
+Aplica SIEMPRE que se:
+
+- Mencione "workflow", "subagent", "agente", "worktree", "paralelizar",
+  "orquestar", "fan-out", "en paralelo", "olas de agentes".
+- Diseñe o ejecute un fan-out de agentes.
+- Cree un plan (elegir que primitiva usa cada fase — ver
+  [plan-format.md](plan-format.md) secciones 8 y 10).
+- Decida si una tarea va inline, en un subagente, o en un workflow.
+
+## Politica de modelos (OBLIGATORIA)
+
+- **SIEMPRE** el default es **Opus 4.8** (`claude-opus-4-8`; 1M:
+  `claude-opus-4-8[1m]`) para: el loop principal, planificacion, review,
+  sintesis, y cualquier agente que requiera juicio. La suscripcion Max
+  $200/mes alcanza para operar en Opus 4.8 por defecto.
+- **SIEMPRE** los agentes de un workflow/Task **heredan el modelo de la
+  sesion** si se OMITE `model`. Con la sesion en Opus 4.8, heredan Opus —
+  omitir `model` es lo correcto por defecto.
+- **Sonnet 4.6** (`claude-sonnet-4-6`) SOLO para, y porque alivia la
+  presion de rate-limit en fan-outs grandes:
+  - Fan-outs de **alta concurrencia** (varias olas de agentes a la vez).
+  - Trabajo **mecanico/deterministico** sin juicio profundo: busquedas
+    amplias, scaffolding repetitivo, transforms simples.
+  - En script de workflow: `agent(prompt, {model: 'sonnet'})`.
+- **NUNCA** bajar a Sonnet "para ahorrar" cuando la tarea pide juicio
+  (architecture, plan, review final, security, debugging de causa raiz):
+  ahi va Opus 4.8.
+- **NUNCA** Haiku para codigo de produccion del repo (solo clasificacion
+  o validacion triviales).
+
+## Caps de concurrencia (para NO pegar el rate-limit) — CRITICO
+
+El error `API Error: Server is temporarily limiting requests (not your
+usage limit) · Rate limited` es un throttle transitorio per-minuto / de
+capacidad del servidor — **NO tu cuota del plan** (el `(not your usage
+limit)` lo dice literal). Lo dispara una RAFAGA de agentes concurrentes
+con contexto grande: cada agente Opus 1M hereda todo el contexto ->
+pico de input-tokens/min (ITPM) que excede el limite. Evidencia medida
+en este repo: **14 agentes concurrentes -> 429 inmediato**
+(`subagent_tokens=0`, ningun agente llego a correr). NO hay setting en
+`settings.json` para limitar concurrencia: se controla **batcheando en
+el script**.
+
+Reglas duras:
+
+- **SIEMPRE** maximo **1 workflow a la vez**. NUNCA lanzar 2+ workflows
+  concurrentes (comparten el mismo pool de rate-limit).
+- **SIEMPRE** maximo **4 agentes concurrentes** por workflow cuando
+  llevan contexto grande en Opus 4.8. Diseña el fan-out en **olas de
+  <=4** (batching), aunque pases 100 items a `parallel`/`pipeline`.
+- **SIEMPRE** si necesitas mas paralelismo real, baja esos agentes a
+  Sonnet 4.6 y/o reduce el contexto que cargan; aun asi NO superes
+  **~6 concurrentes**.
+- **NUNCA** lanzar la herramienta `Workflow` para diagnosticar o
+  documentar SOBRE workflows: re-provoca el mismo rate-limit y no es
+  orquestacion.
+- **NUNCA** asumir "mas agentes = mas rapido": por encima del cap, la
+  rafaga pega 429 y el run entero falla con 0 tokens utiles.
+
+> Estos numeros son empiricos (Anthropic NO publica un cap de concurrencia
+> oficial para el plan Max). Son el envelope seguro medido en este repo.
+> Si se observa 429 por debajo de 4 concurrentes, bajar a 3.
+
+### Patron de batching (cap de 4 en un workflow)
+
+```javascript
+function chunk(a, n) { const o = []; for (let i = 0; i < a.length; i += n) o.push(a.slice(i, i + n)); return o }
+
+const results = []
+for (const wave of chunk(ITEMS, 4)) {                 // <=4 concurrentes
+  const r = await parallel(wave.map(it => () =>
+    agent(promptFor(it), {schema: SCHEMA, phase: 'Verify'})))
+  results.push(...r.filter(Boolean))
+}
+// El `await` por ola serializa las olas; la duracion de cada ola ya
+// espacia la carga. NO uses sleep/Date.now/Math.random (no existen en
+// scripts de workflow y rompen el resume).
+```
+
+## Regla de oro: NO 1 agente LLM por tarea deterministica
+
+La causa #1 de rate-limit en este repo fue lanzar **1 agente por suite de
+tests**. Correr `pytest` / lint / build / typecheck es **deterministico**:
+NO necesita un LLM. Patron correcto:
+
+- Correr las suites en **Bash** o en **1-2 agentes** que ejecuten varias
+  suites secuencialmente.
+- Reservar los agentes LLM (y el fan-out) para lo que SI necesita juicio:
+  **review adversarial**, sintesis, deteccion de bugs.
+
+Ej: para verificar el refactor no-barrels NO usar 14 agentes (uno por
+lambda). Usar 1 agente que corra `serverless tests --type=unit --lambda=<X>`
+por cada lambda + shared, y un panel de 2-3 agentes para el review.
+
+## Tabla de decision: que primitiva usar
+
+| Primitiva | Que es | Cuando usarla |
+|-----------|--------|---------------|
+| **inline** (sin delegar) | El loop principal hace el trabajo | Tarea de 1-3 pasos, archivo/dato conocido, conversacional |
+| **Subagente** (Agent tool) | 1 agente delegado en-sesion, model-driven, devuelve la conclusion | Buscar/leer a lo ancho de muchos archivos y querer solo la conclusion; trabajo aislado que inundaria el contexto; usar un agent type (Explore, Plan, researcher, code-reviewer) |
+| **Agent type** (`.claude/agents/*.md`) | Plantilla **Markdown + frontmatter** de un rol fijo (tools + prompt) | Reutilizar un rol (researcher, code-reviewer) con tools acotadas. NO es `.yaml` |
+| **Workflow** (script JS) | Orquestacion determinística en background, fan-out a N agentes | >1 fase con loops/condicionales/fan-out; verificacion cruzada (review adversarial); migracion/audit a escala; pipeline por items. SOLO con opt-in explicito del usuario |
+| **Worktree** (`isolation: 'worktree'`) | Checkout git aislado por agente | Agentes que **mutan archivos en paralelo** y colisionarian. NUNCA read-only (cuesta ~200-500ms + disco; se auto-borra si no cambia nada) |
+| **run_in_background** (Bash) | Comando async detached | Builds/tests/deploys largos que no deben bloquear la sesion |
+| **/loop** | Re-ejecuta un prompt/comando en intervalo | Polling de estado externo (CI, deploy); tareas auto-paceadas |
+| **Scheduling / routines** (CronCreate) | Agente remoto en cron | Tareas recurrentes sin sesion activa (audits periodicos) |
+
+## Opt-in del Workflow tool
+
+- **NUNCA** llamar la herramienta `Workflow` salvo opt-in EXPLICITO:
+  el usuario escribio "workflow"/"workflows", ultracode esta activo, o
+  pidio orquestacion multi-agente con sus palabras.
+- Diagnosticar, investigar o **documentar SOBRE** workflows NO es opt-in:
+  responder directo (o con 1 subagente), NUNCA disparar un workflow.
+- Para tareas que se beneficiarian de paralelismo pero sin opt-in:
+  describir brevemente el workflow posible y preguntar, o usar subagentes
+  sueltos (<=4 a la vez).
+
+## Patrones de workflow (resumen)
+
+- `pipeline(items, ...stages)` por **DEFECTO** (sin barrera entre stages;
+  wall-clock = la cadena mas lenta).
+- `parallel(thunks)` SOLO si necesitas TODOS los resultados juntos (dedup
+  global, early-exit, "compara con los otros hallazgos"). Es una barrera.
+- Batching en olas de <=4 para el cap de concurrencia.
+- `agent(prompt, {schema})` para salida estructurada validada (sin parseo).
+- `agent(prompt, {isolation: 'worktree'})` solo si muta archivos en paralelo.
+- Patrones de calidad: **adversarial verify** (N escepticos por hallazgo),
+  **judge panel** (N angulos + jueces + sintesis), **loop-until-dry**
+  (hasta K rondas sin nada nuevo), **multi-modal sweep**, **completeness
+  critic**.
+
+## Integracion con planes (plan-format)
+
+Al crear un plan, elegir la primitiva por fase:
+
+- **Seccion 8** (descomposicion): tareas con archivos **disjuntos** son
+  candidatas a fan-out; las que tocan config transversal NO se paralelizan.
+- **Seccion 10** (worktrees): primero la **base secuencial** (commits
+  transversales), luego olas worktree-safe de **<=4 agentes** con
+  `isolation: 'worktree'`.
+- **Implementacion** de tareas independientes: workflow con un agente por
+  tarea en olas de <=4, o subagentes sueltos <=4.
+- **Seccion 11** (verificacion E2E): NUNCA fan-out de 1 agente por comando;
+  correr la bateria en Bash o 1-2 agentes.
+
+## Anti-patrones
+
+| Anti-patron | Por que | Correccion |
+|-------------|---------|------------|
+| 14 (o >6) agentes concurrentes con contexto Opus grande | Rafaga de ITPM -> 429, run entero con 0 tokens | Olas de <=4 (batching); o Sonnet para el fan-out |
+| 2+ workflows a la vez | Comparten pool de rate-limit -> 429 | 1 workflow a la vez |
+| 1 agente LLM por suite de tests / lint / build | Trabajo deterministico no necesita LLM; infla fan-out y rate-limit | Bash o 1-2 agentes corriendo suites secuenciales |
+| `sleep`/`Date.now()`/`Math.random()` en script de workflow | No existen / rompen el resume (lanzan error) | `await` por ola; pasar timestamps via `args` |
+| `parallel()` cuando alcanzaba `pipeline()` | Barrera innecesaria desperdicia wall-clock | `pipeline()` por defecto |
+| `isolation: 'worktree'` para agentes read-only | ~200-500ms + disco por nada | Solo cuando mutan archivos en paralelo |
+| Disparar `Workflow` para investigar/documentar workflows | Re-provoca el rate-limit; no es orquestacion | Responder directo o 1 subagente |
+| Sonnet 4.6 para architecture/plan/review final | Pierde calidad de juicio | Opus 4.8 |
+| Agent type definido en `.yaml` | El formato real es `.md` + frontmatter | `.claude/agents/<rol>.md` |
+
+## Referencias cruzadas
+
+- Skill: [`/orchestration`](../skills/orchestration/SKILL.md) — guia
+  invocable con ejemplos.
+- [plan-format.md](plan-format.md) — secciones 8 (paralelizacion) y 10
+  (worktrees).
+- [harness-protocol.md](harness-protocol.md) — patron output-en-disco de
+  subagentes, regla del 75% de contexto, feature_list.
+- [verify-before-done.md](verify-before-done.md) — la bateria de
+  verificacion (que NO se fan-outea).

--- a/.claude/rules/plan-format.md
+++ b/.claude/rules/plan-format.md
@@ -256,8 +256,17 @@ Descomposicion del plan en tareas atomicas. En Micro: `N/A — cambio atomico`.
 
 Resumen: cada tarea pasa 3 checks (File Exclusivity, Interface Stability,
 Bounded Scope) y tiene 6 campos (**Archivos**, **AC referenciados**, **Depende
-de**, **Paralelizable con**, **Verify**, **Done**). Limite: 5-7 agentes
-concurrentes. Granularidad: Small 3-5, Medium 5-10, Large 10-20 tareas.
+de**, **Paralelizable con**, **Verify**, **Done**). Granularidad: Small 3-5,
+Medium 5-10, Large 10-20 tareas.
+
+**Eleccion de primitiva + concurrencia**: que tarea va en subagente vs
+workflow vs worktree, el CAP de concurrencia y la politica de modelos los
+define [orchestration.md](orchestration.md). Cap duro: **<=4 agentes
+simultaneos** y **1 workflow a la vez** (no 5-7) para no pegar el rate-limit
+"Server is temporarily limiting requests"; mas tareas se corren en **olas de
+<=4**. Default **Opus 4.8**; **Sonnet 4.6** solo para fan-outs mecanicos de
+alta concurrencia. NO uses 1 agente LLM por tarea deterministica (pytest /
+lint / build -> Bash).
 
 ---
 
@@ -293,6 +302,11 @@ Define: la **base secuencial** (commits que todos los worktrees necesitan o
 que tocan archivos transversales), la tabla de fases worktree-safe (archivos
 disjuntos), lo que NO se paraleliza (config central, grilla de comandos,
 limpieza, la seccion 11), y como lanzar cada worktree.
+
+`isolation: 'worktree'` SOLO cuando los agentes mutan archivos en paralelo y
+colisionarian (NUNCA read-only). La eleccion de primitiva, el CAP de
+concurrencia (**<=4 agentes**, **1 workflow a la vez**) y la politica de
+modelos los gobierna [orchestration.md](orchestration.md).
 
 **Documento detallado**: `.claude/docs/plan-format-large/README.md` capitulo 3
 (regla base, tabla de colisiones, plantilla, anti-patrones).

--- a/.claude/skills/orchestration/SKILL.md
+++ b/.claude/skills/orchestration/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: orchestration
+description: >
+  Orchestration primitives reference for Claude Code in this repo: when and
+  how to use the Workflow tool (deterministic JS multi-agent script), subagents
+  (Agent/Task tool), agent types (.claude/agents/*.md), git worktrees
+  (isolation), background tasks, and /loop. Includes the empirical concurrency
+  CAPS to avoid the "Server is temporarily limiting requests (not your usage
+  limit)" rate-limit (max 4 concurrent agents per workflow, 1 workflow at a
+  time), the model policy (Opus 4.8 default everywhere, Sonnet 4.6 only for
+  high-concurrency mechanical fan-outs), and how to pick a primitive when
+  building a plan. ALWAYS invoke this skill BEFORE running a workflow, designing
+  a fan-out, or deciding inline vs subagent vs workflow vs worktree. NEVER fire
+  the Workflow tool just to investigate or document workflows — it re-triggers
+  the rate-limit.
+  Use when the user says "workflow", "workflows", "dynamic workflow", "subagent",
+  "subagents", "subagente", "agent", "agente", "agentes", "agent type",
+  "worktree", "worktrees", "isolation", "paralelizar", "en paralelo", "fan-out",
+  "fan out", "orquestar", "orquestacion", "orchestrate", "olas de agentes",
+  "concurrencia agentes", "rate limit workflow", "server is temporarily limiting
+  requests", "cuantos agentes", "cuantos workflows", "ultracode", "background
+  task", "run in background", "que modelo uso", "opus o sonnet".
+user-invocable: true
+allowed-tools: Read, Glob, Grep
+argument-hint: "que quiero orquestar o que primitiva evaluar"
+---
+
+# Orquestacion en Claude Code
+
+> Como elegir y operar workflow / subagents / agents / worktree en este
+> repo, sin pegar el rate-limit. La regla dura vive en
+> [.claude/rules/orchestration.md](../../rules/orchestration.md); esta skill
+> es la guia invocable con ejemplos.
+
+## Arbol de decision
+
+```
+¿La tarea es de 1-3 pasos con archivos/datos conocidos?
+  SI -> inline (el loop principal lo hace)
+
+¿Necesito buscar/leer a lo ancho de muchos archivos y solo quiero la conclusion?
+  SI -> Subagente (Agent tool: Explore / Plan / researcher / general-purpose)
+
+¿Es un rol reutilizable (review, research) con tools acotadas?
+  SI -> Agent type (.claude/agents/<rol>.md) via Agent tool
+
+¿Es deterministico (pytest, lint, build, typecheck)?
+  SI -> Bash (o 1-2 agentes corriendo suites). NUNCA 1 agente por suite.
+
+¿>1 fase con loops/condicionales/fan-out, verificacion cruzada, o audit/migracion a escala?
+  Y ¿el usuario hizo opt-in explicito ("workflow", ultracode, pedido directo)?
+    SI -> Workflow (script JS), con olas de <=4 agentes
+
+¿Los agentes mutan archivos en paralelo y colisionarian?
+  SI -> isolation: 'worktree'
+
+¿Comando largo que no debe bloquear (build/deploy)?
+  SI -> run_in_background
+
+¿Polling de estado externo / recurrente?
+  SI -> /loop (sesion) o routines/CronCreate (sin sesion)
+```
+
+## Caps de concurrencia (memoriza esto)
+
+El rate-limit `Server is temporarily limiting requests (not your usage
+limit)` NO es tu cuota: es un throttle per-minuto/capacidad disparado por
+una rafaga de agentes con contexto grande. Medido: **14 concurrentes ->
+429** (`subagent_tokens=0`).
+
+- **1 workflow a la vez.** Nunca 2+ en paralelo.
+- **<=4 agentes concurrentes** por workflow en Opus 4.8 (contexto grande).
+- Mas paralelismo real -> Sonnet 4.6 y/o menos contexto; nunca >6.
+- NO hay setting de concurrencia: se batchea en el script.
+
+## Politica de modelos
+
+- **Opus 4.8** (`claude-opus-4-8`) por DEFECTO en todo lo que pide juicio:
+  loop principal, plan, review, sintesis, debugging. La suscripcion Max
+  $200 alcanza.
+- Omitir `model` en `agent()` -> hereda Opus de la sesion (correcto).
+- **Sonnet 4.6** (`claude-sonnet-4-6`) SOLO en fan-outs de alta
+  concurrencia o trabajo mecanico (busquedas amplias, scaffolding,
+  transforms): `agent(prompt, {model: 'sonnet'})`. Tambien alivia el
+  rate-limit del pool de Opus.
+
+## Anatomia minima de un workflow
+
+```javascript
+export const meta = {
+  name: 'verify-refactor',
+  description: 'Corre suites por lambda + review adversarial',
+  phases: [{ title: 'Tests' }, { title: 'Review' }],
+}
+
+// Tests: NO 1 agente por suite. 1 agente que corre todo via Bash.
+phase('Tests')
+const testReport = await agent(
+  'Corre `python devtools/run.py serverless tests --type=unit` para cada ' +
+  'lambda + shared, secuencialmente. Devuelve un resumen por suite.',
+  { phase: 'Tests' },   // hereda Opus; o {model:'sonnet'} si es puramente mecanico
+)
+
+// Review: panel chico (<=4), adversarial, en una ola
+phase('Review')
+const DIMENSIONS = ['imports concretos', 'inits vacios', 'cross-domain FK']
+const reviews = await parallel(DIMENSIONS.map(d => () =>
+  agent(`Revisa adversarialmente el refactor no-barrels en la dimension: ${d}. ` +
+        `Intenta REFUTAR que esta bien. Reporta hallazgos reales.`,
+        { label: `review:${d}`, phase: 'Review', schema: FINDINGS })))
+
+return { testReport, findings: reviews.filter(Boolean).flatMap(r => r.findings) }
+```
+
+## Patrones de calidad
+
+- **Adversarial verify**: N escepticos por hallazgo; matas si la mayoria refuta.
+- **Judge panel**: N intentos por angulos distintos + jueces + sintesis.
+- **Loop-until-dry**: seguir buscando hasta K rondas sin nada nuevo.
+- **Multi-modal sweep**: cada agente busca por un eje distinto.
+- **Completeness critic**: agente final que pregunta "¿que falta?".
+
+## Reglas que NO se rompen
+
+- `pipeline()` por defecto; `parallel()` solo si necesitas todos juntos.
+- NUNCA `sleep`/`Date.now()`/`Math.random()` en el script (rompen resume).
+- NUNCA disparar `Workflow` para investigar/documentar workflows.
+- NUNCA fan-outear la bateria de verificacion (1 agente por comando).
+- `isolation: 'worktree'` solo si mutan archivos en paralelo.
+
+## Referencias
+
+- Regla dura: [.claude/rules/orchestration.md](../../rules/orchestration.md)
+- Planes: [.claude/rules/plan-format.md](../../rules/plan-format.md) (sec. 8 y 10)
+- Harness: [.claude/rules/harness-protocol.md](../../rules/harness-protocol.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,7 @@ Antes de trabajar, identifica que contexto necesitas:
 | Client env sync | [.claude/rules/client-env-sync.md](.claude/rules/client-env-sync.md) | Detalle del flujo client (rule hija de secrets-strategy): catalogo, rotacion de Turnstile sitekey, comando `sync_secrets --category=client` |
 | Plan format | [.claude/rules/plan-format.md](.claude/rules/plan-format.md) + [.claude/docs/plan-format-large/README.md](.claude/docs/plan-format-large/README.md) | En plan mode o al planificar features. Todo plan vive en `docs/specs/<nombre>/` y trae 4 secciones de ejecucion obligatorias: descomposicion, commits, paralelizacion con worktrees y verificacion E2E iterativa |
 | Harness protocol | [.claude/rules/harness-protocol.md](.claude/rules/harness-protocol.md) | Subagentes, feature_list, current/history |
+| Orquestacion (workflow/subagents/agents/worktree) | [.claude/rules/orchestration.md](.claude/rules/orchestration.md) o skill `orchestration` | Antes de ejecutar un workflow, diseñar un fan-out, o decidir inline vs subagente vs workflow vs worktree (incl. al crear un plan). CAPS de concurrencia para NO pegar el rate-limit "Server is temporarily limiting requests": **1 workflow a la vez**, **<=4 agentes concurrentes** por workflow en Opus 4.8 (14 -> 429 medido), batching en olas. Politica de modelos: **Opus 4.8 por defecto**, Sonnet 4.6 solo para fan-outs mecanicos de alta concurrencia. Regla de oro: NO 1 agente LLM por tarea deterministica (pytest/lint/build -> Bash) |
 | Markdown docs | [.claude/rules/markdown-docs.md](.claude/rules/markdown-docs.md) | Editar archivos de `docs/` |
 | Skills (frontmatter) | [.claude/rules/skills.md](.claude/rules/skills.md) | Crear / modificar skills |
 | Testing config Claude | [.claude/rules/claude-config-testing.md](.claude/rules/claude-config-testing.md) | Antes de commitear cambios en `.claude/*` |
@@ -305,6 +306,7 @@ prompt. Detalles del frontmatter: [.claude/rules/skills.md](.claude/rules/skills
 | `fix-hooks` | Reparar errores de pre-commit / pre-push iterativamente |
 | `github-actions` | Workflows CI + testing local con `act` (nektos/act) |
 | `mermaid` | Crear / modificar diagramas `.mmd` en `docs/diagrams/` |
+| `orchestration` | Como usar workflow / subagents / agents / worktree y cuando; CAPS de concurrencia (1 workflow a la vez, <=4 agentes) para evitar el rate-limit; politica de modelos (Opus 4.8 default, Sonnet 4.6 acotado); eleccion de primitiva al crear un plan |
 | `python-devtools` | Entorno Python del proyecto (`devtools/` + `.git-hooks/`): interprete correcto (`.venv` 3.14 vs `python3` 3.12 del shell), PEP 758, estructura de paquetes, comandos. Invocar ANTES de tocar/verificar cualquier `.py` |
 | `research` | Deep research de tecnologías y librerías (skill con web habilitada) |
 | `rotate-secrets` | Devtools script `rotate_secrets` para rotar/configurar credenciales de servicios externos (hoy: Cloudflare Turnstile) y escribir `docker/env/{server,client}/.{env}`. Subcommand-style: cada servicio exige sus credenciales como flags explicitas. Paso 1 de la rotacion antes de `serverless setup-ssm` |


### PR DESCRIPTION
## Problema

Claude Code no tenia contexto persistente sobre como usar las primitivas de orquestacion (workflow / subagents / agents / worktree) ni un cap de concurrencia. Al lanzar 14 agentes concurrentes en un dynamic workflow se disparaba el rate-limit `Server is temporarily limiting requests (not your usage limit)` (subagent_tokens=0, los agentes ni corrian).

## Solucion

- Nueva regla `.claude/rules/orchestration.md`: cuando usar cada primitiva, caps de concurrencia, politica de modelos, integracion con planes, anti-patrones.
- Nueva skill `.claude/skills/orchestration/SKILL.md` (invocable, dispara con workflow/subagents/worktree/paralelizar/opus o sonnet).
- Cap para evitar el rate-limit: **1 workflow a la vez**, **<=4 agentes concurrentes** por workflow en Opus 4.8, batching en olas.
- Politica de modelos: **Opus 4.8 por defecto**, **Sonnet 4.6** solo para fan-outs mecanicos de alta concurrencia.
- Regla de oro: NO 1 agente LLM por tarea deterministica (pytest/lint/build -> Bash).
- Cross-referencia en `CLAUDE.md` (arbol de conocimiento + skills) y `plan-format.md` (sec 8 y 10). Reconcilia plan-format sec 8: baja 5-7 a <=4 agentes concurrentes.

## Como probar

Validacion con el comando canonico de `claude-config-testing.md` (5/5 angulos PASS):

```bash
claude --permission-mode bypassPermissions --disallowedTools "WebSearch" "WebFetch" \
  --strict-mcp-config --mcp-config '{"mcpServers":{}}' --output-format json \
  -p "cuantos agentes y workflows maximo puedo correr para no pegar el rate-limit?"
```

Resultado: 4 prompts positivos turns=3 (regla/skill activadas, respuesta correcta), 1 negativo (formatear fecha TS) turns=1 (no sobre-activa).

## TODO

Ninguno.