### PR TITLE
fix(api_e2e): repara estado roto en dev (unit collision + cleanup + ruff)

### DIFF
--- a/devtools/api_e2e/environment.py
+++ b/devtools/api_e2e/environment.py
@@ -95,6 +95,9 @@ class Environment:
         ]
         if not ids:
             return 0
+        # NO incluye auth_user_admin_actions: esa tabla referencia por
+        # actor_user_id/target_user_id (no user_id), y el user sintetico
+        # nunca es actor ni target ahi -> no deja filas.
         children = (
             'auth_email_codes',
             'auth_magic_links',
@@ -105,12 +108,12 @@ class Environment:
             'auth_user_sessions',
             'auth_audit_log',
             'auth_user_consent_log',
-            'auth_user_admin_actions',
         )
         total = 0
         for table in children:
+
             total += self._exec(
-                f'DELETE FROM {table} WHERE user_id = ANY(%s)',
+                f'DELETE FROM {table} WHERE user_id = ANY(%s)',  # noqa: S608
                 (ids,),
                 ignore_missing=True,
             )
@@ -127,7 +130,7 @@ class Environment:
         n = 0
         for table in ('tracking_events', 'session_visits', 'sessions'):
             n += self._exec(
-                f'DELETE FROM {table} WHERE session_id = ANY(%s)',
+                f'DELETE FROM {table} WHERE session_id = ANY(%s)',  # noqa: S608
                 (session_ids,),
                 ignore_missing=True,
             )
@@ -159,7 +162,7 @@ class Environment:
             ):
                 cur.execute(sql, params)
                 return cur.rowcount
-        except psycopg.errors.UndefinedTable:
+        except (psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn):
             if ignore_missing:
                 return 0
             raise

--- a/devtools/api_e2e/flow_auth.py
+++ b/devtools/api_e2e/flow_auth.py
@@ -31,7 +31,8 @@ from api_e2e.runner import make_body
 from api_e2e.support import HttpClient
 
 
-_STRONG_PASSWORD = 'api-e2e-Str0ng-Passphrase!'
+# Password de prueba del harness (NO es un secreto real).
+_STRONG_PASSWORD = 'api-e2e-Str0ng-Passphrase!'  # noqa: S105
 _FAKE_JWT = 'FAKE-TOKEN-API-E2E-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX'
 
 

--- a/devtools/api_e2e/flow_readonly.py
+++ b/devtools/api_e2e/flow_readonly.py
@@ -18,8 +18,16 @@ from api_e2e.support import HttpClient
 
 
 _CV_ACTIONS = (
-    'get', 'profile', 'experiences', 'projects', 'certificates',
-    'awards', 'education', 'languages', 'references', 'skills',
+    'get',
+    'profile',
+    'experiences',
+    'projects',
+    'certificates',
+    'awards',
+    'education',
+    'languages',
+    'references',
+    'skills',
 )
 
 
@@ -53,7 +61,9 @@ def run_cv(runner: Runner, http: HttpClient, env: str) -> None:
         name='cv (error: sin operation)',
         method='GET',
         call=lambda: http.get(
-            '/cv', params={'action': 'get'}, origin=origin,
+            '/cv',
+            params={'action': 'get'},
+            origin=origin,
         ),
         expected='4xx',
     )
@@ -79,12 +89,15 @@ def run_contact(
             call=lambda: http.post(
                 '/contact',
                 body=make_body(
-                    'contact', 'create',
-                    name='API E2E', email=email,
+                    'contact',
+                    'create',
+                    name='API E2E',
+                    email=email,
                     message='Mensaje de prueba E2E del harness api_e2e.',
                     cf_token='',
                 ),
-                origin=origin, bypass_secret=bypass,
+                origin=origin,
+                bypass_secret=bypass,
             ),
             expected='2xx',
             samples=2,
@@ -100,11 +113,14 @@ def run_contact(
         call=lambda: http.post(
             '/contact',
             body=make_body(
-                'contact', 'create',
-                name='API E2E', email='success+e2e@simulator.amazonses.com',
+                'contact',
+                'create',
+                name='API E2E',
+                email='success+e2e@simulator.amazonses.com',
                 cf_token='',
             ),
-            origin=origin, bypass_secret=bypass,
+            origin=origin,
+            bypass_secret=bypass,
         ),
         expected='4xx',
     )
@@ -115,12 +131,15 @@ def run_contact(
         call=lambda: http.post(
             '/contact',
             body=make_body(
-                'contact', 'create',
-                name='API E2E', email='no-es-un-email',
+                'contact',
+                'create',
+                name='API E2E',
+                email='no-es-un-email',
                 message='mensaje suficientemente largo para pasar',
                 cf_token='',
             ),
-            origin=origin, bypass_secret=bypass,
+            origin=origin,
+            bypass_secret=bypass,
         ),
         expected='4xx',
     )
@@ -139,16 +158,21 @@ def run_tracking(
     created_sessions.append(session_id)
 
     def _track_body(**over: object) -> dict:
-        base: dict[str, object] = dict(
-            session_id=session_id,
-            event_id='a1b2c3d4e5f60718293a4b5c6d7e8f90',
-            event_type_id=TRACKING_EVENT_TYPE_ID,
-            page_url='https://the-full-stack.com/projects',
-            page_title='Projects', page_path='/projects',
-            utm_source='e2e', utm_medium='api',
-            utm_campaign='verify', utm_content='run',
-            viewport_width=1920, viewport_height=1080, niche=NICHE,
-        )
+        base: dict[str, object] = {
+            'session_id': session_id,
+            'event_id': 'a1b2c3d4e5f60718293a4b5c6d7e8f90',
+            'event_type_id': TRACKING_EVENT_TYPE_ID,
+            'page_url': 'https://the-full-stack.com/projects',
+            'page_title': 'Projects',
+            'page_path': '/projects',
+            'utm_source': 'e2e',
+            'utm_medium': 'api',
+            'utm_campaign': 'verify',
+            'utm_content': 'run',
+            'viewport_width': 1920,
+            'viewport_height': 1080,
+            'niche': NICHE,
+        }
         base.update(over)
         return make_body('tracking', 'track', **base)
 
@@ -167,14 +191,20 @@ def run_tracking(
         call=lambda: http.post(
             '/track',
             body=make_body(
-                'tracking', 'track',
+                'tracking',
+                'track',
                 session_id=session_id,
                 event_id='a1b2c3d4e5f60718293a4b5c6d7e8f90',
                 page_url='https://the-full-stack.com/p',
-                page_title='P', page_path='/p',
-                utm_source='e2e', utm_medium='api',
-                utm_campaign='verify', utm_content='run',
-                viewport_width=1920, viewport_height=1080, niche=NICHE,
+                page_title='P',
+                page_path='/p',
+                utm_source='e2e',
+                utm_medium='api',
+                utm_campaign='verify',
+                utm_content='run',
+                viewport_width=1920,
+                viewport_height=1080,
+                niche=NICHE,
             ),
             origin=origin,
         ),
@@ -185,7 +215,9 @@ def run_tracking(
         name='tracking.track (error: viewport invalido)',
         method='POST',
         call=lambda: http.post(
-            '/track', body=_track_body(viewport_width=999999), origin=origin,
+            '/track',
+            body=_track_body(viewport_width=999999),
+            origin=origin,
         ),
         expected='4xx',
     )


### PR DESCRIPTION
## Problema

Tras #204/#205/#206, `api_e2e` quedo **roto en dev** y se filtro porque (a) `ci.yml` NO gatea `devtools/` (solo apps Astro) y (b) varios fixes previos no aterrizaron (Writes fallaron en silencio por el reformat del hook + commitee sin re-verificar). Estado real medido en dev:

- `devtools:unit` **FAIL**: `ModuleNotFoundError: No module named 'api_e2e.reporter'`
- **4 errores ruff** (C408, S105, S608 x2)
- `cleanup` dejaba **users sinteticos huerfanos** en Neon

(El fix de `users` 401 SI aterrizo en #206 — ese flujo ya estaba 200.)

## Solucion (3 gates verdes, verificado desde cero)

1. **unit collision**: `devtools/tests/unit/src/api_e2e/__init__.py` convertia el dir de tests en un paquete `api_e2e` que tapaba al paquete-script `devtools/api_e2e/`. Fix: **eliminar ese `__init__.py`** (igual que `ai_audit`, sin `__init__`). Los tests ya usan imports package-qualified.
2. **cleanup huerfanos**: `auth_user_admin_actions` no tiene columna `user_id` (usa `actor_user_id`/`target_user_id`) -> `UndefinedColumn` abortaba el cleanup. Fix: se quita esa tabla + `_exec` tolera `UndefinedColumn`.
3. **ruff**: C408 -> dict literal; S105 (password de test) + S608 x2 (DELETE f-string con table name de constante, no input) -> `noqa` con razon.

## Como probar (salidas reales)

```bash
devtools/.venv/bin/ruff check devtools/api_e2e/ devtools/tests/unit/src/api_e2e/ --config devtools/ruff.toml
#   -> All checks passed!
python devtools/run.py test_runner --module=devtools --type=unit
#   -> devtools:unit OK
python devtools/run.py api_e2e --env=dev --aws-profile=tfs-dev
#   -> 37/37 PASS; users profile/status 200; cleanup borrados sin WARN
```

`users` ahora 200 en profile.get/update + status.get/list-sessions, 404 admin no-admin, 401 sin/JWT-falso. Cleanup sin WARN (barrio ademas 8 leftovers de las corridas rotas anteriores). Tiempos: GLOBAL warm 1.74s / cold 2.36s.

## TODO (causa raiz de la recurrencia)

`ci.yml` no corre ruff/tests de `devtools/`, por eso varios PRs mergearon rotos. PR aparte: agregar al job `quality-gates` `ruff check devtools/` + `test_runner --module=devtools --type=unit`.