### PR TITLE
fix(api_e2e): agrupa el cold start por Lambda en el reporte

### DIFF
--- a/.claude/commands/push-pr-merge.md
+++ b/.claude/commands/push-pr-merge.md
@@ -1,8 +1,10 @@
 ---
 description: >
   Push de la rama actual, crea PR con gh, espera GitHub Actions, mergea
-  con merge commit a la base (default dev) y deja al usuario en dev con el
-  pull aplicado. Flujo end-to-end de cierre de feature.
+  con merge commit a la base (default dev), deja al usuario en dev con el
+  pull aplicado y corre la bateria completa de tests (unit, integration,
+  feature/E2E, api_e2e segun scope) para confirmar que la base quedo
+  estable. Flujo end-to-end de cierre de feature.
 argument-hint: "[base=dev] [--draft]"
 ---
 
@@ -192,7 +194,96 @@ el merge. Si quedo colgante:
 git branch -d "$BRANCH" 2>&1 || true
 ```
 
-### 8. Reporte final
+### 8. Verificacion post-merge: bateria completa de tests (OBLIGATORIA)
+
+Si el PR es draft NO se llego a mergear -> SALTAR este paso (no hay nada que
+verificar sobre la base). En cualquier otro caso, con la base ya checkouteada
+y el merge aplicado (paso 7), correr SIEMPRE la bateria completa para
+confirmar que el merge NO desestabilizo la base.
+
+> El codigo YA esta mergeado: estas verificaciones no pueden des-mergear. Por
+> eso una falla NO es un blocker silencioso — se reporta FUERTE como
+> **"BASE INESTABLE"** con la causa y el comando de reproduccion, y el
+> siguiente paso es un fix forward (commit/PR nuevo), nunca dejar la base
+> rota sin avisar.
+
+Detectar el scope del merge para decidir que suites aplican (ante la duda,
+correr TODO):
+
+```bash
+# Archivos que trajo el branch mergeado (HEAD = merge commit; ^1 = base previa).
+CHANGED=$(git diff --name-only "HEAD^1" HEAD 2>/dev/null)
+printf '%s\n' "$CHANGED" | rg -q '^serverless/'        && BACKEND=1 || BACKEND=0
+printf '%s\n' "$CHANGED" | rg -q '^(apps|packages)/'   && FRONTEND=1 || FRONTEND=0
+printf '%s\n' "$CHANGED" | rg -q '^devtools/'          && DEVTOOLS=1 || DEVTOOLS=0
+```
+
+Correr cada bloque que aplique, en orden, capturando PASS/FAIL por suite:
+
+**A. Frontend (host, sin Docker) — siempre que `FRONTEND=1` (o ante la duda):**
+
+```bash
+pnpm install                 # reconcilia deps tras el merge (el lockfile pudo cambiar)
+pnpm run lint                # Biome check
+pnpm run typecheck           # tsc --noEmit + astro check (recursivo)
+pnpm run test                # Vitest recursivo en packages (unit)
+pnpm run build               # build estatico de las 6 apps
+```
+
+**B. Backend serverless — solo si `BACKEND=1`:**
+
+```bash
+python devtools/run.py serverless lint-deps                  # shared-only + dedup D-3
+python devtools/run.py serverless tests --type=unit          # 4 lambdas + shared
+python devtools/run.py serverless tests --type=integration   # E2E con recursos reales
+```
+
+**C. Feature E2E (Playwright contra el stack local) — siempre que `FRONTEND=1`:**
+
+```bash
+python devtools/run.py docker up --env=local
+python devtools/run.py test_runner --module=feature --type=feature --env=local
+python devtools/run.py docker down --env=local   # opcional, si terminaste
+```
+
+Si Docker no esta disponible o un container queda `unhealthy`, marcar
+**[OMITIDO]** (igual que el pre-push hook) y anotarlo en el reporte — NO es
+PASS ni FAIL, es cobertura no ejecutada.
+
+**D. api_e2e (HTTP real contra el entorno desplegado) — solo si `BASE=dev` (o
+`stage`) y `BACKEND=1`:**
+
+El merge a `dev` dispara `deploy-backend.yml`, que redeploya los Lambdas. Hay
+que ESPERAR a que termine antes de pegarle a la API (si no, da 500s por
+deploy en vuelo):
+
+```bash
+# Esperar a que el deploy del backend termine (workflow file deploy-backend.yml)
+DEPLOY_RUN=$(gh run list --branch "$BASE" --workflow deploy-backend.yml \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$DEPLOY_RUN" --exit-status 2>&1 | tail -20
+
+# Recien ahi, E2E real (token Ed25519 firmado localmente; ver skill api_e2e)
+python devtools/run.py api_e2e --env="$BASE" --aws-profile=tfs-dev 2>&1 | tail -40
+```
+
+**E. devtools — solo si `DEVTOOLS=1`:**
+
+```bash
+python devtools/run.py test_runner --module=devtools --type=unit
+```
+
+Bucle de diagnostico (no parar hasta entender CADA falla): si una suite
+falla, leer el output, identificar el archivo/test y la causa, y dejarlo
+documentado en el reporte con el comando de reproduccion. Distinguir SIEMPRE
+una regresion del merge de una falla pre-existente (infra caida, deuda de
+cobertura previa): si es pre-existente, decirlo explicitamente.
+
+Time-box: maximo ~15 minutos para esta bateria. Si el deploy de la API o el
+stack Docker tarda mas, reportar timeout en la suite correspondiente y seguir
+con el reporte (las demas suites ya corrieron).
+
+### 9. Reporte final
 
 ```markdown
 ## Push + PR + Merge completado
@@ -208,13 +299,23 @@ git branch -d "$BRANCH" 2>&1 || true
 - quality-gates: <status> (<duration>)
 - clean: <status> (<duration>)
 
+### Verificacion post-merge (paso 8)
+- Frontend lint/typecheck/unit/build: PASS / FAIL / [OMITIDO]
+- Backend serverless unit/integration/lint-deps: PASS / FAIL / [OMITIDO]
+- Feature E2E (Playwright): PASS / FAIL / [OMITIDO]
+- api_e2e (<base>): PASS / FAIL / [OMITIDO]
+- devtools unit: PASS / FAIL / [OMITIDO]
+- Veredicto base: ESTABLE / **INESTABLE** (con causa + comando de repro si FAIL)
+
 ### Local
 - Rama actual: <base>
 - Sincronizado con origin/<base>: si/no
 - Working tree: limpio/sucio
 
 ### Siguiente paso sugerido
-- Si todo OK: "Listo para nueva feature."
+- Si todo OK: "Base estable. Listo para nueva feature."
+- Si la base quedo INESTABLE: "Fix forward: <comando concreto> y abrir PR de
+  correccion (la base ya esta mergeada, no se des-mergea)."
 - Si CI fallo: "Inspecciona <comando concreto>"
 - Si draft: "Revisa el PR y mergea manualmente cuando este listo."
 ```
@@ -231,6 +332,13 @@ git branch -d "$BRANCH" 2>&1 || true
 - NUNCA atribucion de IA en titulo, body, ni comentarios del PR (politica
   global, hook `prepare-commit-msg` la elimina si se cuela).
 - NUNCA mergear si el PR es draft — solo reportar.
+- SIEMPRE correr la bateria completa de tests tras el merge (paso 8: unit,
+  integration, feature/E2E, api_e2e segun scope) para confirmar que la base
+  quedo estable. Una falla NO bloquea (ya esta mergeado) pero se reporta como
+  **BASE INESTABLE** + fix forward. NUNCA declarar el command exitoso si la
+  base quedo en rojo sin avisarlo en el reporte.
+- Distinguir SIEMPRE una regresion del merge de una falla pre-existente
+  (infra caida, deuda de cobertura previa) en el reporte post-merge.
 - Si gh CLI falla con MCP github disponible (`mcp__github__*`), usar
   fallback MCP. Si ambos fallan, detente y sugiere creacion manual.
 - Time-box: maximo 10 minutos para CI watch. Si CI tarda mas, reportar
@@ -246,6 +354,11 @@ git branch -d "$BRANCH" 2>&1 || true
 - ❌ Inventar contenido para el body del PR sin leer los commits reales.
 - ❌ Usar `gh pr merge --auto` (espera condiciones que pueden tardar
   horas; este command es sincrono).
+- ❌ Declarar el command completo SIN correr la bateria post-merge (paso 8):
+  el CI verde no cubre integration/feature/api_e2e, que viven en local.
+- ❌ Correr `api_e2e` contra `dev` ANTES de que `deploy-backend.yml` termine
+  (da 500s por deploy en vuelo) — esperar el run con `gh run watch`.
+- ❌ Dejar la base en rojo sin reportarlo como BASE INESTABLE.
 
 ## Cuando NO usar este command
 

--- a/devtools/api_e2e/README.md
+++ b/devtools/api_e2e/README.md
@@ -56,8 +56,14 @@ python devtools/run.py api_e2e --env=dev --keep-data --aws-profile=tfs-dev
 
 ## Como funciona (detalles)
 
-- **Tiempos**: cada caso se invoca N veces; el reporte separa `cold`
-  (1ra muestra) de `warm` (promedio 2..N) y da un promedio global.
+- **Tiempos**: el cold start es POR-LAMBDA (lo paga solo el PRIMER invoke
+  del contenedor). El reporte lo agrupa por Lambda: el bloque
+  `COLD START POR LAMBDA` lista un cold por Lambda (la 1ra muestra de su
+  primer caso) y la tabla `TIEMPOS POR CASO` muestra ese cold solo en el
+  primer caso de cada Lambda (`-` en el resto, que ya corren calientes).
+  El `warm` de un caso es el promedio de sus muestras calientes: del primer
+  caso del Lambda son las muestras 2..N; del resto, TODAS sus muestras. El
+  `GLOBAL` promedia el cold por Lambda (no por caso) y el warm por caso.
 - **Datos sinteticos + cleanup**: emails `success+api-e2e-<run>-<slot>@
   simulator.amazonses.com` (SES mailbox simulator: globalmente
   entregable, sin entrega real). Al final borra users/contacts/tracking

--- a/devtools/api_e2e/reporter.py
+++ b/devtools/api_e2e/reporter.py
@@ -2,7 +2,13 @@
 
 Cada llamada a un endpoint produce un `CaseResult`. El `Reporter`
 acumula todos, imprime cada caso al vuelo y, al final, un resumen de
-tiempos de respuesta promedio por endpoint + el veredicto pass/fail.
+tiempos de respuesta + el veredicto pass/fail.
+
+El cold start es un fenomeno POR-LAMBDA (lo paga solo el PRIMER invoke del
+contenedor). Por eso el reporte NO atribuye un cold a cada caso: lo agrupa
+por Lambda y lo asigna al PRIMER caso de cada Lambda (en orden de ejecucion,
+que es el orden de insercion). Los casos siguientes ya corren sobre el
+contenedor caliente -> su tiempo cuenta como warm, NO como cold.
 """
 
 from __future__ import annotations
@@ -26,19 +32,35 @@ class CaseResult:
 
     @property
     def avg(self) -> float:
-        """Promedio de todos los samples (segundos)."""
+        """Promedio de TODOS los samples (segundos)."""
         return sum(self.elapsed) / len(self.elapsed) if self.elapsed else 0.0
 
     @property
     def cold(self) -> float:
-        """Primer sample (peor caso / cold)."""
+        """Primer sample del caso (peor caso del caso, NO el cold del Lambda).
+
+        OJO: solo es el cold start REAL del Lambda si este caso fue el PRIMER
+        invoke de su contenedor. La atribucion correcta la hace el Reporter
+        en `timing_rows()`; esta propiedad es el dato crudo per-caso.
+        """
         return self.elapsed[0] if self.elapsed else 0.0
 
-    @property
-    def warm_avg(self) -> float:
-        """Promedio de los samples 2..N; cae al unico si hay 1 sample."""
-        warm = self.elapsed[1:] or self.elapsed
-        return sum(warm) / len(warm) if warm else 0.0
+
+@dataclass
+class TimingRow:
+    """Fila de tiempos ya clasificada cold/warm a nivel Lambda.
+
+    `cold` solo esta poblado en el PRIMER caso de cada Lambda (su primer
+    invoke real); en el resto es None porque el contenedor ya estaba caliente.
+    `warm` es el promedio de los samples calientes del caso: del primer caso
+    son los samples 2..N (el 1ro fue el cold); del resto, TODOS sus samples.
+    """
+
+    lambda_name: str
+    name: str
+    cold: float | None
+    warm: float | None
+    passed: bool
 
 
 @dataclass
@@ -66,25 +88,102 @@ class Reporter:
         """True si todos los casos pasaron."""
         return all(r.passed for r in self.results)
 
+    def timing_rows(self) -> list[TimingRow]:
+        """Clasifica cada caso en cold (1er invoke del Lambda) + warm.
+
+        Recorre los resultados en orden de ejecucion (= orden de insercion).
+        El PRIMER caso con samples de cada Lambda se lleva el cold start; el
+        resto corre caliente (cold=None). Ver el docstring del modulo.
+        """
+        seen: set[str] = set()
+        rows: list[TimingRow] = []
+        for r in self.results:
+            is_first = r.lambda_name not in seen
+            if not r.elapsed:
+                rows.append(
+                    TimingRow(r.lambda_name, r.name, None, None, r.passed)
+                )
+                continue
+            seen.add(r.lambda_name)
+            if is_first:
+                cold: float | None = r.elapsed[0]
+                warm_samples = r.elapsed[1:]
+            else:
+                cold = None
+                warm_samples = r.elapsed
+            warm = (
+                sum(warm_samples) / len(warm_samples) if warm_samples else None
+            )
+            rows.append(TimingRow(r.lambda_name, r.name, cold, warm, r.passed))
+        return rows
+
+    def cold_start_by_lambda(self) -> dict[str, float]:
+        """Cold start por Lambda: el primer invoke (passed) de cada contenedor.
+
+        Mapea lambda_name -> segundos del primer invoke real. Solo cuenta
+        casos que pasaron (un caso fallido tiene timing no confiable).
+        """
+        cold: dict[str, float] = {}
+        for row in self.timing_rows():
+            if row.cold is not None and row.passed:
+                cold[row.lambda_name] = row.cold
+        return cold
+
     def print_timing_summary(self) -> None:
-        """Tabla de tiempos de respuesta promedio por endpoint."""
+        """Cold start por Lambda (agrupado) + tiempos por caso (cold/warm)."""
+        rows = self.timing_rows()
+        cold_by_lambda = self.cold_start_by_lambda()
+
+        # 1) Cold start por Lambda (agrupado por path: 1 cold por contenedor).
         print()
         print('=' * 80)
-        print('TIEMPOS DE RESPUESTA PROMEDIO (segundos)')
+        print('COLD START POR LAMBDA (primer invoke del contenedor, segundos)')
+        print('=' * 80)
+        print(f'{"Lambda":<15}{"cold":>8}  primer caso')
+        print('-' * 80)
+        first_case: dict[str, str] = {}
+        for row in rows:
+            if row.cold is not None and row.lambda_name not in first_case:
+                first_case[row.lambda_name] = row.name
+        for lambda_name, cold in cold_by_lambda.items():
+            print(
+                f'{lambda_name:<15}{cold:>8.3f}  '
+                f'{first_case.get(lambda_name, "")}'
+            )
+        print('-' * 80)
+        if cold_by_lambda:
+            avg_cold = sum(cold_by_lambda.values()) / len(cold_by_lambda)
+            print(f'{"COLD avg":<15}{avg_cold:>8.3f}')
+
+        # 2) Detalle por caso: cold solo en el 1er invoke; el resto, warm.
+        print()
+        print('=' * 80)
+        print("TIEMPOS POR CASO (segundos) — cold='-' = Lambda ya caliente")
         print('=' * 80)
         print(f'{"Lambda":<15}{"Caso":<48}{"cold":>8}{"warm":>8}')
         print('-' * 80)
-        for r in self.results:
-            print(
-                f'{r.lambda_name:<15}{r.name:<48}'
-                f'{r.cold:>8.3f}{r.warm_avg:>8.3f}'
+        warm_ok: list[float] = []
+        for row in rows:
+            cold_cell = (
+                f'{row.cold:>8.3f}' if row.cold is not None else f'{"-":>8}'
             )
+            warm_cell = (
+                f'{row.warm:>8.3f}' if row.warm is not None else f'{"-":>8}'
+            )
+            print(f'{row.lambda_name:<15}{row.name:<48}{cold_cell}{warm_cell}')
+            if row.warm is not None and row.passed:
+                warm_ok.append(row.warm)
         print('-' * 80)
-        ok = [r for r in self.results if r.passed and r.elapsed]
-        if ok:
-            g_warm = sum(r.warm_avg for r in ok) / len(ok)
-            g_cold = sum(r.cold for r in ok) / len(ok)
-            print(f'{"GLOBAL (OK)":<15}{"":<48}{g_cold:>8.3f}{g_warm:>8.3f}')
+        g_cold = (
+            sum(cold_by_lambda.values()) / len(cold_by_lambda)
+            if cold_by_lambda
+            else None
+        )
+        g_warm = sum(warm_ok) / len(warm_ok) if warm_ok else None
+        g_cold_cell = f'{g_cold:>8.3f}' if g_cold is not None else f'{"-":>8}'
+        g_warm_cell = f'{g_warm:>8.3f}' if g_warm is not None else f'{"-":>8}'
+        label = 'cold=avg/Lambda, warm=avg casos'
+        print(f'{"GLOBAL":<15}{label:<48}{g_cold_cell}{g_warm_cell}')
 
     def print_final(self) -> None:
         """Resumen pass/fail + listado de fallos."""

--- a/devtools/tests/unit/src/api_e2e/test_reporter.py
+++ b/devtools/tests/unit/src/api_e2e/test_reporter.py
@@ -1,0 +1,264 @@
+"""Tests del Reporter de api_e2e: atribucion del cold start POR-LAMBDA.
+
+El cold start lo paga solo el PRIMER invoke del contenedor de cada Lambda.
+El reporter NO debe atribuir un cold a cada caso: el 1er caso de un Lambda se
+lleva el cold (elapsed[0]); los casos siguientes corren calientes (cold=None)
+y su tiempo cuenta como warm.
+"""
+
+from api_e2e.reporter import CaseResult
+from api_e2e.reporter import Reporter
+
+
+def _case(
+    lambda_name: str,
+    name: str,
+    elapsed: list[float],
+    *,
+    passed: bool = True,
+) -> CaseResult:
+    """Builder de CaseResult con status/expected triviales (solo importa
+    el timing + lambda_name + passed para estos tests)."""
+    return CaseResult(
+        lambda_name=lambda_name,
+        name=name,
+        method='GET',
+        status_codes=[200] * len(elapsed),
+        expected='200',
+        passed=passed,
+        elapsed=elapsed,
+    )
+
+
+def _reporter(*cases: CaseResult) -> Reporter:
+    rep = Reporter()
+    rep.results.extend(cases)
+    return rep
+
+
+def test_timing_rows_first_case_of_lambda_carries_cold() -> None:
+    """
+    Given el PRIMER caso de un Lambda con samples [12.0, 7.0, 9.0],
+    When timing_rows clasifica,
+    Then ese caso tiene cold=12.0 (sample 1) y warm=8.0 (avg de 7.0 y 9.0).
+    """
+    rep = _reporter(_case('cv', 'cv.get', [12.0, 7.0, 9.0]))
+
+    rows = rep.timing_rows()
+
+    assert rows[0].cold == 12.0
+    assert rows[0].warm == 8.0
+
+
+def test_timing_rows_second_case_of_lambda_has_no_cold() -> None:
+    """
+    Given un segundo caso del MISMO Lambda con samples [0.5, 1.5],
+    When timing_rows clasifica,
+    Then ese caso tiene cold=None (contenedor ya caliente) y warm=1.0
+         (promedio de TODOS sus samples, no descarta el primero).
+    """
+    rep = _reporter(
+        _case('cv', 'cv.get', [12.0, 7.0, 9.0]),
+        _case('cv', 'cv.profile', [0.5, 1.5]),
+    )
+
+    rows = rep.timing_rows()
+
+    assert rows[1].cold is None
+    assert rows[1].warm == 1.0
+
+
+def test_timing_rows_single_sample_first_case_has_cold_no_warm() -> None:
+    """
+    Given el primer caso de un Lambda con un UNICO sample [14.0],
+    When timing_rows clasifica,
+    Then cold=14.0 y warm=None (no quedan samples calientes tras el cold).
+    """
+    rep = _reporter(_case('auth', 'register.start', [14.0]))
+
+    rows = rep.timing_rows()
+
+    assert rows[0].cold == 14.0
+    assert rows[0].warm is None
+
+
+def test_timing_rows_single_sample_later_case_is_warm() -> None:
+    """
+    Given un caso posterior del mismo Lambda con un UNICO sample [3.9],
+    When timing_rows clasifica,
+    Then cold=None y warm=3.9 (el sample unico es warm, no cold).
+    """
+    rep = _reporter(
+        _case('auth', 'register.start', [14.0]),
+        _case('auth', 'login.start', [3.9]),
+    )
+
+    rows = rep.timing_rows()
+
+    assert rows[1].cold is None
+    assert rows[1].warm == 3.9
+
+
+def test_timing_rows_each_lambda_resets_cold_attribution() -> None:
+    """
+    Given casos de DOS Lambdas distintos intercalados por bloques,
+    When timing_rows clasifica,
+    Then el primer caso de CADA Lambda se lleva su propio cold.
+    """
+    rep = _reporter(
+        _case('cv', 'cv.get', [12.0, 8.0]),
+        _case('cv', 'cv.profile', [1.0, 1.0]),
+        _case('auth', 'register.start', [14.0]),
+        _case('auth', 'login.start', [4.0, 2.0]),
+    )
+
+    rows = rep.timing_rows()
+
+    assert [r.cold for r in rows] == [12.0, None, 14.0, None]
+    assert [r.warm for r in rows] == [8.0, 1.0, None, 3.0]
+
+
+def test_timing_rows_empty_elapsed_yields_none_none() -> None:
+    """
+    Given un caso sin samples (elapsed vacio),
+    When timing_rows clasifica,
+    Then cold=None y warm=None y NO marca el Lambda como visto.
+    """
+    rep = _reporter(
+        _case('cv', 'cv.empty', []),
+        _case('cv', 'cv.get', [12.0, 8.0]),
+    )
+
+    rows = rep.timing_rows()
+
+    assert rows[0].cold is None
+    assert rows[0].warm is None
+    # El caso vacio NO consumio el cold: el siguiente caso real SI lo lleva.
+    assert rows[1].cold == 12.0
+
+
+def test_cold_start_by_lambda_one_entry_per_lambda() -> None:
+    """
+    Given dos casos por Lambda en dos Lambdas distintos,
+    When cold_start_by_lambda,
+    Then devuelve exactamente un cold por Lambda (el primer invoke).
+    """
+    rep = _reporter(
+        _case('cv', 'cv.get', [12.0, 8.0]),
+        _case('cv', 'cv.profile', [1.0, 1.0]),
+        _case('auth', 'register.start', [14.0]),
+        _case('auth', 'login.start', [4.0, 2.0]),
+    )
+
+    cold = rep.cold_start_by_lambda()
+
+    assert cold == {'cv': 12.0, 'auth': 14.0}
+
+
+def test_cold_start_by_lambda_excludes_failed_first_invoke() -> None:
+    """
+    Given que el PRIMER invoke de un Lambda FALLO (passed=False),
+    When cold_start_by_lambda,
+    Then ese Lambda NO aporta cold (timing de un fallo no es confiable) y el
+         segundo caso tampoco lo aporta (el contenedor ya estaba caliente).
+    """
+    rep = _reporter(
+        _case('cv', 'cv.get', [12.0, 8.0], passed=False),
+        _case('cv', 'cv.profile', [1.0, 1.0], passed=True),
+    )
+
+    cold = rep.cold_start_by_lambda()
+
+    assert cold == {}
+
+
+def test_print_timing_summary_groups_cold_and_shows_dash(capsys) -> None:
+    """
+    Given dos Lambdas con cold 12.0 y 14.0 + casos calientes,
+    When print_timing_summary,
+    Then imprime el bloque agrupado por Lambda con COLD avg=13.0 y la tabla
+         por caso muestra '-' en cold para los casos del Lambda ya caliente.
+    """
+    rep = _reporter(
+        _case('cv', 'cv.get', [12.0, 8.0]),
+        _case('cv', 'cv.profile', [1.0, 1.0]),
+        _case('auth', 'register.start', [14.0]),
+    )
+
+    rep.print_timing_summary()
+    out = capsys.readouterr().out
+
+    assert 'COLD START POR LAMBDA' in out
+    assert 'TIEMPOS POR CASO' in out
+    # cold avg = (12.0 + 14.0) / 2 = 13.000
+    assert '13.000' in out
+    # el bloque agrupado nombra el primer caso de cada Lambda
+    assert 'cv.get' in out
+    assert 'register.start' in out
+    # la tabla por caso muestra cold '-' para el caso del Lambda ya caliente
+    assert '-' in out
+
+
+def test_print_timing_summary_empty_reporter_does_not_crash(capsys) -> None:
+    """
+    Given un reporter sin resultados,
+    When print_timing_summary,
+    Then imprime los encabezados sin filas y sin lanzar excepcion.
+    """
+    rep = Reporter()
+
+    rep.print_timing_summary()
+    out = capsys.readouterr().out
+
+    assert 'COLD START POR LAMBDA' in out
+    assert 'GLOBAL' in out
+
+
+def test_passed_count_and_all_passed_with_mixed_results() -> None:
+    """
+    Given 2 casos passed y 1 failed,
+    When passed_count / all_passed,
+    Then passed_count==2 y all_passed==False.
+    """
+    rep = _reporter(
+        _case('cv', 'cv.get', [1.0]),
+        _case('cv', 'cv.profile', [1.0]),
+        _case('auth', 'login.start', [1.0], passed=False),
+    )
+
+    assert rep.passed_count() == 2
+    assert rep.all_passed() is False
+
+
+def test_print_final_lists_failures(capsys) -> None:
+    """
+    Given un caso fallido,
+    When print_final,
+    Then imprime el veredicto N/total y la seccion FALLOS con el caso.
+    """
+    rep = _reporter(
+        _case('cv', 'cv.get', [1.0]),
+        _case('auth', 'login.start', [1.0], passed=False),
+    )
+
+    rep.print_final()
+    out = capsys.readouterr().out
+
+    assert 'RESULTADO: 1/2 casos PASS' in out
+    assert 'FALLOS:' in out
+    assert 'auth.login.start' in out
+
+
+def test_print_final_all_passed_omits_failures_section(capsys) -> None:
+    """
+    Given todos los casos passed,
+    When print_final,
+    Then imprime el veredicto completo y NO imprime la seccion FALLOS.
+    """
+    rep = _reporter(_case('cv', 'cv.get', [1.0]))
+
+    rep.print_final()
+    out = capsys.readouterr().out
+
+    assert 'RESULTADO: 1/1 casos PASS' in out
+    assert 'FALLOS:' not in out

--- a/docs/specs/serverless-sqs-to-async-invoke/01-contexto-y-decision.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/01-contexto-y-decision.md
@@ -1,0 +1,177 @@
+# 01 — Contexto, solución y criterios de aceptación
+
+[← README](README.md) · [siguiente: 02 shared foundations →](02-shared-foundations.md)
+
+## 1. Contexto / Problema
+
+El backend usa un patrón **encoder + worker** con 3 colas SQS:
+
+| Cola | Productor | Worker | Trabajo |
+|------|-----------|--------|---------|
+| `portfolio-auth-email-${stage}` | `auth` + `users` | `auth_email_worker` | render template + SES + audit |
+| `portfolio-contact-form-${stage}` | `contact_form` | `contact_worker` | persistir contacto (Neon) + email owner |
+| `portfolio-tracking-events-${stage}` | `tracking_pixel` | `tracking_worker` | persistir tracking event (Neon) |
+
+Problemas:
+
+1. **Complejidad de infra**: 3 colas + 3 DLQ + 3 workers + Event Source
+   Mappings + el feature flag `ASYNC_MODE` (que mantiene VIVO un path sync
+   legacy duplicado en `contact_form` y `tracking_pixel`).
+2. **Referencias muertas**: `stream_processor` se documenta en CLAUDE.md,
+   devtools, docs y comentarios pero **NO existe** como Lambda.
+3. **Email rígido**: templates hardcodeados en el `core/` de cada worker con
+   un render mustache-lite casero. Sin config central de qué email se manda
+   ni desde dónde; cambiar copy = redeploy del worker.
+
+### Hallazgos de la investigación (2025-2026) sobre el cold start
+
+Una investigación (4 fuentes 2025-2026) sobre "async en Lambda" concluyó:
+
+- **En Lambda NO hay "async fire-and-forget en proceso"**: el container se
+  congela al `return` del handler (doc oficial AWS). Diferir trabajo exige un
+  segundo invoke (otro Lambda / self-invoke) o una Extension — no hay tercera
+  vía sin un bus.
+- **El delay real NO es la query**: un INSERT a Neon con conexión pooled
+  caliente es **~10-25ms** (imperceptible). El cold start lo domina el
+  **import** (sqlalchemy/psycopg) — y con **SnapStart** (ya activo) ese import
+  está en el snapshot, así que el cold es el *restore* (~1s), constante.
+- **Python 3.14 es irrelevante**: Lambda sólo ofrece runtime 3.13; forzar
+  3.14 vía container **pierde SnapStart**. El no-GIL de 3.14 es CPU-bound, no
+  I/O.
+- **Driver**: psycopg3 (no asyncpg, no ORM en el write path). `gather` sólo
+  ayuda con 2+ queries independientes (no aplica a estos encoders).
+- **`tracking_pixel` usa `sendBeacon`**: el browser no espera la respuesta →
+  la latencia server-side de escribir Neon **el usuario nunca la percibe**.
+
+**Conclusión: NO desacoplar.** Escribir síncrono rápido. Esto elimina SQS
+**y** evita crear `db_writer`. El cold start ya lo cubre SnapStart; este
+refactor NO lo mejora (su valor es simplicidad + email flexible).
+
+## 2. Solución propuesta
+
+```
+ANTES                                  DESPUÉS
+─────                                  ───────
+contact_form ─SQS→ contact_worker      contact_form: escribe Neon inline (sync)
+                                                     + invoke(Event) send_email [owner]
+tracking_pixel ─SQS→ tracking_worker   tracking_pixel: escribe Neon inline (sync)
+auth/users ─SQS→ auth_email_worker     auth/users ─invoke(Event)→ send_email
+```
+
+### Decisiones clave
+
+- **Decisión 1: persistencia inline síncrona** en `contact_form` y
+  `tracking_pixel` (psycopg3 vía `shared.db`, endpoint pooled, `warm_db()` en
+  INIT para SnapStart). NO se crea `db_writer`. NO async driver.
+- **Decisión 2: email vía `send_email`** (Lambda `direct` invocado con
+  `InvocationType='Event'`). Cero SQS.
+- **Decisión 3: `send_email` puro** — DynamoDB (config) + S3 (template) +
+  Jinja2 + SES. Config en `email-config` (PK=`kind`), una plantilla por kind.
+- **Decisión 4: owner-email = `contact_form` invoca `send_email` siempre**
+  (tras escribir el contacto). No idempotente.
+- **Decisión 5: eliminar `ASYNC_MODE`** — un único path.
+- **Decisión 6: provider-swappable** — `shared.aws.lambda_invoke` (nuevo),
+  `shared.templating` (nuevo), `shared.aws.s3`/`ses`/`db` (existen).
+
+### Inventario de kinds (10) → templates (10) → callers
+
+| kind | caller | recipient | template vars |
+|------|--------|-----------|---------------|
+| `register-magic-link` | auth | user | `verify_url`, `expires_in_min` |
+| `login-magic-link` | auth | user | `verify_url`, `expires_in_min` |
+| `password-reset` | auth | user | `verify_url`, `expires_in_min` |
+| `email-change-verify` | users | user (nuevo) | `verify_url`, `expires_in_min` |
+| `register-code` | auth | user | `code`, `expires_in_min` |
+| `login-code` | auth | user | `code`, `expires_in_min` |
+| `email-changed` | users | user (viejo) | `new_email` |
+| `account-disabled` | users | user | `reason` |
+| `account-deleted` | users | user | — |
+| `contact` | contact_form | owner | `name`, `email`, `message`, `company`, `role`, `service_type`, `budget`, `timeline`, `niche` |
+
+## 3. Criterios de aceptación (BDD)
+
+- **AC-1**: Given un POST `/contact` válido, When el handler procesa, Then
+  escribe el contacto a Neon **síncrono** (`ensure_session_and_visit` + INSERT
+  idempotente), invoca `send_email` (`kind=contact`) async, y responde HTTP
+  201 con el contacto persistido.
+- **AC-2**: Given un POST `/track` válido, When el handler procesa, Then
+  escribe el tracking_event a Neon **síncrono** (UPSERT session+visit + INSERT
+  idempotente, con parse de user-agent) y responde HTTP 202.
+- **AC-3**: Given `send_email` recibe `{kind, to, data}`, When ejecuta, Then
+  lee `email-config[kind]`, descarga el template html+txt de S3, renderiza con
+  Jinja2 y envía vía SES.
+- **AC-4**: Given un `kind` que NO existe en `email-config`, When `send_email`
+  ejecuta, Then retorna error de validación (code 1xxx) sin llamar SES.
+- **AC-5**: Given un `core/**/*.py`, When `serverless lint-deps` corre, Then
+  no hay imports directos de `boto3`/`jinja2`/`sqlalchemy` (sólo vía
+  `shared.*`) — exit 0.
+- **AC-6**: Given el manifest declara `uses.invokes: [send_email]`, When
+  devtools provisiona, Then el rol IAM tiene `lambda:InvokeFunction` scoped al
+  ARN de `portfolio-send-email-${stage}` + env var
+  `LAMBDA_SEND_EMAIL_FUNCTION_NAME`.
+- **AC-7**: Given el manifest declara `uses.buckets: [{name, access:read}]`,
+  When devtools provisiona, Then el rol IAM tiene `s3:GetObject` scoped al ARN
+  del bucket + env var `S3_<NAME>_BUCKET`.
+- **AC-8**: Given el repo tras el refactor, When se busca `stream_processor`
+  (fuera de `_archive/`), Then 0 referencias.
+- **AC-9**: Given el repo tras el refactor, When se busca SQS (`shared.queue`,
+  `resources/sqs/`, `*_worker`, `uses.queues`, `trigger.type==sqs`,
+  `ASYNC_MODE`), Then 0 referencias.
+- **AC-10**: Given `auth`/`users` disparan un email, When ejecutan, Then
+  invocan `send_email` async (NO publican a SQS) y NO escriben audit
+  email-level.
+- **AC-11**: Given `auth` crea un user / guarda code/magic-link, When ejecuta,
+  Then SIGUE escribiendo a Neon síncrono (sin cambios).
+- **AC-12**: Given `send_email` para `kind=contact`, When ejecuta, Then `to`
+  son los owner emails y `reply_to` el email del visitante.
+- **AC-13**: Given `infra_provision`, When provisiona, Then crea la tabla
+  `email-config` + el bucket `portfolio-email-templates-${stage}`, publica sus
+  ids a SSM, y NO crea ninguna cola SQS.
+- **AC-14**: Given el bucket recién creado, When se corre el seed, Then los 20
+  templates + las 10 filas de `email-config` están cargados.
+- **AC-15**: Given `serverless tests --type=unit` para los Lambdas + shared,
+  Then todos verdes con coverage ≥80% per-file en archivos modificados.
+- **AC-16**: Given el deploy de `send_email`, When devtools empaqueta, Then su
+  cierre shared NO incluye `shared.db`/sqlalchemy (es puro, sin Neon).
+
+## 4. Diagrama de flujo
+
+### Antes
+
+```
+POST /contact ─► contact_form (ASYNC_MODE?)
+                   ├─ true  ─► SQS ─► contact_worker ─► Neon + SES
+                   └─ false ─► Neon + SES (sync legacy)
+```
+
+### Después
+
+```
+POST /contact ─► contact_form
+                   ├─ rate-limit + Turnstile (igual)
+                   ├─ escribe contacto a Neon (sync, ~10-25ms)
+                   ├─ invoke(Event) send_email [kind=contact, owner]
+                   └─ 201 con el contacto persistido
+
+POST /track   ─► tracking_pixel
+                   ├─ rate-limit (igual)
+                   ├─ escribe tracking_event a Neon (sync; parse UA)
+                   └─ 202 (sendBeacon ni espera)
+
+auth/users    ─► (Neon sync) ─► invoke(Event) send_email [kind=...] ─► S3+SES
+```
+
+## 5. Diagrama ER (DynamoDB `email-config` — NUEVO)
+
+```
+email-config (DynamoDB, PK=kind)
+  kind          string  (PK)   -- 'contact', 'register-code', ...
+  bucket        string         -- portfolio-email-templates-${stage}
+  html_path     string         -- 'contact.html'
+  txt_path      string         -- 'contact.txt'
+  subject       string         -- Jinja2 ('Nuevo contacto de {{ name }}')
+```
+
+Sin cambios en el schema Neon (se reutilizan los repositories existentes).
+
+[← README](README.md) · [siguiente: 02 shared foundations →](02-shared-foundations.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/02-shared-foundations.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/02-shared-foundations.md
@@ -1,0 +1,143 @@
+# 02 — Shared foundations (portadores nuevos)
+
+[← 01 contexto](01-contexto-y-decision.md) · [siguiente: 03 devtools →](03-devtools-provisioning.md)
+
+> Fase 1. Crea los dos portadores `shared.*` que faltan para que el `core/`
+> de los Lambdas nunca importe `boto3`/`jinja2` directo (provider-swappable).
+> `shared.aws.s3` y `shared.aws.ses` YA existen y se reutilizan.
+
+## 2.1 `shared.aws.lambda_invoke` (NUEVO)
+
+Portador del cliente Lambda de boto3 para invocación async. Mismo patrón
+lazy (PEP 562) que `shared.aws.ses`/`shared.aws.s3`.
+
+### Crear
+- `serverless/lambda/shared/aws/lambda_invoke.py`
+  - `_client()` — `boto3.client('lambda', region_name=...)` lazy.
+  - `__getattr__('lambda_client')` — PEP 562, crea al primer acceso.
+  - `invoke_async(*, function_name: str, payload: dict) -> None` — hace
+    `client.invoke(FunctionName=function_name, InvocationType='Event',
+    Payload=json.dumps(payload, default=str).encode())`. NO espera respuesta;
+    loggea `event_invoked` + métrica `LambdaInvokeOk`/`LambdaInvokeFailed`.
+    Una excepción se loggea y se **re-lanza** como `LambdaInvokeError` para
+    que el caller decida (en `contact_form`/`tracking_pixel` se captura y se
+    degrada a un log — best-effort, NO rompe el 202).
+  - `LambdaInvokeError(Exception)` — error tipado.
+  - Verificar: `serverless tests --type=unit --shared` (test con moto/stub).
+
+### Tests (TDD primero)
+- `shared/tests/unit/shared/aws/test_lambda_invoke_async.py` — Given un
+  function_name + payload, When `invoke_async`, Then llama `client.invoke`
+  con `InvocationType='Event'` y el Payload JSON exacto (assert exacto sobre
+  los kwargs con un stub/mock del cliente).
+- `shared/tests/unit/shared/aws/test_lambda_invoke_reexport.py` — el módulo
+  expone `invoke_async` + `LambdaInvokeError`.
+
+## 2.2 `shared.templating` (NUEVO — Jinja2)
+
+Portador único de Jinja2. El `core/` de `send_email` NUNCA importa `jinja2`.
+
+### Crear
+- `serverless/lambda/shared/templating/__init__.py` — VACÍO (docstring-only).
+- `serverless/lambda/shared/templating/jinja.py`
+  - `render(template_str: str, context: dict) -> str` — usa
+    `jinja2.Environment(autoescape=...)`. Para HTML: `autoescape=True`
+    (anti-XSS en las vars del visitante). Para TXT/subject: render con
+    `autoescape=False` o un Environment separado. Exponer dos helpers:
+    `render_html(template, ctx)` y `render_text(template, ctx)`.
+  - `TemplateRenderError(Exception)` — envuelve `jinja2.TemplateError`.
+  - Jinja2 se importa LAZY dentro de `render_*` (no en el top del módulo)
+    para no penalizar el cold de un Lambda que importe `shared.templating`
+    sin renderizar.
+- `serverless/lambda/shared/templating/pyproject.toml` — declara
+  `jinja2>=3.1` en `[project.dependencies]`. Sin `internal-deps` (no depende
+  de otros shared salvo observability si loggea).
+
+### Tests (TDD primero)
+- `shared/tests/unit/shared/templating/test_render_html_substitutes_vars.py`
+  — Given `'<p>Hola {{ name }}</p>'` + `{name:'Pablo'}`, When `render_html`,
+  Then `'<p>Hola Pablo</p>'`.
+- `..._escapes_html_in_html.py` — Given `{name:'<script>'}`, When
+  `render_html`, Then la var queda escapada (`&lt;script&gt;`).
+- `..._text_does_not_escape.py` — Given `render_text` con `&`, Then no
+  escapa.
+- `..._missing_var_raises_or_blank.py` — define el comportamiento (Jinja2
+  por default deja `''` en undefined; assert exacto del contrato elegido:
+  usar `StrictUndefined` → `TemplateRenderError` si falta una var, para
+  fallar ruidoso en `send_email`).
+
+## 2.3 `shared.db.read_async` (NUEVO — patrón de read concurrente)
+
+> Decisión del usuario: "agregar patrón de read async". La investigación
+> mostró que async NO sirve para las ESCRITURAS de estos encoders (1 request
+> por container, escritura síncrona ~10-25ms). Pero los **reads multi-query**
+> (varias agregaciones independientes, caso del dashboard analytics) SÍ se
+> benefician de `asyncio.gather` cuando van por **conexiones separadas**.
+> Este helper es la utilidad canónica para esos reads.
+
+**Aviso de honestidad**: en ESTE plan NO hay consumidor (contact_form,
+tracking_pixel, send_email sólo escriben/envían). El consumidor real es el
+Lambda de lectura del dashboard (`docs/specs/analytics-dashboard-api`, otro
+plan). Se agrega aquí porque el usuario lo pidió explícitamente y para fijar
+el patrón antes de que el dashboard lo necesite. Si se prefiere evitar código
+sin consumidor, esta sub-fase (T2b) puede diferirse al plan del dashboard —
+queda anotado como decisión revisable.
+
+### Crear
+- `serverless/lambda/shared/db/read_async.py`
+  - `gather_reads(*coros) -> tuple` — wrapper sobre `asyncio.gather` que
+    ejecuta N corutinas de lectura concurrentes y devuelve sus resultados en
+    orden. Cada corutina abre su propia `AsyncConnection` de psycopg3 al
+    endpoint pooled (las conexiones separadas son lo que permite el
+    paralelismo real; sobre una sola conexión PgBouncer serializa).
+  - `run_reads(builder) -> result` — helper sync-friendly que hace
+    `asyncio.run(...)` para invocar `gather_reads` desde un handler Lambda
+    sync (el runtime no soporta handler async nativo).
+  - psycopg3 `AsyncConnection` se importa LAZY (no penaliza el cold de un
+    Lambda que no lea async).
+- Documentar que es para READS (idempotentes, sin efectos); NUNCA para
+  escrituras (serializan + no se benefician).
+
+### Tests (TDD primero)
+- `shared/tests/unit/shared/db/test_read_async_gathers_results_in_order.py`
+  — Given 3 corutinas read mockeadas, When `gather_reads`, Then devuelve los
+  3 resultados en el orden de entrada (assert exacto).
+- `..._run_reads_executes_via_asyncio_run.py` — `run_reads` corre el builder
+  bajo un loop nuevo y devuelve el resultado.
+
+## 2.4 Catálogo de portadores (actualizar la rule)
+
+Agregar a la tabla de `.claude/rules/lambda-shared-imports.md` (lo hace la
+fase 6, archivo 07, pero se referencia aquí):
+
+| Paquete externo | Portador | Import |
+|---|---|---|
+| `boto3` lambda client | `shared.aws.lambda_invoke` | `from shared.aws.lambda_invoke import invoke_async` |
+| `jinja2` | `shared.templating.jinja` | `from shared.templating.jinja import render_html, render_text` |
+| `psycopg` AsyncConnection (reads) | `shared.db.read_async` | `from shared.db.read_async import gather_reads, run_reads` |
+
+## 2.5 Reglas
+
+- **SIEMPRE** los `__init__.py` nuevos quedan VACÍOS (sin barrels).
+- **SIEMPRE** boto3/jinja2/psycopg-async se importan LAZY dentro de la función.
+- **SIEMPRE** `read_async` es SÓLO para reads (idempotentes); NUNCA escrituras.
+- **NUNCA** `import boto3` / `import jinja2` en ningún `core/` de service.
+
+## Archivos afectados (fase 1)
+
+### Crear
+- `serverless/lambda/shared/aws/lambda_invoke.py` — invoke async + error.
+  - Verificar: `serverless tests --type=unit --shared`
+- `serverless/lambda/shared/templating/__init__.py` (vacío)
+- `serverless/lambda/shared/templating/jinja.py` — render html/text.
+- `serverless/lambda/shared/templating/pyproject.toml` — dep jinja2.
+- `serverless/lambda/shared/db/read_async.py` — `gather_reads` + `run_reads`
+  (patrón read concurrente; sin consumidor en este plan — ver §2.3).
+- tests unit de los tres (ver arriba).
+  - Verificar: `serverless lint-deps --shared` exit 0.
+
+### Modificar
+- (ninguno en esta fase; `shared.aws.s3` y `shared.aws.ses` se reutilizan
+  tal cual).
+
+[← 01 contexto](01-contexto-y-decision.md) · [siguiente: 03 devtools →](03-devtools-provisioning.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/03-devtools-provisioning.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/03-devtools-provisioning.md
@@ -1,0 +1,146 @@
+# 03 — Devtools provisioning (uses.invokes, uses.buckets, quitar SQS)
+
+[← 02 shared](02-shared-foundations.md) · [siguiente: 04 send_email →](04-send-email-lambda.md)
+
+> Fase 2. Extiende el provisioner para `uses.invokes` (Lambda→Lambda) y
+> `uses.buckets` (S3 read), agrega el recurso `s3-bucket` + la tabla
+> `email-config`, y ELIMINA todo lo de SQS. devtools es Python 3.14
+> (`devtools/.venv/bin/python`). TDD con los tests en
+> `devtools/tests/unit/src/serverless/`.
+
+## 3.1 `uses.invokes` — invocación Lambda→Lambda (NUEVO)
+
+En `devtools/serverless/provisioner.py`, `_build_statements`:
+
+- Leer `uses.invokes: [<lambda-short-name>, ...]` (lista de nombres cortos;
+  hoy el único target es `send_email`, invocado por contact_form/auth/users).
+- Por cada target: agregar Statement IAM
+  `{Effect:Allow, Action:['lambda:InvokeFunction'], Resource:
+  'arn:aws:lambda:${region}:${account}:function:portfolio-<target>-${stage}'}`.
+  (Usar el ARN base; el único target hoy es `send_email`, un Lambda `direct`
+  sin SnapStart, invocado async por nombre `portfolio-send-email-${stage}`
+  que resuelve a `$LATEST`.)
+- Inyectar env var `LAMBDA_<TARGET_UPPER>_FUNCTION_NAME =
+  portfolio-<target>-${stage>` en `_build_env_vars` (para que
+  `shared.aws.lambda_invoke` resuelva el nombre sin hardcodear).
+- El caller resuelve el nombre con
+  `os.environ['LAMBDA_SEND_EMAIL_FUNCTION_NAME']`.
+
+### Validación
+- En el validador del manifest: `uses.invokes` debe ser lista de strings que
+  resuelven a Lambdas existentes (`available_lambdas()`); error si no.
+
+## 3.2 `uses.buckets` — S3 read (NUEVO)
+
+En `_build_statements`:
+- Leer `uses.buckets: [{name: portfolio-email-templates-${stage},
+  access: read}]`.
+- `read` → `['s3:GetObject']` sobre `arn:aws:s3:::<name>/*`; agregar también
+  `s3:ListBucket` sobre `arn:aws:s3:::<name>` si se necesita (no por ahora).
+- Inyectar env var `S3_<NAME_UPPER>_BUCKET = <name interpolado>`.
+- `_SES`/`_DYNAMO` ya son el patrón a imitar (`_s3_statements` análogo a
+  `_dynamodb_statements`).
+
+## 3.3 Recurso `s3-bucket` (NUEVO) + tabla `email-config`
+
+En `devtools/serverless/infra_provision.py`:
+- Agregar `s3` a `_RESOURCE_TYPES` y `s3-bucket` a los kinds válidos.
+- `_provision_s3_bucket(rendered)`: `aws s3api create-bucket` idempotente
+  (`get-bucket-location` para detectar existencia), aplicar
+  `put-public-access-block` (bloquear todo acceso público), `put-bucket-
+  encryption` (SSE-S3), y publicar a SSM el `name`/`arn`.
+- Crear `serverless/lambda/resources/s3/email-templates.yaml`:
+  ```yaml
+  kind: s3-bucket
+  name: portfolio-email-templates-${stage}
+  block_public_access: true
+  encryption: true
+  publishes_ssm:
+    name: /portfolio/${stage}/s3/email-templates/name
+    arn: /portfolio/${stage}/s3/email-templates/arn
+  tags: { Project: portfolio, ManagedBy: devtools }
+  ```
+- Crear `serverless/lambda/resources/dynamodb/email-config.yaml`:
+  ```yaml
+  kind: dynamodb-table
+  name: portfolio-email-config-${stage}
+  billing_mode: PAY_PER_REQUEST
+  hash_key: { name: kind, type: S }
+  range_key: null
+  stream: null
+  point_in_time_recovery: false
+  encryption: true
+  ttl_attribute: null
+  publishes_ssm:
+    name: /portfolio/${stage}/dynamodb/email-config/name
+    arn: /portfolio/${stage}/dynamodb/email-config/arn
+  tags: { Project: portfolio, ManagedBy: devtools }
+  ```
+- `discover_resources()` debe recorrer también `s3/`.
+
+## 3.4 Eliminar SQS de devtools
+
+### Modificar `devtools/serverless/provisioner.py`
+- `_build_trigger`: quitar la rama `ttype == 'sqs'`. Trigger válidos:
+  `direct`, `http`.
+- `TriggerSpec`: quitar `queue_name`, `batch_size`, `function_response_types`.
+- `_build_statements`: quitar el bloque `uses.queues` (IAM SQS + SSM queue
+  url paths) y `_SQS_ACTIONS`.
+- `_wire_trigger` / `_rewire_trigger_on_update`: quitar la rama sqs.
+- Borrar `_wire_sqs_trigger` completo.
+
+### Modificar `devtools/serverless/infra_provision.py`
+- Quitar `sqs` de `_RESOURCE_TYPES`, `sqs-queue` de los kinds, y
+  `_provision_sqs_queue` completo + su rama en el dispatcher.
+- Quitar `sqs/` de `discover_resources`.
+
+### Modificar
+- `devtools/serverless/lambda_controller.py`, `change_detector.py`,
+  `flags.py`, `main.py`, `help.py`: quitar refs a sqs/queues/worker/
+  stream_processor (el detalle exacto lo da la fase 6, archivo 07).
+- Tests en `devtools/tests/unit/src/serverless/*`: actualizar/eliminar los
+  que cubren trigger sqs, uses.queues, _provision_sqs_queue,
+  stream_processor.
+
+## 3.5 Seed de `email-config` + templates S3
+
+Modelar análogo a `rate_limit_cmds.py` (que seedea `rate-limit-rules`):
+- Agregar un comando devtools (o un command del Lambda `db`/un script) que:
+  1. Sube los 20 templates (`serverless/lambda/services/send_email/seeds/templates/<kind>.{html,txt}`)
+     al bucket `portfolio-email-templates-${stage}` (`aws s3 cp`).
+  2. Hace `PutItem` de las 10 filas de `email-config` (PK=kind, bucket,
+     html_path, txt_path, subject).
+- Fuente de verdad de las 10 filas: un YAML/py en
+  `serverless/lambda/services/send_email/seeds/email_config.py`.
+- Decisión de ubicación del comando: nuevo subcomando
+  `serverless seed-email-config --stage=<X>` en devtools (simétrico con
+  `serverless setup-ssm` / `rate_limit_cmds`). Detalle en archivo 04.
+
+## 3.6 Reglas
+
+- **SIEMPRE** verificar devtools con `devtools/.venv/bin/python` (3.14), NO
+  `python3` del shell. Ver skill `python-devtools`.
+- **SIEMPRE** los recursos se declaran en `resources/<tipo>/*.yaml` (esquema
+  plano devtools, sin IaC declarativa).
+- **NUNCA** dejar código muerto de SQS "dormido".
+
+## Archivos afectados (fase 2)
+
+### Crear
+- `serverless/lambda/resources/s3/email-templates.yaml`
+- `serverless/lambda/resources/dynamodb/email-config.yaml`
+- (tests devtools de `uses.invokes`, `uses.buckets`, `s3-bucket`)
+  - Verificar: `test_runner --module=devtools --type=unit`
+
+### Modificar
+- `devtools/serverless/provisioner.py` — +invokes/+buckets, −sqs.
+  - Verificar: `test_runner --module=devtools --type=unit`
+- `devtools/serverless/infra_provision.py` — +s3, −sqs.
+- `devtools/serverless/{lambda_controller,change_detector,flags,main,help}.py`
+  — limpiar sqs/queues.
+- `devtools/tests/unit/src/serverless/*` — actualizar/eliminar.
+
+### Eliminar (fase 5, listado aquí por contexto)
+- `serverless/lambda/resources/sqs/` completo (7 archivos).
+
+[← 02 shared](02-shared-foundations.md) · [siguiente: 04 send_email →](04-send-email-lambda.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/04-send-email-lambda.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/04-send-email-lambda.md
@@ -1,0 +1,167 @@
+# 04 — Lambda `send_email` (puro: DynamoDB + S3 + Jinja2 + SES)
+
+[← 03 devtools](03-devtools-provisioning.md) · [siguiente: 05 encoders →](05-encoders-refactor.md)
+
+> Fase 3. Lambda `direct` puro de envío de email. NO toca Neon. Lee la
+> config del email de DynamoDB (`email-config`), baja el template de S3,
+> renderiza con Jinja2 y envía por SES. Sigue lambda-controller.
+
+## 4.1 Estructura (scaffold lambda-controller)
+
+```
+serverless/lambda/services/send_email/
+├── manifest.yaml
+├── pyproject.toml            # deps: NINGUNA externa directa (todo via shared)
+├── .gitignore
+├── seeds/
+│   ├── email_config.py       # las 10 filas {kind,bucket,html_path,txt_path,subject}
+│   └── templates/
+│       ├── register-magic-link.html / .txt
+│       ├── login-magic-link.html / .txt
+│       ├── password-reset.html / .txt
+│       ├── email-change-verify.html / .txt
+│       ├── register-code.html / .txt
+│       ├── login-code.html / .txt
+│       ├── email-changed.html / .txt
+│       ├── account-disabled.html / .txt
+│       ├── account-deleted.html / .txt
+│       └── contact.html / .txt
+├── core/
+│   ├── handler.py            # direct: {operation:'email', action:'send', data}
+│   ├── controllers/email/send.py     # clase Send(BaseController)
+│   ├── services/email_service.py     # config + template + render + SES
+│   ├── models/email.py               # EmailSendRequest (Pydantic)
+│   └── settings/{config.py, operations.py}
+└── tests/{unit,integration}/...
+```
+
+## 4.2 Contrato de invocación
+
+`send_email` se invoca async con:
+
+```json
+{ "operation": "email", "action": "send",
+  "data": {
+    "kind": "register-code",
+    "to": ["user@example.com"],
+    "data": { "code": "ABC123", "expires_in_min": 15 },
+    "reply_to": ["visitor@example.com"]
+  } }
+```
+
+- `kind` (str, requerido) — clave en `email-config`.
+- `to` (list[str], requerido) — destinatarios. Para `kind=contact` los pasa
+  `contact_form` (owner emails); para auth/users el email del user.
+- `data` (dict) — variables del template (Jinja2 context).
+- `reply_to` (list[str], opcional) — sólo `contact` lo usa (email del
+  visitante).
+
+## 4.3 `email_service.py` (lógica)
+
+```
+1. config = get_email_config(kind)            # GET DynamoDB email-config[kind]
+   - tabla resuelta de env var SSM_EMAIL_CONFIG_TABLE_PATH (uses.tables)
+   - si no existe el kind -> EmailConfigNotFound -> code 1xxx (AC-6)
+2. html_tpl = s3.get_object_text(config.bucket, config.html_path)
+   txt_tpl  = s3.get_object_text(config.bucket, config.txt_path)
+   - bucket también disponible en env var S3_EMAIL_TEMPLATES_BUCKET
+     (uses.buckets); el de config debe coincidir.
+3. subject = render_text(config.subject, data)
+   html    = render_html(html_tpl, data)
+   text    = render_text(txt_tpl, data)
+4. from_address = get_secret_by_name('ses-from-address', local_env='EMAIL_FROM')
+5. send_email(from_address=f'The Full Stack <{from}>', to_addresses=to,
+              subject=subject, text_body=text, html_body=html,
+              reply_to=reply_to)
+```
+
+Imports (todo via shared):
+- `from shared.aws.dynamodb import get_table` (config)
+- `from shared.aws.s3 import get_object_text`
+- `from shared.templating.jinja import render_html, render_text`
+- `from shared.aws.ses import send_email`
+- `from shared.aws.ssm import get_secret_by_name`
+
+## 4.4 `manifest.yaml`
+
+```yaml
+name: send-email
+description: Lambda puro de envio de email (DynamoDB config + S3 template + SES).
+runtime: python3.13
+handler: core.handler.lambda_handler
+memory: 256      # MB — MEDIR. SES + jinja2 + boto3 (dynamodb+s3+ses). Sin
+                 # Neon (no sqlalchemy). Estimado 256; bajar a 128 sólo si la
+                 # medicion lo permite (jinja2 pesa). Ver lambda-config.md.
+timeout: 30
+trigger:
+  type: direct
+uses:
+  tables:
+    email-config: read
+  buckets:
+    - name: portfolio-email-templates-${stage}
+      access: read
+  secrets:
+    - ses-from-address
+  sends-email: true
+env:
+  default:
+    LOG_LEVEL: INFO
+    AWS_SES_REGION: us-east-1
+  prod:
+    LOG_LEVEL: WARNING
+```
+
+> `memory`/`timeout` son provisionales: MEDIR con el procedimiento de
+> `.claude/rules/lambda-config.md` y dejar el mínimo justificado.
+
+## 4.5 Templates (migración del contenido existente)
+
+- Los 9 kinds de auth/users → portar el contenido de
+  `auth_email_worker/core/templates/es/<kind>.{html,txt}` a
+  `send_email/seeds/templates/<kind>.{html,txt}`, **convirtiendo los
+  placeholders** del render mustache-lite/`string.Template` (`${var}` o
+  `{{var}}`) a sintaxis **Jinja2** (`{{ var }}`).
+- `contact` → portar `contact_worker/core/templates/owner_email.{html,txt}`
+  a `send_email/seeds/templates/contact.{html,txt}`, convirtiendo el
+  mustache-lite (`{{#var}}block{{/var}}`) a Jinja2 (`{% if var %}...{% endif %}`).
+- Los `subject` de cada kind: hoy viven en `template_service._SUBJECTS_ES`
+  del worker (auth) y hardcoded en `persistence.py` (contact). Portar a la
+  columna `subject` de cada fila de `email-config` (pueden ser Jinja2:
+  `'Nuevo contacto de {{ name }}'`).
+
+## 4.6 Seed (`serverless seed-email-config --stage=<X>`)
+
+- Sube `seeds/templates/*` al bucket del stage (`aws s3 cp --recursive`).
+- `PutItem` de las 10 filas desde `seeds/email_config.py`.
+- Idempotente (overwrite). Detalle del comando devtools en archivo 03 §3.5.
+
+## 4.7 Tests (TDD primero)
+
+Unit (`tests/unit/`, un archivo por escenario, asserts exactos):
+- `test_email_model_rejects_unknown_kind_missing.py` — kind requerido.
+- `test_send_service_reads_config_from_dynamodb.py` — mock `get_table`.
+- `test_send_service_unknown_kind_returns_error.py` — AC-6 (code 1xxx, sin SES).
+- `test_send_service_renders_with_jinja.py` — mock S3 + assert render.
+- `test_send_service_calls_ses_with_rendered_bodies.py` — mock `send_email`,
+  assert subject/html/text/reply_to exactos.
+- `test_send_controller_normalizes_success.py`.
+- `test_handler_routes_email_send_to_controller.py`.
+- `test_handler_rejects_unknown_operation.py`.
+
+Integration (`tests/integration/`, opcional, con DynamoDB/S3/SES reales o moto).
+
+## 4.8 Reglas
+- **NUNCA** `import boto3`/`jinja2` en `core/` (sólo shared). lint-deps verde.
+- **NUNCA** `send_email` toca Neon (es puro). Su cierre shared NO incluye
+  `shared.db` (AC-16).
+- **SIEMPRE** `to` lo provee el caller; `from_address` lo resuelve send_email.
+
+## Archivos afectados (fase 3)
+
+### Crear
+- `serverless/lambda/services/send_email/**` (estructura completa arriba).
+  - Verificar: `serverless tests --type=unit --lambda=send_email` (≥80%)
+  - Verificar: `serverless lint-deps --lambda=send_email` exit 0
+
+[← 03 devtools](03-devtools-provisioning.md) · [siguiente: 05 encoders →](05-encoders-refactor.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/05-encoders-refactor.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/05-encoders-refactor.md
@@ -1,0 +1,139 @@
+# 05 — Encoders: quitar ASYNC_MODE + escritura inline síncrona
+
+[← 04 send_email](04-send-email-lambda.md) · [siguiente: 06 migrar auth/users →](06-migrate-callers-remove-sqs.md)
+
+> Fase 4. `contact_form` y `tracking_pixel` dejan de ser encoders SQS:
+> escriben a Neon **inline y síncrono** (psycopg3 vía `shared.db`, pooled,
+> `warm_db()` en INIT para SnapStart) y se elimina el flag `ASYNC_MODE` + el
+> path sync legacy duplicado. NO se crea `db_writer`. `contact_form` además
+> invoca `send_email` async para el owner.
+
+## 5.1 `contact_form`
+
+### `core/settings/config.py`
+- Eliminar `async_mode` + su doc (líneas ~131-138).
+
+### `core/handler.py`
+- `success_status` SIEMPRE **201** (quitar el condicional 202/201 por
+  `AppConfig.async_mode`).
+
+### `core/controllers/contact/create.py`
+- Eliminar el branch por `AppConfig.async_mode` y los métodos `_execute_async`
+  (SQS) y `_execute_sync` (legacy). El cuerpo de `execute()` queda como flujo
+  único:
+  1. rate-limit (`check_or_raise`) — igual.
+  2. Turnstile (`verify_captcha_or_bypass`) — igual.
+  3. resolver `session_id` + `origin_niche` — igual.
+  4. pre-generar `contact_id` (UUIDv7) + `created_at`.
+  5. **escribir contacto a Neon síncrono** (`save_contact` del service:
+     `ensure_session_and_visit` + INSERT idempotente `ON CONFLICT (id)`).
+  6. **invocar `send_email` async** (`InvocationType='Event'`,
+     `kind=contact`, `to=owner_emails`, `data=form_fields`,
+     `reply_to=[email]`). Degrada a log si falla (no rompe el 201).
+  7. `_auto_blacklist_step` — igual.
+  8. responder 201 con `ContactCreatedOutput` (contacto persistido).
+- Importa el invoke vía `from shared.aws.lambda_invoke import invoke_async` +
+  `os.environ['LAMBDA_SEND_EMAIL_FUNCTION_NAME']`.
+
+### `core/services/contact_service.py`
+- Eliminar `enqueue_contact_message` (SQS) + el import `send_to_queue` +
+  `QueuePublishError`.
+- Conservar/limpiar `save_contact` (la escritura Neon) — quitar de ahí el
+  envío SES directo (lo hace `send_email` ahora). El render mustache-lite y
+  `send_owner_email` se ELIMINAN (el email lo arma `send_email` con Jinja2).
+- `owner_emails`: `get_secret_by_name('owner-email')` (se conserva el secret).
+
+### `manifest.yaml`
+- −`uses.queues`; +`uses.invokes: [send_email]`.
+- `uses.secrets`: conservar `turnstile-secret`, `turnstile-bypass-public-key`,
+  `owner-email`, `neon-url`. Quitar `ses-from-address` (ya no manda SES
+  directo; lo hace send_email).
+- `uses.tables`: `cache`, `rate-limit-rules`, `rate-limit-buckets` (igual).
+- `sends-email`: **false** (manda vía send_email).
+- `env`: eliminar `ASYNC_MODE` de los 4 bloques.
+- `memory`: ya es 256 (footprint Neon) — se mantiene; MEDIR.
+- `snap_start: true` — se mantiene (clave para el cold).
+
+## 5.2 `tracking_pixel`
+
+### `core/settings/config.py`
+- Eliminar `async_mode`.
+
+### `core/controllers/tracking/track.py`
+- Eliminar branch + `_execute_async` (SQS) y `_execute_sync`. Flujo único:
+  1. rate-limit — igual.
+  2. pre-generar `page_id` (UUIDv7) + `created_at`.
+  3. **escribir tracking_event a Neon síncrono** (parse UA +
+     `ensure_session_and_visit` + INSERT idempotente
+     `ON CONFLICT (created_at, visit_id, page_id)`).
+  4. responder **202** (`sendBeacon` no espera).
+
+### `core/services/tracking_service.py`
+- Eliminar `enqueue_tracking_message` (SQS) + import `send_to_queue`.
+- El path sync legacy (`process_tracking_event`, `parse_user_agent`,
+  `_ensure_db_deps`) pasa a ser el ÚNICO path. **Ahora `shared.db` es
+  incondicional** → import al TOP (no lazy) + `warm_db()` en INIT. El
+  `_ensure_db_deps` lazy-hack se elimina (ya no hay path que no use Neon).
+- `parse_user_agent` (ua_parser) se conserva (era del worker; ahora inline).
+
+### `core/models/tracking.py`
+- Quitar refs a `ASYNC_MODE` si las hay.
+
+### `manifest.yaml` — TRADEOFF DE MEMORIA
+- −`uses.queues`; SIN `uses.invokes` (tracking no manda email).
+- `uses.secrets`: conservar `neon-url`.
+- `uses.tables`: `cache` (UA cache), `rate-limit-rules`,
+  `rate-limit-buckets`.
+- `env`: eliminar `ASYNC_MODE`.
+- **`memory: 128 → 256`**: ahora importa `shared.db` (sqlalchemy) en cada
+  invocación. Por `lambda-config.md`, ningún Lambda con `shared.db` baja de
+  256 MB (footprint ~117-127 MB a 128 = OOM). Es una **regresión aceptada**
+  a cambio de eliminar el worker. Documentar la medición en el comentario.
+- `snap_start: true` — se mantiene.
+- Agregar `warm_db()` en INIT del handler (como los otros Lambdas Neon) +
+  `import shared.db.models.<dominios usados>` para que las FK resuelvan.
+
+### Mitigación opcional (NO construir sin medir)
+Si la medición de fase 7 muestra que 256 MB / el restore de SnapStart con
+sqlalchemy es un problema para `/track` (alto volumen): evaluar un **write
+path raw psycopg3** en `shared.db` (sin ORM) — más liviano de importar (la
+investigación lo recomendó para escrituras simples). Es un mecanismo paralelo
+al `shared.db.repository` (sqlalchemy); sólo se justifica con números. Default:
+reusar `shared.db.repository` (consistente, testeado).
+
+## 5.3 Tests
+
+- contact_form: eliminar/portar los tests de `ASYNC_MODE`/202-vs-201/sync
+  legacy (`test_handler_returns_201_*`,
+  `test_async_mode_does_not_call_send_email`,
+  `test_handler_returns_202_with_contact_id_in_async_mode`,
+  `test_handler_returns_201_in_sync_mode_legacy`,
+  `test_enqueue_failure_returns_500`, `test_rate_limit_failure_does_not_enqueue`,
+  `test_turnstile_failure_does_not_enqueue`). Nuevos: el flujo único escribe
+  Neon (mock repository) + invoca send_email (mock `invoke_async`) + 201.
+- tracking_pixel: idem (`test_handler_returns_204_*`,
+  `test_async_mode_does_not_call_neon`, `test_encoder_does_not_parse_user_agent`,
+  `test_handler_returns_202_with_page_id_in_async_mode`,
+  `test_enqueue_failure_returns_error`). Nuevos: escribe Neon inline (mock) +
+  parse UA + 202.
+
+## 5.4 Reglas
+- **SIEMPRE** el invoke de send_email se degrada a log si falla (best-effort):
+  el 201/202 sale igual. NUNCA rompe el request.
+- **SIEMPRE** rate-limit + Turnstile + bot-detection se conservan, mismo orden.
+- **NUNCA** queda un import de `shared.queue` ni una ref a `ASYNC_MODE`.
+- **NUNCA** se crea `db_writer` ni un segundo invoke para la escritura.
+
+## Archivos afectados (fase 4)
+
+### Modificar
+- `contact_form/{core/settings/config.py, core/handler.py,
+  core/controllers/contact/create.py, core/services/contact_service.py,
+  manifest.yaml}` + tests
+- `tracking_pixel/{core/settings/config.py, core/controllers/tracking/track.py,
+  core/services/tracking_service.py, core/models/tracking.py, manifest.yaml,
+  core/handler.py (warm_db en INIT)}` + tests
+  - Verificar (cada uno): `serverless tests --type=unit --lambda=<X>` (≥80%)
+    + `serverless lint-deps --lambda=<X>` exit 0
+
+[← 04 send_email](04-send-email-lambda.md) · [siguiente: 06 migrar auth/users →](06-migrate-callers-remove-sqs.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/06-migrate-callers-remove-sqs.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/06-migrate-callers-remove-sqs.md
@@ -1,0 +1,71 @@
+# 06 — Migrar auth/users a send_email + borrar SQS y workers
+
+[← 05 encoders](05-encoders-refactor.md) · [siguiente: 07 cleanup →](07-cleanup-stream-processor.md)
+
+> Fase 5. Reapunta `auth` y `users` a invocar `send_email` async (en vez de
+> publicar a SQS), y borra los 3 workers + `shared.queue` + `resources/sqs/`.
+> (`contact_form` y `tracking_pixel` ya se migraron en la fase 4 / archivo
+> 05.) Esta fase es secuencial tras la 4: borrar `shared.queue` antes de
+> migrar los callers rompería imports.
+
+## 6.1 `auth` → invoca `send_email`
+
+- `auth/core/services/email_dispatch_service.py`:
+  - Quitar `from shared.queue.publisher import send_to_queue`.
+  - `_publish(kind, to, user_id, niche, data)` → construir el payload
+    `{operation:'email', action:'send', data:{kind, to:[to], data}}` e invocar
+    `invoke_async(function_name=os.environ['LAMBDA_SEND_EMAIL_FUNCTION_NAME'],
+    payload=...)`. Import: `from shared.aws.lambda_invoke import invoke_async`.
+  - Quitar `subject_id` del payload (lo resuelve `send_email` desde
+    `email-config`). `publish_magic_link`/`publish_code` mantienen su firma.
+- `auth/manifest.yaml`: −`uses.queues`; +`uses.invokes: [send_email]`.
+  `sends-email` queda `false`. `auth` SIGUE escribiendo Neon síncrono
+  (sin cambios en repositories).
+- Call sites read-only (no cambian): `register/start.py`, `login/start.py`,
+  `verify/resend_code.py`.
+
+## 6.2 `users` → invoca `send_email`
+
+- `users/core/services/email_dispatch_service.py`: igual que auth para sus 4
+  kinds (`email-change-verify`, `email-changed`, `account-disabled`,
+  `account-deleted`). Quitar `_subject_id` + `send_to_queue`.
+- `users/manifest.yaml`: −`uses.queues`; +`uses.invokes: [send_email]`.
+
+## 6.3 Borrar SQS + workers + shared.queue
+
+### Eliminar (dirs/archivos completos)
+- `serverless/lambda/services/auth_email_worker/` (completo)
+- `serverless/lambda/services/contact_worker/` (completo)
+- `serverless/lambda/services/tracking_worker/` (completo)
+- `serverless/lambda/shared/queue/` (completo: publisher.py, client.py,
+  `__init__.py`, pyproject.toml, tests/)
+- `serverless/lambda/resources/sqs/` (completo: 6 yaml + README.md)
+
+### Modificar (pyproject.toml: quitar comentarios/deps de shared.queue)
+- `auth/pyproject.toml`, `contact_form/pyproject.toml`,
+  `tracking_pixel/pyproject.toml`, `users/pyproject.toml`.
+
+### Destruir en AWS (operación, en deploy de fase 7)
+- `serverless destroy --lambda=auth_email_worker --stage=<X>` (×3 workers).
+- Borrar las colas/DLQ (`aws sqs delete-queue`) una vez; al quitar los yaml,
+  `infra_provision` no las recrea.
+
+## 6.4 Reglas
+- **SIEMPRE** el invoke de send_email se degrada a log si falla (best-effort).
+- **NUNCA** queda un import de `shared.queue`.
+
+## Archivos afectados (fase 5) — resumen
+
+### Modificar
+- `auth/{core/services/email_dispatch_service.py, manifest.yaml, pyproject.toml}`
+  - Verificar: `serverless tests --type=unit --lambda=auth` + `lint-deps --lambda=auth`
+- `users/{core/services/email_dispatch_service.py, manifest.yaml, pyproject.toml}`
+  - Verificar: `serverless tests --type=unit --lambda=users` + `lint-deps --lambda=users`
+- `contact_form/pyproject.toml`, `tracking_pixel/pyproject.toml` (limpieza shared.queue)
+
+### Eliminar
+- 3 workers + `shared/queue/` + `resources/sqs/` (ver §6.3).
+  - Verificar: `serverless tests --type=unit` (suite completa) + `lint-deps`
+    + `rg "shared.queue|ASYNC_MODE"` → 0.
+
+[← 05 encoders](05-encoders-refactor.md) · [siguiente: 07 cleanup →](07-cleanup-stream-processor.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/07-cleanup-stream-processor.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/07-cleanup-stream-processor.md
@@ -1,0 +1,87 @@
+# 07 — Limpieza `stream_processor` + promover convenciones a rules
+
+[← 06 migrar callers](06-migrate-callers-remove-sqs.md) · [siguiente: 08 descomposición →](08-descomposicion.md)
+
+> Fase 6. Borra TODA referencia a `stream_processor` (nunca existió como
+> Lambda) y promueve a `.claude/rules/` las convenciones nuevas antes de que
+> la carpeta del plan se elimine.
+
+## 7.1 Referencias a `stream_processor` a eliminar/corregir
+
+Detectadas con `rg -l stream_processor` (verificar la lista al ejecutar):
+
+| Archivo | Acción |
+|---------|--------|
+| `CLAUDE.md` | Quitar `stream_processor` de la lista de Lambdas, del árbol de conocimiento y de las descripciones de skills backend. Actualizar a los Lambdas reales (auth, contact_form, cv, db, send_email, tracking_pixel, users). |
+| `devtools/serverless/lambda_controller.py` | Quitar refs en comentarios/listas. |
+| `devtools/serverless/provisioner.py` | Quitar mención en comentario (`on-table-changes se elimino…`). |
+| `devtools/serverless/change_detector.py` | Quitar de listas/comentarios. |
+| `devtools/tests/unit/src/serverless/{infra_provision,provisioner,change_detector}.py` | Actualizar/eliminar casos. |
+| `serverless/lambda/shared/aws/dynamodb_types.py` | Quitar comentario especulativo. |
+| `serverless/lambda/shared/dynamodb/README.md` | Quitar mención. |
+| `serverless/lambda/shared/db/cv_repository.py` | Quitar comentario especulativo sobre stream_processor. |
+| `serverless/scripts/seed_test_contact.py` | Revisar y limpiar. |
+| `serverless/lambda/services/tracking_pixel/core/services/tracking_service.py` | Ya se reescribe en fase 5; confirmar sin refs. |
+| `docs/specs/analytics-dashboard-api/*`, `docs/specs/dashboard/*` | Specs de otros planes: corregir la mención (o nota de que el stream_processor nunca existió). NO borrar esas specs. |
+| `serverless/migrations/_archive/*.sql` | Archivo histórico: dejar (es `_archive`), o agregar nota. |
+
+> Regla: tras esta fase, `rg "stream_processor|stream-processor"` en código
+> activo (fuera de `_archive/`) debe dar **0 resultados** (AC-10).
+
+## 7.2 Promover convenciones a rules (antes de borrar la carpeta del plan)
+
+La carpeta `docs/specs/serverless-sqs-to-async-invoke/` es efímera. Lo que
+debe sobrevivir se promueve a `.claude/rules/`:
+
+1. **`.claude/rules/lambda-shared-imports.md`** — agregar al catálogo de
+   portadores: `shared.aws.lambda_invoke` (invoke async) y
+   `shared.templating.jinja` (Jinja2). Agregar `import jinja2` / `import
+   boto3` lambda a la lista de imports prohibidos en `core/`.
+2. **`.claude/rules/lambda-controller.md`** o una rule nueva
+   **`.claude/rules/async-lambda-invoke.md`** — documentar el patrón
+   `uses.invokes` (IAM `lambda:InvokeFunction` + env var
+   `LAMBDA_<X>_FUNCTION_NAME`) y `uses.buckets` (`s3:GetObject` + env var
+   `S3_<X>_BUCKET`), y la decisión "async = InvocationType=Event,
+   best-effort, sin SQS".
+3. **`.claude/rules/devtools.md`** — actualizar: trigger válidos
+   `direct`/`http` (sin `sqs`); recursos válidos dynamodb/api_gateway/
+   cloudwatch_alarms/**s3** (sin sqs); comando `serverless seed-email-config`.
+4. **`.claude/rules/serverless-secrets.md`** — actualizar la matriz de IAM
+   por Lambda: quitar las colas SQS, agregar `email-config` (DynamoDB) +
+   bucket S3 + los `uses.invokes`. Quitar `ses-from-address` de
+   `contact_form` (lo usa `send_email`); `contact_form`/`tracking_pixel`
+   conservan `neon-url` (escriben inline).
+5. **`.claude/rules/auth-system.md`** — actualizar: `auth_email_worker`
+   eliminado; auth/users invocan `send_email` async. Quitar refs a la cola
+   SQS auth-email y al worker.
+6. **CLAUDE.md** — actualizar el árbol de la estructura del repo
+   (`serverless/lambda/services/`), la tabla de Lambdas y las descripciones
+   de skills backend (quitar workers + stream_processor + SQS;
+   agregar send_email + invoke async + escritura inline en los encoders).
+7. **Skills afectadas** (`.claude/skills/auth-system/`,
+   `serverless-rate-limit`, `aws-*`): revisar menciones a SQS/workers; el
+   detalle de validación con `claude -p` lo cubre la regla
+   `.claude/rules/claude-config-testing.md` (validar las skills/rules
+   tocadas en 5 ángulos).
+
+## 7.3 Eliminar la carpeta del plan
+
+En el último commit (fase 7, archivo 11) — tras la batería E2E verde:
+`git rm -r docs/specs/serverless-sqs-to-async-invoke/`.
+
+## Archivos afectados (fase 6)
+
+### Modificar
+- `CLAUDE.md`, `.claude/rules/{lambda-shared-imports,devtools,serverless-secrets,auth-system}.md`,
+  `.claude/rules/async-lambda-invoke.md` (nueva o dentro de lambda-controller),
+  `devtools/serverless/{lambda_controller,provisioner,change_detector}.py`,
+  `serverless/lambda/shared/aws/dynamodb_types.py`,
+  `serverless/lambda/shared/dynamodb/README.md`,
+  `serverless/lambda/shared/db/cv_repository.py`,
+  `serverless/scripts/seed_test_contact.py`,
+  `docs/specs/{analytics-dashboard-api,dashboard}/*` (corrección de mención).
+  - Verificar: `rg "stream_processor" --glob '!**/_archive/**' --glob '!docs/specs/serverless-sqs-to-async-invoke/**'` → 0 resultados.
+  - Verificar: validar las rules/skills tocadas con `claude -p`
+    (`.claude/rules/claude-config-testing.md`).
+
+[← 06 migrar callers](06-migrate-callers-remove-sqs.md) · [siguiente: 08 descomposición →](08-descomposicion.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/08-descomposicion.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/08-descomposicion.md
@@ -1,0 +1,108 @@
+# 08 — Descomposición para paralelización
+
+[← 07 cleanup](07-cleanup-stream-processor.md) · [siguiente: 09 commits →](09-commits.md)
+
+> Tareas atómicas. Cada una: File Exclusivity + Interface Stability + Bounded
+> Scope. Orquestación: ver [orchestration.md](../../../.claude/rules/orchestration.md)
+> — **≤4 agentes concurrentes**, **1 workflow a la vez**, Opus 4.8 por
+> defecto. Las suites (pytest/lint/build) van por **Bash o 1-2 agentes**,
+> NUNCA 1 agente por suite. **NO hay `db_writer`.**
+
+## Leyenda
+
+Cada tarea: **Archivos** · **AC** · **Depende de** · **Paralelizable con** ·
+**Verify**.
+
+## Base secuencial
+
+- **T0 — Carpeta del plan + rama** · `docs/specs/serverless-sqs-to-async-invoke/**`
+  · Dep: — · Verify: rama `feature/serverless-sqs-to-async-invoke` desde `dev`,
+  carpeta commiteada.
+
+## Fase 1 — Shared foundations
+
+- **T1 — `shared.aws.lambda_invoke`** · `shared/aws/lambda_invoke.py` + 2 tests
+  · AC-6 (parcial) · Dep: T0 · Paral. con T2 · Verify:
+  `serverless tests --type=unit --shared` + `lint-deps --shared`
+- **T2 — `shared.templating` (Jinja2)** ·
+  `shared/templating/{__init__.py,jinja.py,pyproject.toml}` + tests · AC-3
+  (parcial) · Dep: T0 · Paral. con T1 · Verify: idem
+- **T2b — `shared.db.read_async` (patrón read concurrente, sin consumidor en
+  este plan)** · `shared/db/read_async.py` + tests · AC: — (decisión del
+  usuario) · Dep: T0 · Paral. con T1/T2 · Verify:
+  `serverless tests --type=unit --shared` + `lint-deps --shared`
+
+## Fase 2 — Devtools (T3/T4 paralelos; T5 tras ambos)
+
+- **T3 — `uses.invokes` + `uses.buckets`** · `devtools/serverless/provisioner.py`
+  + tests · AC-6, AC-7 · Dep: T0 · Paral. con T4 (archivo distinto) · Verify:
+  `test_runner --module=devtools --type=unit`
+- **T4 — recurso `s3-bucket` + tabla `email-config`** ·
+  `devtools/serverless/infra_provision.py`, `resources/s3/email-templates.yaml`,
+  `resources/dynamodb/email-config.yaml` + tests · AC-13 · Dep: T0 · Paral.
+  con T3 · Verify: idem
+- **T5 — quitar SQS de devtools** ·
+  `devtools/serverless/{provisioner,infra_provision,lambda_controller,change_detector,flags,main,help}.py`
+  + tests · AC-9 (parcial) · Dep: **T3, T4** · Paral. con: — · Verify: idem
+
+## Fase 3 — Lambda `send_email`
+
+- **T6 — `send_email` (lambda + tests)** · `services/send_email/**` · AC-3,
+  AC-4, AC-12, AC-16 · Dep: T1, T2, T3, T4 · Paral. con T7/T8 (dirs distintos)
+  · Verify: `serverless tests --type=unit --lambda=send_email` (≥80%) +
+  `lint-deps --lambda=send_email`
+- **T6b — seed templates + email_config + comando devtools** ·
+  `services/send_email/seeds/**`, comando seed en devtools · AC-14 · Dep: T6,
+  T4 · Verify: dry-run del seed (deploy real en fase 7)
+
+## Fase 4 — Encoders refactor (un lambda cada uno, dirs disjuntos)
+
+- **T7 — `contact_form`: quitar ASYNC_MODE + escritura inline + invoke send_email**
+  · `services/contact_form/**` + tests · AC-1, AC-5 · Dep: T1, T6 · Paral.
+  con T8 · Verify: `serverless tests --type=unit --lambda=contact_form` +
+  `lint-deps --lambda=contact_form`
+- **T8 — `tracking_pixel`: quitar ASYNC_MODE + escritura inline (256 MB)** ·
+  `services/tracking_pixel/**` + tests · AC-2, AC-5 · Dep: T1 · Paral. con T7
+  · Verify: `serverless tests --type=unit --lambda=tracking_pixel` +
+  `lint-deps --lambda=tracking_pixel`
+
+## Fase 5 — Migrar auth/users + borrar SQS
+
+- **T9 — migrar `auth`** · `services/auth/{email_dispatch_service,manifest,pyproject}`
+  · AC-10, AC-11 · Dep: T1, T6 · Paral. con T10
+- **T10 — migrar `users`** · `services/users/{...}` · AC-10 · Dep: T1, T6 ·
+  Paral. con T9
+  - Verify (T9/T10): `serverless tests --type=unit --lambda=<X>` + `lint-deps --lambda=<X>`
+- **T11 — borrar workers + shared.queue + resources/sqs** · eliminar 3 workers,
+  `shared/queue/`, `resources/sqs/`; limpiar pyproject de los 4 callers · AC-9
+  · Dep: **T7, T8, T9, T10** · Paral. con: — · Verify:
+  `serverless tests --type=unit` (suite) + `lint-deps` + `rg "shared.queue|ASYNC_MODE"` → 0
+
+## Fase 6 — Limpieza stream_processor + rules
+
+- **T12 — limpiar `stream_processor`** · ver [07](07-cleanup-stream-processor.md) §7.1
+  · AC-8 · Dep: T5, T11 · Paral. con T13 · Verify: `rg stream_processor`
+  (fuera de `_archive/` y la carpeta del plan) → 0
+- **T13 — promover convenciones a rules + CLAUDE.md + validar skills** ·
+  `.claude/rules/*`, `CLAUDE.md` · Dep: T5, T11 · Paral. con T12 · Verify:
+  `claude -p` 5 ángulos (`.claude/rules/claude-config-testing.md`)
+
+## Fase 7 — Verificación E2E (NO paralelizable)
+
+- **T14 — batería E2E + deploy dev + seed + smoke + medir cold start + borrar
+  carpeta del plan** · ver [11](11-verificacion-e2e.md) · Dep: TODO
+
+## Granularidad — olas de ≤4 agentes
+
+- Ola A: T1, T2, T2b, T3 (4; archivos disjuntos: lambda_invoke, templating,
+  db/read_async, provisioner).
+- Ola A2: T4 (infra_provision) + T5 tras T3/T4 (secuencial, re-tocan provisioner).
+- Ola B: T6 (+T6b tras T6).
+- Ola C: T7, T8, T9, T10 (4; un lambda cada uno, dirs disjuntos).
+- T11 secuencial tras Ola C.
+- Ola D: T12, T13.
+- T14 secuencial final.
+
+16 tareas (Large).
+
+[← 07 cleanup](07-cleanup-stream-processor.md) · [siguiente: 09 commits →](09-commits.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/09-commits.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/09-commits.md
@@ -1,0 +1,87 @@
+# 09 — Commits
+
+[← 08 descomposición](08-descomposicion.md) · [siguiente: 10 worktrees →](10-paralelizacion-worktrees.md)
+
+> Conventional Commits en español. Cada commit deja el repo verde (lint +
+> compileall + tests del scope) y ejecuta su verificación incremental ANTES
+> de commitear. Un solo PR `feature/serverless-sqs-to-async-invoke → dev`.
+> **NO hay commit de `db_writer`.**
+
+## Secuencia
+
+1. **`docs(specs): plan eliminar SQS + email centralizado + encoders sync`** (T0)
+   - La carpeta del plan. Verify: markdown válido.
+
+2. **`feat(shared): portador shared.aws.lambda_invoke para invoke async`** (T1)
+   - `shared/aws/lambda_invoke.py` + tests.
+   - Verify: `serverless tests --type=unit --shared` + `lint-deps --shared`.
+
+3. **`feat(shared): portador shared.templating con Jinja2`** (T2)
+   - `shared/templating/**` + tests. Verify: idem.
+
+3b. **`feat(shared): shared.db.read_async (gather de reads concurrentes)`** (T2b)
+   - `shared/db/read_async.py` + tests. Patrón para reads multi-query del
+     dashboard; sin consumidor en este plan (decisión del usuario).
+   - Verify: `serverless tests --type=unit --shared` + `lint-deps --shared`.
+
+4. **`feat(devtools): uses.invokes + uses.buckets en el provisioner`** (T3)
+   - `provisioner.py` + tests. Verify: `test_runner --module=devtools --type=unit`.
+
+5. **`feat(devtools): recurso s3-bucket + tabla email-config`** (T4)
+   - `infra_provision.py`, `resources/s3/email-templates.yaml`,
+     `resources/dynamodb/email-config.yaml` + tests. Verify: idem.
+
+6. **`refactor(devtools): elimina soporte de SQS del provisioning`** (T5)
+   - Quita trigger sqs + uses.queues + _provision_sqs_queue + tests sqs.
+   - Verify: `test_runner --module=devtools --type=unit`.
+
+7. **`feat(send_email): lambda puro de email (DynamoDB+S3+Jinja2+SES)`** (T6)
+   - `services/send_email/**`. Verify:
+     `serverless tests --type=unit --lambda=send_email` (≥80%) +
+     `lint-deps --lambda=send_email`.
+
+8. **`feat(send_email): seed de email-config + templates S3`** (T6b)
+   - `services/send_email/seeds/**` + comando seed devtools. Verify: dry-run
+     del seed; `test_runner --module=devtools --type=unit`.
+
+9. **`refactor(contact_form): escritura Neon inline + invoke send_email, sin ASYNC_MODE`** (T7)
+   - `contact_form/**` + tests. Verify:
+     `serverless tests --type=unit --lambda=contact_form` + `lint-deps`.
+
+10. **`refactor(tracking_pixel): escritura Neon inline (256MB), sin ASYNC_MODE`** (T8)
+    - `tracking_pixel/**` + tests. Verify:
+      `serverless tests --type=unit --lambda=tracking_pixel` + `lint-deps`.
+    - Body: documentar el bump de memoria 128→256 con la razón (shared.db).
+
+11. **`refactor(auth): invoca send_email async en vez de SQS`** (T9)
+    - `auth/{email_dispatch_service,manifest,pyproject}`. Verify:
+      `--lambda=auth` + lint-deps.
+
+12. **`refactor(users): invoca send_email async en vez de SQS`** (T10)
+    - `users/{...}`. Verify: `--lambda=users` + lint-deps.
+
+13. **`refactor(serverless): elimina los 3 workers SQS, shared.queue y colas`** (T11)
+    - Borra `auth_email_worker`, `contact_worker`, `tracking_worker`,
+      `shared/queue/`, `resources/sqs/`; limpia pyproject.
+    - Verify: `serverless tests --type=unit` (suite) + `lint-deps` +
+      `rg "shared.queue|ASYNC_MODE"` → 0.
+
+14. **`refactor(backend): elimina toda referencia a stream_processor`** (T12)
+    - Código + docs + devtools. Verify: `rg stream_processor` (fuera de
+      `_archive/` y la carpeta del plan) → 0.
+
+15. **`docs(rules): promueve uses.invokes/buckets + portadores a rules`** (T13)
+    - `.claude/rules/*`, `CLAUDE.md`. Verify: `claude -p` 5 ángulos.
+
+16. **`test(serverless): verificacion E2E + medicion cold start + elimina spec`** (T14)
+    - Incluye `git rm -r docs/specs/serverless-sqs-to-async-invoke/`.
+    - Verify: batería completa de [11](11-verificacion-e2e.md) en verde.
+
+## PR
+
+- Único: `feature/serverless-sqs-to-async-invoke → dev`, merge commit.
+- Body: Problema / Solución / Cómo probar (reusa la batería de la sección 11)
+  / TODO (incluir: medición de cold start + tradeoff memoria tracking_pixel).
+  Sin atribución de IA.
+
+[← 08 descomposición](08-descomposicion.md) · [siguiente: 10 worktrees →](10-paralelizacion-worktrees.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/10-paralelizacion-worktrees.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/10-paralelizacion-worktrees.md
@@ -1,0 +1,61 @@
+# 10 — Paralelización con git worktrees
+
+[← 09 commits](09-commits.md) · [siguiente: 11 verificación E2E →](11-verificacion-e2e.md)
+
+> Qué se paraleliza con worktrees / subagentes y qué no. Gobernado por
+> [orchestration.md](../../../.claude/rules/orchestration.md): **≤4 agentes
+> concurrentes**, **1 workflow a la vez**, Opus 4.8. `isolation:'worktree'`
+> SÓLO cuando los agentes mutan archivos en paralelo.
+
+## Base secuencial (commits 1-8) — NO worktree
+
+- Commit 1 (carpeta del plan).
+- Commits 2-3 (shared T1, T2): archivos disjuntos (`lambda_invoke.py` vs
+  `templating/`) → 2 agentes o inline.
+- Commits 4-6 (devtools T3, T4, T5): T3 (`provisioner.py`) y T4
+  (`infra_provision.py`) en 2 agentes concurrentes; **T5 NO** (re-toca ambos
+  → secuencial tras T3/T4).
+- Commits 7-8 (`send_email` T6 + seed T6b): un solo dir nuevo → 1 agente o
+  worktree único. Habilita a los callers (T7, T9, T10).
+
+> No se lanza ninguna ola worktree hasta tener la base (commits 1-8)
+> commiteada: `shared.aws.lambda_invoke` y `send_email` son dependencias de
+> los callers.
+
+## Ola worktree A — Encoders + auth/users (tras la base)
+
+| Worktree | Tarea | Archivos (disjuntos) |
+|----------|-------|----------------------|
+| wt-contact | T7 | `services/contact_form/**` |
+| wt-tracking | T8 | `services/tracking_pixel/**` |
+| wt-auth | T9 | `services/auth/**` |
+| wt-users | T10 | `services/users/**` |
+
+4 agentes concurrentes (cap exacto), `isolation:'worktree'`. Cada lambda es un
+dir disjunto → cero colisión. Todos dependen de T6 (`send_email`) ya commiteado
+en la base, NO entre sí. Cada agente corre sus tests + lint-deps antes de su
+commit.
+
+## NO se paraleliza
+
+- **T5** (quitar SQS de devtools): toca varios módulos compartidos → secuencial.
+- **T11** (borrar workers + `shared.queue` + `resources/sqs/`): los 4 callers
+  referencian `shared.queue` en su pyproject → DESPUÉS de Ola A, secuencial.
+  Borrar `shared/queue/` antes rompería los imports.
+- **T12/T13** (cleanup stream_processor + rules): tocan CLAUDE.md, rules,
+  devtools, docs transversales → 2 agentes (archivos distintos) pero NO
+  worktree (cambios de docs/config, mejor en el árbol principal con review).
+- **T14** (verificación E2E): SIEMPRE secuencial, árbol principal, al final.
+  La batería de la sección 11 NO se fan-outea.
+
+## Lanzamiento y merge
+
+- La Ola A se orquesta con UN workflow (1 a la vez) en una ola de 4, o con 4
+  subagentes `isolation:'worktree'`. Modelo: Opus 4.8.
+- Cada worktree commitea en su rama temporal; al cerrar, se integra a
+  `feature/serverless-sqs-to-async-invoke`. Tras integrar la Ola A, se corre
+  T11 (borrado) en el árbol principal.
+- Las suites de verificación las corre cada agente en su worktree con Bash —
+  NO un agente por suite.
+
+[← 09 commits](09-commits.md) · [siguiente: 11 verificación E2E →](11-verificacion-e2e.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/11-verificacion-e2e.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/11-verificacion-e2e.md
@@ -1,0 +1,126 @@
+# 11 — Verificación E2E iterativa + medición de cold start (gate del PR)
+
+[← 10 worktrees](10-paralelizacion-worktrees.md) · [README](README.md)
+
+> Última fase y último commit. Bucle "no parar hasta que funcione". El `git
+> push` + PR ocurren SÓLO con esta batería completa en verde. NO se fan-outea
+> (Bash o 1-2 agentes secuenciales). **NO hay `db_writer`.**
+
+## Parte A — Refactor de tests (barrido global)
+
+Confirmar con `rg -l` (0 resultados, fuera de `_archive/` y de la carpeta del
+plan mientras exista):
+
+```bash
+rg -l "shared.queue|send_to_queue|QueuePublishError"     serverless/lambda
+rg -l "ASYNC_MODE|async_mode"                            serverless/lambda
+rg -l "auth_email_worker|contact_worker|tracking_worker" serverless devtools
+rg -l "uses.queues|trigger.*sqs|_provision_sqs"          devtools serverless
+rg -l "db_writer|db-writer"                              serverless devtools
+rg -l "stream_processor|stream-processor" --glob '!**/_archive/**'
+```
+
+- Ningún test referencia los 3 workers, `shared.queue`, `ASYNC_MODE` ni
+  `db_writer`.
+- Los modelos de mensaje SQS (`ContactQueueMessage`/`TrackingQueueMessage`/
+  `AuthEmailMessage`) se eliminaron (su lógica de persistencia vive ahora
+  inline en los encoders).
+- Tests nuevos en ruta/convención correcta (mirror + BDD-style, asserts
+  exactos).
+
+## Parte B — Batería de comandos (orden, todo verde)
+
+```bash
+python -m compileall -q serverless/lambda                          # 1. sintaxis
+python devtools/run.py serverless lint-deps                        # 2. imports + dedup
+for L in send_email auth users contact_form tracking_pixel; do     # 3. unit+cov ≥80%
+  python devtools/run.py serverless tests --type=coverage --lambda=$L
+done
+python devtools/run.py serverless tests --type=unit --shared       # 4. portadores nuevos
+python devtools/run.py test_runner --module=devtools --type=unit   # 5. devtools
+python devtools/run.py serverless tests --type=unit                # 6. suite backend completa
+```
+
+## Parte C — Deploy a dev + seed + smoke (`--aws-profile=tfs-dev`)
+
+```bash
+# Infra: tabla email-config + bucket S3 (idempotente). NO crea colas SQS.
+python devtools/run.py serverless provision-infra --stage=dev --aws-profile=tfs-dev
+
+# Deploy de send_email + seed de templates/config
+python devtools/run.py serverless deploy --lambda=send_email --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless seed-email-config --stage=dev --aws-profile=tfs-dev
+
+# Redeploy de los callers migrados
+for L in auth users contact_form tracking_pixel; do
+  python devtools/run.py serverless deploy --lambda=$L --stage=dev --aws-profile=tfs-dev
+done
+
+# Destruir los 3 workers (ya sin código)
+for W in auth_email_worker contact_worker tracking_worker; do
+  python devtools/run.py serverless destroy --lambda=$W --stage=dev --yes --aws-profile=tfs-dev 2>/dev/null || true
+done
+```
+
+### Smoke E2E (HTTP real contra dev) — reusar patrón de `api_e2e`
+
+- `POST /contact` válido → **201** con el contacto persistido; verificar en
+  Neon que se escribió (AC-1) y que llegó el email al owner (SES /
+  `simulator.amazonses.com`) (AC-12).
+- `POST /track` válido → **202**; verificar el tracking_event en Neon (AC-2).
+- `auth register.start` → llegan magic-link + code (send_email) (AC-10).
+- `send_email` con `kind` inexistente (invoke directo) → error sin SES (AC-4).
+
+## Parte D — Medición de cold start (el punto de honestidad del plan)
+
+Con el procedimiento de `.claude/rules/lambda-config.md` (memorias
+decrecientes sobre `$LATEST`, sin SnapStart restore = peor caso), medir y
+documentar en el comentario de cada manifest:
+
+```bash
+# Por cada lambda nuevo/cambiado: send_email, contact_form, tracking_pixel
+for mem in 512 256 128; do
+  aws lambda update-function-configuration --function-name <fn> \
+    --memory-size $mem --region us-east-1 --profile tfs-dev >/dev/null
+  aws lambda wait function-updated --function-name <fn> --region us-east-1 --profile tfs-dev
+  aws lambda invoke --function-name <fn> --payload fileb://<event>.json \
+    --log-type Tail --region us-east-1 --profile tfs-dev ./tmp/out.json \
+    --query 'LogResult' --output text | base64 -d \
+    | rg 'Init Duration|^REPORT.*Duration|Max Memory'
+done
+```
+
+- **send_email**: medir el mínimo (Jinja2 + boto3 dynamodb/s3/ses, sin Neon).
+  Estimado 256; bajar a 128 sólo si la medición lo permite.
+- **tracking_pixel**: CONFIRMAR el bump a 256 (footprint Neon a 128 = OOM).
+  Documentar Init/handler/Max Memory reales.
+- **contact_form**: confirmar que sigue en 256 sin regresión.
+- **Comparar** con las métricas previas (encoder SQS): registrar en el body
+  del PR que el cold start es ~neutro (SnapStart) y que `tracking_pixel`
+  subió a 256 MB (tradeoff aceptado). Si la medición muestra que el restore
+  de `tracking_pixel` se degradó por sqlalchemy y es inaceptable para `/track`:
+  evaluar el write path raw psycopg3 (mitigación de [05](05-encoders-refactor.md)).
+
+## Parte E — Cierre
+
+```bash
+git rm -r docs/specs/serverless-sqs-to-async-invoke/
+```
+
+Definition of Done:
+- [ ] AC-1..AC-16 cubiertos por test/smoke que pasa.
+- [ ] Coverage ≥80% per-file en archivos nuevos/modificados.
+- [ ] `compileall` + `lint-deps` + `test_runner devtools` + suite backend verdes.
+- [ ] Deploy dev + seed + smoke OK.
+- [ ] memory/timeout MEDIDOS y justificados (incl. tracking_pixel 256).
+- [ ] `rg` de SQS/ASYNC_MODE/stream_processor/db_writer → 0 (fuera de `_archive/`).
+- [ ] rules/CLAUDE.md actualizadas y validadas con `claude -p`.
+- [ ] Sin atribución de IA.
+
+## Gate del PR
+
+`git push` + `gh pr create --base dev` SÓLO con TODA esta batería en verde. Si
+algo falla: diagnosticar → corregir → re-ejecutar → repetir. NUNCA push/PR con
+un comando fallando, un test rojo o coverage < 80%.
+
+[← 10 worktrees](10-paralelizacion-worktrees.md) · [README](README.md)

--- a/docs/specs/serverless-sqs-to-async-invoke/README.md
+++ b/docs/specs/serverless-sqs-to-async-invoke/README.md
@@ -1,0 +1,108 @@
+# Plan: backend serverless — eliminar SQS, email centralizado, encoders sync
+
+> Elimina SQS (3 colas + 3 DLQ + 3 workers) y el feature flag `ASYNC_MODE`,
+> borra las referencias muertas a `stream_processor`, centraliza el envío de
+> email en un Lambda `send_email` (config en DynamoDB + templates en S3 +
+> Jinja2, invocado async con `InvocationType='Event'`), y deja la
+> persistencia a Neon **inline y síncrona** en los encoders
+> (`contact_form`, `tracking_pixel`) con psycopg3 + SnapStart. **NO** se crea
+> `db_writer`. Principio rector: **error-proof, escalable y
+> provider-swappable** — todo acceso AWS detrás de `shared.*`.
+
+Escala: **Large** (1 Lambda nuevo `send_email`, 3 eliminados, 4 services
+migrados, devtools tocado, 1 tabla DynamoDB + 1 bucket S3 nuevos).
+
+## Honestidad sobre el cold start (leer primero)
+
+Este refactor **NO reduce el cold start de los encoders** — lo aclaro porque
+fue la motivación inicial. Con SnapStart (ya activo en `contact_form` y
+`tracking_pixel`) el cold es el *restore* (~1s), no el import: el import ya
+está en el snapshot. `contact_form` ya importaba `shared.db`. El valor real
+del plan es **simplicidad** (−SQS, −3 workers, −`ASYNC_MODE`) y **flexibilidad
+de emails** (config central editable sin redeploy). Ver
+[01 §1](01-contexto-y-decision.md).
+
+**Tradeoff conocido**: `tracking_pixel` deja de tocar-Neon-solo-en-sync y pasa
+a escribir inline siempre → **128 MB → 256 MB** (necesita `shared.db`). Es una
+regresión de memoria en el Lambda de mayor volumen, aceptada a cambio de
+eliminar el worker. Mitigación opcional (write path raw psycopg3, más liviano)
+documentada en [05](05-encoders-refactor.md); se evalúa sólo si la medición de
+fase 7 lo justifica.
+
+## Cuándo leer cada archivo
+
+| Archivo | Cuándo leer |
+|---------|-------------|
+| [01-contexto-y-decision.md](01-contexto-y-decision.md) | Problema, solución, AC-1..AC-16 (secciones 1-3) |
+| [02-shared-foundations.md](02-shared-foundations.md) | `shared.aws.lambda_invoke` (para invocar send_email) + `shared.templating` (Jinja2) |
+| [03-devtools-provisioning.md](03-devtools-provisioning.md) | `uses.invokes`, `uses.buckets`, recurso S3, tabla email-config, quitar SQS |
+| [04-send-email-lambda.md](04-send-email-lambda.md) | Lambda `send_email` + tabla `email-config` + templates S3 |
+| [05-encoders-refactor.md](05-encoders-refactor.md) | `contact_form`/`tracking_pixel`: quitar `ASYNC_MODE`, escritura inline síncrona, invocar send_email, memoria |
+| [06-migrate-callers-remove-sqs.md](06-migrate-callers-remove-sqs.md) | auth/users → send_email; borrar workers + SQS + `shared.queue` |
+| [07-cleanup-stream-processor.md](07-cleanup-stream-processor.md) | Limpiar refs a `stream_processor` + promover convenciones a rules |
+| [08-descomposicion.md](08-descomposicion.md) | Sección 8 — tareas atómicas + paralelización |
+| [09-commits.md](09-commits.md) | Sección 9 — secuencia de commits |
+| [10-paralelizacion-worktrees.md](10-paralelizacion-worktrees.md) | Sección 10 — worktrees / olas de agentes |
+| [11-verificacion-e2e.md](11-verificacion-e2e.md) | Sección 11 — batería + medición de cold start (gate del PR) |
+
+## Estado por fase
+
+| Fase | Archivo | Estado |
+|------|---------|--------|
+| 0 | docs del plan | `pending` |
+| 1 | Shared foundations (02) | `pending` |
+| 2 | Devtools provisioning (03) | `pending` |
+| 3 | Lambda `send_email` (04) | `pending` |
+| 4 | Encoders refactor (05) | `pending` |
+| 5 | Migrar auth/users + borrar SQS (06) | `pending` |
+| 6 | Limpieza `stream_processor` (07) | `pending` |
+| 7 | Verificación E2E + medición (11) | `pending` |
+
+## Decisiones no-reabribles (confirmadas con el usuario)
+
+1. **NO se crea `db_writer`.** La persistencia a Neon es **inline y síncrona**
+   en `contact_form`/`tracking_pixel` (la investigación mostró que un INSERT
+   warm pooled es ~10-25ms, imperceptible; y que en Lambda no hay
+   "async fire-and-forget en proceso").
+2. **Transporte de email = Lambda `InvocationType='Event'`** hacia
+   `send_email`. **CERO SQS** (ni DLQ). Email best-effort.
+3. **`send_email` puro**: DynamoDB (config) + S3 (template) + Jinja2 + SES.
+   NO toca Neon. Tabla `email-config` (PK=`kind`), **una plantilla por kind**
+   (10 kinds → 10 templates html + 10 txt en S3).
+4. **Owner-email del contacto**: `contact_form` invoca `send_email` async,
+   **siempre** (tras escribir el contacto inline). No idempotente.
+5. **`users` ENTRA en scope** (migra sus 4 kinds a `send_email`).
+6. **Bucket S3 per-env**: `portfolio-email-templates-{dev,stage,prod}`.
+7. **Eliminar `ASYNC_MODE`** y el path sync legacy duplicado: queda un único
+   path (escribir + responder).
+8. **Provider-swappable**: AWS detrás de `shared.*`. Se crean
+   `shared.aws.lambda_invoke` y `shared.templating`; se reusan
+   `shared.aws.s3` (`get_object_text`, ya existe), `shared.aws.ses`,
+   `shared.db`.
+9. **"Consultas async" (reads multi-query con gather) FUERA de scope** — eso
+   pertenece al Lambda de lectura del dashboard (otro plan). Se anota allí.
+10. **`tracking_pixel` 128→256 MB** aceptado (escribe Neon inline). Mitigación
+    raw-psycopg3 sólo si la medición de fase 7 la justifica.
+
+## Reglas críticas (siempre activas)
+
+- **SIEMPRE** los `core/**/*.py` importan AWS sólo vía `shared.*`
+  (`shared.aws.lambda_invoke`, `shared.aws.s3`, `shared.aws.ses`,
+  `shared.aws.dynamodb`, `shared.db`, `shared.templating`). `lint-deps` verde.
+- **SIEMPRE** los `__init__.py` de `shared/*` quedan VACÍOS (sin barrels).
+- **SIEMPRE** los encoders importan `shared.db` al top + `warm_db()` en INIT
+  (van al snapshot de SnapStart). NO lazy si la dep es incondicional.
+- **SIEMPRE** `memory`/`timeout` = MÍNIMO medido y justificado en el manifest
+  (`.claude/rules/lambda-config.md`).
+- **SIEMPRE** invocación async de email = `InvocationType='Event'`; el caller
+  no espera; degrada a log si falla (no rompe el request).
+- **SIEMPRE** TDD: test primero, asserts EXACTOS, coverage ≥80% per-file.
+- **NUNCA** atribución de IA. **NUNCA** reintroducir SQS. **NUNCA** crear
+  `db_writer`.
+
+## Ciclo de vida
+
+Carpeta **efímera**: el último commit (fase 7) la elimina con
+`git rm -r`. Convenciones que sobreviven (formato `uses.invokes`/
+`uses.buckets`, portadores `shared.*` nuevos, patrón send_email) se promueven
+a `.claude/rules/` ANTES de borrar (fase 6).


### PR DESCRIPTION
## Problema

1. **El cold start del reporte `api_e2e` estaba mal atribuido.** Se medía por-caso (`elapsed[0]` de cada caso), pero el cold start lo paga solo el **primer invoke del contenedor de cada Lambda**. Del 2º caso en adelante del mismo Lambda el contenedor ya está caliente, así que su "cold" era mentira (ej. `cv.get`=11.9s cold real, pero `cv.profile`=0.8s se mostraba como "cold" siendo warm). El `GLOBAL cold` promediaba los 37 `elapsed[0]` → número inflado-a-la-baja (~2.5s).

2. **El command `/push-pr-merge` no verificaba la base tras el merge.** El CI verde solo cubre Biome + build; integration/feature/api_e2e viven en local y no se corrían tras mergear a `dev`.

3. **El plan `serverless-sqs-to-async-invoke` estaba sin versionar** (untracked en el working tree).

## Solucion

1. La atribución del cold pasa al `Reporter` (conoce el orden de ejecución = orden de inserción):
   - `timing_rows()` clasifica cold/warm a nivel Lambda: el primer caso con samples de cada Lambda se lleva el cold; el resto es `cold='-'` (ya caliente) y su warm promedia **todos** sus samples.
   - Nuevo bloque **COLD START POR LAMBDA** (1 cold por contenedor) + tabla por caso.
   - `GLOBAL`: cold = promedio **por Lambda**, no por caso.
   - Se elimina `warm_avg` (sin uso); 13 tests nuevos en `test_reporter.py`; README actualizado.

2. Nuevo **paso 8** en `/push-pr-merge`: batería completa de tests tras el merge (unit, integration, feature/E2E, api_e2e según scope), con reporte **BASE INESTABLE** + fix forward si algo falla.

3. Se versiona la spec completa (17 archivos) en `docs/specs/serverless-sqs-to-async-invoke/` (pendiente de implementar).

## Como probar

```bash
# 1. Tests del reporter (13 nuevos, BDD/AAA, asserts exactos)
python devtools/run.py test_runner --module=devtools --type=unit   # 956 passed

# 2. Ver el reporte corregido contra dev (HTTP real, firma bypass Ed25519 local)
python devtools/run.py api_e2e --env=dev --aws-profile=tfs-dev
#    -> bloque "COLD START POR LAMBDA" con 1 cold por Lambda; 37/37 PASS

# 3. Lint devtools
cd devtools && .venv/bin/python -m ruff check api_e2e/reporter.py tests/unit/src/api_e2e/test_reporter.py
```

Verificado contra dev: 37/37 PASS con cold agrupado (cv 13.9, contact_form 9.8, tracking_pixel 3.7, auth 11.3, users 8.5; COLD avg 9.4).

## TODO

- **Pre-push local**: `build_tests` (vitest project "build") falla con `Cannot find package '@portfolio/seo'` en `tests/build/openapi-endpoint.test.ts` — bug de resolución del workspace en ese proyecto vitest, **pre-existente** y ajeno a este cambio (no toca apps/packages). `feature_tests` E2E omitido por `portfolio-dynamodb-local` unhealthy (infra local). Ambos gates saltados en este push; ameritan un fix dedicado.