### PR TITLE
fix(ci): serializa el deploy de lambdas + retry create-deployment + IAM S3 templates

### DIFF
--- a/.claude/docs/ci-cd-pipeline/aws-oidc-setup.md
+++ b/.claude/docs/ci-cd-pipeline/aws-oidc-setup.md
@@ -227,10 +227,36 @@ mkdir -p ./tmp/iam
         "arn:aws:s3:::portfolio-devtools-state",
         "arn:aws:s3:::portfolio-devtools-state/*"
       ]
+    },
+    {
+      "Sid": "S3EmailTemplates",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:PutEncryptionConfiguration",
+        "s3:GetEncryptionConfiguration",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::portfolio-email-templates-dev",
+        "arn:aws:s3:::portfolio-email-templates-dev/*",
+        "arn:aws:s3:::portfolio-email-templates-stage",
+        "arn:aws:s3:::portfolio-email-templates-stage/*",
+        "arn:aws:s3:::portfolio-email-templates-prod",
+        "arn:aws:s3:::portfolio-email-templates-prod/*"
+      ]
     }
   ]
 }
 ```
+
+> El statement `S3EmailTemplates` lo necesita `provision-infra` + `seed-email-config`
+> para crear/configurar el bucket de templates de email y subir los archivos.
+> El statement `SQS` quedo OBSOLETO tras eliminar SQS del backend (invoke async
+> Lambda->Lambda): no hace dano (no hay colas que crear) pero se puede quitar.
 
 ### 2.3 — Crear los 3 roles
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -224,6 +224,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       fail-fast: false
+      # max-parallel: 1 serializa los deploys. Cada lambda HTTP llama
+      # `apigateway create-deployment` sobre la MISMA REST API, y API Gateway
+      # limita create-deployment a ~1 cada pocos segundos por cuenta: en
+      # paralelo varios chocan con TooManyRequestsException (exit 254).
+      max-parallel: 1
       matrix:
         lambda: ${{ fromJSON(needs.detect-changes.outputs.affected) }}
     # Mismas 20 keys que migrate-db (el deploy de cada lambda invoca

--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -1110,6 +1110,44 @@ def _cleanup_legacy_permissions(
         )
 
 
+# Backoff para `create-deployment`: API Gateway limita create-deployment a
+# ~1 cada pocos segundos por cuenta. Deploys (semi)concurrentes de varios
+# lambdas HTTP sobre la MISMA REST API chocan con TooManyRequestsException.
+_DEPLOYMENT_RETRY_DELAYS = (3, 8, 20)
+
+
+def _create_deployment(
+    api_id: str,
+    stage: str,
+    *,
+    profile: str | None,
+    region: str,
+) -> None:
+    """`apigateway create-deployment` con retry ante TooManyRequests."""
+    delays: tuple[int | None, ...] = (*_DEPLOYMENT_RETRY_DELAYS, None)
+    args = [
+        'apigateway',
+        'create-deployment',
+        '--rest-api-id',
+        api_id,
+        '--stage-name',
+        stage,
+    ]
+    for attempt, delay in enumerate(delays):
+        try:
+            aws(args, profile=profile, region=region)
+        except AwsError as exc:
+            if 'TooManyRequests' not in exc.stderr or delay is None:
+                raise
+            print(
+                f'  create-deployment throttled (intento {attempt + 1}), '
+                f'reintento en {delay}s'
+            )
+            time.sleep(delay)
+        else:
+            return
+
+
 def _wire_http_trigger(
     rendered: RenderedLambda,
     stage: str,
@@ -1237,18 +1275,7 @@ def _wire_http_trigger(
         profile=profile,
         region=region,
     )
-    aws(
-        [
-            'apigateway',
-            'create-deployment',
-            '--rest-api-id',
-            api_id,
-            '--stage-name',
-            stage,
-        ],
-        profile=profile,
-        region=region,
-    )
+    _create_deployment(api_id, stage, profile=profile, region=region)
     source_arn = (
         f'arn:aws:execute-api:{region}:{account}:{api_id}/{stage}/'
         f'{trigger.method}{trigger.path}'


### PR DESCRIPTION
## Problema

Tras mergear el refactor SQS (#211) y el fix del bucket (#212), el `deploy-backend.yml` seguía fallando en dos puntos nuevos:

1. **IAM**: el rol OIDC `portfolio-deploy-*` no tenía permisos para crear/configurar el bucket `portfolio-email-templates-*` (su statement S3 estaba scoped solo a `portfolio-devtools-state`) → `create-bucket` daba `AccessDenied` (exit 254).
2. **API Gateway throttle**: el matrix `deploy-lambdas` deploya los lambdas en paralelo sin `max-parallel`. El refactor agregó más lambdas HTTP (auth, users, cv); cada deploy llama `apigateway create-deployment` sobre la **misma** REST API, y API Gateway limita create-deployment a ~1 cada pocos segundos por cuenta → `TooManyRequestsException` (exit 254) en deploys concurrentes.

## Solución

1. **IAM** (ya aplicado a los 3 roles con AWS CLI, documentado aquí): nuevo statement `S3EmailTemplates` con `CreateBucket` + `PutBucketPublicAccessBlock` + `PutEncryptionConfiguration` + objetos sobre `portfolio-email-templates-{dev,stage,prod}`. Statement `SQS` marcado obsoleto.
2. **`max-parallel: 1`** en el matrix `deploy-lambdas`: serializa los deploys para que los `create-deployment` no choquen.
3. **Retry + backoff** (3s/8s/20s) en `_create_deployment` del provisioner ante `TooManyRequests`, como defensa en profundidad para deploys manuales concurrentes.

## Cómo probar

```bash
python devtools/run.py test_runner --module=devtools --type=unit   # 965 passed
```

Al mergear a `dev`, `deploy-backend.yml` debe completar: provision-infra (bucket OK), migrate, y el matrix de lambdas serializado sin throttle de API Gateway.

## TODO

- (opcional) Quitar el statement `SQS` del rol OIDC (obsoleto tras eliminar SQS).