### PR TITLE
chore(rules): exige verificacion de despliegue real antes de declarar listo

### DIFF
--- a/.claude/rules/ci-cd-pipeline.md
+++ b/.claude/rules/ci-cd-pipeline.md
@@ -37,6 +37,22 @@ Aplica SIEMPRE al editar:
   migracion nueva que revierta (forward fix).
 - **NUNCA** usar `cancel-in-progress: true` en workflows que tocan AWS
   (cancelar mid-deploy deja AWS en estado parcial).
+- **SIEMPRE** tras un merge que dispara un workflow de deploy, ESPERAR y
+  REVISAR su resultado real antes de declarar el deploy hecho: el
+  `conclusion` global Y el de CADA job (`gh run view <id> --json jobs`).
+  Un job en `failure` (ej. `Verify <app> dist matches env`) significa que
+  el deploy NO esta sano, aunque "se haya disparado". Diagnosticar ESE job.
+- **SIEMPRE** despues de un deploy de apps, hacer `curl` a la URL canonica
+  real de cada env tocado (no al `.pages.dev`): debe dar 200 + el marcador
+  esperado. "El workflow corrio" / "CI verde" NO es evidencia de que el
+  site sirve — la evidencia es el HTTP de la URL final (ver
+  [verify-before-done.md](verify-before-done.md), "Verificacion de
+  despliegue REAL").
+- **SIEMPRE** que se provisione un app/subdominio NUEVO, correr
+  `cloudflare_setup all --env=<X>` (NO solo `projects`): `domains` attacha
+  el custom domain y `dns` crea el registro CNAME. Sin el CNAME el custom
+  domain queda en `pending`, el cert ACM no se emite y la URL canonica da
+  `Could not resolve host` aunque el `.pages.dev` sirva.
 - **NUNCA** atribuir a IA en codigo, commits ni mensajes del workflow.
 
 ## Workflows
@@ -167,6 +183,9 @@ datos ni cambiar el endpoint:
 | Path-detection para apps | Apps son baratas, consistencia importa | Apps SIEMPRE rebuild + deploy |
 | Usar el rol `portfolio-deploy-prod` desde una rama que no sea `main` | El sub del OIDC no matchea, falla con AccessDenied | Lanzar el workflow desde la rama correcta |
 | Repetir las credenciales AWS en cada job | Multiplica el tiempo de assumeRole | Reutilizar el step `configure-aws-credentials` por job |
+| Declarar el deploy "listo" tras `gh pr merge` sin mirar el workflow | El workflow puede fallar (un job `Verify * dist` rojo) y el site no servir | Revisar `conclusion` global + de cada job; curl a la URL real |
+| Provisionar un app nuevo con `cloudflare_setup projects` solamente | Sin `domains`+`dns` el custom domain queda `pending` y no resuelve | `cloudflare_setup all --env=<X>` (projects -> domains -> dns -> status) |
+| Asumir el `.pages.dev` con prefijo `portfolio-` | El naming real del project/subdomain es `<niche>-<env>` (ej. `admin-dev`, subdomain `admin-dev-exl.pages.dev`) | Consultar el project real en la API antes de curl |
 
 ## Referencias cruzadas
 

--- a/.claude/rules/plan-format.md
+++ b/.claude/rules/plan-format.md
@@ -60,9 +60,16 @@ Resumen del orden NO negociable:
 ```text
 verificar rama -> (si protegida) crear rama de trabajo
   -> implementar + commits con verificacion incremental
-  -> bateria E2E completa (seccion 11) en VERDE
-  -> recien ahi: git push + crear PR
+  -> bateria E2E completa (seccion 11 Partes A+B) en VERDE
+  -> recien ahi: git push + crear PR -> merge
+  -> [si el plan despliega/provisiona infra] Parte C: mirar el workflow
+     de deploy + curl real a cada URL canonica de cada env (200 + marcador)
+  -> recien ahi: declarar el plan "listo" al usuario (con los HTTP reales)
 ```
+
+Un plan que despliega NO esta terminado al mergear: esta terminado cuando
+su URL real responde 200. La Parte C (post-merge, post-deploy) es parte del
+plan, NO un favor opcional que el usuario tiene que pedir.
 
 ## Todo plan vive en una carpeta
 
@@ -316,7 +323,7 @@ modelos los gobierna [orchestration.md](orchestration.md).
 ### 11. Verificacion E2E iterativa (fase final) — OBLIGATORIA
 
 Fase de cierre del plan. Archivo dedicado `NN-verificacion-e2e.md`. SIEMPRE es
-la ultima fase y el ultimo commit. Dos partes:
+la ultima fase y el ultimo commit. Tres partes:
 
 - **Parte A — refactor de tests**: ningun test viejo referencia codigo
   eliminado; tests nuevos en ruta y convencion correctas; barrido global con
@@ -326,11 +333,25 @@ la ultima fase y el ultimo commit. Dos partes:
   ejecutar -> si falla, diagnosticar -> corregir -> re-ejecutar la suite ->
   repetir. NO se marca completa con un comando fallando, un test rojo o
   coverage < 80%.
+- **Parte C — verificacion de despliegue REAL** (OBLIGATORIA si el plan
+  despliega o provisiona infra: Cloudflare Pages, un Lambda, custom domain,
+  DNS, recurso AWS): tras el merge que dispara el deploy, MIRAR el resultado
+  del workflow (cada job) Y hacer `curl` a CADA URL canonica de CADA env
+  tocado hasta obtener 200 + el marcador esperado. Si hay custom domain
+  nuevo: confirmar Pages project (naming `<niche>-<env>`, sin prefijo
+  `portfolio-`) + custom domain en status `active` (no `pending`) + registro
+  DNS CNAME existente (si falta -> `cloudflare_setup dns --env=<X>`). Esta
+  parte NO se omite ni se difiere a "que el usuario lo pruebe": el plan no
+  esta listo hasta que su URL real responde. Bucle de correccion identico al
+  de la Parte B. Detalle del gate: ver "Verificacion de despliegue REAL" en
+  [verify-before-done.md](verify-before-done.md).
 
 Esta fase consolida — no sustituye — la verificacion incremental de cada fase.
 El "Como probar" del PR reutiliza esta bateria. Es el gate del PR: el `git
-push` y la creacion del PR ocurren SOLO cuando esta bateria pasa completa en
-verde (ver "Regla de ejecucion" arriba).
+push` y la creacion del PR ocurren SOLO cuando las Partes A y B pasan en
+verde (ver "Regla de ejecucion" arriba). La Parte C corre DESPUES del merge
+(es post-deploy) y es el gate para declarar el plan REALMENTE terminado al
+usuario: un plan con deploy no se reporta "listo" sin la Parte C verde.
 
 **Documento detallado**: `.claude/docs/plan-format-large/README.md` capitulo 4
 (plantilla, bucle de correccion, regla de cierre).

--- a/.claude/rules/verify-before-done.md
+++ b/.claude/rules/verify-before-done.md
@@ -83,6 +83,75 @@ Errores comunes que esta verificación detecta:
 - View transitions o theme toggle con bug visual
 - Mapping de subdominios mal alineado entre `astro.config.ts` y nginx
 
+### Verificación de despliegue REAL (OBLIGATORIO — gate de "listo")
+
+> CRÍTICO: push + merge + "CI verde" NO es "listo". Un site/app/endpoint
+> solo está listo cuando su URL real responde 200 con el contenido
+> esperado. NUNCA declarar listo un trabajo que despliega o provisiona
+> infra sin haber hecho `curl` a la URL final. Esta regla nace de un
+> caso real: se mergeó el admin con "CI verde" pero ninguna de sus 3
+> URLs (local/dev/custom-domain) servía — el custom domain no resolvía
+> en DNS y un job `Verify admin dist` del CI estaba en rojo sin que
+> nadie lo mirara.
+
+Aplica SIEMPRE que el trabajo: despliega a Cloudflare Pages / un Lambda /
+cualquier hosting, provisiona infra (custom domain, DNS, Pages project,
+recurso AWS), o mergea a una rama que dispara un workflow de deploy.
+
+Pasos NO negociables ANTES de declarar listo:
+
+1. **Esperar y MIRAR el resultado del deploy**, no solo dispararlo. Si el
+   merge dispara un workflow, revisar su `conclusion` Y el de CADA job:
+
+   ```bash
+   gh run list --workflow=deploy-apps.yml --branch=<branch> --limit=1 \
+     --json databaseId,conclusion,status
+   # Si conclusion != success -> ver los jobs:
+   gh run view <id> --json jobs --jq '.jobs[] | {name, conclusion}'
+   ```
+
+   Un solo job en `failure` (ej. `Verify <app> dist matches env`) =
+   NO listo. Diagnosticar ESE job, no ignorarlo.
+
+2. **`curl` real a CADA URL canónica afectada** (todos los envs tocados):
+
+   ```bash
+   # Astro/Next en Cloudflare Pages (custom domain). --resolve saltea el
+   # cache DNS de WSL2 (rc=6 'Could not resolve host' es del cache local,
+   # NO del estado real -> confirmar con nslookup contra 1.1.1.1).
+   curl -fsS -o /dev/null -w "HTTP %{http_code}\n" --max-time 25 \
+     https://<subdominio>.portfolio.<env>.the-full-stack.com/
+   # rutas clave de la app (no solo el home): /login/, etc.
+   ```
+
+   Aceptación: HTTP 200 (o el código correcto del endpoint) + el body
+   contiene un marcador esperado (ej. `<title>` correcto). 404/502/000
+   = NO listo.
+
+3. **Si hay custom domain nuevo**: confirmar las 3 piezas, NO asumir que
+   el deploy las creó:
+   - Pages project existe con el nombre correcto (ojo: el naming real es
+     `<niche>-<env>`, ej. `admin-dev`, SIN prefijo `portfolio-`).
+   - Custom domain attachado al project en status `active` (no `pending`).
+   - Registro DNS CNAME existe en la zona (`matches: 0` = falta crearlo
+     con `cloudflare_setup dns --env=<X>`). El cert ACM no se emite hasta
+     que el DNS resuelve.
+
+4. **DNS recién creado**: verificar propagación contra un resolver público
+   antes de concluir que "no sirve":
+
+   ```bash
+   nslookup <fqdn> 1.1.1.1   # debe devolver IPs de Cloudflare
+   ```
+
+   Propagación + emisión de cert tras crear un CNAME nuevo puede tardar
+   minutos: reintentar el curl con backoff, no declarar fallo al primer
+   intento.
+
+NUNCA reportar "desplegado / listo / funcionando" basándose en
+`gh pr merge` exitoso, "CI passed" o "el deploy se disparó". El estado
+real es lo que devuelve el `curl` a la URL final.
+
 ### Configuración `.claude/`
 
 | Cambio | Verificación mínima |
@@ -97,17 +166,29 @@ Errores comunes que esta verificación detecta:
 1. Implementar cambio (con TDD si es lógica nueva — ver tdd-workflow)
 2. Ejecutar verificación(es) correspondiente(s)
 3. Si falla → corregir → volver a paso 2
-4. Si pasa → AHORA reportar al usuario que esta listo
+4. Si el cambio DESPLIEGA o provisiona infra:
+   a. Esperar y MIRAR el resultado del workflow de deploy (cada job)
+   b. curl real a CADA URL canónica afectada -> debe dar 200 + marcador
+   c. Si hay custom domain/DNS nuevo, confirmar project + domain + CNAME
+5. Si todo pasa → AHORA reportar al usuario que esta listo (con los
+   códigos HTTP reales de las URLs como evidencia)
 ```
 
 ## Reglas estrictas
 
-- NUNCA decir "listo", "done", "implementado", "creado" sin haber ejecutado la verificación
+- NUNCA decir "listo", "done", "implementado", "creado", "desplegado" sin
+  haber ejecutado la verificación
+- NUNCA tratar `gh pr merge` exitoso, "CI passed" o "el deploy se disparó"
+  como evidencia de que algo funciona. La evidencia es el `curl` a la URL
+  real desplegada (ver "Verificación de despliegue REAL" arriba)
+- NUNCA ignorar un job en `failure` dentro de un workflow cuyo
+  `conclusion` global es `failure` — diagnosticar ESE job
 - NUNCA asumir que un cambio funciona solo porque el codigo "se ve correcto"
 - Si hay tests existentes para el archivo afectado, ejecutarlos
 - Si se crean archivos nuevos, verificar que importan correctamente
 - Si se modifica `astro.config.ts`, verificar que el build sigue funcionando
-- Reportar al usuario tanto el resultado de la verificación como el del cambio
+- Reportar al usuario tanto el resultado de la verificación como el del
+  cambio (incluyendo los códigos HTTP de las URLs cuando hubo deploy)
 
 ## Errores comunes que esta regla previene
 
@@ -118,6 +199,11 @@ Errores comunes que esta verificación detecta:
 - Tokens del DS que dejaron de existir y rompen estilos
 - Imports faltantes en archivos nuevos
 - Hex colors inline cuando hay token equivalente
+- Custom domain en `pending` por falta de registro DNS (el `.pages.dev`
+  sirve pero la URL canónica da `Could not resolve host`)
+- Declarar un deploy "listo" con un job `Verify * dist` del CI en rojo
+- Pages project con nombre equivocado (asumir prefijo `portfolio-` cuando
+  el naming real es `<niche>-<env>`)
 
 ## Cuando NO aplica
 

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -264,18 +264,39 @@ jobs:
         run: |
           # El admin Next.js no emite data-api-endpoint ni el dropdown de
           # nichos; solo se valida que responda 200.
-          sleep 5
-          curl -fsSL --max-time 30 -o /dev/null "${{ steps.url.outputs.url }}/"
-          echo "OK: ${{ steps.url.outputs.url }}/ responde 200"
+          # Reintentos con backoff: un custom domain recien creado tarda en
+          # propagar el DNS + emitir el cert ACM (un solo sleep 5 + curl da
+          # falso negativo 'Could not resolve host' -> ver
+          # .claude/rules/verify-before-done.md "Verificacion de despliegue REAL").
+          url="${{ steps.url.outputs.url }}/"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 25 "$url" || echo 000)
+            if [[ "$code" == "200" ]]; then
+              echo "OK: $url responde 200 (intento $i)"
+              exit 0
+            fi
+            echo "intento $i: HTTP $code -> reintentando en 30s"
+            sleep 30
+          done
+          echo "::error::$url no respondio 200 tras 10 intentos (~5min)"
+          exit 1
 
       - name: Curl y assert data-api-endpoint
         if: steps.url.outputs.is_admin != 'true'
         run: |
-          # Esperar un poco a que Cloudflare propague el deploy
-          sleep 5
-          html=$(curl -fsSL --max-time 30 "${{ steps.url.outputs.url }}/" || true)
+          # Reintentos con backoff: Cloudflare puede tardar en propagar el
+          # deploy / el DNS de un subdominio nuevo (un solo sleep 5 da falso
+          # negativo). Ver .claude/rules/verify-before-done.md.
+          url="${{ steps.url.outputs.url }}/"
+          html=""
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            html=$(curl -fsSL --max-time 25 "$url" || true)
+            [[ -n "$html" ]] && { echo "curl OK (intento $i)"; break; }
+            echo "intento $i: sin respuesta -> reintentando en 30s"
+            sleep 30
+          done
           if [[ -z "$html" ]]; then
-            echo "::error::No pude curl ${{ steps.url.outputs.url }}/"
+            echo "::error::No pude curl $url tras 10 intentos (~5min)"
             exit 1
           fi
           expected='data-api-endpoint="${{ steps.url.outputs.api }}"'


### PR DESCRIPTION
## Problema

El admin (plan a-admin) se declaro "listo" con "CI verde" pero ninguna de sus 3 URLs (local / dev / custom domain) servia. Causa raiz:

1. El custom domain `admin.portfolio.dev.the-full-stack.com` quedo en status `pending` porque NUNCA se creo su registro DNS CNAME (la fase `dns` de cloudflare_setup no corrio). El `.pages.dev` real (`admin-dev-exl.pages.dev`) si servia, pero la URL canonica daba `Could not resolve host`.
2. El job `Verify admin dist matches env` del `deploy-apps.yml` estaba en `failure` (mismo `Could not resolve host`), pero se reporto "listo" sin mirar ese job.

El proceso permitia declarar "desplegado/listo" basandose en `gh pr merge` + "CI verde" + "el deploy se disparo", sin verificar el resultado real desplegado.

## Solucion

1. **verify-before-done.md** — nueva seccion "Verificacion de despliegue REAL" como gate de "listo": mirar cada job del workflow de deploy, `curl` 200 a cada URL canonica de cada env, confirmar Pages project + custom domain `active` + registro DNS CNAME, verificar propagacion DNS contra resolver publico antes de declarar fallo. NUNCA tratar merge / CI-verde / "deploy disparado" como evidencia.
2. **plan-format.md** — la seccion 11 (verificacion E2E, fase final) gana **Parte C: verificacion de despliegue real** (post-merge, OBLIGATORIA si el plan despliega/provisiona infra). Orden no negociable: un plan que despliega no esta listo al mergear, sino cuando su URL real responde 200.
3. **ci-cd-pipeline.md** — reglas duras (revisar `conclusion` global + de cada job, `curl` a la URL canonica, `cloudflare_setup all` para apps nuevas) + 3 anti-patrones nuevos.
4. **deploy-apps.yml** — el step `Verify * dist` reintenta con backoff (10x30s) en vez de `sleep 5` + un solo curl (que da falso negativo con un custom domain recien creado).

El efecto: la validacion real post-deploy pasa a ser obligatoria y automatica, sin que el usuario tenga que pedirla.

## Como probar

- Las reglas se validaron con `claude -p` (bypassPermissions, sin web/MCP): ante "mergee un PR que despliega y el CI quedo verde, ya esta listo?" el modelo responde "No", revisa el workflow real, hace el curl real y detecta el job en rojo (`num_turns: 11`). Ante "que incluyo en la seccion 11 de un plan con deploy?" menciona Parte C + curl/URL + DNS/custom domain.
- `deploy-apps.yml`: YAML valido (`yaml.safe_load`).
- Verificacion real del admin (lo que motivo el cambio), ya aplicada en dev:
  - `http://admin.localhost:9970/` -> HTTP 200
  - `https://admin.portfolio.dev.the-full-stack.com/` -> HTTP 200
  - `https://admin.portfolio.dev.the-full-stack.com/login/` -> HTTP 200
  - registro DNS CNAME creado (`cloudflare_setup dns --env=dev`), custom domain attachado, rerun del `deploy-apps.yml` -> success.

## TODO

- Promover estas reglas + el fix del workflow a stage/main cuando se decida.
- Considerar mover la Parte C (smoke de URL real) a un job opcional post-deploy del propio workflow para que el CI lo enforce sin depender del operador.