### PR TITLE
fix(api_e2e): corrige estado roto mergeado (users token + cleanup + imports + lint)

### DIFF
--- a/devtools/api_e2e/flow_auth.py
+++ b/devtools/api_e2e/flow_auth.py
@@ -1,22 +1,27 @@
 """Flujo auth: registro completo (exito) + casos de error.
 
 Flujo de exito (con seed de Neon para el paso verify-code):
-  register.start -> seed code -> register.verify-code (access+refresh)
-  -> session.refresh -> login.start -> verify.set-password
-  -> session.logout
+  register.start -> seed code -> register.verify-code (access1+refresh1)
+  -> session.refresh (access2+refresh2) -> login.start
+  -> verify.set-password -> session.logout(access1)
 
 Shapes confirmados contra dev (campos anidados bajo `data`):
   register.start      -> 200 {data: {temp_token, user_id, expires_in, ...}}
   register.verify-code-> 200 {data: {access_token, refresh_token, ...}}
 
+Detalle critico del token: el logout se hace sobre `access1` (el token de
+verify-code), NO sobre `access2` (el de refresh). logout sin refresh_token
+solo blacklistea el jti del access, no la familia — asi `access2` sigue
+vivo y se devuelve para que el flujo de `users` lo reutilice. Si se
+logouteara `access2`, `users` recibiria 401.
+
 Casos de error: login.start de email inexistente (404), tokens falsos en
 los verify (4xx), mfa/webauthn sin JWT valido (401/4xx).
-
-Devuelve el `access_token` del user creado para que el flujo de `users`
-lo reutilice.
 """
 
 from __future__ import annotations
+
+import secrets
 
 from api_e2e.config import admin_origin
 from api_e2e.config import synthetic_email
@@ -39,7 +44,7 @@ def run_auth(
     bypass: str | None,
     created_emails: list[str],
 ) -> str | None:
-    """Corre el flujo auth. Devuelve el access_token del user creado."""
+    """Corre el flujo auth. Devuelve un access_token VIVO para users."""
     origin = admin_origin(env_name)
     access_token: str | None = None
 
@@ -69,7 +74,7 @@ def _run_success(
     bypass: str,
     created_emails: list[str],
 ) -> str | None:
-    """Flujo de registro->sesion completo. Devuelve access_token final."""
+    """Flujo registro->sesion completo. Devuelve access2 (vivo) para users."""
     email = synthetic_email(run_id, 'auth')
     created_emails.append(email)
 
@@ -96,7 +101,7 @@ def _run_success(
     if not (temp_token and user_id):
         return None
 
-    # 2. seed code + register.verify-code -> access+refresh
+    # 2. seed code + register.verify-code -> access1 + refresh1
     seeded = env.seed_code(
         user_id=user_id,
         kind='register',
@@ -119,29 +124,26 @@ def _run_success(
         expected=200,
         note='code sembrado en Neon' if seeded else 'seed FALLO',
     )
-    access_token = _field(r.body, 'access_token')
-    refresh_token = _field(r.body, 'refresh_token')
+    access1 = _field(r.body, 'access_token')
+    refresh1 = _field(r.body, 'refresh_token')
 
-    # 3. session.refresh -> rota el refresh
-    if refresh_token:
+    # 3. session.refresh(refresh1) -> access2 + refresh2 (rota la familia)
+    access2 = access1
+    if refresh1:
         r = runner.step(
             lambda_name='auth',
             name='session.refresh (success)',
             method='POST',
             call=lambda: http.post(
                 '/auth',
-                body=make_body(
-                    'session',
-                    'refresh',
-                    refresh_token=refresh_token,
-                ),
+                body=make_body('session', 'refresh', refresh_token=refresh1),
                 origin=origin,
             ),
             expected=200,
         )
-        access_token = _field(r.body, 'access_token') or access_token
+        access2 = _field(r.body, 'access_token') or access1
 
-    # 4. login.start (success) -> nuevo temp para set-password
+    # 4. login.start (success) -> temp del login
     r = runner.step(
         lambda_name='auth',
         name='login.start (success)',
@@ -161,7 +163,7 @@ def _run_success(
     )
     login_temp = _field(r.body, 'temp_token')
 
-    # 5. verify.set-password con el temp del login
+    # 5. verify.set-password con el temp del login (user nuevo sin password)
     if login_temp:
         runner.step(
             lambda_name='auth',
@@ -180,22 +182,23 @@ def _run_success(
             expected='2xx',
         )
 
-    # 6. session.logout con el access vigente -> 200/204
-    if access_token:
+    # 6. session.logout(access1) -> blacklistea SOLO ese jti (no la familia,
+    #    no se pasa refresh_token). access2 queda vivo para users.
+    if access1:
         runner.step(
             lambda_name='auth',
             name='session.logout (success)',
             method='POST',
             call=lambda: http.post(
                 '/auth',
-                body=make_body('session', 'logout', access_token=access_token),
+                body=make_body('session', 'logout', access_token=access1),
                 origin=origin,
-                bearer=access_token,
+                bearer=access1,
             ),
             expected=[200, 204],
         )
 
-    return access_token
+    return access2
 
 
 def _run_errors(
@@ -206,6 +209,9 @@ def _run_errors(
 ) -> None:
     """Casos de error de auth (no mutan / no requieren estado valido)."""
     if bypass:
+        # Email aleatorio garantizado-inexistente (un email fijo podria
+        # quedar pending de una corrida previa -> 409 en vez de 404).
+        ghost = f'success+ghost-{secrets.token_hex(4)}@simulator.amazonses.com'
         runner.case(
             lambda_name='auth',
             name='login.start (error: email inexistente)',
@@ -215,7 +221,7 @@ def _run_errors(
                 body=make_body(
                     'login',
                     'start',
-                    email='nadie-api-e2e@simulator.amazonses.com',
+                    email=ghost,
                     cf_turnstile_response='',
                 ),
                 origin=origin,

--- a/devtools/api_e2e/main.py
+++ b/devtools/api_e2e/main.py
@@ -29,7 +29,6 @@ from api_e2e.support import HttpClient
 def main(flags: dict[str, Any]) -> int:
     """Corre el harness api_e2e segun las flags."""
     env_name = flags['env']
-    only = flags.get('lambda')
     samples = flags.get('samples', 5)
     keep_data = flags.get('keep_data', False)
     aws_profile = flags.get('aws_profile')
@@ -52,6 +51,36 @@ def main(flags: dict[str, Any]) -> int:
         print(f'[ERROR] setup del entorno: {type(exc).__name__}: {exc}')
         return 2
 
+    _print_bypass_note(env_name, bypass)
+
+    run_id = _secrets.token_hex(2)
+    http = HttpClient(base_url=api_base(env_name))
+    reporter = Reporter()
+    runner = Runner(reporter, samples=samples)
+
+    created_emails: list[str] = []
+    created_sessions: list[str] = []
+
+    try:
+        _run_flows(
+            runner=runner, http=http, env=env, env_name=env_name,
+            only=flags.get('lambda'), run_id=run_id, bypass=bypass,
+            created_emails=created_emails, created_sessions=created_sessions,
+        )
+    finally:
+        http.close()
+        if keep_data:
+            print('\n[INFO] --keep-data: datos sinteticos NO eliminados.')
+        else:
+            _cleanup(env, created_emails, created_sessions)
+
+    reporter.print_timing_summary()
+    reporter.print_final()
+    return 0 if reporter.all_passed() else 1
+
+
+def _print_bypass_note(env_name: str, bypass: str | None) -> None:
+    """Avisa si el bypass de Turnstile no esta disponible para el env."""
     if bypass is None and turnstile_bypass_supported(env_name):
         print(
             '[WARN] bypass de Turnstile no disponible: los flujos de '
@@ -63,60 +92,42 @@ def main(flags: dict[str, Any]) -> int:
             'flujos con Turnstile omitidos (solo errores).'
         )
 
-    run_id = _secrets.token_hex(2)
-    http = HttpClient(base_url=api_base(env_name))
-    reporter = Reporter()
-    runner = Runner(reporter, samples=samples)
 
-    created_emails: list[str] = []
-    created_sessions: list[str] = []
-
-    def _want(name: str) -> bool:
+def _run_flows(
+    *,
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    env_name: str,
+    only: str | None,
+    run_id: str,
+    bypass: str | None,
+    created_emails: list[str],
+    created_sessions: list[str],
+) -> None:
+    """Corre los flujos de los Lambdas pedidos (o todos si only es None)."""
+    def want(name: str) -> bool:
         return only is None or only == name
 
-    try:
-        if _want('cv'):
-            print('\n--- cv ---')
-            run_cv(runner, http, env_name)
-        if _want('contact_form'):
-            print('\n--- contact_form ---')
-            run_contact(
-                runner,
-                http,
-                env_name,
-                run_id,
-                bypass,
-                created_emails,
-            )
-        if _want('tracking_pixel'):
-            print('\n--- tracking_pixel ---')
-            run_tracking(runner, http, env_name, run_id, created_sessions)
+    if want('cv'):
+        print('\n--- cv ---')
+        run_cv(runner, http, env_name)
+    if want('contact_form'):
+        print('\n--- contact_form ---')
+        run_contact(runner, http, env_name, run_id, bypass, created_emails)
+    if want('tracking_pixel'):
+        print('\n--- tracking_pixel ---')
+        run_tracking(runner, http, env_name, run_id, created_sessions)
 
-        access_token = None
-        if _want('auth') or _want('users'):
-            print('\n--- auth ---')
-            access_token = run_auth(
-                runner,
-                http,
-                env,
-                env_name,
-                run_id,
-                bypass,
-                created_emails,
-            )
-        if _want('users'):
-            print('\n--- users ---')
-            run_users(runner, http, env_name, access_token)
-    finally:
-        http.close()
-        if not keep_data:
-            _cleanup(env, created_emails, created_sessions)
-        else:
-            print('\n[INFO] --keep-data: datos sinteticos NO eliminados.')
-
-    reporter.print_timing_summary()
-    reporter.print_final()
-    return 0 if reporter.all_passed() else 1
+    access_token = None
+    if want('auth') or want('users'):
+        print('\n--- auth ---')
+        access_token = run_auth(
+            runner, http, env, env_name, run_id, bypass, created_emails,
+        )
+    if want('users'):
+        print('\n--- users ---')
+        run_users(runner, http, env_name, access_token)
 
 
 def _cleanup(
@@ -131,7 +142,8 @@ def _cleanup(
         contacts = env.cleanup_contacts(emails)
         tracking = env.cleanup_tracking(sessions)
         print(
-            f'  borrados: users={users} contacts={contacts} tracking={tracking}'
+            f'  borrados: users={users} contacts={contacts} '
+            f'tracking={tracking}'
         )
     except Exception as exc:  # noqa: BLE001 -- best-effort
         print(f'  [WARN] cleanup parcial: {type(exc).__name__}: {exc}')

--- a/devtools/tests/unit/src/api_e2e/test_config.py
+++ b/devtools/tests/unit/src/api_e2e/test_config.py
@@ -48,10 +48,10 @@ def test_synthetic_email_is_unique_per_call() -> None:
     When synthetic_email se llama 2 veces,
     Then los emails difieren (suffix random embebido).
     """
-    a = synthetic_email('run1', 'auth')
-    b = synthetic_email('run1', 'auth')
+    first = synthetic_email('run1', 'auth')
+    second = synthetic_email('run1', 'auth')
 
-    assert a != b
+    assert first != second
 
 
 def test_api_base_dev_is_dev_subdomain() -> None:

--- a/devtools/tests/unit/src/api_e2e/test_flags.py
+++ b/devtools/tests/unit/src/api_e2e/test_flags.py
@@ -1,4 +1,8 @@
-"""Tests de validacion de flags de api_e2e (logica pura, sin red)."""
+"""Tests de validacion de flags de api_e2e (logica pura, sin red).
+
+El conftest de devtools (devtools/tests/conftest.py) agrega devtools/ al
+sys.path, asi que `api_e2e` resuelve como paquete.
+"""
 
 import pytest
 


### PR DESCRIPTION
## Problema

Los PRs #204/#205 dejaron `api_e2e` en `dev` con **4 fallos reales** que se filtraron porque (a) `ci.yml` solo lintea/buildea las apps Astro — NO corre `ruff`/tests de `devtools/` — y (b) la verificacion E2E no se completo (SSO caido + confie en un smoke parcial de solo `cv`):

1. **users 401 en los flujos de exito**: el flujo auth hacia `session.logout` del **mismo** access token que devolvia para `users` -> `users` lo reusaba ya blacklisted -> 401.
2. **cleanup fallaba**: `auth_user_admin_actions` no tiene columna `user_id` (usa `actor_user_id`/`target_user_id`) -> `UndefinedColumn` abortaba el cleanup y dejaba users sinteticos **huerfanos** en Neon.
3. **imports bare** (`from config import ...`) -> `ModuleNotFoundError` al invocar via `run.py` (cwd=`devtools/`).
4. **ruff**: C901 (`main` complejo) + C408 (`dict()`).

## Solucion

1. logout sobre `access1` (el de verify-code), devolver `access2` (el de refresh, jti independiente, vivo). logout sin `refresh_token` solo blacklistea ese jti, no la familia.
2. quita `auth_user_admin_actions` del cleanup (el user sintetico nunca es actor/target) + `_exec` tolera `UndefinedColumn`.
3. imports package-qualified (`from api_e2e.X import`) en codigo y tests; tests sin el `sys.path` hack (el conftest de devtools ya pone `devtools/` en el path).
4. extrae `_run_flows` + `_print_bypass_note` de `main` (C901); dict literal en `_track_body` (C408).

## Como probar (verificado end-to-end esta vez)

```bash
devtools/.venv/bin/ruff check devtools/api_e2e/ --config devtools/ruff.toml   # All checks passed
python devtools/run.py test_runner --module=devtools --type=unit              # OK
python devtools/run.py api_e2e --env=dev --aws-profile=tfs-dev                 # 39/39 PASS
```

Resultado real contra dev: **39/39 casos PASS**, cleanup borro users=8 contacts=1 tracking=2, **0 huerfanos** sinteticos en Neon verificado por query. users ahora 200 en profile.get/update + status.get/list-sessions; admin.list-users 404 (no-admin).

## TODO (recurrencia)

La causa de que #204/#205 mergearan rotos es que **CI no gatea `devtools/`**. Propongo (PR aparte) agregar al job `quality-gates` de `ci.yml`:
- `ruff check devtools/ --config devtools/ruff.toml`
- `python devtools/run.py test_runner --module=devtools --type=unit`

asi un script devtools roto NO vuelve a pasar CI. (No lo incluyo aqui para no mezclar un cambio de workflow con el fix; requiere su propia verificacion con act.)