### PR TITLE
fix(admin): turnstile en dev + limpia service worker MSW huerfano

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "next dev --port 3000",
 		"build": "NODE_ENV=production next build",
+		"postbuild": "rm -f out/mockServiceWorker.js",
 		"preview": "npx serve out -p 3000",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",

--- a/admin/src/components/msw-provider.tsx
+++ b/admin/src/components/msw-provider.tsx
@@ -16,7 +16,23 @@ export function MswProvider({ children }: { children: ReactNode }) {
 	const [ready, setReady] = useState(!useMsw);
 
 	useEffect(() => {
-		if (!useMsw || typeof window === "undefined") return;
+		if (typeof window === "undefined") return;
+
+		// MSW INACTIVO (dev/stage/prod): des-registrar cualquier
+		// mockServiceWorker.js que haya quedado registrado en una visita
+		// previa. Si no, el SW huerfano intercepta requests y cierra el
+		// canal postMessage -> "Connection closed" + la app se cuelga.
+		if (!useMsw) {
+			void navigator.serviceWorker?.getRegistrations?.().then((regs) => {
+				for (const reg of regs) {
+					if (reg.active?.scriptURL.includes("mockServiceWorker")) {
+						void reg.unregister();
+					}
+				}
+			});
+			return;
+		}
+
 		let active = true;
 		void (async () => {
 			const { worker } = await import("@tests/mocks/browser");

--- a/devtools/rotate_secrets/turnstile.py
+++ b/devtools/rotate_secrets/turnstile.py
@@ -15,11 +15,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from shared.paths import PROJECT_ROOT
-
 from rotate_secrets.cloudflare_api import CloudflareError
 from rotate_secrets.cloudflare_api import TurnstileClient
 from rotate_secrets.env_writer import update_env_file
+from shared.paths import PROJECT_ROOT
 
 
 ENV_SERVER_DIR = PROJECT_ROOT / 'docker' / 'env' / 'server'
@@ -44,6 +43,7 @@ _WIDGETS = {
             'leader.portfolio.dev.the-full-stack.com',
             'vibe.portfolio.dev.the-full-stack.com',
             'generic.portfolio.dev.the-full-stack.com',
+            'admin.portfolio.dev.the-full-stack.com',
         ],
     },
     'stage': {
@@ -56,6 +56,7 @@ _WIDGETS = {
             'leader.portfolio.stage.the-full-stack.com',
             'vibe.portfolio.stage.the-full-stack.com',
             'generic.portfolio.stage.the-full-stack.com',
+            'admin.portfolio.stage.the-full-stack.com',
         ],
     },
     'prod': {
@@ -69,6 +70,7 @@ _WIDGETS = {
             'leader.portfolio.the-full-stack.com',
             'vibe.portfolio.the-full-stack.com',
             'generic.portfolio.the-full-stack.com',
+            'admin.portfolio.the-full-stack.com',
         ],
     },
 }


### PR DESCRIPTION
## Problema

Dos bugs en el admin dev (`https://admin.portfolio.dev.the-full-stack.com/`):

1. **Turnstile no carga en dev** (en local si). El widget Turnstile dev tenia en su allowlist los 6 niches (hub/fintech/architect/leader/vibe/generic) + `portfolio.dev`, pero **NO `admin.portfolio.dev.the-full-stack.com`** -> el widget rechaza renderizar en ese hostname. En local funciona porque `localhost` si esta permitido. Cuando se agrego el admin (plan a-admin) nadie actualizo el catalogo de hostnames del widget.

2. **`/` se queda en "Verificando sesion..."** sin redirigir a login, con `Uncaught (in promise) Error: Connection closed` en consola. Causa: el `mockServiceWorker.js` (MSW) se servia en dev (esta en `admin/public/`, se deployaba) y quedaba registrado en el browser; sin el cliente MSW activo (dev NO usa MSW), el SW huerfano interceptaba requests y cerraba el canal `postMessage` -> "Connection closed" + la navegacion/refresh del AuthGuard nunca completaba.

## Solucion

1. **Turnstile**: agregado `admin.portfolio.<env>` a los 3 widgets en `devtools/rotate_secrets/turnstile.py` (fuente de verdad) + aplicado al widget dev via API de Cloudflare. Limite de 10 hostnames/widget: se consolido quitando el `127.0.0.1` redundante (`localhost` lo cubre).

2. **Service worker MSW huerfano** (fix doble):
   - `admin/package.json` postbuild: `rm -f out/mockServiceWorker.js` -> el SW de MSW NO se deploya a dev/stage/prod (MSW es solo desarrollo local + tests).
   - `MswProvider`: cuando MSW esta inactivo, des-registra cualquier `mockServiceWorker.js` residual del browser (limpia visitas previas que ya lo tenian registrado).

## Como probar

- Turnstile: widget dev ya incluye `admin.portfolio.dev.the-full-stack.com` (verificado via API: `admin.portfolio.dev presente: True`). Tras el deploy, el Turnstile renderiza en `/login` y `/register` del admin dev.
- Service worker: `pnpm --filter @portfolio/admin build` + postbuild confirma que `out/mockServiceWorker.js` NO existe. El `MswProvider` des-registra SW residuales al cargar sin MSW.
- Admin verde: 301 tests, coverage 97.8% per-file, typecheck, lint. `turnstile.py` ruff limpio. Pre-push completo (build + E2E) verde.

## TODO

- Tras el merge + deploy a dev, validar en navegador real que (a) el Turnstile renderiza y (b) `/` redirige a `/login` sin colgarse. El SW residual del navegador del usuario se limpia al cargar el build nuevo (unregister defensivo), o el usuario puede hacer hard-reload / borrar el SW manualmente una vez.
- Promover a stage/main cuando se decida (los widgets stage/prod ya tienen admin en el catalogo; aplicar sus hostnames via API o rotate_secrets al promover).