### PR TITLE
test(api_e2e): script devtools de tests E2E reales contra el backend desplegado

### DIFF
--- a/devtools/api_e2e/README.md
+++ b/devtools/api_e2e/README.md
@@ -1,0 +1,93 @@
+# api_e2e — tests E2E reales contra el backend desplegado
+
+> Corre los flujos completos (exito + un par de errores) de cada Lambda
+> HTTP del portfolio contra un entorno de DEPLOY real (dev | stage,
+> NUNCA prod) via HTTP, midiendo el tiempo de respuesta de cada endpoint.
+
+## Que prueba
+
+Los 5 Lambdas HTTP (`trigger.type=http`):
+
+| Lambda | Exito | Errores |
+|--------|-------|---------|
+| `cv` | las 10 actions read (GET, 2xx) | action invalida, sin operation |
+| `contact_form` | `contact.create` 202 (via bypass Turnstile) | sin message, email invalido |
+| `tracking_pixel` | `tracking.track` 202 | sin event_type_id, viewport invalido |
+| `auth` | register.start -> verify-code -> refresh -> login.start -> logout | set-password ya seteada (400), email inexistente (404), tokens falsos (4xx/401) |
+| `users` | profile.get/update, status.get/list-sessions | admin no-admin (404), sin JWT (401), JWT falso (401) |
+
+Los 3 workers (`*_worker`, SQS) y `db` (direct) NO son invocables por
+HTTP — quedan fuera (los cubren sus unit tests).
+
+## Por que NO es parte de `test_runner`
+
+`test_runner` corre en CI/pre-push con entornos Docker (local/dev/test).
+`api_e2e` es distinto: **muta el entorno desplegado** (crea users,
+contacts, tracking events), **lee secretos de SSM** y **siembra hashes en
+Neon**. Por eso es un comando dedicado, opt-in, fuera de la bateria de CI.
+
+## Uso
+
+```bash
+# Todos los Lambdas contra dev (requiere SSO activo del perfil)
+AWS_PROFILE=tfs-dev python devtools/run.py api_e2e --env=dev --aws-profile=tfs-dev
+
+# Un solo Lambda
+python devtools/run.py api_e2e --env=dev --lambda=auth --aws-profile=tfs-dev
+
+# Mas muestras por endpoint read-safe (default 5)
+python devtools/run.py api_e2e --env=dev --samples=10 --aws-profile=tfs-dev
+
+# Conservar los datos sinteticos creados (no limpiar Neon)
+python devtools/run.py api_e2e --env=dev --keep-data --aws-profile=tfs-dev
+```
+
+## Flags
+
+| Flag | Default | Descripcion |
+|------|---------|-------------|
+| `--env` | `dev` | Entorno de deploy: `dev` o `stage` (NUNCA prod) |
+| `--lambda` | (todos) | `cv` / `contact_form` / `tracking_pixel` / `auth` / `users` |
+| `--samples` | `5` | Muestras por endpoint read-safe (los pasos mutantes usan menos) |
+| `--aws-profile` | (shell) | Perfil AWS CLI para SSM/Neon (ej. `tfs-dev`) |
+| `--keep-data` | `false` | No limpiar los datos sinteticos creados |
+
+## Como funciona (detalles)
+
+- **Tiempos**: cada caso se invoca N veces; el reporte separa `cold`
+  (1ra muestra) de `warm` (promedio 2..N) y da un promedio global.
+- **Datos sinteticos + cleanup**: emails `success+api-e2e-<run>-<slot>@
+  simulator.amazonses.com` (SES mailbox simulator: globalmente
+  entregable, sin entrega real). Al final borra users/contacts/tracking
+  creados en Neon (salvo `--keep-data`).
+- **IP rotada**: 1 IP de TEST-NET (RFC 5737) por request para no agotar
+  el rate-limit ni auto-blacklistear una IP real.
+- **Seed de Neon (auth)**: el code de verify NO vuelve en la respuesta
+  (solo el hash SHA-256 va a Neon). El harness genera un plaintext
+  conocido, UPDATEa el `code_hash` de la fila vigente y envia el
+  plaintext. Connection string resuelta de SSM en proceso (hermetico).
+- **Turnstile bypass**: solo `dev` evalua `X-Turnstile-Bypass-Secret`
+  (de SSM). En `stage` el bypass es inerte -> los flujos de exito con
+  Turnstile (contact/auth) se omiten; los casos de error siguen.
+
+## Hermetico (secretos)
+
+Ningun valor de secreto (bypass, Neon URL) se imprime jamas en
+stdout/stderr. Se resuelven via boto3 en proceso y se pasan directo a
+httpx/psycopg. Cumple `.claude/rules/env-files.md`.
+
+## Estructura
+
+```text
+api_e2e/
+├── main.py          # orquesta los flujos + cleanup + reporte
+├── flags.py         # validacion de flags + describe()
+├── config.py        # URLs/origins por env + IpRotator + emails sinteticos
+├── support.py       # HttpClient (httpx + timing) + Response
+├── runner.py        # Runner: corre N samples, clasifica PASS/FAIL
+├── reporter.py      # CaseResult + tabla de tiempos + veredicto
+├── environment.py   # SSM secrets + seed/cleanup en Neon (boto3 + psycopg)
+├── flow_readonly.py # cv + contact_form + tracking_pixel
+├── flow_auth.py     # flujo auth completo + errores
+└── flow_users.py    # profile + status + admin
+```

--- a/devtools/api_e2e/__init__.py
+++ b/devtools/api_e2e/__init__.py
@@ -1,0 +1,12 @@
+"""api_e2e — tests E2E reales contra el backend serverless desplegado.
+
+Corre los flujos completos (exito + errores) de cada Lambda HTTP del
+portfolio (cv, contact_form, tracking_pixel, auth, users) contra un
+entorno de DEPLOY real (dev | stage, NUNCA prod) via HTTP (httpx),
+midiendo el tiempo de respuesta de cada endpoint.
+
+NO es parte de `test_runner` (cuyo `--type=all` corre en CI/pre-push y
+cuyos `--env` son entornos Docker local/dev/test): estos tests MUTAN el
+entorno desplegado, leen secretos de SSM y siembran hashes en Neon, asi
+que son un comando devtools dedicado, opt-in, fuera de la bateria de CI.
+"""

--- a/devtools/api_e2e/config.py
+++ b/devtools/api_e2e/config.py
@@ -1,0 +1,130 @@
+"""Configuracion del harness api_e2e: URLs, origins, pool de IPs.
+
+Una sola fuente para los endpoints por entorno de deploy y los helpers de
+datos sinteticos (emails del SES simulator, IPs de documentacion).
+"""
+
+from __future__ import annotations
+
+import secrets as _secrets
+
+
+# Entornos de DEPLOY soportados (NUNCA prod: el harness muta el entorno).
+VALID_ENVS = ('dev', 'stage')
+
+# Region de los recursos AWS (SSM, Lambda) del backend.
+AWS_REGION = 'us-east-1'
+
+_API_BASE = {
+    'dev': 'https://api.portfolio.dev.the-full-stack.com',
+    'stage': 'https://api.portfolio.stage.the-full-stack.com',
+}
+
+_ADMIN_ORIGIN = {
+    'dev': 'https://admin.portfolio.dev.the-full-stack.com',
+    'stage': 'https://admin.portfolio.stage.the-full-stack.com',
+}
+_CV_ORIGIN = {
+    'dev': 'https://fintech.portfolio.dev.the-full-stack.com',
+    'stage': 'https://fintech.portfolio.stage.the-full-stack.com',
+}
+_APEX_ORIGIN = {
+    'dev': 'https://the-full-stack.com',
+    'stage': 'https://the-full-stack.com',
+}
+
+_BYPASS_SSM = {
+    'dev': '/portfolio/dev/turnstile-bypass-secret',
+    'stage': '/portfolio/stage/turnstile-bypass-secret',
+}
+
+_NEON_SSM = {
+    'dev': '/portfolio/dev/neon-url',
+    'stage': '/portfolio/stage/neon-url',
+}
+
+# UUID de un event_type valido (catalogo taxonomy) para tracking.
+TRACKING_EVENT_TYPE_ID = '019e372b-e0a7-7154-8279-8829bcf6a08c'
+
+# Niche valido para cv/tracking.
+NICHE = 'fintech'
+
+
+def api_base(env: str) -> str:
+    """Base URL del API Gateway para el entorno de deploy."""
+    return _API_BASE[env]
+
+
+def admin_origin(env: str) -> str:
+    """Origin del dashboard (auth/users) para el entorno."""
+    return _ADMIN_ORIGIN[env]
+
+
+def cv_origin(env: str) -> str:
+    """Origin de un niche (cv) para el entorno."""
+    return _CV_ORIGIN[env]
+
+
+def apex_origin(env: str) -> str:
+    """Origin del apex (contact/tracking) para el entorno."""
+    return _APEX_ORIGIN[env]
+
+
+def bypass_ssm_path(env: str) -> str:
+    """SSM path del bypass secret de Turnstile."""
+    return _BYPASS_SSM[env]
+
+
+def neon_ssm_path(env: str) -> str:
+    """SSM path de la connection string de Neon."""
+    return _NEON_SSM[env]
+
+
+def turnstile_bypass_supported(env: str) -> bool:
+    """True si el entorno evalua el header X-Turnstile-Bypass-Secret.
+
+    Solo `dev` (y `local`) lo evaluan; en `stage` el bypass es inerte
+    (shared.http.turnstile._BYPASS_ALLOWED_STAGES), asi que los flujos
+    que dependen del bypass se omiten en stage.
+    """
+    return env == 'dev'
+
+
+# Pool de IPs de documentacion (TEST-NET RFC 5737): 1 IP unica por request
+# para no agotar el rate-limit ni auto-blacklistear una IP real.
+_IP_POOL: list[str] = [
+    f'{net}.{host}'
+    for net in ('198.51.100', '203.0.113', '192.0.2')
+    for host in range(1, 255)
+]
+
+
+class IpRotator:
+    """Entrega una IP distinta por llamada (round-robin sobre TEST-NET)."""
+
+    def __init__(self) -> None:
+        self._idx = 0
+
+    def next(self) -> str:
+        """Siguiente IP del pool (cicla)."""
+        ip = _IP_POOL[self._idx % len(_IP_POOL)]
+        self._idx += 1
+        return ip
+
+
+# Marca para identificar (y limpiar) todo lo creado por el harness.
+RUN_TAG = 'api-e2e'
+
+
+def synthetic_email(run_id: str, slot: str) -> str:
+    """Email sintetico unico via el SES mailbox simulator.
+
+    `success+<tag>@simulator.amazonses.com`: globalmente entregable (pasa
+    el EmailStr de pydantic) y el worker "envia" sin entrega real. El tag
+    embebe el RUN_TAG + run_id + slot para unicidad y trazabilidad.
+    """
+    suffix = _secrets.token_hex(3)
+    return (
+        f'success+{RUN_TAG}-{run_id}-{slot}-{suffix}'
+        '@simulator.amazonses.com'
+    )

--- a/devtools/api_e2e/environment.py
+++ b/devtools/api_e2e/environment.py
@@ -1,0 +1,172 @@
+"""Acceso al entorno desplegado: secretos SSM + seed/cleanup en Neon.
+
+HERMETICO: ningun valor de secreto (bypass, connection string de Neon) se
+imprime jamas en stdout/stderr. Se resuelven en proceso via boto3 y se
+pasan a httpx/psycopg directo. Cumple `.claude/rules/env-files.md`.
+
+El seed de Neon es necesario para el paso verify-code del flujo auth: el
+backend NO devuelve el code en claro (solo el hash SHA-256 va a Neon).
+Tecnica: generamos un plaintext conocido, calculamos su SHA-256 y
+UPDATEamos el `code_hash` de la fila vigente, luego enviamos el plaintext.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import boto3
+from config import AWS_REGION
+from config import bypass_ssm_path
+from config import neon_ssm_path
+import psycopg
+
+
+class Environment:
+    """Resuelve secretos del entorno y opera Neon para seed + cleanup."""
+
+    def __init__(self, env: str, *, aws_profile: str | None = None) -> None:
+        self._env = env
+        session = boto3.Session(profile_name=aws_profile)
+        self._ssm = session.client('ssm', region_name=AWS_REGION)
+        self._neon_url: str | None = None
+        self._bypass: str | None = None
+
+    # --- Secretos (nunca a stdout) ---
+
+    def bypass_secret(self) -> str | None:
+        """Bypass de Turnstile desde SSM (None si no esta configurado)."""
+        if self._bypass is None:
+            try:
+                self._bypass = self._ssm.get_parameter(
+                    Name=bypass_ssm_path(self._env),
+                    WithDecryption=True,
+                )['Parameter']['Value']
+            except Exception:  # noqa: BLE001 -- ausente -> sin bypass
+                self._bypass = ''
+        return self._bypass or None
+
+    def _neon(self) -> str:
+        if self._neon_url is None:
+            self._neon_url = self._ssm.get_parameter(
+                Name=neon_ssm_path(self._env),
+                WithDecryption=True,
+            )['Parameter']['Value']
+        return self._neon_url
+
+    # --- Neon: seed del code para el paso verify ---
+
+    def seed_code(self, *, user_id: str, kind: str, plaintext: str) -> bool:
+        """Fija el code_hash de la fila vigente a sha256(plaintext).
+
+        Filtra por user_id + kind + consumed_at IS NULL, resetea attempts
+        y refresca expires_at. Devuelve True si actualizo >=1 fila.
+        """
+        digest = hashlib.sha256(plaintext.encode('utf-8')).digest()
+        sql = (
+            'UPDATE auth_email_codes '
+            'SET code_hash = %s, attempts = 0, '
+            "expires_at = now() + interval '10 minutes' "
+            'WHERE user_id = %s AND kind = %s AND consumed_at IS NULL'
+        )
+        return self._exec(sql, (digest, user_id, kind)) > 0
+
+    def find_user_id(self, email: str) -> str | None:
+        """user_id (uuid str) del email, o None si no existe."""
+        rows = self._query(
+            'SELECT id FROM auth_users WHERE email = %s',
+            (email.lower(),),
+        )
+        return str(rows[0][0]) if rows else None
+
+    # --- Cleanup ---
+
+    def cleanup_users(self, emails: list[str]) -> int:
+        """Borra (hard) los users de prueba + sus filas hijas en Neon."""
+        if not emails:
+            return 0
+        ids = [
+            r[0]
+            for r in self._query(
+                'SELECT id FROM auth_users WHERE email = ANY(%s)',
+                ([e.lower() for e in emails],),
+            )
+        ]
+        if not ids:
+            return 0
+        children = (
+            'auth_email_codes',
+            'auth_magic_links',
+            'auth_credentials',
+            'auth_mfa_methods',
+            'auth_mfa_recovery_codes',
+            'auth_webauthn_credentials',
+            'auth_user_sessions',
+            'auth_audit_log',
+            'auth_user_consent_log',
+            'auth_user_admin_actions',
+        )
+        total = 0
+        for table in children:
+            total += self._exec(
+                f'DELETE FROM {table} WHERE user_id = ANY(%s)',
+                (ids,),
+                ignore_missing=True,
+            )
+        total += self._exec(
+            'DELETE FROM auth_users WHERE id = ANY(%s)',
+            (ids,),
+        )
+        return total
+
+    def cleanup_tracking(self, session_ids: list[str]) -> int:
+        """Borra los tracking events + sessions sinteticos creados."""
+        if not session_ids:
+            return 0
+        n = 0
+        for table in ('tracking_events', 'session_visits', 'sessions'):
+            n += self._exec(
+                f'DELETE FROM {table} WHERE session_id = ANY(%s)',
+                (session_ids,),
+                ignore_missing=True,
+            )
+        return n
+
+    def cleanup_contacts(self, emails: list[str]) -> int:
+        """Borra los contacts sinteticos creados (por email)."""
+        if not emails:
+            return 0
+        return self._exec(
+            'DELETE FROM contacts WHERE email = ANY(%s)',
+            ([e.lower() for e in emails],),
+            ignore_missing=True,
+        )
+
+    # --- Internos psycopg ---
+
+    def _exec(
+        self,
+        sql: str,
+        params: tuple,
+        *,
+        ignore_missing: bool = False,
+    ) -> int:
+        try:
+            with (
+                psycopg.connect(self._neon(), connect_timeout=15) as conn,
+                conn.cursor() as cur,
+            ):
+                cur.execute(sql, params)
+                return cur.rowcount
+        except psycopg.errors.UndefinedTable:
+            if ignore_missing:
+                return 0
+            raise
+
+    def _query(self, sql: str, params: tuple) -> list[tuple[Any, ...]]:
+        with (
+            psycopg.connect(self._neon(), connect_timeout=15) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(sql, params)
+            return cur.fetchall()

--- a/devtools/api_e2e/flags.py
+++ b/devtools/api_e2e/flags.py
@@ -1,0 +1,125 @@
+"""Validacion de flags del script api_e2e (monocommand).
+
+Flags:
+  --env=dev|stage      entorno de DEPLOY (NUNCA prod; default dev)
+  --lambda=<name>      filtra a un Lambda (cv|contact_form|tracking_pixel|
+                       auth|users); default todos
+  --samples=N          muestras por endpoint read-safe (default 5)
+  --aws-profile=<X>    perfil AWS CLI para SSM/Neon (default: shell)
+  --keep-data          NO limpiar los datos sinteticos creados en Neon
+  --verbose / --quiet
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from config import VALID_ENVS
+from utils.describe import ScriptDescribe
+from utils.flags_to_dict import set_default_values
+from utils.flags_to_dict import validate_allowed_flags
+
+
+VALID_LAMBDAS = ('cv', 'contact_form', 'tracking_pixel', 'auth', 'users')
+
+ALLOWED_FLAGS = [
+    'env',
+    'lambda',
+    'samples',
+    'aws_profile',
+    'keep_data',
+    'verbose',
+    'quiet',
+    'help',
+]
+
+DEFAULTS: dict[str, Any] = {
+    'env': 'dev',
+    'lambda': None,
+    'samples': 5,
+    'aws_profile': None,
+    'keep_data': False,
+    'verbose': False,
+    'quiet': False,
+}
+
+
+def flag(flags_dict: dict[str, Any]) -> dict[str, Any]:
+    """Valida y normaliza las flags de api_e2e."""
+    validate_allowed_flags(flags_dict, ALLOWED_FLAGS)
+    flags_dict = set_default_values(flags_dict, DEFAULTS)
+
+    env = flags_dict.get('env')
+    if env not in VALID_ENVS:
+        raise ValueError(
+            f"--env invalido: '{env}'. api_e2e MUTA el entorno y lee Neon: "
+            f'solo {", ".join(VALID_ENVS)} (NUNCA prod).',
+        )
+
+    lam = flags_dict.get('lambda')
+    if lam is not None and lam not in VALID_LAMBDAS:
+        raise ValueError(
+            f"--lambda invalido: '{lam}'. "
+            f'Validos: {", ".join(VALID_LAMBDAS)}',
+        )
+
+    samples = flags_dict.get('samples')
+    if not isinstance(samples, int):
+        try:
+            flags_dict['samples'] = int(samples)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                f'--samples debe ser un entero. Recibido: {samples!r}',
+            ) from exc
+    if flags_dict['samples'] < 1:
+        raise ValueError('--samples debe ser >= 1')
+
+    return flags_dict
+
+
+def describe() -> ScriptDescribe:
+    """Inventario machine-readable de las flags de api_e2e."""
+    return {
+        'name': 'api_e2e',
+        'kind': 'monocommand',
+        'summary': (
+            'Tests E2E reales (HTTP) contra el backend desplegado '
+            '(dev|stage): flujos de exito + errores por Lambda, con '
+            'tiempos de respuesta'
+        ),
+        'commands': [],
+        'flags': {
+            'env': {
+                'type': 'choice',
+                'choices': list(VALID_ENVS),
+                'default': 'dev',
+                'summary': 'Entorno de deploy (NUNCA prod)',
+            },
+            'lambda': {
+                'type': 'choice',
+                'choices': list(VALID_LAMBDAS),
+                'summary': 'Filtra a un Lambda (default: todos)',
+            },
+            'samples': {
+                'type': 'int',
+                'default': 5,
+                'summary': 'Muestras por endpoint read-safe',
+            },
+            'aws_profile': {
+                'type': 'string',
+                'summary': 'Perfil AWS CLI para SSM/Neon (ej. tfs-dev)',
+            },
+            'keep_data': {
+                'type': 'bool',
+                'default': False,
+                'summary': 'No limpiar los datos sinteticos creados',
+            },
+            'verbose': {'type': 'bool', 'default': False, 'summary': 'Detalle'},
+            'quiet': {'type': 'bool', 'default': False, 'summary': 'Silencia'},
+        },
+    }

--- a/devtools/api_e2e/flow_auth.py
+++ b/devtools/api_e2e/flow_auth.py
@@ -1,0 +1,292 @@
+"""Flujo auth: registro completo (exito) + casos de error.
+
+Flujo de exito (con seed de Neon para el paso verify-code):
+  register.start -> seed code -> register.verify-code (access+refresh)
+  -> session.refresh -> login.start -> verify.set-password
+  -> session.logout
+
+Shapes confirmados contra dev (campos anidados bajo `data`):
+  register.start      -> 200 {data: {temp_token, user_id, expires_in, ...}}
+  register.verify-code-> 200 {data: {access_token, refresh_token, ...}}
+
+Casos de error: login.start de email inexistente (404), tokens falsos en
+los verify (4xx), mfa/webauthn sin JWT valido (401/4xx).
+
+Devuelve el `access_token` del user creado para que el flujo de `users`
+lo reutilice.
+"""
+
+from __future__ import annotations
+
+from config import admin_origin
+from config import synthetic_email
+from environment import Environment
+from runner import Runner
+from runner import make_body
+from support import HttpClient
+
+
+_STRONG_PASSWORD = 'api-e2e-Str0ng-Passphrase!'
+_FAKE_JWT = 'FAKE-TOKEN-API-E2E-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX'
+
+
+def run_auth(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    env_name: str,
+    run_id: str,
+    bypass: str | None,
+    created_emails: list[str],
+) -> str | None:
+    """Corre el flujo auth. Devuelve el access_token del user creado."""
+    origin = admin_origin(env_name)
+    access_token: str | None = None
+
+    if bypass:
+        access_token = _run_success(
+            runner,
+            http,
+            env,
+            origin,
+            run_id,
+            bypass,
+            created_emails,
+        )
+    else:
+        print('  [SKIP] flujo auth de exito: bypass Turnstile no disponible')
+
+    _run_errors(runner, http, origin, bypass)
+    return access_token
+
+
+def _run_success(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> str | None:
+    """Flujo de registro->sesion completo. Devuelve access_token final."""
+    email = synthetic_email(run_id, 'auth')
+    created_emails.append(email)
+
+    # 1. register.start -> temp_token, user_id
+    r = runner.step(
+        lambda_name='auth',
+        name='register.start (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'register',
+                'start',
+                email=email,
+                cf_turnstile_response='',
+            ),
+            origin=origin,
+            bypass_secret=bypass,
+        ),
+        expected=200,
+    )
+    temp_token = _field(r.body, 'temp_token')
+    user_id = _field(r.body, 'user_id') or env.find_user_id(email)
+    if not (temp_token and user_id):
+        return None
+
+    # 2. seed code + register.verify-code -> access+refresh
+    seeded = env.seed_code(
+        user_id=user_id,
+        kind='register',
+        plaintext='ABCDEFGH',
+    )
+    r = runner.step(
+        lambda_name='auth',
+        name='register.verify-code (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'register',
+                'verify-code',
+                code='ABCDEFGH',
+                temp_token=temp_token,
+            ),
+            origin=origin,
+        ),
+        expected=200,
+        note='code sembrado en Neon' if seeded else 'seed FALLO',
+    )
+    access_token = _field(r.body, 'access_token')
+    refresh_token = _field(r.body, 'refresh_token')
+
+    # 3. session.refresh -> rota el refresh
+    if refresh_token:
+        r = runner.step(
+            lambda_name='auth',
+            name='session.refresh (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body(
+                    'session',
+                    'refresh',
+                    refresh_token=refresh_token,
+                ),
+                origin=origin,
+            ),
+            expected=200,
+        )
+        access_token = _field(r.body, 'access_token') or access_token
+
+    # 4. login.start (success) -> nuevo temp para set-password
+    r = runner.step(
+        lambda_name='auth',
+        name='login.start (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'login',
+                'start',
+                email=email,
+                cf_turnstile_response='',
+            ),
+            origin=origin,
+            bypass_secret=bypass,
+        ),
+        expected=200,
+    )
+    login_temp = _field(r.body, 'temp_token')
+
+    # 5. verify.set-password con el temp del login
+    if login_temp:
+        runner.step(
+            lambda_name='auth',
+            name='verify.set-password (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body(
+                    'verify',
+                    'set-password',
+                    password=_STRONG_PASSWORD,
+                    temp_token=login_temp,
+                ),
+                origin=origin,
+            ),
+            expected='2xx',
+        )
+
+    # 6. session.logout con el access vigente -> 200/204
+    if access_token:
+        runner.step(
+            lambda_name='auth',
+            name='session.logout (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body('session', 'logout', access_token=access_token),
+                origin=origin,
+                bearer=access_token,
+            ),
+            expected=[200, 204],
+        )
+
+    return access_token
+
+
+def _run_errors(
+    runner: Runner,
+    http: HttpClient,
+    origin: str,
+    bypass: str | None,
+) -> None:
+    """Casos de error de auth (no mutan / no requieren estado valido)."""
+    if bypass:
+        runner.case(
+            lambda_name='auth',
+            name='login.start (error: email inexistente)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body(
+                    'login',
+                    'start',
+                    email='nadie-api-e2e@simulator.amazonses.com',
+                    cf_turnstile_response='',
+                ),
+                origin=origin,
+                bypass_secret=bypass,
+            ),
+            expected=404,
+        )
+    runner.case(
+        lambda_name='auth',
+        name='register.verify-code (error: token falso)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'register',
+                'verify-code',
+                code='ABCDEFGH',
+                temp_token=_FAKE_JWT,
+            ),
+            origin=origin,
+        ),
+        expected='4xx',
+    )
+    runner.case(
+        lambda_name='auth',
+        name='session.refresh (error: token falso)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('session', 'refresh', refresh_token=_FAKE_JWT),
+            origin=origin,
+        ),
+        expected='4xx',
+    )
+    runner.case(
+        lambda_name='auth',
+        name='mfa.list (error: JWT falso)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('mfa', 'list'),
+            origin=origin,
+            bearer=_FAKE_JWT,
+        ),
+        expected=401,
+    )
+    runner.case(
+        lambda_name='auth',
+        name='webauthn.login-verify (error: payload vacio)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'webauthn',
+                'login-verify',
+                email='x@simulator.amazonses.com',
+                credential={},
+            ),
+            origin=origin,
+        ),
+        expected='4xx',
+    )
+
+
+def _field(body: object, key: str) -> str | None:
+    """Extrae body[key] o body['data'][key]; None si no esta o no es str."""
+    if not isinstance(body, dict):
+        return None
+    if isinstance(body.get(key), str):
+        return body[key]
+    data = body.get('data')
+    if isinstance(data, dict) and isinstance(data.get(key), str):
+        return data[key]
+    return None

--- a/devtools/api_e2e/flow_readonly.py
+++ b/devtools/api_e2e/flow_readonly.py
@@ -1,0 +1,191 @@
+"""Flujos cv (read), contact_form y tracking_pixel.
+
+Casos de exito + error de los 3 Lambdas HTTP que NO requieren JWT. cv es
+read-only (GET, sin mutacion). contact_form y tracking_pixel mutan (crean
+un contact / tracking event) pero el cleanup borra lo creado.
+"""
+
+from __future__ import annotations
+
+from config import NICHE
+from config import TRACKING_EVENT_TYPE_ID
+from config import apex_origin
+from config import cv_origin
+from config import synthetic_email
+from runner import Runner
+from runner import make_body
+from support import HttpClient
+
+
+_CV_ACTIONS = (
+    'get', 'profile', 'experiences', 'projects', 'certificates',
+    'awards', 'education', 'languages', 'references', 'skills',
+)
+
+
+def run_cv(runner: Runner, http: HttpClient, env: str) -> None:
+    """cv: las 10 actions read (2xx) + 2 errores (action/operation)."""
+    origin = cv_origin(env)
+    for action in _CV_ACTIONS:
+        params = {'operation': 'cv', 'action': action, 'locale': 'es'}
+        if action != 'profile':
+            params['niche'] = NICHE
+        runner.case(
+            lambda_name='cv',
+            name=f'cv.{action} (success)',
+            method='GET',
+            call=lambda p=params: http.get('/cv', params=p, origin=origin),
+            expected='2xx',
+        )
+    runner.case(
+        lambda_name='cv',
+        name='cv.nope (error: action invalida)',
+        method='GET',
+        call=lambda: http.get(
+            '/cv',
+            params={'operation': 'cv', 'action': 'nope', 'locale': 'es'},
+            origin=origin,
+        ),
+        expected='4xx',
+    )
+    runner.case(
+        lambda_name='cv',
+        name='cv (error: sin operation)',
+        method='GET',
+        call=lambda: http.get(
+            '/cv', params={'action': 'get'}, origin=origin,
+        ),
+        expected='4xx',
+    )
+
+
+def run_contact(
+    runner: Runner,
+    http: HttpClient,
+    env: str,
+    run_id: str,
+    bypass: str | None,
+    created_emails: list[str],
+) -> None:
+    """contact_form: create exitoso (202 via bypass) + errores de payload."""
+    origin = apex_origin(env)
+    if bypass:
+        email = synthetic_email(run_id, 'contact')
+        created_emails.append(email)
+        runner.case(
+            lambda_name='contact_form',
+            name='contact.create (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/contact',
+                body=make_body(
+                    'contact', 'create',
+                    name='API E2E', email=email,
+                    message='Mensaje de prueba E2E del harness api_e2e.',
+                    cf_token='',
+                ),
+                origin=origin, bypass_secret=bypass,
+            ),
+            expected='2xx',
+            samples=2,
+            note='via bypass Turnstile',
+        )
+    else:
+        print('  [SKIP] contact.create (success): bypass no disponible')
+
+    runner.case(
+        lambda_name='contact_form',
+        name='contact.create (error: sin message)',
+        method='POST',
+        call=lambda: http.post(
+            '/contact',
+            body=make_body(
+                'contact', 'create',
+                name='API E2E', email='success+e2e@simulator.amazonses.com',
+                cf_token='',
+            ),
+            origin=origin, bypass_secret=bypass,
+        ),
+        expected='4xx',
+    )
+    runner.case(
+        lambda_name='contact_form',
+        name='contact.create (error: email invalido)',
+        method='POST',
+        call=lambda: http.post(
+            '/contact',
+            body=make_body(
+                'contact', 'create',
+                name='API E2E', email='no-es-un-email',
+                message='mensaje suficientemente largo para pasar',
+                cf_token='',
+            ),
+            origin=origin, bypass_secret=bypass,
+        ),
+        expected='4xx',
+    )
+
+
+def run_tracking(
+    runner: Runner,
+    http: HttpClient,
+    env: str,
+    run_id: str,
+    created_sessions: list[str],
+) -> None:
+    """tracking_pixel: track exitoso (202) + errores de payload."""
+    origin = apex_origin(env)
+    session_id = f'sess-{run_id}-track-000000000000'
+    created_sessions.append(session_id)
+
+    def _track_body(**over: object) -> dict:
+        base: dict[str, object] = dict(
+            session_id=session_id,
+            event_id='a1b2c3d4e5f60718293a4b5c6d7e8f90',
+            event_type_id=TRACKING_EVENT_TYPE_ID,
+            page_url='https://the-full-stack.com/projects',
+            page_title='Projects', page_path='/projects',
+            utm_source='e2e', utm_medium='api',
+            utm_campaign='verify', utm_content='run',
+            viewport_width=1920, viewport_height=1080, niche=NICHE,
+        )
+        base.update(over)
+        return make_body('tracking', 'track', **base)
+
+    runner.case(
+        lambda_name='tracking_pixel',
+        name='tracking.track (success)',
+        method='POST',
+        call=lambda: http.post('/track', body=_track_body(), origin=origin),
+        expected='2xx',
+        samples=3,
+    )
+    runner.case(
+        lambda_name='tracking_pixel',
+        name='tracking.track (error: sin event_type_id)',
+        method='POST',
+        call=lambda: http.post(
+            '/track',
+            body=make_body(
+                'tracking', 'track',
+                session_id=session_id,
+                event_id='a1b2c3d4e5f60718293a4b5c6d7e8f90',
+                page_url='https://the-full-stack.com/p',
+                page_title='P', page_path='/p',
+                utm_source='e2e', utm_medium='api',
+                utm_campaign='verify', utm_content='run',
+                viewport_width=1920, viewport_height=1080, niche=NICHE,
+            ),
+            origin=origin,
+        ),
+        expected='4xx',
+    )
+    runner.case(
+        lambda_name='tracking_pixel',
+        name='tracking.track (error: viewport invalido)',
+        method='POST',
+        call=lambda: http.post(
+            '/track', body=_track_body(viewport_width=999999), origin=origin,
+        ),
+        expected='4xx',
+    )

--- a/devtools/api_e2e/flow_users.py
+++ b/devtools/api_e2e/flow_users.py
@@ -1,0 +1,135 @@
+"""Flujo users: profile + status + admin.
+
+Reutiliza el access_token del flujo auth (un user `active` recien creado).
+profile.get / profile.update / status.get / status.list-sessions son
+operaciones del propio user. admin.* se prueba en su variante de error:
+un user NO-admin recibe 404 NOT_FOUND (anti-enumeration). Casos sin JWT
+valido -> 401.
+"""
+
+from __future__ import annotations
+
+from config import admin_origin
+from runner import Runner
+from runner import make_body
+from support import HttpClient
+
+
+_FAKE_JWT = 'FAKE-TOKEN-API-E2E-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX'
+_FAKE_UUID = '00000000-0000-7000-8000-000000000000'
+
+
+def run_users(
+    runner: Runner,
+    http: HttpClient,
+    env_name: str,
+    access_token: str | None,
+) -> None:
+    """Corre los casos de users (success si hay access_token + errores)."""
+    origin = admin_origin(env_name)
+
+    if access_token:
+        runner.case(
+            lambda_name='users',
+            name='profile.get (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/users',
+                body=make_body('profile', 'get'),
+                origin=origin,
+                bearer=access_token,
+            ),
+            expected='2xx',
+        )
+        runner.case(
+            lambda_name='users',
+            name='profile.update (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/users',
+                body=make_body(
+                    'profile',
+                    'update',
+                    display_name='API E2E User',
+                    locale='es',
+                ),
+                origin=origin,
+                bearer=access_token,
+            ),
+            expected='2xx',
+            samples=2,
+        )
+        runner.case(
+            lambda_name='users',
+            name='status.get (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/users',
+                body=make_body('status', 'get'),
+                origin=origin,
+                bearer=access_token,
+            ),
+            expected='2xx',
+        )
+        runner.case(
+            lambda_name='users',
+            name='status.list-sessions (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/users',
+                body=make_body('status', 'list-sessions'),
+                origin=origin,
+                bearer=access_token,
+            ),
+            expected='2xx',
+        )
+        runner.case(
+            lambda_name='users',
+            name='admin.list-users (error: no-admin -> 404)',
+            method='POST',
+            call=lambda: http.post(
+                '/users',
+                body=make_body('admin', 'list-users'),
+                origin=origin,
+                bearer=access_token,
+            ),
+            expected=404,
+        )
+    else:
+        print('  [SKIP] users success: no hay access_token del flujo auth')
+
+    runner.case(
+        lambda_name='users',
+        name='profile.get (error: sin JWT)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('profile', 'get'),
+            origin=origin,
+        ),
+        expected=401,
+    )
+    runner.case(
+        lambda_name='users',
+        name='status.get (error: JWT falso)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('status', 'get'),
+            origin=origin,
+            bearer=_FAKE_JWT,
+        ),
+        expected=401,
+    )
+    runner.case(
+        lambda_name='users',
+        name='status.revoke-session (error: JWT falso)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('status', 'revoke-session', session_id=_FAKE_UUID),
+            origin=origin,
+            bearer=_FAKE_JWT,
+        ),
+        expected=401,
+    )

--- a/devtools/api_e2e/main.py
+++ b/devtools/api_e2e/main.py
@@ -1,0 +1,137 @@
+"""Entry point de api_e2e: orquesta los flujos E2E reales.
+
+Resuelve secretos del entorno (SSM, hermetico), corre los flujos de cada
+Lambda (cv, contact_form, tracking_pixel, auth, users) contra el API
+Gateway real, limpia los datos sinteticos creados en Neon y reporta
+pass/fail + tiempos de respuesta promedio.
+
+Exit codes: 0 (todos PASS), 1 (algun caso FAIL), 2 (error de setup).
+"""
+
+from __future__ import annotations
+
+import secrets as _secrets
+from typing import Any
+
+from config import api_base
+from config import turnstile_bypass_supported
+from environment import Environment
+from flow_auth import run_auth
+from flow_readonly import run_contact
+from flow_readonly import run_cv
+from flow_readonly import run_tracking
+from flow_users import run_users
+from reporter import Reporter
+from runner import Runner
+from support import HttpClient
+
+
+def main(flags: dict[str, Any]) -> int:
+    """Corre el harness api_e2e segun las flags."""
+    env_name = flags['env']
+    only = flags.get('lambda')
+    samples = flags.get('samples', 5)
+    keep_data = flags.get('keep_data', False)
+    aws_profile = flags.get('aws_profile')
+
+    print('=' * 80)
+    print(
+        f'api_e2e — tests reales contra {env_name.upper()} '
+        f'({api_base(env_name)})'
+    )
+    print('=' * 80)
+
+    try:
+        env = Environment(env_name, aws_profile=aws_profile)
+        bypass = (
+            env.bypass_secret()
+            if turnstile_bypass_supported(env_name)
+            else None
+        )
+    except Exception as exc:  # noqa: BLE001 -- setup
+        print(f'[ERROR] setup del entorno: {type(exc).__name__}: {exc}')
+        return 2
+
+    if bypass is None and turnstile_bypass_supported(env_name):
+        print(
+            '[WARN] bypass de Turnstile no disponible: los flujos de '
+            'exito de contact/auth se omiten (solo errores).'
+        )
+    elif not turnstile_bypass_supported(env_name):
+        print(
+            f'[INFO] {env_name} no soporta bypass de Turnstile: '
+            'flujos con Turnstile omitidos (solo errores).'
+        )
+
+    run_id = _secrets.token_hex(2)
+    http = HttpClient(base_url=api_base(env_name))
+    reporter = Reporter()
+    runner = Runner(reporter, samples=samples)
+
+    created_emails: list[str] = []
+    created_sessions: list[str] = []
+
+    def _want(name: str) -> bool:
+        return only is None or only == name
+
+    try:
+        if _want('cv'):
+            print('\n--- cv ---')
+            run_cv(runner, http, env_name)
+        if _want('contact_form'):
+            print('\n--- contact_form ---')
+            run_contact(
+                runner,
+                http,
+                env_name,
+                run_id,
+                bypass,
+                created_emails,
+            )
+        if _want('tracking_pixel'):
+            print('\n--- tracking_pixel ---')
+            run_tracking(runner, http, env_name, run_id, created_sessions)
+
+        access_token = None
+        if _want('auth') or _want('users'):
+            print('\n--- auth ---')
+            access_token = run_auth(
+                runner,
+                http,
+                env,
+                env_name,
+                run_id,
+                bypass,
+                created_emails,
+            )
+        if _want('users'):
+            print('\n--- users ---')
+            run_users(runner, http, env_name, access_token)
+    finally:
+        http.close()
+        if not keep_data:
+            _cleanup(env, created_emails, created_sessions)
+        else:
+            print('\n[INFO] --keep-data: datos sinteticos NO eliminados.')
+
+    reporter.print_timing_summary()
+    reporter.print_final()
+    return 0 if reporter.all_passed() else 1
+
+
+def _cleanup(
+    env: Environment,
+    emails: list[str],
+    sessions: list[str],
+) -> None:
+    """Borra los datos sinteticos creados por la corrida (best-effort)."""
+    print('\n--- cleanup (datos sinteticos) ---')
+    try:
+        users = env.cleanup_users(emails)
+        contacts = env.cleanup_contacts(emails)
+        tracking = env.cleanup_tracking(sessions)
+        print(
+            f'  borrados: users={users} contacts={contacts} tracking={tracking}'
+        )
+    except Exception as exc:  # noqa: BLE001 -- best-effort
+        print(f'  [WARN] cleanup parcial: {type(exc).__name__}: {exc}')

--- a/devtools/api_e2e/reporter.py
+++ b/devtools/api_e2e/reporter.py
@@ -1,0 +1,105 @@
+"""Registro de resultados + reporte (pass/fail por caso + tiempos avg).
+
+Cada llamada a un endpoint produce un `CaseResult`. El `Reporter`
+acumula todos, imprime cada caso al vuelo y, al final, un resumen de
+tiempos de respuesta promedio por endpoint + el veredicto pass/fail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+
+@dataclass
+class CaseResult:
+    """Resultado de un caso (1 endpoint, 1 escenario, N samples)."""
+
+    lambda_name: str
+    name: str
+    method: str
+    status_codes: list[int]
+    expected: str
+    passed: bool
+    elapsed: list[float]
+    note: str = ''
+
+    @property
+    def avg(self) -> float:
+        """Promedio de todos los samples (segundos)."""
+        return sum(self.elapsed) / len(self.elapsed) if self.elapsed else 0.0
+
+    @property
+    def cold(self) -> float:
+        """Primer sample (peor caso / cold)."""
+        return self.elapsed[0] if self.elapsed else 0.0
+
+    @property
+    def warm_avg(self) -> float:
+        """Promedio de los samples 2..N; cae al unico si hay 1 sample."""
+        warm = self.elapsed[1:] or self.elapsed
+        return sum(warm) / len(warm) if warm else 0.0
+
+
+@dataclass
+class Reporter:
+    """Acumula CaseResult e imprime el reporte final."""
+
+    results: list[CaseResult] = field(default_factory=list)
+
+    def add(self, result: CaseResult) -> None:
+        """Registra un caso e imprime su linea inmediatamente."""
+        self.results.append(result)
+        mark = 'PASS' if result.passed else 'FAIL'
+        suffix = f'  ({result.note})' if result.note else ''
+        print(
+            f'  [{mark}] {result.name:<48} '
+            f'codes={result.status_codes} avg={result.avg:.3f}s{suffix}',
+            flush=True,
+        )
+
+    def passed_count(self) -> int:
+        """Numero de casos que pasaron."""
+        return sum(1 for r in self.results if r.passed)
+
+    def all_passed(self) -> bool:
+        """True si todos los casos pasaron."""
+        return all(r.passed for r in self.results)
+
+    def print_timing_summary(self) -> None:
+        """Tabla de tiempos de respuesta promedio por endpoint."""
+        print()
+        print('=' * 80)
+        print('TIEMPOS DE RESPUESTA PROMEDIO (segundos)')
+        print('=' * 80)
+        print(f'{"Lambda":<15}{"Caso":<48}{"cold":>8}{"warm":>8}')
+        print('-' * 80)
+        for r in self.results:
+            print(
+                f'{r.lambda_name:<15}{r.name:<48}'
+                f'{r.cold:>8.3f}{r.warm_avg:>8.3f}'
+            )
+        print('-' * 80)
+        ok = [r for r in self.results if r.passed and r.elapsed]
+        if ok:
+            g_warm = sum(r.warm_avg for r in ok) / len(ok)
+            g_cold = sum(r.cold for r in ok) / len(ok)
+            print(f'{"GLOBAL (OK)":<15}{"":<48}{g_cold:>8.3f}{g_warm:>8.3f}')
+
+    def print_final(self) -> None:
+        """Resumen pass/fail + listado de fallos."""
+        total = len(self.results)
+        ok = self.passed_count()
+        print()
+        print('=' * 80)
+        print(f'RESULTADO: {ok}/{total} casos PASS')
+        print('=' * 80)
+        fails = [r for r in self.results if not r.passed]
+        if fails:
+            print('FALLOS:')
+            for r in fails:
+                note = f' ({r.note})' if r.note else ''
+                print(
+                    f'  {r.lambda_name}.{r.name} '
+                    f'codes={r.status_codes} esperado={r.expected}{note}'
+                )

--- a/devtools/api_e2e/runner.py
+++ b/devtools/api_e2e/runner.py
@@ -1,0 +1,105 @@
+"""Runner de casos: ejecuta una llamada N veces y clasifica el resultado.
+
+Un "caso" es una funcion `() -> Response`. El runner la corre `samples`
+veces, recolecta status + elapsed y decide PASS/FAIL contra el status
+esperado (int, lista de ints, o rango '2xx'/'4xx'/'5xx').
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from reporter import CaseResult
+from reporter import Reporter
+from support import Response
+
+
+SAMPLES_DEFAULT = 5
+
+
+def _matches(code: int, expected: object) -> bool:
+    if isinstance(expected, bool):  # bool es subclase de int: descartar
+        return False
+    if isinstance(expected, int):
+        return code == expected
+    if isinstance(expected, list):
+        return code in expected
+    if expected == '2xx':
+        return 200 <= code < 300
+    if expected == '4xx':
+        return 400 <= code < 500
+    if expected == '5xx':
+        return 500 <= code < 600
+    return False
+
+
+def _describe(expected: object) -> str:
+    if isinstance(expected, str):
+        return expected
+    if isinstance(expected, list):
+        return f'in {expected}'
+    return str(expected)
+
+
+class Runner:
+    """Ejecuta casos contra un reporter compartido."""
+
+    def __init__(self, reporter: Reporter, *, samples: int = SAMPLES_DEFAULT):
+        self._reporter = reporter
+        self._samples = samples
+
+    def case(
+        self,
+        *,
+        lambda_name: str,
+        name: str,
+        method: str,
+        call: Callable[[], Response],
+        expected: object,
+        samples: int | None = None,
+        note: str = '',
+    ) -> Response:
+        """Corre `call` N veces, clasifica, registra. Devuelve la ultima
+        Response (para encadenar pasos del flujo)."""
+        n = samples if samples is not None else self._samples
+        codes: list[int] = []
+        elapsed: list[float] = []
+        last: Response | None = None
+        for _ in range(n):
+            last = call()
+            codes.append(last.status)
+            elapsed.append(last.elapsed)
+        passed = all(_matches(code, expected) for code in codes)
+        self._reporter.add(CaseResult(
+            lambda_name=lambda_name,
+            name=name,
+            method=method,
+            status_codes=codes,
+            expected=_describe(expected),
+            passed=passed,
+            elapsed=elapsed,
+            note=note,
+        ))
+        return last  # type: ignore[return-value]
+
+    def step(
+        self,
+        *,
+        lambda_name: str,
+        name: str,
+        method: str,
+        call: Callable[[], Response],
+        expected: object,
+        note: str = '',
+    ) -> Response:
+        """Como `case` pero 1 sola muestra (paso que muta estado y no se
+        puede repetir, ej. consumir un code single-use)."""
+        return self.case(
+            lambda_name=lambda_name, name=name, method=method, call=call,
+            expected=expected, samples=1, note=note,
+        )
+
+
+def make_body(operation: str, action: str, **fields: object) -> dict:
+    """Body FLAT del request: operation/action + campos al nivel raiz."""
+    return {'operation': operation, 'action': action, **fields}

--- a/devtools/api_e2e/support.py
+++ b/devtools/api_e2e/support.py
@@ -1,0 +1,112 @@
+"""Cliente HTTP con timing para el harness api_e2e.
+
+`HttpClient` envuelve httpx: arma el shape correcto del request (GET con
+query params; POST con `operation`/`action` + campos FLAT en el body),
+inyecta una IP rotada + headers, mide el tiempo y devuelve un `Response`
+con `(status, body, elapsed)`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from config import IpRotator
+import httpx
+
+
+class Response:
+    """Resultado de una llamada HTTP: status, body parseado y elapsed (s)."""
+
+    def __init__(self, status: int, body: Any, elapsed: float) -> None:
+        self.status = status
+        self.body = body
+        self.elapsed = elapsed
+
+
+class HttpClient:
+    """Cliente httpx para el API Gateway del backend (1 IP por request)."""
+
+    def __init__(self, *, base_url: str, timeout: float = 35.0) -> None:
+        self._base = base_url.rstrip('/')
+        self._client = httpx.Client(timeout=timeout)
+        self._ips = IpRotator()
+
+    def close(self) -> None:
+        """Cierra el cliente httpx."""
+        self._client.close()
+
+    def _headers(
+        self,
+        *,
+        origin: str,
+        bypass_secret: str | None,
+        bearer: str | None,
+    ) -> dict[str, str]:
+        headers = {
+            'Origin': origin,
+            'CF-Connecting-IP': self._ips.next(),
+            'CF-IPCountry': 'CL',
+            'User-Agent': 'portfolio-api-e2e/1.0',
+            'Content-Type': 'application/json',
+        }
+        if bypass_secret:
+            headers['X-Turnstile-Bypass-Secret'] = bypass_secret
+        if bearer:
+            headers['Authorization'] = f'Bearer {bearer}'
+        return headers
+
+    def get(
+        self,
+        path: str,
+        *,
+        params: dict[str, str],
+        origin: str,
+    ) -> Response:
+        """GET con query params (operation/action van en params)."""
+        headers = self._headers(
+            origin=origin,
+            bypass_secret=None,
+            bearer=None,
+        )
+        start = time.monotonic()
+        resp = self._client.get(
+            f'{self._base}{path}',
+            params=params,
+            headers=headers,
+        )
+        elapsed = time.monotonic() - start
+        return Response(resp.status_code, _parse(resp), elapsed)
+
+    def post(
+        self,
+        path: str,
+        *,
+        body: dict[str, Any],
+        origin: str,
+        bypass_secret: str | None = None,
+        bearer: str | None = None,
+    ) -> Response:
+        """POST con body JSON (operation/action + campos FLAT en el body)."""
+        headers = self._headers(
+            origin=origin,
+            bypass_secret=bypass_secret,
+            bearer=bearer,
+        )
+        start = time.monotonic()
+        resp = self._client.post(
+            f'{self._base}{path}',
+            content=json.dumps(body),
+            headers=headers,
+        )
+        elapsed = time.monotonic() - start
+        return Response(resp.status_code, _parse(resp), elapsed)
+
+
+def _parse(resp: httpx.Response) -> Any:
+    """Parsea el body como JSON; si no es JSON devuelve el texto crudo."""
+    try:
+        return resp.json()
+    except (json.JSONDecodeError, ValueError):
+        return resp.text

--- a/devtools/pyproject.toml
+++ b/devtools/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "playwright>=1.49.0",
     # HTML parser (used by ai_audit/tools/ to parse scraped DOM)
     "beautifulsoup4>=4.13.0",
+    # PostgreSQL driver (used by api_e2e/ to seed code hashes in the deployed
+    # Neon dev/stage DB for the auth verify flow + cleanup of synthetic data)
+    "psycopg[binary]>=3.2.0",
 ]
 
 [tool.uv]

--- a/devtools/tests/unit/src/api_e2e/test_config.py
+++ b/devtools/tests/unit/src/api_e2e/test_config.py
@@ -1,0 +1,81 @@
+"""Tests de config de api_e2e: IpRotator, emails sinteticos, env helpers."""
+
+from pathlib import Path
+import sys
+
+
+_API_E2E_DIR = Path(__file__).resolve().parents[4] / 'api_e2e'
+if str(_API_E2E_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_E2E_DIR))
+
+from config import IpRotator
+from config import api_base
+from config import synthetic_email
+from config import turnstile_bypass_supported
+
+
+def test_ip_rotator_yields_distinct_ips_consecutively() -> None:
+    """
+    Given un IpRotator,
+    When se piden 3 IPs seguidas,
+    Then las 3 son distintas (no se repite IP en requests consecutivos).
+    """
+    rot = IpRotator()
+
+    ips = [rot.next(), rot.next(), rot.next()]
+
+    assert len(set(ips)) == 3
+
+
+def test_ip_rotator_first_ip_is_testnet() -> None:
+    """
+    Given un IpRotator nuevo,
+    When se pide la primera IP,
+    Then es del rango TEST-NET RFC 5737 (198.51.100.x).
+    """
+    rot = IpRotator()
+
+    assert rot.next() == '198.51.100.1'
+
+
+def test_synthetic_email_uses_ses_simulator_domain() -> None:
+    """
+    Given un run_id y un slot,
+    When synthetic_email,
+    Then el email usa el dominio del SES mailbox simulator.
+    """
+    email = synthetic_email('abcd', 'auth')
+
+    assert email.endswith('@simulator.amazonses.com')
+    assert email.startswith('success+api-e2e-abcd-auth-')
+
+
+def test_synthetic_email_is_unique_per_call() -> None:
+    """
+    Given el mismo run_id y slot,
+    When synthetic_email se llama 2 veces,
+    Then los emails difieren (suffix random embebido).
+    """
+    a = synthetic_email('run1', 'auth')
+    b = synthetic_email('run1', 'auth')
+
+    assert a != b
+
+
+def test_api_base_dev_is_dev_subdomain() -> None:
+    """
+    Given env=dev,
+    When api_base,
+    Then la URL es el subdominio dev del API Gateway.
+    """
+    assert api_base('dev') == 'https://api.portfolio.dev.the-full-stack.com'
+
+
+def test_turnstile_bypass_only_dev() -> None:
+    """
+    Given los entornos dev y stage,
+    When turnstile_bypass_supported,
+    Then solo dev soporta el bypass (stage lo trata inerte).
+    """
+    assert turnstile_bypass_supported('dev') is True
+    assert turnstile_bypass_supported('stage') is False

--- a/devtools/tests/unit/src/api_e2e/test_flags.py
+++ b/devtools/tests/unit/src/api_e2e/test_flags.py
@@ -1,0 +1,101 @@
+"""Tests de validacion de flags de api_e2e (logica pura, sin red)."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+
+# Agregar el dir del script api_e2e al path para los imports bare.
+_API_E2E_DIR = Path(__file__).resolve().parents[4] / 'api_e2e'
+if str(_API_E2E_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_E2E_DIR))
+
+from flags import flag
+
+
+def test_flag_when_no_args_then_applies_defaults() -> None:
+    """
+    Given flags vacias,
+    When flag(),
+    Then aplica los defaults (env=dev, samples=5, sin lambda).
+    """
+    result = flag({})
+
+    assert result['env'] == 'dev'
+    assert result['samples'] == 5
+    assert result['lambda'] is None
+    assert result['keep_data'] is False
+
+
+def test_flag_when_env_prod_then_raises() -> None:
+    """
+    Given --env=prod,
+    When flag(),
+    Then lanza ValueError (api_e2e NUNCA corre contra prod).
+    """
+    with pytest.raises(ValueError, match='NUNCA prod'):
+        flag({'env': 'prod'})
+
+
+def test_flag_when_env_stage_then_accepted() -> None:
+    """
+    Given --env=stage,
+    When flag(),
+    Then se acepta (stage es valido).
+    """
+    result = flag({'env': 'stage'})
+
+    assert result['env'] == 'stage'
+
+
+def test_flag_when_lambda_invalid_then_raises() -> None:
+    """
+    Given --lambda=nope,
+    When flag(),
+    Then lanza ValueError con los lambdas validos.
+    """
+    with pytest.raises(ValueError, match='lambda invalido'):
+        flag({'lambda': 'nope'})
+
+
+def test_flag_when_lambda_valid_then_accepted() -> None:
+    """
+    Given --lambda=users,
+    When flag(),
+    Then se acepta.
+    """
+    result = flag({'lambda': 'users'})
+
+    assert result['lambda'] == 'users'
+
+
+def test_flag_when_samples_string_then_coerced_to_int() -> None:
+    """
+    Given --samples='3' (string del CLI),
+    When flag(),
+    Then se convierte a int 3.
+    """
+    result = flag({'samples': '3'})
+
+    assert result['samples'] == 3
+
+
+def test_flag_when_samples_zero_then_raises() -> None:
+    """
+    Given --samples=0,
+    When flag(),
+    Then lanza ValueError (debe ser >= 1).
+    """
+    with pytest.raises(ValueError, match='>= 1'):
+        flag({'samples': '0'})
+
+
+def test_flag_when_samples_not_int_then_raises() -> None:
+    """
+    Given --samples='abc',
+    When flag(),
+    Then lanza ValueError (no es entero).
+    """
+    with pytest.raises(ValueError, match='entero'):
+        flag({'samples': 'abc'})

--- a/devtools/tests/unit/src/api_e2e/test_runner.py
+++ b/devtools/tests/unit/src/api_e2e/test_runner.py
@@ -1,0 +1,131 @@
+"""Tests del runner de api_e2e: clasificacion de status + body helper."""
+
+from pathlib import Path
+import sys
+
+
+_API_E2E_DIR = Path(__file__).resolve().parents[4] / 'api_e2e'
+if str(_API_E2E_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_E2E_DIR))
+
+from reporter import Reporter
+from runner import Runner
+from runner import make_body
+from support import Response
+
+
+def _runner() -> tuple[Runner, Reporter]:
+    rep = Reporter()
+    return Runner(rep, samples=1), rep
+
+
+def test_case_when_status_matches_exact_int_then_pass() -> None:
+    """
+    Given un endpoint que devuelve 200 y expected=200,
+    When el runner corre el caso,
+    Then lo marca passed=True.
+    """
+    runner, rep = _runner()
+    runner.case(
+        lambda_name='cv',
+        name='x',
+        method='GET',
+        call=lambda: Response(200, {}, 0.1),
+        expected=200,
+    )
+
+    assert rep.results[0].passed is True
+
+
+def test_case_when_status_in_2xx_range_then_pass() -> None:
+    """
+    Given un 202 y expected='2xx',
+    When el runner corre el caso,
+    Then passed=True.
+    """
+    runner, rep = _runner()
+    runner.case(
+        lambda_name='cf',
+        name='x',
+        method='POST',
+        call=lambda: Response(202, {}, 0.1),
+        expected='2xx',
+    )
+
+    assert rep.results[0].passed is True
+
+
+def test_case_when_status_outside_expected_then_fail() -> None:
+    """
+    Given un 500 y expected='2xx',
+    When el runner corre el caso,
+    Then passed=False.
+    """
+    runner, rep = _runner()
+    runner.case(
+        lambda_name='cf',
+        name='x',
+        method='POST',
+        call=lambda: Response(500, {}, 0.1),
+        expected='2xx',
+    )
+
+    assert rep.results[0].passed is False
+
+
+def test_case_when_status_in_list_then_pass() -> None:
+    """
+    Given un 204 y expected=[200, 204],
+    When el runner corre el caso,
+    Then passed=True.
+    """
+    runner, rep = _runner()
+    runner.case(
+        lambda_name='auth',
+        name='logout',
+        method='POST',
+        call=lambda: Response(204, {}, 0.1),
+        expected=[200, 204],
+    )
+
+    assert rep.results[0].passed is True
+
+
+def test_case_records_all_samples() -> None:
+    """
+    Given samples=3 con tiempos crecientes,
+    When el runner corre el caso,
+    Then registra los 3 status codes y el cold == primer sample.
+    """
+    rep = Reporter()
+    runner = Runner(rep, samples=3)
+    seq = iter(
+        [Response(200, {}, 0.5), Response(200, {}, 0.2), Response(200, {}, 0.3)]
+    )
+    runner.case(
+        lambda_name='cv',
+        name='x',
+        method='GET',
+        call=lambda: next(seq),
+        expected=200,
+    )
+
+    result = rep.results[0]
+    assert result.status_codes == [200, 200, 200]
+    assert result.cold == 0.5
+
+
+def test_make_body_puts_operation_action_at_root() -> None:
+    """
+    Given operation, action y campos extra,
+    When make_body,
+    Then el dict tiene operation/action al nivel raiz + los campos FLAT.
+    """
+    result = make_body('contact', 'create', name='X', email='a@b.com')
+
+    assert result == {
+        'operation': 'contact',
+        'action': 'create',
+        'name': 'X',
+        'email': 'a@b.com',
+    }

--- a/devtools/uv.lock
+++ b/devtools/uv.lock
@@ -235,6 +235,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "httpx" },
     { name = "playwright" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
@@ -248,10 +249,46 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.49" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "playwright", specifier = ">=1.49.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", specifier = ">=0.15.12" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
 ]
 
 [[package]]
@@ -412,6 +449,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problema

1. **Tarea 2 — verificar que `users` tiene API**: la medicion previa de endpoints (en la conversacion) no incluyo `users`, lo que sugeria que el Lambda no tenia la API configurada.
2. **Tarea 3 — script de tests reales**: no existia una forma de correr los flujos completos (exito + errores) de cada Lambda HTTP contra el entorno desplegado, midiendo tiempos.

## Solucion

### Tarea 2 (resuelto, sin cambios de codigo)

`users` **SI tiene la API configurada y funcionando**: `POST /users` existe en API Gateway, `users-dev.json` esta deployado, y `{operation:status,action:get}` sin JWT devuelve 401 `MISSING_AUTHORIZATION` (correcto). No aparecio en la medicion previa por una **omision del mapeo** (solo se mapearon 4 de los 5 Lambdas HTTP), no por un defecto del backend. El script de la Tarea 3 cubre los 5.

### Tarea 3 (script `devtools/api_e2e/`)

Nuevo comando `python devtools/run.py api_e2e --env=dev|stage` que corre, contra el entorno de **deploy real** (NUNCA prod), los flujos de exito + un par de errores de cada Lambda HTTP:

| Lambda | Exito | Errores |
|--------|-------|---------|
| `cv` | 10 actions read (2xx) | action invalida, sin operation |
| `contact_form` | create 202 (bypass) | sin message, email invalido |
| `tracking_pixel` | track 202 | sin event_type_id, viewport invalido |
| `auth` | register.start->verify-code->refresh->login.start->logout | set-password ya seteada (400), email inexistente (404), tokens falsos |
| `users` | profile.get/update, status.get/list-sessions | admin no-admin (404), sin JWT (401), JWT falso |

Detalles:
- **Flujos auth con seed de Neon**: el code de verify no vuelve en la respuesta (solo su hash SHA-256 va a Neon); el harness siembra un plaintext conocido en `auth_email_codes` y lo envia.
- **Datos sinteticos + cleanup**: emails `@simulator.amazonses.com`; al final borra users/contacts/tracking creados (salvo `--keep-data`).
- **IP rotada** (TEST-NET RFC 5737) por request para no agotar el rate-limit.
- **Hermetico**: secretos (bypass Turnstile, Neon URL) resueltos de SSM en proceso, NUNCA impresos (cumple `env-files.md`).
- **No es parte de `test_runner`**: muta el entorno desplegado + lee SSM + siembra Neon, asi que es opt-in, fuera de CI.
- Dep nueva: `psycopg[binary]` en devtools.
- 20 tests unit (flags + runner + config, logica pura sin red).

## Como probar

```bash
# unit (logica pura del script)
python devtools/run.py test_runner --module=devtools --type=unit   # incluye 20 de api_e2e

# E2E real contra dev (requiere SSO activo)
AWS_PROFILE=tfs-dev python devtools/run.py api_e2e --env=dev --aws-profile=tfs-dev
```

Resultado verificado contra dev: **43/43 casos PASS**, cleanup borro los datos sinteticos (users=10, contacts=1, tracking=2). Tiempos: GLOBAL warm 0.808s, cold 0.879s; `auth.register.start` el mas lento (3.49s, cold init de SnapStart + bcrypt/argon2).

## TODO

- Cuando `stage` tenga el backend desplegado, validar `--env=stage` (los flujos con Turnstile se omiten alli porque el bypass solo aplica en dev; los casos de error siguen corriendo).