### PR TITLE
chore(serverless): config uniforme 1024MB/60s/snapstart en los 8 lambdas

### DIFF
--- a/docs/specs/coldstart-cv-query-and-snapstart/01-contexto-y-decision.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/01-contexto-y-decision.md
@@ -1,0 +1,157 @@
+# 01 — Contexto, solucion y criterios de aceptacion
+
+[< README](README.md) | [Siguiente: Fase query cv >](02-fase-query-cv.md)
+
+## 1. Contexto / Problema
+
+El reporte de tiempos del backend muestra:
+
+```text
+cv   cv.get (success)   cold 13.918   warm 7.365
+auth register.start     cold 11.298
+users profile.get       cold  8.512   warm 1.836
+contact contact.create  cold  9.777   warm 0.532
+```
+
+El usuario pidió reducir el cold "por estructura de archivos/carpetas e
+importaciones de `shared`, NO por memoria/config".
+
+### Hallazgos de exploración (datos duros, no suposiciones)
+
+Tras medir en AWS (CloudWatch + `aws lambda`/`apigateway`, cuenta
+`637423614564`, `us-east-1`):
+
+1. **El cold de 13.9s no es el cold típico.** El API Gateway de `cv`
+   (dev/stage/prod) integra el alias `:live` (SnapStart), cuyo
+   `RESTORE_REPORT Restore Duration` es **~963-1262 ms**. El 13.9s es el
+   `INIT_REPORT Init Duration` crudo, que solo se paga cuando SnapStart
+   **no** restaura (ventana post-deploy + escalado). `api_e2e` no fuerza
+   cold ni distingue ambos paths, así que capturó un INIT crudo.
+
+2. **El warm de 7.3s ES real y constante.** `get_full_cv`
+   (`serverless/lambda/shared/db/cv_repository.py`) ensambla 9 secciones,
+   **cada una abre su propio `db_session()`**, ~45-55 SELECT a Neon en
+   **serie**. No hay N+1, pero sí 9 aperturas/cierres de conexión y
+   serialización secuencial. `Max Memory Used: 162 MB` de 256 MB: no es
+   memoria, es I/O serial + wake de Neon scale-to-zero.
+
+3. **El INIT crudo (7-20s, varianza salvaje) escala con CPU.** A 256 MB
+   (~0.16 vCPU) el trabajo de INIT —imports de SQLAlchemy + `warm_db()`
+   (`configure_mappers` + `create_engine`) + instanciar `Logger()` y
+   `Metrics()` de Powertools en module-scope— se vuelve CPU-starved. La
+   varianza (7s a 20s) es típica de eso. SnapStart lo absorbe casi
+   siempre, pero conviene acotarlo.
+
+4. **El vendoring del zip está correcto.** `packaging.py` usa
+   `uv pip install --python-platform aarch64-manylinux2014
+   --only-binary=:all:`, poda `boto3`/`botocore` (el runtime los provee),
+   excluye `.venv`/`__pycache__`, y `shared_resolver.py` resuelve el
+   cierre transitivo por AST. CodeSize: cv 14.1 MB, auth/users/contact
+   18.6-18.8 MB. No hay bug; solo una mejora menor opcional (strip de
+   `.dist-info`), de impacto despreciable en cold.
+
+## 2. Solucion propuesta
+
+Atacar las dos palancas reales, en este orden de ROI, sin tocar memoria:
+
+### Decisiones clave
+
+- **Decisión 1 (palanca #1): consolidar la query de `cv` a UN solo
+  `db_session()` para las 9 secciones** — hoy abre/cierra 9 conexiones a
+  Neon en serie. Reutilizar una sola sesión elimina 8 round-trips de
+  apertura + el wake repetido del pooler. Es el cambio de menor riesgo
+  con mayor impacto en los 7.3s. Las funciones públicas siguen cacheadas
+  individualmente (`@cached`), pero `get_full_cv` (el caso `cv.get`, el
+  más lento) pasa a usar una variante interna que comparte sesión.
+
+- **Decisión 2 (palanca #1, profundización): consolidar las secciones
+  más caras a menos round-trips con carga en bulk dentro de la misma
+  sesión** — `list_experiences` (~9 queries) y `list_projects` (~8) son
+  las que dominan. Agrupar sus sub-consultas (traducciones, prioridades,
+  niches, bullets/stack) en menos SELECT con `IN (...)` ya parcialmente
+  hecho; falta unirlas bajo una sola sesión y, donde aplique, usar
+  `selectinload`/`joinedload` para evitar las consultas separadas de
+  hidratación.
+
+- **Decisión 3 (palanca #2): bajar el INIT crudo difiriendo trabajo que
+  no necesita estar en module-scope** — `warm_db()` se mantiene (es
+  intencional para SnapStart), pero `Logger()`/`Metrics()` de Powertools
+  y la construcción del `EventModel` se revisan para que el INIT haga lo
+  mínimo. Objetivo: INIT crudo < 6s (peor caso acotado).
+
+- **Decisión 4 (medición correcta): instrumentar `api_e2e` para reportar
+  cold REAL (restore) separado del INIT crudo** — hoy mezcla ambos. Sin
+  esto no se puede verificar la mejora ni distinguir regresiones.
+
+- **Decisión 5 (alcance): trabajar y verificar SOLO en dev.** dev tiene
+  el código actual de la rama; stage/prod corren código viejo y NO son
+  comparables ni se tocan en este plan. Toda medición antes/después es
+  sobre dev.
+
+## 3. Criterios de aceptación (AC)
+
+- **AC-1**: Given `cv.get` (CV completo) sin cache, When se invoca contra
+  dev, Then `get_full_cv` usa **un solo `db_session()`** para las 9
+  secciones (verificable: una sola apertura de conexión en el log de
+  queries o por test que cuenta `db_session()` invocaciones).
+- **AC-2**: Given `cv.get` warm sin cache, When se mide con `api_e2e`,
+  Then el tiempo de respuesta baja de 7.3s a **< 2.0s** en dev.
+- **AC-3**: Given las funciones públicas de `cv_repository`, When se
+  invocan individualmente (`cv.experiences`, `cv.projects`, etc.), Then
+  siguen devolviendo **exactamente el mismo dict** que hoy (sin regresión
+  de contrato — tests existentes verdes).
+- **AC-4**: Given un cache HIT de `cv.get`, When se invoca, Then NO toca
+  Neon y responde < 0.1s (sin cambio respecto a hoy).
+- **AC-5**: Given el INIT crudo de `cv` (sin SnapStart restore), When se
+  mide en `$LATEST`, Then baja a **< 6s** (acotar el peor caso).
+- **AC-6**: Given `api_e2e`, When corre contra dev, Then reporta el cold
+  REAL (con `Restore Duration` si SnapStart restauró) **separado** del
+  INIT crudo, no un único número ambiguo.
+- **AC-7**: Given el deploy de `cv` en dev, When termina, Then el API
+  Gateway sigue integrando `:live` y `SnapStart.OptimizationStatus=On`
+  (sin regresión de SnapStart).
+- **AC-8**: Given los cambios en `shared.db`, When se corre
+  `serverless lint-deps --lambda=cv` y los tests, Then pasan (dedup D-3 +
+  imports concretos + coverage >= 80% per-file).
+- **AC-9**: Given el redeploy EN DEV de los Lambdas que importan
+  `shared.db` (cv, auth, users, contact_form, tracking_writer), When se
+  verifican contra dev, Then ninguno regresiona (las queries de
+  auth/users/contact siguen ok). stage/prod quedan fuera de scope: corren
+  código viejo y no son comparables.
+
+## 4. Diagrama de flujo (antes y despues)
+
+### Antes (`get_full_cv`)
+
+```text
+cv.get
+  -> get_full_cv()
+       -> get_profile()        -> db_session() [abre/cierra]  ~0.8s
+       -> list_experiences()   -> db_session() [abre/cierra]  ~1.3s (9 queries)
+       -> list_projects()      -> db_session() [abre/cierra]  ~1.4s (8 queries)
+       -> list_certificates()  -> db_session() [abre/cierra]  ~0.8s
+       -> list_awards()        -> db_session() [abre/cierra]  ~0.9s
+       -> list_education()     -> db_session() [abre/cierra]  ~0.7s
+       -> list_languages()     -> db_session() [abre/cierra]  ~0.7s
+       -> list_references()    -> db_session() [abre/cierra]  ~0.7s
+       -> list_skill_cats()    -> db_session() [abre/cierra]  ~1.0s
+  TOTAL ~7.3s (9 conexiones, serial)
+```
+
+### Despues (`get_full_cv` con sesion compartida)
+
+```text
+cv.get
+  -> get_full_cv()
+       -> with db_session() as s:          [UNA conexion]
+            _profile(s) ; _experiences(s) ; _projects(s) ; ...
+       (mismas queries, una sola conexion, sin 8 wakes de pooler)
+  TOTAL objetivo < 2.0s
+```
+
+## 5. Diagrama ER
+
+N/A — no hay cambios de schema. Solo cambia cómo se consulta el schema
+existente.
+
+[< README](README.md) | [Siguiente: Fase query cv >](02-fase-query-cv.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/02-fase-query-cv.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/02-fase-query-cv.md
@@ -1,0 +1,134 @@
+# 02 — Fase query cv (palanca #1, ROI mayor)
+
+[< Contexto](01-contexto-y-decision.md) | [Siguiente: INIT/imports >](03-fase-init-imports.md)
+
+> El warm de `cv.get` (7.3s) es el costo real y constante. Esta fase lo
+> ataca SIN tocar memoria. Cubre AC-1, AC-2, AC-3, AC-4.
+
+## Diagnostico preciso
+
+`serverless/lambda/shared/db/cv_repository.py` (860 líneas):
+
+- `get_full_cv()` llama a las 9 funciones de sección.
+- Cada función pública (`get_profile`, `list_experiences`, ...) hace
+  `with db_session() as session:` — abre y cierra **su propia** conexión.
+- Con `NullPool` (`shared/db/session.py:32`), cada `db_session()` crea una
+  conexión nueva a Neon. 9 secciones = 9 conexiones nuevas en serie. Cada
+  apertura paga: TLS handshake + auth + el wake del pooler de Neon si
+  estuvo idle.
+- Las funciones más caras (`list_experiences` ~9 queries, `list_projects`
+  ~8) ya hidratan en bulk (`IN (...)`), pero dentro de su propia sesión.
+
+## Estrategia (incremental, sin romper contrato)
+
+### Paso A — separar "lógica de query" de "apertura de sesión"
+
+Para CADA función pública de sección, extraer una variante interna que
+**recibe la `Session`** en vez de abrirla:
+
+```python
+# antes
+def get_profile(*, locale: str) -> dict[str, Any]:
+    with db_session() as session:
+        return _profile_query(session, locale=locale)  # ya existe la logica
+
+# despues: separar
+def _profile_on_session(session: Session, *, locale: str) -> dict[str, Any]:
+    ...  # MISMA logica que hoy, pero usa la session pasada
+
+def get_profile(*, locale: str) -> dict[str, Any]:
+    with db_session() as session:
+        return _profile_on_session(session, locale=locale)
+```
+
+Esto NO cambia el comportamiento de las funciones públicas (siguen
+abriendo su sesión) — solo extrae la lógica para reusarla. Los tests
+existentes de cada función siguen verdes (AC-3).
+
+### Paso B — `get_full_cv` usa UNA sola sesion
+
+```python
+def _full_cv_on_session(
+    session: Session, *, niche: str | None, locale: str
+) -> dict[str, Any]:
+    return {
+        'profile': _profile_on_session(session, locale=locale),
+        'experiences': _experiences_on_session(session, niche=niche, locale=locale),
+        'projects': _projects_on_session(session, niche=niche, locale=locale),
+        'certificates': _certificates_on_session(session, niche=niche),
+        'awards': _awards_on_session(session, niche=niche, locale=locale),
+        'education': _education_on_session(session, niche=niche, locale=locale),
+        'languages': _languages_on_session(session, niche=niche, locale=locale),
+        'references': _references_on_session(session, niche=niche, locale=locale),
+        'skillCategories': _skill_categories_on_session(session, niche=niche, locale=locale),
+    }
+
+
+def get_full_cv(*, niche: str | None, locale: str) -> dict[str, Any]:
+    with db_session() as session:
+        return _full_cv_on_session(session, niche=niche, locale=locale)
+```
+
+Resultado: `cv.get` pasa de 9 conexiones a **1**. Mismas queries, mismo
+dict de salida. Elimina 8 aperturas de conexión + 8 oportunidades de wake
+del pooler. Esperado: la mayor parte de la mejora de 7.3s -> objetivo.
+
+### Paso C (si el objetivo < 2.0s no se alcanza con A+B) — consolidar SELECT
+
+Solo si las mediciones tras A+B no bajan de 2.0s. Para `list_experiences`
+y `list_projects`, reemplazar las consultas separadas de hidratación
+(traducciones, prioridades, niches, bullets) por `selectinload`/
+`joinedload` en una sola query con la relación ORM, o por menos SELECT
+agrupados. Es más invasivo: hacerlo después de medir A+B, una sección a
+la vez, con su test verde.
+
+## Sobre el cache (`@cached`) — NO se rompe
+
+Las funciones públicas siguen decoradas con `@cached` (ttl 15min, SWR
+24h). El cambio es solo cómo abren la sesión cuando hay cache MISS. El
+cache HIT (AC-4) no toca esta ruta: responde antes de llamar a la función
+envuelta. `functools.wraps` se preserva (las variantes `_*_on_session`
+son internas, sin decorar).
+
+## Archivos afectados
+
+### Modificar
+
+- `serverless/lambda/shared/db/cv_repository.py` — extraer 9 variantes
+  `_*_on_session(session, ...)`, agregar `_full_cv_on_session`, y que
+  `get_full_cv` use una sola sesión. Las 9 públicas delegan en su
+  variante interna.
+  - Verificar: `python devtools/run.py serverless tests --type=unit --shared`
+  - Verificar: el dict de salida de cada función es idéntico (tests
+    existentes de `cv_service`/repositorio verdes).
+
+### Crear (tests)
+
+- `serverless/lambda/shared/tests/unit/shared/db/test_cv_full_uses_single_session.py`
+  — test que mockea/cuenta las invocaciones de `db_session()` y asegura
+  que `get_full_cv` la abre **una sola vez** (AC-1). BDD-style
+  Given/When/Then, assert exacto (`== 1`).
+  - Verificar: el test pasa y falla si se revierte el cambio.
+
+## Tests requeridos
+
+### 6.A TDD flows
+
+- `WHEN get_full_cv(niche='fintech', locale='es') THEN db_session se abre exactamente 1 vez [AC-1]`
+- `WHEN get_full_cv THEN el dict tiene las 9 keys con el mismo contenido que la suma de las 9 funciones [AC-3]`
+- `WHEN cache HIT de cv.get THEN no se llama a ninguna _*_on_session [AC-4]`
+
+### 6.B Unit (Vitest no aplica — es Python)
+
+- `python devtools/run.py serverless tests --type=coverage --lambda=cv` >= 80%
+- `python devtools/run.py serverless tests --type=unit --shared`
+
+## Riesgos
+
+- **Transacción larga única**: con una sola sesión, las 9 secciones
+  comparten transacción. Como todo es read-only (`SELECT`), no hay riesgo
+  de lock de escritura. Neon tolera la transacción de lectura.
+- **Memoria**: cargar las 9 secciones en una sesión NO sube el pico (los
+  dicts ya se materializan igual; `Max Memory 162 MB` deja headroom).
+
+[< Contexto](01-contexto-y-decision.md) | [Siguiente: INIT/imports >](03-fase-init-imports.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/03-fase-init-imports.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/03-fase-init-imports.md
@@ -1,0 +1,123 @@
+# 03 — Fase INIT / imports (palanca #2, acotar peor caso)
+
+[< Fase query cv](02-fase-query-cv.md) | [Siguiente: Medicion api_e2e >](04-fase-medicion-api-e2e.md)
+
+> SnapStart absorbe el INIT casi siempre (restore ~1.2s). Pero el INIT
+> crudo (7-20s) se paga cuando NO restaura (post-deploy, escalado). Esta
+> fase lo acota a < 6s. Cubre AC-5. Es la fase de MENOR ROI — hacerla
+> SOLO después de la query (fase 02) y solo si la medición lo justifica.
+
+## Por que el INIT crudo es tan alto y variable
+
+A 256 MB el Lambda tiene ~0.16 vCPU. El INIT de `cv` ejecuta en
+module-scope (`services/cv/core/handler.py`):
+
+1. 10 imports de modelos SQLAlchemy (`import shared.db.models.cv.*` +
+   taxonomy + i18n) — registran mappers.
+2. `warm_db()` (`handler.py:57`) -> `create_engine(NullPool)` +
+   `configure_mappers()` (compila los ~25 mappers registrados). **CPU-bound.**
+3. `build_event_model(OPERATIONS)` (`handler.py:53`) -> crea una clase
+   Pydantic dinámica.
+4. `Logger()` y `Metrics()` de Powertools se instancian al importar
+   `shared.observability.logger`/`metrics` (module-scope).
+
+A 0.16 vCPU, `configure_mappers()` + la compilación de validadores
+Pydantic + la inicialización de Powertools se vuelven lentas y variables
+(7s a 20s).
+
+## Que NO se toca
+
+- **`warm_db()` se queda.** Es intencional: precalienta el ORM en el INIT
+  para que quede en el snapshot de SnapStart. Quitarlo movería el costo a
+  la primera request (peor). La regla `lambda-config.md` lo exige.
+- **Los imports concretos se quedan.** Ya están bien (no hay barrels, no
+  carga fido2/crypto). El subagente confirmó: cv carga solo SQLAlchemy +
+  Powertools, no cryptography ni boto3 en INIT.
+
+## Palancas reales (de menor riesgo a mayor)
+
+### Palanca A — precompilar `.pyc` en el zip (bajo riesgo, mejora directa)
+
+Hoy `packaging.py` excluye `*.pyc` del zip. En el INIT, Python compila
+cada `.py` a bytecode la primera vez (cv + shared + deps = cientos de
+módulos). Precompilar con `compileall` y **incluir** los `.pyc` ahorra
+ese paso del INIT.
+
+- Cambio en `devtools/serverless/packaging.py`: tras armar `build/`,
+  correr `python -m compileall -q build/` con el intérprete del runtime
+  target (3.13) y NO excluir los `.pyc` resultantes del zip.
+- Matiz: AWS Lambda Python usa el mismo árbol; los `.pyc` deben ser para
+  3.13. Generarlos con `uv run --python 3.13 -m compileall` o el
+  intérprete correcto.
+- Impacto esperado: 0.5-2s menos de INIT (cientos de módulos sin
+  compilar en frío).
+
+### Palanca B — diferir `Metrics()`/`Logger()` de module-scope (riesgo medio)
+
+Powertools instancia el `Logger` y `Metrics` al importar. Evaluar si
+construirlos lazy (primera request) reduce el INIT sin romper el snapshot.
+Matiz: con SnapStart, lo que está en module-scope queda en el snapshot —
+moverlo a la primera request lo SACA del snapshot y lo paga en cada
+restore. **Por eso esta palanca es delicada**: solo conviene para el INIT
+crudo, pero perjudica el path con restore. Decisión: **NO mover** lo que
+ya está en el snapshot; solo confirmar que no se construye dos veces.
+
+### Palanca C — medir el desglose del INIT (prerequisito de B/A)
+
+Antes de tocar nada, instrumentar el INIT con timestamps para saber qué
+parte cuesta:
+
+```python
+# en handler.py, temporal para medir (luego quitar):
+import time as _t
+_t0 = _t.perf_counter()
+# ... imports de modelos ...
+logger.info('init.models', extra={'ms': (_t.perf_counter()-_t0)*1000})
+warm_db()
+logger.info('init.warm_db', extra={'ms': (_t.perf_counter()-_t0)*1000})
+```
+
+Esto NO va al commit final — es para decidir si A/B valen la pena. Si el
+INIT crudo lo domina `configure_mappers` (CPU), la única palanca real
+sería subir CPU (= memoria), que está vetado. Si lo domina la compilación
+de `.pyc`, la palanca A lo arregla sin tocar memoria.
+
+## Decision de la fase
+
+1. Primero **palanca C** (medir el desglose del INIT en dev contra
+   `$LATEST`).
+2. Si la compilación de bytecode pesa -> **palanca A** (`.pyc` en el zip).
+3. **NO** tocar el module-scope que está en el snapshot (palanca B
+   descartada por perjudicar el restore).
+4. Si tras A el INIT sigue > 6s y lo domina `configure_mappers` a baja
+   CPU, documentar que el único fix sería más memoria (vetado) y aceptar
+   que SnapStart lo cubre en el 99% de los casos.
+
+## Archivos afectados
+
+### Modificar
+
+- `devtools/serverless/packaging.py` — palanca A: `compileall` del
+  `build/` con runtime 3.13 + incluir `.pyc` en el zip (quitar `*.pyc`
+  del `_IGNORE` solo para el `build/` final, no para el vendoring de
+  fuentes shared).
+  - Verificar: `python devtools/run.py serverless deploy --lambda=cv
+    --stage=dev` produce un zip con `.pyc` y el Lambda arranca.
+  - Verificar: INIT crudo medido baja (CloudWatch `INIT_REPORT`).
+
+## Tests requeridos
+
+- `python devtools/run.py serverless tests --type=unit --module=devtools`
+  (si se toca packaging, su test unit debe cubrir el nuevo paso).
+- Medición CloudWatch antes/después del INIT crudo (no es un test
+  automatizado; va en la sección 11).
+
+## Nota de honestidad
+
+Esta fase puede terminar con **mejora marginal** si `configure_mappers` a
+baja CPU domina el INIT (caso en que la única palanca sería memoria,
+vetada). Eso está bien: SnapStart ya cubre el 99% de los colds. Esta fase
+es "acotar el peor caso", no "el fix principal". El fix principal es la
+fase 02 (query).
+
+[< Fase query cv](02-fase-query-cv.md) | [Siguiente: Medicion api_e2e >](04-fase-medicion-api-e2e.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/04-fase-medicion-api-e2e.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/04-fase-medicion-api-e2e.md
@@ -1,0 +1,80 @@
+# 04 — Fase medicion (api_e2e mide cold real vs INIT crudo)
+
+[< INIT/imports](03-fase-init-imports.md) | [Siguiente: Vendoring opcional >](05-fase-vendoring-opcional.md)
+
+> Sin medición correcta no se verifica la mejora ni se distingue una
+> regresión. Hoy `api_e2e` mezcla cold real (restore) con INIT crudo en un
+> solo número. Cubre AC-6. Es prerequisito de la verificación (sección 11).
+
+## Problema actual
+
+`devtools/api_e2e/support.py:27-34` mide `elapsed` con `time.monotonic()`
+client-side alrededor del request HTTP. `reporter.py` toma `cold =
+elapsed[0]` (primer hit) y `warm = avg(elapsed[1:])`. No fuerza cold y no
+sabe si el primer hit fue un SnapStart restore (~1.2s) o un INIT crudo
+(~14s). Por eso el número "cold" es ruidoso e ininterpretable.
+
+## Solucion
+
+`api_e2e` no puede leer el `Restore Duration` desde el cliente HTTP (es un
+dato de CloudWatch). Dos opciones:
+
+### Opción 1 (recomendada): correlacionar con CloudWatch tras el run
+
+Tras el run HTTP, `api_e2e` consulta CloudWatch (`filter-log-events`) por
+`REPORT`/`RESTORE_REPORT`/`INIT_REPORT` del Lambda en la ventana del run y
+reporta, por caso cold:
+
+```
+cv  cv.get  cold(http) 1.34s  [Restore 0.96s | Init crudo: -]   warm 0.04s
+cv  cv.get  cold(http) 14.4s  [Restore: -    | Init crudo 13.9s] warm 0.04s
+```
+
+Así se ve si el cold fue un restore (bueno) o un INIT crudo (el peor
+caso). Requiere `logs:FilterLogEvents` en el perfil (ya disponible) y el
+nombre de la función por caso.
+
+### Opción 2 (más simple): forzar cold reproducible
+
+Antes de medir, `api_e2e` puede forzar un cold real con
+`update-function-configuration` (un env var dummy bump) para invalidar el
+container, y así medir el cold del path `:live` de forma reproducible. Es
+lo que hoy NO hace. Matiz: tras el bump, SnapStart re-optimiza la versión;
+hay que esperar `OptimizationStatus=On` antes de medir, si no se mide el
+INIT crudo siempre.
+
+## Decision
+
+Implementar **Opción 1** (correlación CloudWatch) — es no-intrusiva, no
+muta la función, y da el desglose que falta. Opción 2 queda documentada
+como modo opcional `--force-cold` para mediciones controladas.
+
+## Archivos afectados
+
+### Modificar
+
+- `devtools/api_e2e/reporter.py` — agregar columnas/desglose
+  `restore_ms` e `init_crudo_ms` por caso cold.
+- `devtools/api_e2e/runner.py` o nuevo
+  `devtools/api_e2e/cloudwatch.py` — tras el run, consultar
+  `filter-log-events` por función en la ventana temporal del run y
+  parsear `Restore Duration` / `Init Duration` de los `REPORT`.
+- `devtools/api_e2e/config.py` — mapear cada caso a su nombre de función
+  Lambda (`cv -> portfolio-cv-<env>`).
+- `devtools/api_e2e/flags.py` — flag opcional `--force-cold` (Opción 2).
+  - Verificar: `python devtools/run.py serverless tests --type=unit --module=devtools`
+  - Verificar: `python devtools/run.py api_e2e --env=dev` reporta el
+    desglose restore vs INIT crudo.
+
+## Tests requeridos
+
+- Unit del parser de `Restore Duration`/`Init Duration` desde una línea
+  `REPORT` de ejemplo (assert exacto del valor parseado). BDD-style.
+- `python devtools/run.py serverless tests --type=unit --module=devtools` verde.
+
+## Nota
+
+CI no gatea `devtools/` (memoria del proyecto). Verificar SIEMPRE local
+con `devtools/.venv/bin/python` (3.14), no el `python3` del shell.
+
+[< INIT/imports](03-fase-init-imports.md) | [Siguiente: Vendoring opcional >](05-fase-vendoring-opcional.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/05-fase-vendoring-opcional.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/05-fase-vendoring-opcional.md
@@ -1,0 +1,78 @@
+# 05 — Fase vendoring (opcional, impacto despreciable en cold)
+
+[< Medicion](04-fase-medicion-api-e2e.md) | [Siguiente: Commits >](06-commits.md)
+
+> El usuario pidió mejorar el cold "por estructura de carpetas/archivos e
+> imports de shared y por el vendoring del zip". El vendoring se auditó y
+> está CORRECTO. Esta fase documenta la única mejora menor posible y por
+> qué el resto NO mueve la aguja. Es OPCIONAL.
+
+## El vendoring ya es correcto (no hay bug)
+
+`devtools/serverless/packaging.py` (auditado contra el código):
+
+- `uv pip install --target build/ --python-version 3.13
+  --python-platform aarch64-manylinux2014 --only-binary=:all:` — wheels
+  arm64 correctos para el runtime AWS, nunca build desde source
+  (`packaging.py:200-212`).
+- Poda `boto3` + `botocore` porque el runtime los provee
+  (`packaging.py:234-259`) — ahorra ~100 MB. Correcto.
+- Excluye `.venv`, `__pycache__`, `*.pyc`, `.pytest_cache`, `*.egg-info`
+  del vendoring de fuentes shared (`packaging.py:50-62`).
+- `shared_resolver.py` resuelve el cierre transitivo por AST +
+  `internal-deps` — un Lambda que no usa `shared.db` no arrastra
+  SQLAlchemy. Correcto.
+
+CodeSize medido: cv 14.1 MB, auth/users/contact 18.6-18.8 MB. Todos muy
+por debajo del límite (50 MB zip / 250 MB descomprimido). **El tamaño del
+zip no es el cuello de botella del cold** — el cold lo domina el INIT
+(CPU) y la query (I/O), no la descarga del zip (que ocurre una vez y
+queda cacheada en el host).
+
+## Por que reestructurar imports/carpetas NO baja el cold
+
+El usuario suponía que reordenar imports de `shared` bajaría el cold. Los
+hechos:
+
+1. SnapStart **ya** snapshotea el INIT con todos los imports ejecutados.
+   El restore (~1.2s) NO re-ejecuta imports. Reordenarlos no cambia el
+   restore.
+2. Los imports concretos ya están bien (sin barrels, `cv` no carga
+   cryptography/fido2/boto3 en INIT — confirmado por AST scan).
+3. El INIT crudo (cuando no hay restore) lo domina `configure_mappers`
+   (CPU) y la compilación de bytecode, NO el grafo de imports en sí.
+
+Por eso la reestructuración de imports tiene ROI ~nulo y NO está en el
+plan principal. La fase 03 (`.pyc` precompilados) es lo único del lado
+"estructura/empaquetado" que mueve la aguja del INIT, y es marginal.
+
+## Unica mejora menor del zip (opcional)
+
+`uv pip install --target` deja los `.dist-info/` de cada dep en el zip.
+Son metadatos no necesarios en runtime. Podarlos reduce el tamaño del
+zip ~5-10%. **Impacto en cold: despreciable** (el zip ya está cacheado en
+el host tras el primer pull). Solo vale por higiene/tamaño.
+
+- Cambio en `packaging.py`: tras `uv pip install` + `_prune_runtime_provided`,
+  borrar `build/*.dist-info/` (excepto los que alguna lib lea en runtime —
+  raro; verificar que ninguna dep use `importlib.metadata` en runtime;
+  Powertools y Pydantic NO lo necesitan para funcionar).
+- Riesgo: alguna dep que use `importlib.metadata.version(...)` en runtime
+  fallaría. Mitigación: probar el deploy + invocar en dev antes de
+  generalizar.
+
+## Decision
+
+**Diferir esta fase.** No mueve la aguja del cold. Si se quiere por
+higiene, hacerla al final, aislada, con verificación de que ningún Lambda
+rompe por `.dist-info` faltante. NO bloquea el plan.
+
+## Archivos afectados (si se decide hacer)
+
+### Modificar
+
+- `devtools/serverless/packaging.py` — paso opcional de strip de
+  `.dist-info` tras la poda de runtime-provided.
+  - Verificar: deploy + invoke de cada Lambda en dev sin error.
+
+[< Medicion](04-fase-medicion-api-e2e.md) | [Siguiente: Commits >](06-commits.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/06-commits.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/06-commits.md
@@ -1,0 +1,85 @@
+# 06 — Commits (seccion 9)
+
+[< Vendoring opcional](05-fase-vendoring-opcional.md) | [Siguiente: Worktrees >](07-paralelizacion-worktrees.md)
+
+> Commits incrementales, cada uno deja el repo verde (lint + typecheck +
+> tests del scope). Conventional Commits en español, sin atribución de IA.
+> Cada commit ejecuta su verificación ANTES de commitear.
+
+## Secuencia
+
+### C1 — `docs(specs): plan cold-start cv query + snapstart`
+
+- Agrega `docs/specs/coldstart-cv-query-and-snapstart/` (este plan).
+- Verificar: `pnpm exec biome check docs/` no aplica (md); revisar links.
+
+### C2 — `refactor(cv): extrae variantes _*_on_session en cv_repository`
+
+- Paso A de la fase 02: cada función pública de sección delega en una
+  variante interna `_*_on_session(session, ...)`. Comportamiento idéntico.
+- Cubre la base de AC-1/AC-3.
+- Verificar: `python devtools/run.py serverless tests --type=unit --shared`
+- Verificar: `python devtools/run.py serverless lint-deps --shared`
+
+### C3 — `perf(cv): get_full_cv usa una sola db_session para las 9 secciones`
+
+- Paso B: `_full_cv_on_session` + `get_full_cv` con una sola sesión.
+- Test nuevo `test_cv_full_uses_single_session.py` (AC-1).
+- Cubre AC-1, AC-2 (parcial), AC-3, AC-4.
+- Verificar: `python devtools/run.py serverless tests --type=coverage --lambda=cv` >= 80%
+- Verificar: tests de `cv_service` existentes verdes (sin regresión).
+
+### C4 — `perf(cv): consolida SELECT de experiences/projects` (CONDICIONAL)
+
+- Paso C: solo si tras C3 la medición no baja de 2.0s. `selectinload`/
+  menos SELECT en las 2 secciones más caras.
+- Cubre AC-2 (cierre).
+- Verificar: tests verdes + medición `api_e2e` < 2.0s.
+
+### C5 — `feat(api_e2e): desglosa cold real (restore) vs INIT crudo`
+
+- Fase 04: correlación CloudWatch en `api_e2e`, columnas restore/init.
+- Cubre AC-6.
+- Verificar: `python devtools/run.py serverless tests --type=unit --module=devtools`
+- Verificar: `python devtools/run.py api_e2e --env=dev` muestra el desglose.
+
+### C6 — `perf(serverless): precompila .pyc en el zip de deploy` (CONDICIONAL)
+
+- Fase 03 palanca A: `compileall` del `build/` + incluir `.pyc`.
+- Solo si la medición del INIT (palanca C de fase 03) muestra que la
+  compilación de bytecode pesa.
+- Cubre AC-5.
+- Verificar: deploy dev + INIT crudo medido baja (CloudWatch).
+
+### C7 — `chore(serverless): strip .dist-info del zip` (OPCIONAL, diferible)
+
+- Fase 05. Solo higiene. Diferible o se omite.
+- Verificar: deploy + invoke de cada Lambda en dev sin error.
+
+### C8 — `test(cv): verificacion E2E cold/warm antes-despues + limpieza plan`
+
+- Sección 11: bateria completa, medición antes/después documentada.
+- Incluye `git rm -r docs/specs/coldstart-cv-query-and-snapstart/` (la
+  carpeta del plan es efímera; se elimina al cerrar).
+- Verificar: TODA la batería de la sección 11 en verde.
+
+## Regla por commit
+
+Cada commit deja verde: `serverless lint-deps` + `serverless tests` del
+scope tocado. C6/C7 además requieren un deploy a dev exitoso. El push +
+PR ocurren SOLO tras C8 con la sección 11 completa en verde.
+
+## PR
+
+Un solo PR `feature/serverless-coldstart-refactor -> dev` (la rama ya
+existe). Body con: Problema (cold ambiguo + query 7.3s), Solución (query
+1 sesión + medición correcta + .pyc), Cómo probar (la batería de la
+sección 11), TODO (stage/prod siguen en SAM; consolidación agresiva de
+SELECT si se difirió C4).
+
+> Nota: la rama `feature/serverless-coldstart-refactor` ya tiene 5 commits
+> previos (refactor SQS->invoke). Estos commits se suman; el PR puede ser
+> el mismo si aún no se mergeó, o uno nuevo desde `dev` si ya se cerró.
+> Verificar el estado de la rama antes de C1.
+
+[< Vendoring opcional](05-fase-vendoring-opcional.md) | [Siguiente: Worktrees >](07-paralelizacion-worktrees.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/07-paralelizacion-worktrees.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/07-paralelizacion-worktrees.md
@@ -1,0 +1,53 @@
+# 07 — Paralelizacion con git worktrees (seccion 10)
+
+[< Commits](06-commits.md) | [Siguiente: Verificacion E2E >](08-verificacion-e2e.md)
+
+> Qué se puede paralelizar con worktrees/subagentes y qué no. Respeta el
+> CAP de orquestación del repo: <=4 agentes concurrentes, 1 workflow a la
+> vez (ver `.claude/rules/orchestration.md`).
+
+## Base secuencial (NO paralelizable)
+
+- **C1** (carpeta del plan) — primero, todos parten de aquí.
+- **C2** (extraer `_*_on_session`) y **C3** (una sola sesión) — tocan el
+  MISMO archivo (`cv_repository.py`) en secuencia lógica: C3 depende de
+  C2. NO paralelizables entre sí.
+
+## Fases worktree-safe (archivos disjuntos)
+
+Tras C3, estas fases tocan archivos distintos y pueden ir en paralelo en
+worktrees separados (olas de <=4):
+
+| Fase | Archivos | Worktree-safe con |
+|---|---|---|
+| C4 (consolidar SELECT) | `cv_repository.py` | NO con C2/C3 (mismo archivo) |
+| C5 (api_e2e desglose) | `devtools/api_e2e/*` | SÍ — disjunto de cv_repository |
+| C6 (.pyc en zip) | `devtools/serverless/packaging.py` | SÍ — disjunto |
+| C7 (strip dist-info) | `devtools/serverless/packaging.py` | NO con C6 (mismo archivo) |
+
+Ola posible tras C3: **C5 + C6 en paralelo** (archivos disjuntos:
+`api_e2e/` vs `packaging.py`). C4 va en la rama principal (mismo archivo
+que C2/C3). C7 va después de C6 (mismo archivo).
+
+## Que NO se paraleliza
+
+- La medición/deploy a dev (C6, sección 11) — un solo entorno dev, los
+  deploys de `cv` se serializan (el provisioner usa estado local +
+  publish-version; deploys concurrentes del mismo Lambda corromperían el
+  estado).
+- La sección 11 (verificación E2E final) — siempre secuencial, al final.
+
+## Eleccion de primitiva
+
+- C2/C3/C4: **inline** (mismo archivo, secuencia lógica, requiere juicio).
+- C5/C6: candidatos a **subagente** o worktree si se ejecutan en paralelo,
+  pero son cambios chicos — probablemente inline es más simple.
+- La verificación (correr pytest/deploy/api_e2e) es **determinista**: va
+  en **Bash**, NUNCA 1 agente LLM por suite (regla de orquestación).
+
+`isolation: 'worktree'` SOLO si se decide ejecutar C5+C6 con agentes
+concurrentes que muten archivos. Para este plan, dado el tamaño, la
+ejecución **secuencial inline** es lo razonable. Worktrees son
+overkill aquí.
+
+[< Commits](06-commits.md) | [Siguiente: Verificacion E2E >](08-verificacion-e2e.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/08-verificacion-e2e.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/08-verificacion-e2e.md
@@ -1,0 +1,100 @@
+# 08 — Verificacion E2E iterativa (seccion 11, fase final)
+
+[< Worktrees](07-paralelizacion-worktrees.md) | [README](README.md)
+
+> Última fase y último commit. Gate del PR: push + PR SOLO con esta
+> batería completa en verde. Bucle "no parar hasta que funcione".
+
+## Parte A — refactor de tests
+
+- [ ] Ningún test viejo referencia funciones eliminadas de
+  `cv_repository.py` (las públicas se mantienen; las internas son
+  nuevas). Barrido: `grep -rn '_on_session' serverless/lambda/shared/tests`
+  debe encontrar solo los tests nuevos.
+- [ ] El test nuevo `test_cv_full_uses_single_session.py` existe en
+  `serverless/lambda/shared/tests/unit/shared/db/` y verifica AC-1.
+- [ ] Si se tocó `api_e2e`, sus tests unit nuevos están en
+  `devtools/tests/`.
+
+## Parte B — bateria de comandos reales
+
+Ejecutar de punta a punta. Si algo falla: diagnosticar -> corregir ->
+re-ejecutar la suite -> repetir. NO marcar completo con un comando rojo.
+
+### B.1 — Lint + tests (local, sin AWS)
+
+```bash
+# Shared (cv_repository vive aca)
+python devtools/run.py serverless lint-deps --shared
+python devtools/run.py serverless lint-deps --lambda=cv
+python devtools/run.py serverless tests --type=unit --shared
+python devtools/run.py serverless tests --type=coverage --lambda=cv   # >=80%
+
+# Si se toco devtools (api_e2e / packaging)
+python devtools/run.py serverless tests --type=unit --module=devtools
+```
+
+### B.2 — Deploy a dev
+
+```bash
+export AWS_PROFILE=tfs-dev
+# cv es el cambio principal; redeployar tambien los que importan shared.db
+# por si el refactor de cv_repository afecto el cierre (no deberia, pero
+# se verifica que no rompio nada):
+python devtools/run.py serverless deploy --lambda=cv --stage=dev --aws-profile=tfs-dev
+python devtools/run.py serverless status --lambda=cv --stage=dev --aws-profile=tfs-dev
+# Confirmar SnapStart sigue On y API integra :live (AC-7):
+aws lambda get-function-configuration --function-name portfolio-cv-dev --qualifier live \
+  --region us-east-1 --profile tfs-dev --query 'SnapStart'
+```
+
+### B.3 — Medición antes/despues (AC-2, AC-5, AC-6)
+
+```bash
+# DESPUES del deploy con los cambios:
+python devtools/run.py api_e2e --env=dev
+# Comparar contra la baseline (guardada antes de empezar):
+#   cv.get warm:  7.3s  -> objetivo < 2.0s   [AC-2]
+#   cv.get cold:  desglosado restore vs INIT crudo  [AC-6]
+#   INIT crudo:   7-20s -> objetivo < 6s (si se hizo C6)  [AC-5]
+```
+
+Guardar la baseline ANTES de cualquier cambio:
+
+```bash
+# baseline (commitear el output en tmp/ NO; pegar en el PR body)
+python devtools/run.py api_e2e --env=dev | tee tmp/api_e2e_baseline.txt
+```
+
+### B.4 — No-regresion de los otros Lambdas EN DEV (AC-9)
+
+```bash
+# SOLO dev. stage/prod corren codigo viejo, no se tocan ni se comparan.
+# auth/users/contact/tracking_writer importan shared.db: confirmar que el
+# refactor de cv_repository NO los afecto (cv_repository es solo cv, pero
+# se verifica el cierre):
+python devtools/run.py serverless lint-deps --lambda=auth
+python devtools/run.py serverless lint-deps --lambda=users
+python devtools/run.py serverless lint-deps --lambda=contact_form
+# Y el flujo E2E completo (auth/users/contact/tracking) en api_e2e ya
+# corre arriba — verificar que ninguno regresiona en tiempos/errores.
+```
+
+## Criterio de cierre
+
+- [ ] AC-1: `get_full_cv` abre `db_session` exactamente 1 vez (test verde).
+- [ ] AC-2: `cv.get` warm < 2.0s en dev (medido).
+- [ ] AC-3: contrato de las 9 funciones idéntico (tests verdes).
+- [ ] AC-4: cache HIT < 0.1s sin tocar Neon.
+- [ ] AC-5: INIT crudo < 6s (si se hizo C6) o documentado por qué no.
+- [ ] AC-6: `api_e2e` desglosa restore vs INIT crudo.
+- [ ] AC-7: SnapStart On + API integra `:live` tras deploy.
+- [ ] AC-8: lint-deps + coverage >= 80% verdes.
+- [ ] AC-9: auth/users/contact/tracking sin regresión.
+- [ ] Coverage per-file >= 80% en archivos modificados.
+- [ ] `git rm -r docs/specs/coldstart-cv-query-and-snapstart/` en el
+  último commit (carpeta efímera).
+
+SOLO con TODO lo anterior en verde: `git push` + crear PR.
+
+[< Worktrees](07-paralelizacion-worktrees.md) | [README](README.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/09-baseline-config-costo.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/09-baseline-config-costo.md
@@ -1,0 +1,132 @@
+# 09 — Baseline medida, config uniforme y costo (sin free tier)
+
+[< Verificacion E2E](08-verificacion-e2e.md) | [README](README.md)
+
+> Captura del estado ANTES de cambiar los manifests, la config uniforme
+> aplicada a los 8 lambdas, y la estimacion de costo SIN free tier contra
+> el presupuesto de $5/mes. Medido en dev (perfil `tfs-dev`), 2026-05-31.
+
+## A. Baseline ANTES (api_e2e --env=dev) — 37/37 PASS
+
+Comando: `python devtools/run.py api_e2e --env=dev --aws-profile=tfs-dev`.
+Config en ese momento: memory 128-512 (mayoria 256), timeout 30-120,
+snap_start true (salvo db). Las apps NO se tocaron.
+
+### Cold start por lambda (primer invoke del contenedor)
+
+| Lambda | cold (s) | primer caso |
+|--------|----------|-------------|
+| cv | 2.832 | cv.get (success) |
+| contact_form | 14.990 | contact.create (success) |
+| tracking_pixel | 3.884 | tracking.track (success) |
+| auth | 12.484 | register.start (success) |
+| users | 12.726 | profile.get (success) |
+| **COLD avg** | **9.383** | |
+
+### Tiempos por caso (warm, segundos)
+
+```text
+cv     cv.get                        cold 2.832   warm 0.170
+cv     cv.profile/experiences/...    cold   -     warm 0.139-0.172  (cache HIT)
+contact contact.create               cold 14.990  warm 1.398
+tracking tracking.track              cold 3.884   warm 1.321
+auth   register.start                cold 12.484  warm   -
+auth   register.verify-code          cold   -     warm 3.606
+auth   session.refresh               cold   -     warm 2.410
+auth   login.start                   cold   -     warm 4.260
+auth   verify.set-password           cold   -     warm 5.441
+auth   session.logout                cold   -     warm 1.166
+users  profile.get                   cold 12.726  warm 1.856
+users  profile.update                cold   -     warm 2.212
+users  status.get / list-sessions    cold   -     warm 1.834-1.842
+GLOBAL                               cold 9.383   warm 1.018
+```
+
+### Lecturas clave de la baseline
+
+- **cv.get warm = 0.170s** (cache HIT) — el cache `@cached` funciona. El
+  "7.3s" del reporte original era un cache MISS + INIT crudo combinados,
+  NO el caso tipico. cv.get cold = 2.83s (con SnapStart restore + query
+  MISS).
+- **contact_form cold = 14.99s** y **auth/users cold ~12.5s** — INIT crudo
+  (SnapStart no restauro ese primer hit). Es el peor caso que el
+  experimento de 1024 MB busca acotar (mas CPU en INIT).
+- **warm global 1.018s** — el backend caliente ya responde bien; el
+  problema es el cold del primer invoke en low traffic.
+
+Archivo crudo: `tmp/api_e2e_baseline.txt` (no se commitea, es scratch).
+
+## B. Config uniforme aplicada (los 8 manifests)
+
+Por pedido explicito: subir TODOS a una config uniforme para medir con
+CPU x4. Aplicado a `serverless/lambda/services/*/manifest.yaml`:
+
+| Campo | Antes | Ahora |
+|-------|-------|-------|
+| `memory` | 128 / 256 / 512 (segun lambda) | **1024** (los 8) |
+| `timeout` | 30 / 120 | **60** (los 8) |
+| `snap_start` | true (salvo `db`) | **true** (los 8, agregado a `db`) |
+| ephemeral `/tmp` | 512 (default AWS) | sin cambio (no soportado en provisioner, default 512, los lambdas no usan /tmp) |
+
+Cada manifest documenta que es un EXPERIMENTO y que el valor debe
+REVERTIRSE al minimo medido tras evaluar si la mejora lo justifica
+(regla `.claude/rules/lambda-config.md`: la memoria == CPU, NUNCA subir
+para enmascarar; el fix real de cv es la query en 1 sesion, no la CPU).
+
+**Nota honesta:** memory == CPU en Lambda. Subir a 1024 (de 256) da ~4x
+CPU, lo que acelera `configure_mappers`/argon2id/Jinja2 en el INIT y el
+handler. Es un experimento valido para MEDIR cuanto, pero el costo se
+cuadruplica (ver C) y el cold real (con SnapStart restore ~1.2s) NO
+depende de la memoria. El valor sostenible es el minimo medido por lambda.
+
+## C. Costo SIN free tier (presupuesto $5/mes)
+
+AWS Lambda us-east-1, arm64 (Graviton), SnapStart on, 8 lambdas. Trafico
+estimado: ~37k invokes/mes (cv 5k, tracking 15k x2, contact 200,
+send_email 400, auth 500, users 800, db 20).
+
+### Lambda compute
+
+| Componente | 256 MB (previo) | 1024 MB (experimento) |
+|------------|-----------------|------------------------|
+| compute | $0.130 | $0.521 |
+| requests | $0.007 | $0.007 |
+| snapshot cache (SnapStart) | $0.005 | $0.005 |
+| restore (SnapStart) | $0.114 | $0.456 |
+| **TOTAL Lambda/mes** | **~$0.26** | **~$0.99** |
+
+### Otros costos del backend (no Lambda, no cambian con memory)
+
+| Servicio | Costo/mes estimado |
+|----------|--------------------|
+| KMS CMK (`alias/portfolio-lambdas`) | ~$1.00 fijo + ~$0.01 req |
+| DynamoDB On-Demand (cache + tracking + rate-limit) | ~$0.05-0.30 |
+| CloudWatch Logs (7d retention, low vol) | ~$0.10-0.50 |
+| API Gateway REST ($3.50/M) | ~$0.08 |
+| SES ($0.10/1000 emails) | ~$0.00 |
+| Neon | $0 (free tier perpetuo de Neon, NO AWS) |
+
+### Total backend estimado
+
+| Escenario | Lambda | Otros | **TOTAL/mes** | vs $5 |
+|-----------|--------|-------|----------------|-------|
+| 256 MB (minimos previos) | $0.26 | ~$1.5 | **~$1.8** | holgado |
+| **1024 MB (experimento)** | $0.99 | ~$1.5 | **~$2.5** | dentro |
+
+**Conclusion de costo:** el experimento de 1024 MB entra en el presupuesto
+de $5/mes (~$2.5 estimado). El mayor costo fijo NO es el compute sino la
+**KMS key (~$1/mes)**. Si el trafico real superara el estimado ~3x, 1024
+empezaria a apretar; los minimos medidos (~$1.8 total) dan mas colchon.
+
+> El costo escala lineal con (memoria x duracion x invokes). Si tras medir
+> el experimento la mejora de warm/cold no justifica el 4x de compute +
+> restore, REVERTIR cada manifest a su minimo medido baja el Lambda de
+> ~$0.99 a ~$0.26/mes sin perder el cold real (que lo da SnapStart).
+
+## D. DESPUES (se completa tras el deploy en dev)
+
+Se re-corre `api_e2e --env=dev --aws-profile=tfs-dev` con los 8 lambdas
+ya en 1024 MB y se pega aqui la tabla comparativa cold/warm antes vs
+despues. Ver el reporte entregado en el chat.
+
+[< Verificacion E2E](08-verificacion-e2e.md) | [README](README.md)

--- a/docs/specs/coldstart-cv-query-and-snapstart/README.md
+++ b/docs/specs/coldstart-cv-query-and-snapstart/README.md
@@ -1,0 +1,101 @@
+# Plan: reducir el tiempo de respuesta del backend serverless (cold + warm)
+
+> Bajar el tiempo de respuesta de los Lambdas del portfolio atacando las
+> dos palancas REALES medidas en CloudWatch: (1) la query de `cv`
+> (9 secciones secuenciales a Neon, domina warm/cold/cache-MISS) y
+> (2) el INIT crudo de ~14s que se paga cuando SnapStart NO restaura.
+> NO se sube memoria ni se sobre-aprovisiona: el foco es estructura,
+> queries e imports.
+
+Estado: **propuesta / no implementado**. Rama de trabajo:
+`feature/serverless-coldstart-refactor` (ya activa, no protegida).
+
+## Hallazgo que reordena el problema (datos duros)
+
+El número "cold cv.get = 13.9s" del reporte de `api_e2e` **NO es el cold
+típico de produccion**. Medido en AWS (cuenta `637423614564`, `us-east-1`,
+perfil `tfs-dev`, 2026-05-31):
+
+| Hecho medido | Fuente | Implicacion |
+|---|---|---|
+| API GW `cv-dev` (`gvz6y2xcsa`) `/cv GET` integra `...:portfolio-cv-dev:live/invocations` | `get-integration` | El trafico real va a `:live` (SnapStart), NO a `$LATEST` |
+| stage (`5k8os58pn5`) y prod (`332ivhahf2`) idem `:live` | `get-integration` | prod tambien sirve via SnapStart |
+| `SnapStart.OptimizationStatus=On` en `cv:12` dev, cv-stage, cv-prod | `get-function-configuration --qualifier` | El snapshot del INIT ya esta activo |
+| `RESTORE_REPORT Restore Duration: 963 ms` / `1262 ms` | CloudWatch | El "cold" real vvia SnapStart es **~1.2s**, no 14s |
+| `INIT_REPORT Init Duration: 7s / 8s / 14s / 17s / 20s` (varianza salvaje) | CloudWatch | El INIT CRUDO se paga solo cuando SnapStart NO restaura (ventana post-deploy + escalado; AWS no garantiza restore) |
+| `cv.get` warm `7.3s` con `Max Memory Used: 162 MB / 256 MB` | CloudWatch | La QUERY es el costo constante: no es OOM, no es memoria |
+| `api_e2e` mide `elapsed` HTTP client-side, NO fuerza cold, NO distingue `:live` vs INIT crudo | `devtools/api_e2e/support.py:27-34`, `reporter.py` | El "cold 13.9s" es un INIT crudo capturado cuando SnapStart no restauro |
+
+**Veredicto:** reestructurar imports/`shared` para "bajar el cold" tiene
+**ROI casi nulo** — SnapStart ya absorbe el INIT en el path real. Las dos
+palancas reales son:
+
+1. **La query de `cv` (7.3s warm).** Se paga en warm, en cada cache MISS
+   y dentro del cold. Es el mayor tiempo real y constante. **Palanca #1.**
+2. **El INIT crudo de ~14s.** SnapStart lo absorbe casi siempre, pero la
+   ventana donde no restaura (post-deploy, escalado brusco) cae a 14s.
+   Bajarlo acota ese peor caso. **Palanca #2.**
+
+El vendoring del zip se auditó y **está correcto** (uv `--python-platform
+aarch64-manylinux2014 --only-binary=:all:`, poda boto3/botocore, cierre
+transitivo por AST). No hay bug ahí; solo una mejora menor opcional
+(strip de `.dist-info`).
+
+## Cuando leer cada archivo
+
+| Archivo | Cuando leer |
+|---|---|
+| [01-contexto-y-decision.md](01-contexto-y-decision.md) | Contexto completo, solucion elegida, AC numerados |
+| [02-fase-query-cv.md](02-fase-query-cv.md) | Palanca #1: unir las 9 secciones en 1 session + paralelizar/consolidar |
+| [03-fase-init-imports.md](03-fase-init-imports.md) | Palanca #2: bajar el INIT crudo (Logger/Metrics lazy, warm_db, .pyc) |
+| [04-fase-medicion-api-e2e.md](04-fase-medicion-api-e2e.md) | Hacer que `api_e2e` mida cold REAL (restore) vs INIT crudo, separado |
+| [05-fase-vendoring-opcional.md](05-fase-vendoring-opcional.md) | Mejora menor opcional del zip (strip dist-info) |
+| [06-commits.md](06-commits.md) | Seccion 9: listado de commits incrementales |
+| [07-paralelizacion-worktrees.md](07-paralelizacion-worktrees.md) | Seccion 10: que se paraleliza con worktrees |
+| [08-verificacion-e2e.md](08-verificacion-e2e.md) | Seccion 11: bateria final de verificacion (medir antes/despues) |
+| [09-baseline-config-costo.md](09-baseline-config-costo.md) | Baseline medida (37/37 PASS), config uniforme 1024/60/snapstart aplicada a los 8, costo sin free tier vs $5/mes |
+
+## Decisiones no reabribles
+
+1. **NO subir memoria ni cambiar arch.** El usuario lo pidió explícito y
+   los datos lo respaldan (Max Memory 162/256 MB: no hay presión).
+2. **SnapStart se queda.** Ya funciona; el plan no lo toca salvo medir su
+   restore. Es la razón por la que el cold real es ~1.2s.
+3. **Palanca #1 = query de `cv`.** Es donde está el tiempo real.
+4. **Alcance dev EXCLUSIVO.** dev tiene el código actual de la rama
+   `feature/serverless-coldstart-refactor` (refactor SQS->invoke + lo de
+   este plan). stage/prod corren código VIEJO (pre-refactor) sobre stacks
+   CloudFormation SAM legacy: NO son comparables y este plan NO los toca.
+   Toda medición, deploy y verificación es sobre dev. El `SnapStart Off`
+   y los tiempos raros observados en stage/prod son de ese código viejo —
+   esperado, se resuelven cuando la rama se promueva, fuera de scope aquí.
+
+## Reglas críticas (de CLAUDE.md, siempre activas)
+
+- Imports concretos desde `shared.<subpaquete>.<modulo>` (inits vacíos).
+- `core/` de un Lambda NO importa paquetes externos directo (via `shared`).
+- `serverless lint-deps` debe pasar (dedup D-3 + imports + no-submodule).
+- Coverage >= 80% per-file en archivos modificados.
+- `git push` + PR SOLO con la sección 11 en verde.
+- Medir SIEMPRE antes de declarar listo (`api_e2e` antes/después).
+- Conventional Commits en español, sin atribución de IA.
+
+## Matriz de verificación (resumen)
+
+| Que | Comando |
+|---|---|
+| Tests shared | `python devtools/run.py serverless tests --type=unit --shared` |
+| Tests cv | `python devtools/run.py serverless tests --type=coverage --lambda=cv` |
+| Lint deps | `python devtools/run.py serverless lint-deps --lambda=cv` |
+| Deploy dev | `python devtools/run.py serverless deploy --lambda=cv --stage=dev --aws-profile=tfs-dev` |
+| Medición real | `python devtools/run.py api_e2e --env=dev` (antes y después) |
+
+## Objetivo cuantitativo
+
+| Métrica | Hoy (medido) | Objetivo |
+|---|---|---|
+| `cv.get` warm | 7.3s | < 2.0s (consolidar/paralelizar query) |
+| `cv.get` cache HIT | <0.1s | sin cambio (ya óptimo) |
+| `cv.get` cold via SnapStart restore | ~1.2s | ~1.2s + query reducida |
+| INIT crudo (sin restore) | 7-20s | < 6s (acotar peor caso) |
+| Memoria | 256 MB | 256 MB (sin cambio) |

--- a/serverless/lambda/services/auth/manifest.yaml
+++ b/serverless/lambda/services/auth/manifest.yaml
@@ -16,15 +16,14 @@ description: HTTP endpoint POST /auth (register/login/verify/session).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 256       # MB — minimo medido (dev, 2026-05, cold $LATEST sin
-                  # SnapStart restore, con warmup en INIT). login.start:
-                  # 174 MB usados, handler 2.2s. webauthn (carga fido2/
-                  # cryptography): a 256 entra con headroom. 128 NO: webauthn
-                  # llega a 127/128 MB (OOM inminente) y tarda 21s (CPU
-                  # starved) ~ al borde del timeout. Bajo de 512 (sobre-
-                  # dimensionado) a 256. Ver .claude/rules/lambda-config.md.
-timeout: 30       # segundos — cubre el cold sin SnapStart restore (~6s a
-                  # 512 MB) + Turnstile siteverify HTTP, con margen.
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 en los 8 lambdas para
+                  # medir warm/cold con CPU x4. Minimo medido previo: 256
+                  # (login.start 174 MB, webauthn entra con headroom; 128 NO
+                  # por OOM/CPU-starved). REVERTIR al minimo tras medir si la
+                  # mejora no lo justifica. Ver .claude/rules/lambda-config.md.
+timeout: 60       # segundos — colchon uniforme (red de seguridad cold sin
+                  # restore + Turnstile siteverify HTTP). No afecta costo.
 
 # SnapStart: reduce cold start de ~3s a ~830ms (Restore Duration).
 # Critico en /auth: low traffic prod hace que cada request pague cold

--- a/serverless/lambda/services/contact_form/manifest.yaml
+++ b/serverless/lambda/services/contact_form/manifest.yaml
@@ -16,12 +16,12 @@ description: Form de contacto (valida + Turnstile + escribe Neon inline + invoke
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 256       # MB — minimo medido (dev, 2026-05, cold $LATEST tras
-                  # lazy+warmup). Footprint base Neon (sqlalchemy+httpx+DDB):
-                  # 117/128 a 128 MB (solo 11 MB headroom -> riesgo OOM en el
-                  # submit completo) vs 157 MB a 256 (comodo). 128 NO.
-                  # Bajo de 384 a 256. Ver .claude/rules/lambda-config.md.
-timeout: 30       # segundos — cubre el cold sin SnapStart restore + Turnstile.
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 para medir warm/cold con
+                  # CPU x4. Minimo medido previo: 256 (footprint Neon 157 MB;
+                  # 128 NO por headroom). REVERTIR al minimo tras medir si la
+                  # mejora no lo justifica. Ver .claude/rules/lambda-config.md.
+timeout: 60       # segundos — colchon uniforme (cold sin restore + Turnstile).
 
 # SnapStart: reduce cold start de 3.4s a ~830ms (Restore Duration).
 # Cuando true, cada deploy hace publish-version + update-alias `live`,

--- a/serverless/lambda/services/cv/manifest.yaml
+++ b/serverless/lambda/services/cv/manifest.yaml
@@ -11,12 +11,13 @@ description: Sirve el CV (lectura) desde Neon PostgreSQL via GET /cv.
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 256       # MB — minimo medido (dev, 2026-05, cold $LATEST). Read-only
-                  # Neon: a 256 usa 165 MB; a 128 usa 118/128 (10 MB headroom,
-                  # riesgo OOM con CV mas grande). El handler ~9s es Neon-I/O-
-                  # bound (no escala con memoria). Bajo de 512 a 256. 128 NO
-                  # por headroom. Ver .claude/rules/lambda-config.md.
-timeout: 30       # segundos — cubre el cold sin SnapStart restore (warmup INIT)
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 para medir warm/cold con
+                  # CPU x4. OJO: el handler de cv es Neon-I/O-bound; la palanca
+                  # real es la query (1 sesion), NO la memoria. Minimo medido
+                  # previo: 256 (usa 165 MB). REVERTIR al minimo tras medir.
+                  # Ver .claude/rules/lambda-config.md.
+timeout: 60       # segundos — colchon uniforme (cold sin restore + query).
 
 # SnapStart: el handler precalienta engine + configure_mappers en el INIT
 # (warm_db); el snapshot los captura y el restore evita el costo CPU del

--- a/serverless/lambda/services/db/manifest.yaml
+++ b/serverless/lambda/services/db/manifest.yaml
@@ -16,8 +16,16 @@ description: Gestiona el schema PostgreSQL del portfolio (migraciones Alembic).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 512       # MB
-timeout: 120      # segundos
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 en los 8 lambdas. Previo:
+                  # 512 (migraciones Alembic). REVERTIR tras medir si no lo
+                  # justifica. Ver .claude/rules/lambda-config.md.
+timeout: 60       # segundos — colchon uniforme. NOTA: si una migracion grande
+                  # tardara >60s, subir SOLO este. Ver lambda-config.md.
+
+# SnapStart: snapshotea el INIT (imports + engine) para bajar el cold del
+# invoke directo de migraciones. Uniforme con el resto del backend.
+snap_start: true
 
 # --- Como se invoca este Lambda ---
 # direct  : se invoca directo (aws lambda invoke / deploy hook). Sin HTTP.

--- a/serverless/lambda/services/send_email/manifest.yaml
+++ b/serverless/lambda/services/send_email/manifest.yaml
@@ -12,10 +12,11 @@ description: Envia email transaccional (DynamoDB config + S3 template + Jinja2 +
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 256       # MB — MEDIR (lambda-config.md). jinja2 + boto3 (dynamodb +
-                  # s3 + ses), SIN Neon (no sqlalchemy). Estimado 256; bajar a
-                  # 128 solo si la medicion del cold lo permite.
-timeout: 30       # segundos — cubre el cold sin SnapStart restore.
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 para medir con CPU x4.
+                  # jinja2 + boto3 (dynamodb+s3+ses), SIN Neon. Previo: 256
+                  # (estimado). REVERTIR tras medir. Ver lambda-config.md.
+timeout: 60       # segundos — colchon uniforme (render Jinja2 + SES).
 
 # SnapStart: precalienta imports en el INIT -> snapshot. Habilitado.
 snap_start: true

--- a/serverless/lambda/services/tracking_pixel/manifest.yaml
+++ b/serverless/lambda/services/tracking_pixel/manifest.yaml
@@ -16,12 +16,13 @@ description: Encoder de tracking (valida + rate-limit + invoke tracking_writer).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 128       # MB — minimo medido (dev, 2026-05, cold $LATEST). UNICO
-                  # lambda HTTP a 128: en ASYNC_MODE no toca Neon (sin
-                  # sqlalchemy) -> footprint 63/128 MB (65 MB headroom).
-                  # Init 680ms, handler 17ms. Fire-and-forget (sendBeacon),
-                  # latencia oculta. Ver .claude/rules/lambda-config.md.
-timeout: 30       # segundos — cubre el cold sin SnapStart restore con margen.
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 para medir con CPU x4.
+                  # OJO: es fire-and-forget (sendBeacon), latencia oculta —
+                  # subir memoria aqui es el menos justificado. Minimo medido
+                  # previo: 128 (footprint 63 MB). REVERTIR tras medir.
+                  # Ver .claude/rules/lambda-config.md.
+timeout: 60       # segundos — colchon uniforme.
 
 # SnapStart: snapshotea el INIT (imports + clientes) para bajar el cold y
 # permitir reducir memoria. Aunque la latencia esta oculta (async), el

--- a/serverless/lambda/services/tracking_writer/manifest.yaml
+++ b/serverless/lambda/services/tracking_writer/manifest.yaml
@@ -15,10 +15,11 @@ description: Persiste 1 evento de tracking en Neon (invoke async, idempotente).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 256       # MB — escribe a Neon (sqlalchemy+psycopg). Footprint base
-                  # Neon ~117-127 MB a 128 -> sin headroom; minimo real 256.
-                  # Ver .claude/rules/lambda-config.md.
-timeout: 30       # segundos — cubre el cold sin SnapStart restore + Neon wake.
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 para medir con CPU x4.
+                  # Escribe a Neon (sqlalchemy+psycopg). Minimo medido previo:
+                  # 256. REVERTIR tras medir. Ver .claude/rules/lambda-config.md.
+timeout: 60       # segundos — colchon uniforme (INSERT Neon + wake).
 
 # SnapStart: snapshotea el INIT (imports + engine NullPool + mappers del
 # dominio visitor) para bajar el cold del invoke async.

--- a/serverless/lambda/services/users/manifest.yaml
+++ b/serverless/lambda/services/users/manifest.yaml
@@ -17,11 +17,12 @@ description: HTTP endpoint POST /users (profile/status/admin).
 # --- Runtime ---
 runtime: python3.13
 handler: core.handler.lambda_handler
-memory: 256       # MB — minimo medido (dev, 2026-05). Misma familia que
-                  # auth (shared.auth + Neon). No usa webauthn pero argon2id
-                  # (password) es memory-hard -> 256 da headroom. 128 NO.
-                  # Bajo de 512 (sobre-dimensionado). Ver lambda-config.md.
-timeout: 30       # segundos — cubre el cold sin SnapStart restore con margen.
+memory: 1024      # MB — EXPERIMENTO (docs/specs/coldstart-cv-query-and-
+                  # snapstart). Config uniforme 1024 para medir con CPU x4.
+                  # Familia auth (shared.auth + Neon, argon2id memory-hard).
+                  # Minimo medido previo: 256. REVERTIR tras medir.
+                  # Ver .claude/rules/lambda-config.md.
+timeout: 60       # segundos — colchon uniforme.
 
 # SnapStart: reduce cold start (~830ms Restore). Mismo criterio que auth:
 # low traffic prod hace que cada request pague cold start.


### PR DESCRIPTION
## Problema

El reporte de tiempos del backend mostraba cold ~9-15s en los lambdas. Se pidio subir todos los lambdas a una config uniforme (1024 MB / timeout / SnapStart) para medir el efecto de mas CPU sobre cold/warm, y estimar el costo sin free tier contra un presupuesto de $5/mes.

## Solucion

Config uniforme en los 8 manifests (`serverless/lambda/services/*/manifest.yaml`):
- `memory: 1024` (los 8; antes 128/256/512 segun lambda)
- `timeout: 60` (los 8; antes 30/120)
- `snap_start: true` (los 8; se agrego a `db` que no lo tenia)
- ephemeral `/tmp`: sin cambio (default 512 de AWS; el provisioner no lo soporta y los lambdas no usan /tmp)

Cada manifest documenta que es un EXPERIMENTO y debe revertirse al minimo medido tras evaluar la mejora (regla `lambda-config.md`: memoria == CPU, no subir para enmascarar).

Plan completo en `docs/specs/coldstart-cv-query-and-snapstart/` con: baseline api_e2e medida, diagnostico (el cold real lo da SnapStart restore ~1.2s; el "7.3s" de cv era cache MISS + INIT crudo, no el caso tipico — cv.get warm medido = 0.17s con cache HIT), y estimacion de costo.

## Como probar

1. Merge a dev dispara `deploy-backend.yml` (deploy de los 8 lambdas en dev).
2. `python devtools/run.py api_e2e --env=dev --aws-profile=tfs-dev` para medir cold/warm post-deploy.
3. Comparar contra la baseline en `docs/specs/coldstart-cv-query-and-snapstart/09-baseline-config-costo.md`.

### Baseline ANTES (medida, 37/37 PASS)
- cold avg: 9.38s (contact 14.99 / users 12.73 / auth 12.48 / tracking 3.88 / cv 2.83)
- warm avg: 1.02s

### Costo estimado SIN free tier (~37k invokes/mes)
- Lambda a 1024 MB: ~\$0.99/mes (vs ~\$0.26 a 256 MB)
- + KMS ~\$1 + DynamoDB/CloudWatch/API GW ~\$0.5 = **~\$2.5/mes total** (dentro de \$5)

## TODO

- Tras medir el experimento: si la mejora warm/cold no justifica el 4x de compute+restore, revertir cada manifest a su minimo medido (baja Lambda de ~\$0.99 a ~\$0.26/mes sin perder el cold, que lo da SnapStart).
- Palanca real pendiente para cv: consolidar la query de `get_full_cv` a 1 sola `db_session` (fase 02 del plan), independiente de la memoria.
- stage/prod corren codigo viejo (SAM legacy): fuera de scope, se resuelven al promover.