### PR TITLE
fix(devtools): provision-infra adopta el bucket S3 si ya existe (BucketAlreadyOwnedByYou)

### DIFF
--- a/devtools/serverless/infra_provision.py
+++ b/devtools/serverless/infra_provision.py
@@ -1203,20 +1203,40 @@ def _provision_s3_bucket(
     return resources, published
 
 
+# Codigos de error de create-bucket que significan "el bucket ya es tuyo":
+# no son un fallo, son adopcion. `head-bucket` puede devolver 403 (rol sin
+# s3:ListBucket) y tratarse como "no existe" -> create-bucket -> uno de estos.
+_BUCKET_ALREADY_OWNED = (
+    'BucketAlreadyOwnedByYou',
+    'BucketAlreadyExists',
+)
+
+
 def _create_s3_bucket(
     bucket: str,
     *,
     profile: str | None,
     region: str,
 ) -> None:
-    """Crea el bucket. us-east-1 NO acepta LocationConstraint (es el default)."""
+    """Crea el bucket. us-east-1 NO acepta LocationConstraint (es el default).
+
+    Tolerante a `BucketAlreadyOwnedByYou` / `BucketAlreadyExists`: si el
+    bucket ya existe en la cuenta (head-bucket pudo dar 403 por falta de
+    s3:ListBucket en el rol OIDC del CI), se adopta en vez de fallar.
+    """
     args = ['s3api', 'create-bucket', '--bucket', bucket]
     if region != 'us-east-1':
         args += [
             '--create-bucket-configuration',
             f'LocationConstraint={region}',
         ]
-    aws_cli.aws(args, profile=profile, region=region)
+    try:
+        aws_cli.aws(args, profile=profile, region=region)
+    except AwsError as exc:
+        if any(code in exc.stderr for code in _BUCKET_ALREADY_OWNED):
+            print(_c(CYAN, f'  bucket {bucket} ya existe (adoptado)'))
+            return
+        raise
     aws_cli.aws(
         ['s3api', 'wait', 'bucket-exists', '--bucket', bucket],
         profile=profile,

--- a/devtools/tests/unit/src/serverless/infra_provision.py
+++ b/devtools/tests/unit/src/serverless/infra_provision.py
@@ -837,3 +837,81 @@ class TestCustomDomain:
         assert resources == {}
         assert published == []
         assert fake.calls == []
+
+
+# --------------------------------------------------------------------------
+# _create_s3_bucket — tolerante a BucketAlreadyOwnedByYou
+# --------------------------------------------------------------------------
+class _FakeAwsRaising:
+    """Fake de `aws_cli.aws` que lanza AwsError en el verbo dado."""
+
+    def __init__(self, *, raise_on: str, stderr: str) -> None:
+        from serverless.aws_cli import AwsError
+
+        self._raise_on = raise_on
+        self._exc = AwsError(
+            'create-bucket fallo',
+            returncode=254,
+            stderr=stderr,
+            args_used=['s3api', 'create-bucket'],
+        )
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, **_kwargs):
+        from serverless.aws_cli import AwsResult
+
+        self.calls.append(args)
+        if '.'.join(args[:2]) == self._raise_on:
+            raise self._exc
+        return AwsResult(returncode=0, stdout='', stderr='', json=None)
+
+
+class TestCreateS3Bucket:
+    def test_create_bucket_adopts_when_already_owned(self, monkeypatch):
+        """
+        Given create-bucket falla con BucketAlreadyOwnedByYou (el bucket
+        ya existe, head-bucket dio 403 sin s3:ListBucket en el rol),
+        When _create_s3_bucket corre,
+        Then NO re-lanza (lo adopta) y NO llama `wait bucket-exists`.
+        """
+        from serverless import aws_cli
+        from serverless import infra_provision
+
+        fake = _FakeAwsRaising(
+            raise_on='s3api.create-bucket',
+            stderr='An error occurred (BucketAlreadyOwnedByYou)',
+        )
+        monkeypatch.setattr(aws_cli, 'aws', fake)
+
+        infra_provision._create_s3_bucket(
+            'portfolio-email-templates-dev',
+            profile=None,
+            region='us-east-1',
+        )
+
+        verbs = ['.'.join(c[:2]) for c in fake.calls]
+        assert verbs == ['s3api.create-bucket']
+
+    def test_create_bucket_reraises_other_errors(self, monkeypatch):
+        """
+        Given create-bucket falla con un error que NO es "ya existe"
+        (ej. AccessDenied),
+        When _create_s3_bucket corre,
+        Then re-lanza el AwsError.
+        """
+        from serverless import aws_cli
+        from serverless import infra_provision
+        from serverless.aws_cli import AwsError
+
+        fake = _FakeAwsRaising(
+            raise_on='s3api.create-bucket',
+            stderr='An error occurred (AccessDenied)',
+        )
+        monkeypatch.setattr(aws_cli, 'aws', fake)
+
+        with pytest.raises(AwsError):
+            infra_provision._create_s3_bucket(
+                'portfolio-email-templates-dev',
+                profile=None,
+                region='us-east-1',
+            )


### PR DESCRIPTION
## Problema

El `deploy-backend.yml` del CI falló tras mergear el refactor SQS (PR #211): `provision-infra dev` abortó con

```
[ERROR] provision-infra fallo: Comando aws fallo (exit 254): s3api create-bucket --bucket portfolio-email-templates-dev
```

El bucket `portfolio-email-templates-dev` ya existía (creado en el deploy manual de la migración). El provisioner de S3 chequea existencia con `head-bucket`, pero el rol OIDC del CI (`portfolio-deploy-dev`) no tiene `s3:ListBucket`, así que `head-bucket` devuelve **403** → `aws_resource_exists` lo trata como "no existe" → intenta `create-bucket` → **254 `BucketAlreadyOwnedByYou`** → aborta.

## Solución

`_create_s3_bucket` ahora **tolera** `BucketAlreadyOwnedByYou` / `BucketAlreadyExists`: captura el `AwsError` del `create-bucket` y, si el código indica que el bucket ya es de la cuenta, lo adopta (log + return) en vez de fallar. Esto es robusto independientemente de los permisos del rol (mismo patrón de adopción que las tablas DynamoDB).

## Cómo probar

```bash
cd devtools && .venv/bin/python -m pytest tests/unit/src/serverless/infra_provision.py -k CreateS3Bucket
# 2 passed: adopta ante BucketAlreadyOwnedByYou; re-lanza AccessDenied

python devtools/run.py test_runner --module=devtools --type=unit   # 965 passed
```

Al mergear a `dev`, `deploy-backend.yml` debe pasar el step "Provision shared infrastructure" (ya no aborta por el bucket existente).

## TODO

- (opcional) Dar `s3:ListBucket` al rol OIDC `portfolio-deploy-*` sobre los buckets `portfolio-email-templates-*` para que `head-bucket` resuelva sin el fallback al create.