### PR TITLE
fix: admin/apps local le pegan al API custom domain (no al endpoint crudo)

### DIFF
--- a/.git-hooks/_common.py
+++ b/.git-hooks/_common.py
@@ -224,7 +224,16 @@ def filter_lintable_files(files: list[str]) -> list[str]:
     for f in files:
         if not (f.startswith('apps/') or f.startswith('packages/')):
             continue
-        if 'node_modules/' in f or '/dist/' in f or '/.astro/' in f:
+        # public/ y .next/ contienen artefactos generados (openapi.json,
+        # mockServiceWorker.js, etc.) que biome ignora -> pasarlos a
+        # 'biome check' da 'no files processed' y rompe el pre-commit.
+        if (
+            'node_modules/' in f
+            or '/dist/' in f
+            or '/.astro/' in f
+            or '/.next/' in f
+            or '/public/' in f
+        ):
             continue
         if any(f.endswith(ext) for ext in relevant_exts):
             result.append(f)
@@ -259,7 +268,16 @@ def find_forbidden_js_files(files: list[str]) -> list[str]:
     for f in files:
         if not (f.startswith('apps/') or f.startswith('packages/')):
             continue
-        if 'node_modules/' in f or '/dist/' in f or '/.astro/' in f:
+        # public/ y .next/ contienen artefactos generados (openapi.json,
+        # mockServiceWorker.js, etc.) que biome ignora -> pasarlos a
+        # 'biome check' da 'no files processed' y rompe el pre-commit.
+        if (
+            'node_modules/' in f
+            or '/dist/' in f
+            or '/.astro/' in f
+            or '/.next/' in f
+            or '/public/' in f
+        ):
             continue
         if not any(f.endswith(ext) for ext in _FORBIDDEN_JS_EXTS):
             continue

--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -30,16 +30,27 @@ HOOK_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(HOOK_DIR))
 
 
-# Catalogo de env vars que el build de las apps Astro consume via
-# import.meta.env.* o process.env. Si no estan presentes en os.environ,
-# se inyectan desde docker/env/client/.local antes de correr `pnpm build`.
-# Espejo del SYNCED_KEYS de devtools/github_sync/catalog.py.
+# Catalogo de env vars que el build consume via import.meta.env.* (apps
+# Astro) o process.env.NEXT_PUBLIC_* (admin Next.js). Si no estan en
+# os.environ, se inyectan desde docker/env/client/.local antes de correr
+# `pnpm run build`. Espejo de CLIENT_SYNCED_KEYS de
+# devtools/sync_secrets/catalog.py. El admin (Next.js) valida sus
+# NEXT_PUBLIC_* con Zod en build (admin/src/lib/env.ts) y FALLA el build
+# si falta alguna -> deben estar aqui o el paso 5/7 (build) rompe.
 _BUILD_CATALOG_KEYS = (
+    # Apps Astro
     'BASE_DOMAIN',
     'BASE_SCHEME',
     'APEX_DOMAIN',
     'PUBLIC_API_ENDPOINT',
     'PUBLIC_TURNSTILE_SITEKEY',
+    # Admin Next.js (NEXT_PUBLIC_*)
+    'NEXT_PUBLIC_API_ENDPOINT',
+    'NEXT_PUBLIC_TURNSTILE_SITEKEY',
+    'NEXT_PUBLIC_ADMIN_URL',
+    'NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS',
+    'NEXT_PUBLIC_WEBAUTHN_RP_ID',
+    'NEXT_PUBLIC_FEATURE_MFA',
 )
 
 

--- a/admin/biome.json
+++ b/admin/biome.json
@@ -9,7 +9,9 @@
 			"!**/out",
 			"!**/coverage",
 			"!**/next-env.d.ts",
-			"!src/styles/globals.css"
+			"!src/styles/globals.css",
+			"!**/public",
+			"!public"
 		]
 	},
 	"overrides": [

--- a/admin/src/app/error.tsx
+++ b/admin/src/app/error.tsx
@@ -15,7 +15,6 @@ export default function ErrorBoundary({
 	reset: () => void;
 }) {
 	useEffect(() => {
-		// biome-ignore lint/suspicious/noConsole: error boundary logging
 		console.error(error);
 	}, [error]);
 

--- a/admin/src/components/ui/data-table.tsx
+++ b/admin/src/components/ui/data-table.tsx
@@ -75,10 +75,8 @@ export function DataTable<TData, TValue>({
 				<TableBody>
 					{isLoading ? (
 						Array.from({ length: 5 }).map((_, i) => (
-							// biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholder
 							<TableRow key={`skeleton-${i}`}>
 								{columns.map((_col, ci) => (
-									// biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholder
 									<TableCell key={`skeleton-cell-${ci}`}>
 										<Skeleton className="h-5 w-full" />
 									</TableCell>

--- a/apps/architect/public/openapi.json
+++ b/apps/architect/public/openapi.json
@@ -14,7 +14,7 @@
   },
   "servers": [
     {
-      "url": "https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev",
+      "url": "https://api.portfolio.dev.the-full-stack.com",
       "description": "API Gateway"
     }
   ],

--- a/apps/fintech/public/openapi.json
+++ b/apps/fintech/public/openapi.json
@@ -14,7 +14,7 @@
   },
   "servers": [
     {
-      "url": "https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev",
+      "url": "https://api.portfolio.dev.the-full-stack.com",
       "description": "API Gateway"
     }
   ],

--- a/apps/generic/public/openapi.json
+++ b/apps/generic/public/openapi.json
@@ -14,7 +14,7 @@
   },
   "servers": [
     {
-      "url": "https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev",
+      "url": "https://api.portfolio.dev.the-full-stack.com",
       "description": "API Gateway"
     }
   ],

--- a/apps/hub/public/openapi.json
+++ b/apps/hub/public/openapi.json
@@ -14,7 +14,7 @@
   },
   "servers": [
     {
-      "url": "https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev",
+      "url": "https://api.portfolio.dev.the-full-stack.com",
       "description": "API Gateway"
     }
   ],

--- a/apps/leader/public/openapi.json
+++ b/apps/leader/public/openapi.json
@@ -14,7 +14,7 @@
   },
   "servers": [
     {
-      "url": "https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev",
+      "url": "https://api.portfolio.dev.the-full-stack.com",
       "description": "API Gateway"
     }
   ],

--- a/apps/vibe/public/openapi.json
+++ b/apps/vibe/public/openapi.json
@@ -14,7 +14,7 @@
   },
   "servers": [
     {
-      "url": "https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev",
+      "url": "https://api.portfolio.dev.the-full-stack.com",
       "description": "API Gateway"
     }
   ],

--- a/biome.json
+++ b/biome.json
@@ -60,7 +60,9 @@
       "complexity": {
         "noExcessiveCognitiveComplexity": {
           "level": "error",
-          "options": { "maxAllowedComplexity": 15 }
+          "options": {
+            "maxAllowedComplexity": 15
+          }
         },
         "noUselessFragments": "error",
         "noUselessTernary": "error",
@@ -96,14 +98,18 @@
         "useCollapsedElseIf": "error",
         "useConsistentArrayType": {
           "level": "error",
-          "options": { "syntax": "shorthand" }
+          "options": {
+            "syntax": "shorthand"
+          }
         }
       },
       "suspicious": {
         "noExplicitAny": "error",
         "noConsole": {
           "level": "error",
-          "options": { "allow": ["warn", "error", "info"] }
+          "options": {
+            "allow": ["warn", "error", "info"]
+          }
         },
         "noDoubleEquals": "error",
         "noEmptyBlockStatements": "error",
@@ -132,7 +138,9 @@
       "includes": ["**/tests/e2e/**"],
       "linter": {
         "rules": {
-          "complexity": { "noExcessiveCognitiveComplexity": "off" },
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off"
+          },
           "suspicious": {
             "noConsole": "off",
             "noEmptyBlockStatements": "off"
@@ -141,8 +149,12 @@
             "noUnusedVariables": "off",
             "noUnusedFunctionParameters": "off"
           },
-          "style": { "noNonNullAssertion": "off" },
-          "nursery": { "noFloatingPromises": "off" }
+          "style": {
+            "noNonNullAssertion": "off"
+          },
+          "nursery": {
+            "noFloatingPromises": "off"
+          }
         }
       }
     },
@@ -150,12 +162,19 @@
       "includes": ["**/tests/unit/**", "**/*.test.ts", "**/*.spec.ts"],
       "linter": {
         "rules": {
-          "complexity": { "noExcessiveCognitiveComplexity": "off" },
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off"
+          },
+          "correctness": {
+            "noEmptyPattern": "off"
+          },
           "suspicious": {
             "noConsole": "off",
             "noEmptyBlockStatements": "off"
           },
-          "style": { "noNonNullAssertion": "off" }
+          "style": {
+            "noNonNullAssertion": "off"
+          }
         }
       }
     },
@@ -177,7 +196,9 @@
       "includes": ["**/*.config.{ts,js,mjs,cjs}", "**/astro.config.*"],
       "linter": {
         "rules": {
-          "suspicious": { "noConsole": "off" }
+          "suspicious": {
+            "noConsole": "off"
+          }
         }
       }
     },
@@ -185,8 +206,12 @@
       "includes": ["**/styles/animations.css"],
       "linter": {
         "rules": {
-          "complexity": { "noImportantStyles": "off" },
-          "style": { "noDescendingSpecificity": "off" }
+          "complexity": {
+            "noImportantStyles": "off"
+          },
+          "style": {
+            "noDescendingSpecificity": "off"
+          }
         }
       }
     },

--- a/docker/docker-compose/local.yml
+++ b/docker/docker-compose/local.yml
@@ -78,8 +78,13 @@ services:
     user: root
     volumes:
       - portfolio_dynamodb_local:/home/dynamodblocal/data
+    # DynamoDB Local responde 400 a GET / (solo acepta POST firmados): un
+    # 400 = servidor VIVO. `curl -sf` salia 22 ante el 400 -> unhealthy
+    # perpetuo (FailingStreak miles) aunque el servicio estuviera OK. Sin
+    # `-f`: solo falla si NO hay respuesta HTTP (conexion rechazada).
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000 || exit 1"]
+      test:
+        ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8000 || exit 1"]
       interval: 2s
       timeout: 5s
       retries: 15

--- a/docker/docker-compose/test.yml
+++ b/docker/docker-compose/test.yml
@@ -69,8 +69,12 @@ services:
     user: root
     volumes:
       - portfolio_dynamodb_test:/home/dynamodblocal/data
+    # DynamoDB Local responde 400 a GET / (solo POST firmados): un 400 =
+    # servidor VIVO. `curl -sf` salia 22 ante el 400 -> unhealthy perpetuo.
+    # Sin `-f`: solo falla si NO hay respuesta HTTP (conexion rechazada).
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000 || exit 1"]
+      test:
+        ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8000 || exit 1"]
       interval: 2s
       timeout: 5s
       retries: 15

--- a/packages/ui/src/lib/validate-build-env.ts
+++ b/packages/ui/src/lib/validate-build-env.ts
@@ -38,11 +38,29 @@ export function validateApiEndpoint(apiEndpoint: string | undefined): string {
         'o en docker/env/client/.{env} para builds locales.',
     )
   }
+  // El endpoint NUNCA debe ser el host crudo de API Gateway
+  // (`*.execute-api.<region>.amazonaws.com`): esos endpoints son efimeros
+  // (se recrean/borran al re-provisionar) y un dia dejan de resolver
+  // -> ERR_NAME_NOT_RESOLVED en el browser. SIEMPRE el dominio custom
+  // estable `api.portfolio.<env>.the-full-stack.com`. Este guard aplica
+  // en TODOS los builds, incluido local (un crudo borrado fue justo el
+  // bug que rompio el admin/tracking en local).
+  if (apiEndpoint.includes('.execute-api.')) {
+    throw new Error(
+      `PUBLIC_API_ENDPOINT (${apiEndpoint}) usa el host crudo de API ` +
+        'Gateway (*.execute-api.*.amazonaws.com), que es efimero y puede ' +
+        'dejar de resolver. Usa el dominio custom ' +
+        'api.portfolio.<env>.the-full-stack.com. En docker/env/client/.local ' +
+        'apunta al de dev: https://api.portfolio.dev.the-full-stack.com',
+    )
+  }
   const baseDomain = readBaseDomain()
   // El match estricto solo aplica en builds remotos (dev/stage/prod).
-  // En local docker BASE_DOMAIN=localhost pero PUBLIC_API_ENDPOINT
-  // tipicamente apunta al AWS API Gateway real (no hay api.localhost),
-  // asi que se omite el match para localhost.
+  // En local docker BASE_DOMAIN=localhost pero PUBLIC_API_ENDPOINT apunta
+  // al API custom de dev (api.portfolio.dev.the-full-stack.com), no a
+  // api.localhost (no existe un backend local). Por eso el match estricto
+  // contra BASE_DOMAIN se omite para localhost, pero el guard anti-crudo
+  // de arriba SI corre en local.
   if (baseDomain && !isLocalBuild(baseDomain)) {
     const expected = `https://api.${baseDomain}`
     if (apiEndpoint !== expected) {

--- a/packages/ui/tests/unit/lib/validate-build-env.test.ts
+++ b/packages/ui/tests/unit/lib/validate-build-env.test.ts
@@ -49,11 +49,26 @@ describe('validateApiEndpoint', () => {
     expect(validateApiEndpoint(endpoint)).toBe(endpoint)
   })
 
-  it('Given BASE_DOMAIN=localhost When validate con AWS endpoint Then NO exige match (modo docker local)', () => {
+  it('Given BASE_DOMAIN=localhost y endpoint custom de dev When validate Then retorna el valor (modo docker local)', () => {
     vi.stubEnv('BASE_DOMAIN', 'localhost')
-    const endpoint =
-      'https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev'
+    // En local el endpoint apunta al API custom de dev (estable), no a
+    // api.localhost (no hay backend local) ni a un host crudo efimero.
+    const endpoint = 'https://api.portfolio.dev.the-full-stack.com'
     expect(validateApiEndpoint(endpoint)).toBe(endpoint)
+  })
+
+  it('Given un host crudo de API Gateway When validate Then throws (efimero, no resuelve) [guard anti-crudo]', () => {
+    vi.stubEnv('BASE_DOMAIN', 'localhost')
+    // Este era el bug real: un .execute-api crudo borrado ->
+    // ERR_NAME_NOT_RESOLVED. El guard lo rechaza en TODOS los builds.
+    const raw = 'https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev'
+    expect(() => validateApiEndpoint(raw)).toThrow(/host crudo de API/)
+  })
+
+  it('Given host crudo de API Gateway sin BASE_DOMAIN When validate Then throws igual', () => {
+    vi.stubEnv('BASE_DOMAIN', '')
+    const raw = 'https://332ivhahf2.execute-api.us-east-1.amazonaws.com/prod'
+    expect(() => validateApiEndpoint(raw)).toThrow(/execute-api/)
   })
 
   it('Given BASE_DOMAIN=hub.localhost When validate Then NO exige match (subdominio localhost)', () => {

--- a/tests/feature/smoke/cv-filters.spec.ts
+++ b/tests/feature/smoke/cv-filters.spec.ts
@@ -23,7 +23,7 @@ const APPS_WITH_FILTERS = [
 ] as const
 
 test.describe('Feature: CV filters via query params', () => {
-  test.beforeEach(async (_, testInfo) => {
+  test.beforeEach(async ({}, testInfo) => {
     test.skip(
       testInfo.project.name !== 'desktop-chromium',
       'Spec corre solo en desktop-chromium',

--- a/tests/feature/smoke/cv-screenshots.spec.ts
+++ b/tests/feature/smoke/cv-screenshots.spec.ts
@@ -30,7 +30,6 @@ const VIEWPORTS = [
 test.describe('Feature: CV screenshots - 6 niches x 3 viewports', () => {
   // El spec controla viewports internamente: skip todos los projects excepto
   // desktop-chromium para evitar duplicar ejecucion x5 projects.
-  // biome-ignore lint/correctness/noEmptyPattern: Playwright beforeEach requires destructuring pattern as first arg even when no fixtures used
   test.beforeEach(({}, testInfo) => {
     test.skip(
       testInfo.project.name !== 'desktop-chromium',


### PR DESCRIPTION
## Problema

En local el admin (y el tracking pixel de las apps Astro) le pegaba al endpoint CRUDO de API Gateway `https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev`, que **fue borrado al re-provisionar** y ya no resuelve:

```
tsp.bundle.js  POST https://ssnj6odx7l.execute-api.us-east-1.amazonaws.com/dev/auth
  net::ERR_NAME_NOT_RESOLVED
```

Debe pegarle al API de the-full-stack via su dominio custom estable.

Tres problemas encadenados, todos de proceso/infra preexistentes:

1. `docker/env/client/.local` y `.prod` apuntaban al host crudo de API Gateway (efimero). dev/stage ya usaban el dominio custom. La GH Variable de PROD tambien tenia el crudo.
2. El pre-push corre `pnpm run build` (que incluye el admin) inyectando env desde `docker/env/client/.local`, pero su catalogo `_BUILD_CATALOG_KEYS` solo tenia las `PUBLIC_*` de Astro — faltaban TODAS las `NEXT_PUBLIC_*` del admin -> el build del admin fallaba (Zod en admin/src/lib/env.ts).
3. El healthcheck de `dynamodb-local` usaba `curl -sf`; DynamoDB Local responde 400 a `GET /` (solo POST firmados) y `-f` sale con codigo 22 ante el 400 -> container `unhealthy` perpetuo, bloqueando `docker up` (paso 7/7 del pre-push) y el E2E del CI (test.yml).

## Solucion

1. **Env (no versionado, gitignored)**: `docker/env/client/.local` -> `https://api.portfolio.dev.the-full-stack.com` (local consume el API custom de dev, estable). `.prod` + GH Variables prod -> `https://api.portfolio.the-full-stack.com` (via `sync_secrets --category=client`). Los 4 envs quedan consistentes con dominio custom.
2. **`packages/ui/src/lib/validate-build-env.ts`**: `validateApiEndpoint` ahora RECHAZA cualquier host crudo `*.execute-api.*.amazonaws.com` en TODOS los builds (el validador antes omitia a proposito el check en local). +2 tests, coverage per-file 96%.
3. **`.git-hooks/pre-push`**: agrega las 6 `NEXT_PUBLIC_*` del admin al `_BUILD_CATALOG_KEYS` (espejo de `CLIENT_SYNCED_KEYS`).
4. **`docker/docker-compose/{local,test}.yml`**: healthcheck de dynamodb-local sin `-f` (acepta el 400 = servidor vivo).
5. **`tests/feature/smoke/cv-filters.spec.ts`**: fix de lint preexistente (`beforeEach` destructuring) que bloqueaba la suite E2E.

## Como probar

Verificacion REAL (todo aplicado y comprobado):
- `http://admin.localhost:9970/` + `/login/` -> HTTP 200 (admin local le pega al API custom de dev).
- `POST https://api.portfolio.dev.the-full-stack.com/auth` -> HTTP 400 estructurado (responde, no error de red). CORS preflight desde `admin.localhost` -> 200, `Access-Control-Allow-Origin: *`.
- App Astro generic local: el HTML inyecta `api.portfolio.dev.the-full-stack.com` (no `execute-api`).
- `dynamodb-local` -> healthy al instante con el healthcheck nuevo.
- Build del admin pasa con las env del catalogo cargadas (endpoint custom).
- Pre-push COMPLETO en verde: build (incl. admin) + E2E feature OK (295 passed).
- GH Variables prod -> dominio custom (sincronizado con sync_secrets).

## TODO

- Promover a stage/main cuando se decida (el cambio de GH Variables prod aplica al proximo deploy a prod; el crudo actual igual resuelve, sin outage).