### PR TITLE
fix(admin): kill-switch SW para matar el mockServiceWorker huerfano

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "next dev --port 3000",
 		"build": "NODE_ENV=production next build",
-		"postbuild": "rm -f out/mockServiceWorker.js",
+		"postbuild": "node scripts/postbuild.mjs",
 		"preview": "npx serve out -p 3000",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",

--- a/admin/public/_headers
+++ b/admin/public/_headers
@@ -8,6 +8,14 @@
 /*.html
   Cache-Control: no-cache, must-revalidate
 
+# Service Worker: no-cache para que el browser siempre revalide y reciba el
+# kill-switch (scripts/sw-kill-switch.js, publicado en esta URL). Un usuario
+# con el mockServiceWorker.js de MSW registrado en una visita previa lo
+# re-descarga, ejecuta el unregister + reload y deja de interceptar las
+# requests RSC `.txt` que rompian la navegacion ("Connection closed").
+/mockServiceWorker.js
+  Cache-Control: no-cache, must-revalidate
+
 # Security headers + CSP estricta (defensa primaria de los tokens en
 # localStorage: sin unsafe-inline/unsafe-eval en scripts + SRI en third-party).
 # 'wasm-unsafe-eval' lo requiere el runtime de Next/Turbopack en el cliente.

--- a/admin/scripts/postbuild.mjs
+++ b/admin/scripts/postbuild.mjs
@@ -1,0 +1,26 @@
+/**
+ * @file postbuild.mjs
+ * @description Postbuild del admin export (`next build` con output:'export').
+ *
+ * MSW NUNCA esta activo en un build de export (dev/stage/prod): el
+ * `mockServiceWorker.js` real solo se usa en los unit tests con
+ * `NEXT_PUBLIC_USE_MSW=true`, que corren con Vitest, no con `next build`.
+ *
+ * Si el build deja el `mockServiceWorker.js` de MSW en `out/`, los
+ * navegadores que lo registraron en una visita previa lo seguirian usando
+ * (intercepta las requests RSC `.txt` -> "Connection closed"). Por eso se
+ * REEMPLAZA por el kill-switch SW (scripts/sw-kill-switch.js), que se
+ * auto-desregistra y recarga al usuario afectado. Publicar el kill-switch
+ * en la MISMA URL es lo que mata el SW huerfano; borrar el archivo no basta
+ * (Cloudflare Pages puede seguir sirviendo el viejo de un deploy anterior).
+ */
+import { copyFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const killSwitch = join(here, "sw-kill-switch.js");
+const target = join(here, "..", "out", "mockServiceWorker.js");
+
+copyFileSync(killSwitch, target);
+console.info(`[postbuild] kill-switch SW -> ${target}`);

--- a/admin/scripts/sw-kill-switch.js
+++ b/admin/scripts/sw-kill-switch.js
@@ -1,0 +1,52 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Kill-switch Service Worker.
+ *
+ * Reemplaza al `mockServiceWorker.js` de MSW en los builds donde MSW esta
+ * INACTIVO (dev/stage/prod). NO sirve para mockear nada: su unico trabajo
+ * es DESREGISTRARSE a si mismo y recargar los clientes.
+ *
+ * Por que existe: un usuario que visito el admin cuando MSW estaba activo
+ * quedo con `mockServiceWorker.js` registrado en su navegador. En cada
+ * navegacion el browser re-descarga ese script para chequear updates (por
+ * spec del Service Worker). Si el deploy nuevo simplemente BORRA el archivo,
+ * Cloudflare Pages puede seguir sirviendo el viejo (persistido de un deploy
+ * anterior) -> el SW de MSW sigue vivo e intercepta las requests RSC `.txt`
+ * del client navigation de Next -> el stream se corta con "Connection
+ * closed" y la app se cuelga en "Verificando sesion".
+ *
+ * Al publicar este kill-switch en la MISMA URL (`/mockServiceWorker.js`),
+ * el browser del usuario afectado descarga este script al chequear el
+ * update, ejecuta el unregister + recarga, y la siguiente carga ya no tiene
+ * ningun SW interceptando. Los navegadores que nunca registraron un SW no
+ * descargan este archivo (no hay nada que actualizar) -> sin efecto.
+ */
+
+self.addEventListener("install", () => {
+	// Activar de inmediato, sin esperar a que el SW viejo libere los clientes.
+	self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+	event.waitUntil(
+		(async () => {
+			// Desregistrar esta misma registration.
+			await self.registration.unregister();
+			// Tomar control de los clientes abiertos y recargarlos para que
+			// la pagina vuelva a cargar SIN ningun SW interceptando.
+			const clients = await self.clients.matchAll({ type: "window" });
+			for (const client of clients) {
+				client.navigate(client.url);
+			}
+		})(),
+	);
+});
+
+// Mientras el kill-switch este activo (entre activate y la recarga), NO
+// interceptar ninguna request: passthrough total a la red. Esto evita que
+// el SW toque las requests RSC `.txt` que rompian el stream.
+self.addEventListener("fetch", () => {
+	// Sin respondWith() -> el browser maneja la request normalmente (red).
+});

--- a/admin/src/components/msw-provider.tsx
+++ b/admin/src/components/msw-provider.tsx
@@ -20,15 +20,29 @@ export function MswProvider({ children }: { children: ReactNode }) {
 
 		// MSW INACTIVO (dev/stage/prod): des-registrar cualquier
 		// mockServiceWorker.js que haya quedado registrado en una visita
-		// previa. Si no, el SW huerfano intercepta requests y cierra el
-		// canal postMessage -> "Connection closed" + la app se cuelga.
+		// previa. Si no, el SW huerfano intercepta las requests RSC `.txt`
+		// del client navigation de Next y corta el stream -> "Connection
+		// closed" + la app se cuelga en "Verificando sesion". Tras
+		// desregistrar hay que RECARGAR: el SW sigue controlando esta carga
+		// hasta el proximo navigate, asi que sin reload el usuario queda
+		// colgado en la pagina rota. El kill-switch SW del deploy
+		// (scripts/sw-kill-switch.js) cubre el mismo caso desde el server;
+		// este es el cinturon de seguridad del lado cliente.
 		if (!useMsw) {
 			void navigator.serviceWorker?.getRegistrations?.().then((regs) => {
+				let killed = false;
 				for (const reg of regs) {
-					if (reg.active?.scriptURL.includes("mockServiceWorker")) {
+					const url =
+						reg.active?.scriptURL ??
+						reg.waiting?.scriptURL ??
+						reg.installing?.scriptURL ??
+						"";
+					if (url.includes("mockServiceWorker")) {
+						killed = true;
 						void reg.unregister();
 					}
 				}
+				if (killed) window.location.reload();
 			});
 			return;
 		}


### PR DESCRIPTION
## Problema

Al entrar a `https://admin.portfolio.dev.the-full-stack.com/` la app se quedaba colgada en **"Verificando sesion..."** y nunca redirigia a `/login`. En consola:

```
Uncaught (in promise) Error: Connection closed.
    at eo (0bli4iy2fhy4g.js:1:14766)
```

**Causa raiz** (diagnosticada con curl contra dev + inspeccion de los chunks):

1. El admin tuvo MSW (Mock Service Worker) activo en un build previo. Los navegadores que lo visitaron quedaron con `mockServiceWorker.js` **registrado**.
2. Por spec del Service Worker, el browser re-descarga ese script en cada navegacion para chequear updates. El build nuevo lo BORRA (`postbuild: rm -f`), pero **Cloudflare Pages sigue sirviendo el viejo** (persistido de un deploy anterior) -> el SW de MSW sigue vivo.
3. El SW intercepta las requests RSC `.txt` del client navigation de Next 16 (`output: 'export'` pide `/login/index.txt` al navegar) y corta el stream -> `createFromReadableStream` recibe basura -> **"Connection closed"** -> la app se cuelga.
4. El `unregister()` del `MswProvider` corria tarde (post-hidratacion) y nunca llegaba a ejecutarse porque la pagina ya estaba rota.

## Solucion

En lugar de BORRAR el SW (que deja a los navegadores afectados con el viejo en su cache de SW), se publica un **kill-switch SW** en la misma URL `/mockServiceWorker.js`:

1. **`admin/scripts/sw-kill-switch.js`** (nuevo): self-destructing SW. En `activate` hace `self.registration.unregister()` + recarga los clientes (`client.navigate`). Su `fetch` handler es passthrough total (no intercepta nada).
2. **`admin/scripts/postbuild.mjs`** (nuevo): el `postbuild` ya no hace `rm -f`; copia el kill-switch a `out/mockServiceWorker.js`. El browser del usuario afectado lo descarga al chequear el update, se auto-desregistra y recarga -> app limpia. Los navegadores sin SW registrado no descargan nada (sin efecto).
3. **`admin/public/_headers`**: `no-cache` para `/mockServiceWorker.js` (el browser siempre revalida y recibe el kill-switch).
4. **`admin/src/components/msw-provider.tsx`**: cinturon de seguridad del lado cliente — tras desregistrar el SW huerfano, **recarga** la pagina (el SW controla la carga actual hasta el proximo navigate).

## Como probar

1. Build local del admin (genera el kill-switch):
   ```bash
   pnpm --filter @portfolio/admin build
   rg -c "Kill-switch" admin/out/mockServiceWorker.js   # -> 1 (no es MSW)
   ```
2. Tras el merge + deploy a dev, abrir `https://admin.portfolio.dev.the-full-stack.com/` en un navegador que tuviera el bug:
   - El kill-switch se descarga, desregistra el SW huerfano y recarga.
   - La app redirige a `/login` (sin "Connection closed", sin colgarse en "Verificando sesion").
3. Verificacion server-side:
   ```bash
   curl -sS -o /dev/null -w "%{http_code} %{content_type}\n" \
     https://admin.portfolio.dev.the-full-stack.com/mockServiceWorker.js
   # -> 200 application/javascript (sirviendo el kill-switch)
   ```

## Verificacion ejecutada

- `pnpm --filter @portfolio/admin build` OK + postbuild genera el kill-switch.
- `biome check` limpio + `tsc --noEmit` limpio.
- 301 unit tests del admin verdes.
- Pre-push completo verde (lint + typecheck + unit + coverage + build 7 apps + E2E Playwright).

## TODO

- Tras el deploy a dev: Parte C (curl real a la URL canonica + verificacion en navegador afectado). Se hara post-merge.