### PR TITLE
chore(devtools): ordena imports del modulo serverless lint (ruff I001)

### DIFF
--- a/devtools/serverless/dep_validator.py
+++ b/devtools/serverless/dep_validator.py
@@ -269,14 +269,13 @@ def cmd_lint_deps(flags: dict) -> int:
     valida los lambdas del backend. Los checks 3 y 4 son globales (toda la
     carpeta) y corren SIEMPRE. Exit 0 si ningun check falla; 1 si alguno.
     """
-    from shared.console import GREEN
-    from shared.console import RED
-    from shared.console import _c
-
     from serverless.import_validator import format_import_report
     from serverless.import_validator import scan_lambda_core
     from serverless.resolve import available_lambdas
     from serverless.resolve import resolve_lambda
+    from shared.console import GREEN
+    from shared.console import RED
+    from shared.console import _c
 
     has_target = bool(
         flags.get('lambda') or flags.get('path') or flags.get('module')

--- a/devtools/tests/unit/src/serverless/dep_validator.py
+++ b/devtools/tests/unit/src/serverless/dep_validator.py
@@ -12,12 +12,12 @@ from pathlib import Path
 import textwrap
 
 import pytest
+
+from serverless import dep_validator
 from serverless.dep_validator import DepValidatorError
 from serverless.dep_validator import canonical_name
 from serverless.dep_validator import spec_extras
 from serverless.dep_validator import validate_lambda_deps
-
-from serverless import dep_validator
 
 
 pytestmark = pytest.mark.unit

--- a/devtools/tests/unit/src/serverless/import_validator.py
+++ b/devtools/tests/unit/src/serverless/import_validator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from serverless.import_validator import ForbiddenImport
 from serverless.import_validator import scan_file
 from serverless.import_validator import scan_lambda_core

--- a/devtools/tests/unit/src/serverless/init_validator.py
+++ b/devtools/tests/unit/src/serverless/init_validator.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from serverless.init_validator import scan_empty_inits
 
 

--- a/devtools/tests/unit/src/serverless/submodule_import_validator.py
+++ b/devtools/tests/unit/src/serverless/submodule_import_validator.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from serverless.submodule_import_validator import scan_file
 from serverless.submodule_import_validator import scan_tree
 


### PR DESCRIPTION
## Problema

El working tree tenia 5 archivos del modulo `devtools/serverless/` con imports reordenados por `ruff --fix` (que el autofix aplico al lint-ear `turnstile.py` en otra tarea). El `dep_validator.py` en `dev` tenia un error `I001` (Organize imports) preexistente que ruff corrige.

## Solucion

- `serverless/dep_validator.py`: reordena el bloque de imports local (`serverless.*` antes que `shared.*`) -> corrige el `I001`.
- 4 tests de los validators (`dep/import/init/submodule_import_validator.py`): agrega la linea en blanco entre el grupo stdlib/3rd-party y el local.

Sin cambios de logica. Cosmetico (orden de imports).

## Como probar

- `py_compile` de los 5 archivos: OK.
- `python devtools/run.py test_runner --module=devtools --type=unit`: 969 passed.
- `ruff check` sobre los 5 archivos: All checks passed.

## TODO

- El modulo serverless tiene otros ~25 errores de ruff preexistentes en archivos NO tocados aqui (fuera de scope de este chore). Se pueden limpiar en un PR dedicado.