### PR TITLE
fix(tracking_pixel): elimina timeout de cold start (502/504) en EXECUTE

### DIFF
--- a/.claude/rules/lambda-config.md
+++ b/.claude/rules/lambda-config.md
@@ -107,6 +107,29 @@ warm_db()  # engine (NullPool, sin conexion) + configure_mappers (best-effort)
 DATABASE_URL en un test). NullPool no abre conexion en el INIT (las
 conexiones no sobreviven al snapshot).
 
+Los lambdas que NO usan Neon pero SI DynamoDB/SQS (ej. `tracking_pixel`
+async) tienen el mismo problema con **boto3**: el cliente low-level
+(`get_resource().meta.client`) y CADA modelo de operacion (`get_item`,
+`query`, `update_item`, `send_message`) se construyen LAZY en la PRIMERA
+llamada. A 128 MB (~0.07 vCPU) eso cae en EXECUTE y tarda segundos ->
+puede agotar el timeout (sintoma: el log llega a "Starting execute phase"
+y se cuelga 30s -> 502/504, con `Max Memory` al borde de 128). El fix
+(NUNCA subir memoria) es warmear en INIT:
+
+```python
+from shared.aws.warmup import warm_aws_clients
+
+warm_aws_clients(dynamodb=True, sqs=True)  # materializa .meta.client
+# + ejercitar el read-path idempotente (NO writes) para construir los
+#   modelos get_item/query en el snapshot:
+get_ip_rule('0.0.0.0'); get_endpoint_rule('/track')
+get_effective_count(ip='0.0.0.0', endpoint='/track', window_seconds=60)
+```
+
+`warm_aws_clients` es best-effort igual que `warm_db`. Construir el
+cliente NO basta: hay que ejercitar las OPERACIONES reales que el EXECUTE
+usara, porque boto3 las modela por-operacion bajo demanda.
+
 ## Minimos medidos actuales (dev, 2026-05, cold `$LATEST` sin restore)
 
 Medidos tras el refactor shared-no-barrels: lazy imports + X-Ray eliminado
@@ -118,7 +141,7 @@ Medidos tras el refactor shared-no-barrels: lazy imports + X-Ray eliminado
 | `users` | 256 | 30 | misma familia que auth; argon2id (password) es memory-hard |
 | `cv` | 256 | 30 | read-only Neon usa 118-165 MB; a 128 quedan 10 MB headroom. Handler ~9s es Neon-I/O-bound (no escala con memoria) |
 | `contact_form` | 256 | 30 | footprint Neon 117/128 MB a 128 (11 MB headroom); 157 MB a 256 |
-| `tracking_pixel` | 128 | 30 | UNICO a 128: async (sin Neon -> sin sqlalchemy) usa 63/128 MB (65 MB headroom), Init 680ms |
+| `tracking_pixel` | 128 | 30 | UNICO a 128: async (sin Neon -> sin sqlalchemy). Imports de Neon/ua_parser diferidos al path sync legacy (lazy) + warmup de los clientes boto3 y del read-path del rate-limit en INIT (`shared.aws.warmup.warm_aws_clients` + `get_ip/endpoint_rule`). Restore (SnapStart) ~1.16s, warm ~380ms, 111/128 MB (17 MB headroom). SIN warmup, boto3 construia los modelos de operacion (get_item/query) en EXECUTE a 0.07 vCPU -> >30s -> timeout 502/504 |
 
 **El footprint base de un lambda Neon (sqlalchemy + pydantic + modelos +
 clientes) es ~117-127 MB** -> 128 MB NO deja headroom seguro: el minimo

--- a/serverless/lambda/services/tracking_pixel/core/handler.py
+++ b/serverless/lambda/services/tracking_pixel/core/handler.py
@@ -37,15 +37,59 @@ from typing import Any
 
 from settings.config import AppConfig
 from settings.operations import OPERATIONS
+from shared.aws.warmup import warm_aws_clients
 from shared.lambda_kit.event_model import build_event_model
 from shared.lambda_kit.http_dispatch import http_handler
 from shared.observability.logger import logger
 from shared.observability.metrics import metrics
 
-__version__ = '3.0.0'
+__version__ = '3.2.0'
+
+# Endpoint que el rate-limit usa (mismo literal que el controller track).
+_TRACK_ENDPOINT = '/track'
 
 # Clase EventModel ligada al OPERATIONS del Lambda (la construye el kit).
 _EVENT_MODEL = build_event_model(OPERATIONS)
+
+
+def _warm_init() -> None:
+    """Precalienta el hot path de EXECUTE en la fase INIT (SnapStart).
+
+    Por que: a 128 MB el EXECUTE recibe ~0.07 vCPU. boto3 construye el
+    service model + cada modelo de OPERACION (get_item, query, ...) de
+    forma LAZY en la PRIMERA llamada. Si eso cae en EXECUTE, el cold
+    tardaba >30s -> timeout 502/504. El INIT tiene CPU sin throttle y
+    queda en el SNAPSHOT de SnapStart: warmeando aqui, el EXECUTE solo
+    reusa estructuras ya construidas.
+
+    Dos pasos, ambos best-effort (un fallo NUNCA rompe el INIT — ej. sin
+    red en un test):
+      1. Construye los clientes boto3 (DynamoDB + SQS).
+      2. Ejercita el camino de LECTURA del rate-limit con una IP
+         sintetica. Son lecturas IDEMPOTENTES (get_ip_rule /
+         get_endpoint_rule / get_effective_count): NO incrementan el
+         bucket ni escriben nada, pero materializan los modelos de
+         operacion get_item/query (+ el get_item de la tabla cache que
+         envuelve `@cached`). El INCREMENT real (write) lo hace el
+         EXECUTE; su modelo update_item es barato comparado con las
+         lecturas. Ver .claude/rules/lambda-config.md.
+    """
+    warm_aws_clients(dynamodb=True, sqs=True)
+    try:
+        from shared.rate_limit.buckets import get_effective_count
+        from shared.rate_limit.rules import get_endpoint_rule, get_ip_rule
+
+        _synthetic_ip = '0.0.0.0'
+        get_ip_rule(_synthetic_ip)
+        get_endpoint_rule(_TRACK_ENDPOINT)
+        get_effective_count(
+            ip=_synthetic_ip, endpoint=_TRACK_ENDPOINT, window_seconds=60,
+        )
+    except Exception as exc:  # noqa: BLE001 -- best-effort, no rompe INIT
+        logger.debug('warm rate-limit reads omitido: %s', type(exc).__name__)
+
+
+_warm_init()
 
 
 @logger.inject_lambda_context(

--- a/serverless/lambda/services/tracking_pixel/core/services/tracking_service.py
+++ b/serverless/lambda/services/tracking_pixel/core/services/tracking_service.py
@@ -28,10 +28,49 @@ from typing import Any
 from settings.config import logger
 from shared.cache.decorator import cached
 from shared.core.ulid import new_uuidv7
-from shared.db.repository import ensure_session_and_visit, insert_tracking
-from shared.db.session import db_session
 from shared.queue.publisher import send_to_queue
-from ua_parser import user_agent_parser
+
+# --- Deps pesadas del path sync (lazy) -----------------------------------
+# El cold path async (ASYNC_MODE=true, default) NO toca Neon ni parsea UA:
+# solo encola a SQS. Importar shared.db (sqlalchemy + psycopg) y ua_parser
+# al top inflaba el footprint del encoder de ~63 MB a ~122 MB -> OOM-thrash
+# a 128 MB -> timeout de 30s en EXECUTE (502/504). Se difieren a la primera
+# invocacion del path sync legacy (lambda-config.md: cortar imports, NUNCA
+# subir memoria). Quedan como globals para preservar los monkeypatch de los
+# tests (services.tracking_service.{db_session,ensure_session_and_visit,
+# insert_tracking}).
+db_session: Any = None
+ensure_session_and_visit: Any = None
+insert_tracking: Any = None
+user_agent_parser: Any = None
+
+
+def _ensure_db_deps() -> None:
+    """Importa shared.db.* la primera vez que corre el path sync (lazy)."""
+    global db_session, ensure_session_and_visit, insert_tracking
+    if db_session is None:
+        from shared.db.session import db_session as _db_session
+
+        db_session = _db_session
+    if ensure_session_and_visit is None:
+        from shared.db.repository import ensure_session_and_visit as _ensure
+
+        ensure_session_and_visit = _ensure
+    if insert_tracking is None:
+        from shared.db.repository import insert_tracking as _insert
+
+        insert_tracking = _insert
+
+
+def _parse_ua(user_agent: str) -> dict[str, Any]:
+    """Parsea el UA con ua_parser (lazy import en el primer uso del sync)."""
+    global user_agent_parser
+    if user_agent_parser is None:
+        from ua_parser import user_agent_parser as _ua
+
+        user_agent_parser = _ua
+    return user_agent_parser.Parse(user_agent)
+
 
 # --- Enrichment ---
 
@@ -93,7 +132,7 @@ def parse_user_agent(user_agent: str | None) -> dict[str, str]:
             'device_type': 'unknown',
         }
 
-    parsed = user_agent_parser.Parse(user_agent)
+    parsed = _parse_ua(user_agent)
     ua_block = parsed.get('user_agent') or {}
     os_block = parsed.get('os') or {}
 
@@ -143,6 +182,8 @@ def save_tracking_event(payload: dict[str, Any]) -> dict[str, Any]:
     page_id = new_uuidv7()
     created_at = datetime.now(UTC)
 
+    # Path sync legacy: importa shared.db (sqlalchemy + psycopg) on-demand.
+    _ensure_db_deps()
     with db_session() as session:
         # Paso 1: UPSERT session + visit (en la misma tx). El helper
         # incrementa event_count del visit en 1.

--- a/serverless/lambda/shared/aws/warmup.py
+++ b/serverless/lambda/shared/aws/warmup.py
@@ -1,0 +1,56 @@
+"""@module shared.aws.warmup — precalentamiento de clientes boto3 en INIT.
+
+`warm_aws_clients()` fuerza la creacion de los clientes boto3 (DynamoDB
+resource, SQS client) en el module-scope del handler (fase INIT). En
+Lambda, el INIT tiene CPU SIN throttle (y queda en el SNAPSHOT de
+SnapStart), mientras que el EXECUTE a baja memoria recibe CPU
+proporcional (~0.07 vCPU a 128 MB). boto3 construye el service model +
+resuelve credenciales/endpoint en la PRIMERA creacion de cada cliente:
+ese trabajo CPU caro, si cae en EXECUTE a 128 MB, tarda segundos y puede
+agotar el timeout. Warmeandolo en INIT, el EXECUTE solo reusa el
+singleton ya construido.
+
+Es BEST-EFFORT: cualquier fallo (sin red, sin credenciales en un test) se
+omite silenciosamente — NUNCA rompe el INIT. Mismo contrato que
+`shared.db.warmup.warm_db`. Ver `.claude/rules/lambda-config.md`.
+"""
+
+from __future__ import annotations
+
+from shared.observability.logger import logger
+
+
+def warm_aws_clients(*, dynamodb: bool = False, sqs: bool = False) -> None:
+    """Crea los clientes boto3 pedidos en INIT (best-effort, idempotente).
+
+    Parameters
+    ----------
+    dynamodb : bool
+        Warmea el resource boto3 DynamoDB (`shared.aws.dynamodb.get_resource`).
+        Lo usan rate-limit (rules + buckets) y el cache.
+    sqs : bool
+        Warmea el cliente boto3 SQS (`shared.queue.client.get_sqs_client`).
+        Lo usa el publisher (`send_to_queue`).
+
+    Cada cliente se cachea a module-scope en su modulo, asi que esta
+    llamada solo paga la construccion una vez (las siguientes son no-op).
+    """
+    if dynamodb:
+        try:
+            from shared.aws.dynamodb import get_resource
+
+            # `.meta.client` materializa el cliente low-level boto3 (el que
+            # usa el ORM shared.dynamodb.BaseModel para get_item/query/
+            # update_item). Construye el service model + resuelve
+            # credenciales/endpoint en INIT (CPU sin throttle + snapshot),
+            # no en el EXECUTE a 0.07 vCPU.
+            _ = get_resource().meta.client
+        except Exception as exc:  # noqa: BLE001 -- best-effort
+            logger.debug('warm dynamodb omitido: %s', type(exc).__name__)
+    if sqs:
+        try:
+            from shared.queue.client import get_sqs_client
+
+            get_sqs_client()
+        except Exception as exc:  # noqa: BLE001 -- best-effort
+            logger.debug('warm sqs omitido: %s', type(exc).__name__)

--- a/serverless/lambda/shared/tests/unit/shared/aws/test_warm_aws_clients.py
+++ b/serverless/lambda/shared/tests/unit/shared/aws/test_warm_aws_clients.py
@@ -1,0 +1,122 @@
+"""Unit tests para shared.aws.warm_aws_clients.
+
+Warmup de clientes boto3 en la fase INIT del Lambda: fuerza la
+construccion del resource DynamoDB y/o el cliente SQS antes del EXECUTE
+para que el cold a baja memoria (128 MB ~ 0.07 vCPU) no pague el costo
+CPU de boto3 dentro del handler. Best-effort: nunca propaga excepciones.
+"""
+
+from __future__ import annotations
+
+import pytest
+from shared.aws.warmup import warm_aws_clients
+
+pytestmark = pytest.mark.unit
+
+
+def test_when_dynamodb_true_then_calls_get_resource(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Given warm_aws_clients(dynamodb=True),
+    When se invoca,
+    Then llama get_resource del modulo shared.aws.dynamodb una vez.
+    """
+    calls = {'dynamodb': 0, 'sqs': 0, 'meta_client': 0}
+
+    class _FakeMeta:
+        @property
+        def client(self) -> object:
+            calls['meta_client'] += 1
+            return object()
+
+    class _FakeResource:
+        meta = _FakeMeta()
+
+    def _fake_get_resource() -> object:
+        calls['dynamodb'] += 1
+        return _FakeResource()
+
+    def _fake_get_sqs_client() -> object:
+        calls['sqs'] += 1
+        return object()
+
+    monkeypatch.setattr(
+        'shared.aws.dynamodb.get_resource', _fake_get_resource
+    )
+    monkeypatch.setattr(
+        'shared.queue.client.get_sqs_client', _fake_get_sqs_client
+    )
+
+    warm_aws_clients(dynamodb=True, sqs=False)
+
+    # Warmea el resource Y materializa su .meta.client (el cliente
+    # low-level que usa el ORM en EXECUTE).
+    assert calls == {'dynamodb': 1, 'sqs': 0, 'meta_client': 1}
+
+
+def test_when_sqs_true_then_calls_get_sqs_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Given warm_aws_clients(sqs=True),
+    When se invoca,
+    Then llama get_sqs_client del modulo shared.queue.client una vez.
+    """
+    calls = {'dynamodb': 0, 'sqs': 0}
+
+    monkeypatch.setattr(
+        'shared.aws.dynamodb.get_resource',
+        lambda: calls.__setitem__('dynamodb', calls['dynamodb'] + 1),
+    )
+    monkeypatch.setattr(
+        'shared.queue.client.get_sqs_client',
+        lambda: calls.__setitem__('sqs', calls['sqs'] + 1),
+    )
+
+    warm_aws_clients(dynamodb=False, sqs=True)
+
+    assert calls == {'dynamodb': 0, 'sqs': 1}
+
+
+def test_when_both_false_then_no_client_is_built(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Given warm_aws_clients() sin flags,
+    When se invoca,
+    Then no construye ningun cliente (no-op).
+    """
+    calls = {'dynamodb': 0, 'sqs': 0}
+
+    monkeypatch.setattr(
+        'shared.aws.dynamodb.get_resource',
+        lambda: calls.__setitem__('dynamodb', calls['dynamodb'] + 1),
+    )
+    monkeypatch.setattr(
+        'shared.queue.client.get_sqs_client',
+        lambda: calls.__setitem__('sqs', calls['sqs'] + 1),
+    )
+
+    warm_aws_clients()
+
+    assert calls == {'dynamodb': 0, 'sqs': 0}
+
+
+def test_when_get_resource_raises_then_warmup_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Given get_resource lanza una excepcion (sin red / sin credenciales),
+    When warm_aws_clients(dynamodb=True),
+    Then NO propaga: el INIT nunca se rompe por el warmup (best-effort).
+    """
+    def _boom() -> object:
+        raise RuntimeError('no network')
+
+    monkeypatch.setattr('shared.aws.dynamodb.get_resource', _boom)
+
+    # No raise -> el test pasa si warm_aws_clients no propaga.
+    result = warm_aws_clients(dynamodb=True)
+
+    assert result is None


### PR DESCRIPTION
## Problema

El Lambda `tracking_pixel` (`POST /track`) hacia **timeout a los 30s -> HTTP 502/504** en dev. CloudWatch mostraba que el log llegaba a `Starting execute phase` y se colgaba. Dos defectos combinados (ambos los que advierte `.claude/rules/lambda-config.md`):

1. **Imports eager innecesarios**: `tracking_service.py` importaba `shared.db.*` (sqlalchemy+psycopg) y `ua_parser` al top del modulo. Esas deps solo las usa el path sync legacy, NUNCA el encoder async desplegado (`ASYNC_MODE=true`). Inflaba el footprint de ~63 MB a 122 MB -> OOM-thrash a 128 MB.
2. **boto3 construia los modelos de operacion en EXECUTE**: `get_item`/`query`/`update_item`/`send_message` se construyen lazy en la primera llamada. A 128 MB (~0.07 vCPU) eso caia en EXECUTE y tardaba >30s -> timeout. Ningun lambda warmeaba boto3 en INIT.

## Solucion

Cortar el costo del cold sin subir memoria (sigue **128 MB / 30s**), imitando el patron `warm_db()` de `contact_form`:

1. `tracking_service.py`: imports de `shared.db.*` + `ua_parser` diferidos (lazy) al primer uso del path sync. El async encoder ya no los paga.
2. `shared/aws/warmup.py` (nuevo): `warm_aws_clients()` materializa el cliente boto3 DynamoDB (`.meta.client`) + SQS en INIT. Best-effort.
3. `handler.py`: `_warm_init()` en INIT (CPU sin throttle + snapshot SnapStart) warmea clientes Y ejercita el read-path idempotente del rate-limit (`get_ip_rule`/`get_endpoint_rule`/`get_effective_count`, sin writes) para construir los modelos de operacion en el snapshot.
4. 4 tests unit de `warm_aws_clients` (89% coverage).
5. `lambda-config.md`: actualiza la fila de `tracking_pixel` + documenta el patron de warmup boto3.

## Como probar

```bash
# Unit + lint
python devtools/run.py serverless tests --type=unit --lambda=tracking_pixel   # 28 passed
python devtools/run.py serverless tests --type=unit --shared                  # 510 passed
python devtools/run.py serverless lint-deps                                    # verde

# E2E real contra dev (curl /track, body completo)
curl -sS -o /dev/null -w "%{http_code} %{time_total}s\n" -X POST \
  https://api.portfolio.dev.the-full-stack.com/track \
  -H "Origin: https://the-full-stack.com" -H "CF-Connecting-IP: 192.0.2.101" \
  -H "CF-IPCountry: CL" -H "Content-Type: application/json" \
  -d '{"operation":"tracking","action":"track","session_id":"sess-e2e-0000000000000000","event_id":"a1b2c3d4e5f60718293a4b5c6d7e8f90","event_type_id":"019e372b-e0a7-7154-8279-8829bcf6a08c","page_url":"https://the-full-stack.com/p","page_title":"P","page_path":"/p","utm_source":"e2e","utm_medium":"api","utm_campaign":"verify","utm_content":"run","viewport_width":1920,"viewport_height":1080,"niche":"fintech"}'
```

Resultado medido (dev, alias `live` con SnapStart):

| Metrica | Antes | Despues |
|---|---|---|
| Restore (cold) | 30s -> timeout 502/504 | 1.16s -> 202 |
| Warm | timeout | 362-416ms |
| Max Memory | 122-128 MB (OOM) | 111 MB |
| curl /track x5 | 502/504 @29s | 5/5 HTTP 202, prom 1.15s |

## TODO

- Considerar replicar `warm_aws_clients` en otros lambdas si se bajan a 128 MB en el futuro (hoy solo `tracking_pixel` esta a 128).