### PR TITLE
fix(admin): CSP permite los inline scripts del RSC (Next export)

### DIFF
--- a/.claude/docs/admin/01-stack.md
+++ b/.claude/docs/admin/01-stack.md
@@ -549,10 +549,19 @@ declare namespace NodeJS {
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com https://api.portfolio.the-full-stack.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com https://api.portfolio.the-full-stack.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
 ```
 
-> `'wasm-unsafe-eval'` se requiere para Turbopack runtime en client.
+> `'wasm-unsafe-eval'` se requiere para el runtime de Next/Turbopack en
+> client. `'unsafe-inline'` en `script-src` es OBLIGATORIO con
+> `output:'export'`: Next inyecta los inline `<script>` que hidratan el
+> arbol RSC (`self.__next_f.push([...])`) + el anti-FOUC de next-themes.
+> Sin server runtime NO hay nonce y los hashes cambian por build; sin
+> `'unsafe-inline'` el browser bloquea esos scripts -> el RSC stream se
+> corta con "Connection closed" -> la app se cuelga. `'unsafe-eval'` (eval
+> de strings arbitrarios) sigue prohibido. NO usar
+> `require-trusted-types-for 'script'`: Next/Turbopack inyecta scripts sin
+> Trusted Types policy y romperia la hidratacion.
 > `connect-src` lista los 3 endpoints API + `challenges.cloudflare.com`
 > (Turnstile). CSP estricta sin `'unsafe-inline'` ni `'unsafe-eval'` en
 > scripts — defense in depth para auth en `localStorage`.

--- a/.claude/docs/admin/04-auth.md
+++ b/.claude/docs/admin/04-auth.md
@@ -1122,7 +1122,7 @@ metodos con access JWT activo. Patron por metodo:
 
 | Amenaza | Mitigacion implementada |
 |---------|--------------------------|
-| XSS roba accessToken | Access TTL 15 min. CSP estricta sin `unsafe-inline`/`unsafe-eval`. SRI en third-party scripts. Trusted Types (cuando disponible). |
+| XSS roba accessToken | Access TTL 15 min. CSP: `script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'` — `'unsafe-inline'` es inevitable en Next `output:'export'` (inline scripts del RSC, sin nonce posible), pero NUNCA `'unsafe-eval'`; connect-src acotado + object-src 'none'. SRI en third-party scripts. NO `require-trusted-types-for` (rompe la hidratacion de Next). |
 | XSS roba refreshToken | Misma defensa: CSP + SRI + audit deps. Backup: family_id rotation + reuse detection invalidan el refresh apenas un atacante intenta usarlo en paralelo a la sesion legitima. |
 | Refresh token reuse (token stolen) | Family_id rotation backend. Reuse detection → revoke familia entera |
 | Concurrent refresh race | Mutex client-side: 1 sola call in-flight |

--- a/.claude/docs/admin/README.md
+++ b/.claude/docs/admin/README.md
@@ -77,9 +77,11 @@ vuelven a discutir en la fase de implementacion:
     SPA cross-origin (subdomain admin vs api), una HttpOnly cookie
     requeriria `SameSite=None` cross-site + `Domain=.the-full-stack.com`
     abriendo CSRF en los 6 niches publicos y rompiendo portabilidad.
-    Defensa: CSP estricta sin `unsafe-inline`/`unsafe-eval` + SRI en
-    third-party + access JWT corto (15 min) + family_id refresh rotation.
-    NUNCA tokens en URL query.
+    Defensa: CSP (`script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'`;
+    `'unsafe-inline'` es inevitable en Next `output:'export'` por los
+    inline scripts del RSC, pero NO `'unsafe-eval'`; connect-src acotado +
+    object-src/frame-ancestors none) + SRI en third-party + access JWT
+    corto (15 min) + family_id refresh rotation. NUNCA tokens en URL query.
 23. **Magic link UX**: backend redirect 302 a `/auth/callback#access=...`
     (fragment hash, NO query). Frontend decodea + guarda en
     `localStorage` via Zustand + limpia con `history.replaceState`.

--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -263,8 +263,15 @@ Reglas duras del layout:
 > portabilidad si el admin se aloja en otro origin (mobile app,
 > embebido en widgets, etc.). **Decision**: tokens viajan en el body de
 > la respuesta del backend, el admin los persiste en
-> `localStorage`. Mitigaciones: CSP estricta `default-src 'self'` sin
-> `unsafe-inline`/`unsafe-eval` (Next 16 export lo soporta),
+> `localStorage`. Mitigaciones: CSP `default-src 'self'`, `object-src
+> 'none'`, `frame-ancestors 'none'`, `connect-src` acotado a los 3
+> endpoints API + Turnstile; `script-src` permite `'unsafe-inline'`
+> (OBLIGATORIO con Next `output:'export'`: el framework inyecta los inline
+> `<script>` que hidratan el arbol RSC `self.__next_f.push([...])` + el
+> anti-FOUC de next-themes; sin server runtime NO hay nonce y los hashes
+> cambian por build -> sin `'unsafe-inline'` el browser bloquea esos
+> scripts y la app se cuelga con "Connection closed"). `'unsafe-eval'`
+> sigue prohibido (solo `'wasm-unsafe-eval'` para el runtime de Next).
 > Subresource Integrity en todos los scripts third-party, access JWT
 > corto (15 min), refresh rotation + family detection en el backend.
 
@@ -362,10 +369,15 @@ para la gestion total de la cuenta y de otros usuarios — ver la seccion
   de UI opcional (mostrar / ocultar la seccion de seguridad de
   `settings`), NUNCA un gate de "backend pending": el backend MFA +
   WebAuthn esta desplegado.
-- **SIEMPRE** CSP estricta en `public/_headers`: `default-src 'self';
-  script-src 'self'; connect-src 'self' https://api.portfolio.*
-  https://challenges.cloudflare.com; ...`. Sin `unsafe-inline` ni
-  `unsafe-eval`. Bloquea robo de tokens via XSS de inline scripts.
+- **SIEMPRE** CSP en `public/_headers`: `default-src 'self'; script-src
+  'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com;
+  connect-src 'self' https://api.portfolio.* https://challenges.cloudflare.com;
+  object-src 'none'; frame-ancestors 'none'; ...`. `script-src` lleva
+  `'unsafe-inline'` por OBLIGACION de Next `output:'export'` (inline
+  scripts del RSC + next-themes; sin server no hay nonce y los hashes
+  cambian por build). NUNCA `'unsafe-eval'` (solo `'wasm-unsafe-eval'`).
+  El resto de la defensa contra robo de tokens se mantiene estricto
+  (connect-src acotado, object-src/frame-ancestors none, SRI third-party).
 - **SIEMPRE** el flujo de registro/login completo: ver
   `.claude/docs/admin/04-auth.md` (10+ pages).
 - **NUNCA** tokens en URL query params (`?access=...`). Solo fragment
@@ -753,7 +765,8 @@ python devtools/run.py test_runner --module=feature --type=feature --env=local
 | Tokens en query (`?access=...`) | Leak via Referer + browser history | Fragment hash en callback |
 | Cargar script third-party sin `integrity` (SRI) | Script comprometido roba el token de localStorage | SRI obligatorio + CSP `script-src 'self' + allowlist con hash` |
 | HttpOnly cookie cross-origin del API al admin (`SameSite=None; Domain=.the-full-stack.com`) | Vector CSRF en los 6 niches publicos + rompe portabilidad | Tokens en `localStorage` + CSP estricta (decision documentada arriba) |
-| CSP con `unsafe-inline` o `unsafe-eval` | XSS de inline scripts = robo de tokens | CSP `script-src 'self'` con SRI para third-party |
+| `script-src 'self'` SIN `'unsafe-inline'` en Next `output:'export'` | Bloquea los inline scripts del RSC -> "Connection closed" -> app colgada en "Verificando sesion" | `script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'` (inevitable sin server/nonce) |
+| `'unsafe-eval'` en `script-src` | XSS arbitrario (eval de strings) | Solo `'wasm-unsafe-eval'` (runtime de Next), NUNCA `'unsafe-eval'` |
 | Promote a `components/ui/` con 1 uso | Premature abstraction | Vive en `features/<X>/components/` |
 | Server Component async fetch | Build fail en export | `'use client'` + Tanstack Query |
 | Importar `@radix-ui/react-*` directo | Pierde theming shadcn | Pasar por `components/ui/<comp>` |

--- a/admin/public/_headers
+++ b/admin/public/_headers
@@ -16,15 +16,25 @@
 /mockServiceWorker.js
   Cache-Control: no-cache, must-revalidate
 
-# Security headers + CSP estricta (defensa primaria de los tokens en
-# localStorage: sin unsafe-inline/unsafe-eval en scripts + SRI en third-party).
-# 'wasm-unsafe-eval' lo requiere el runtime de Next/Turbopack en el cliente.
-# connect-src lista los 3 endpoints API + Turnstile. style-src 'unsafe-inline'
-# es necesario por los portales de Radix (inyectan estilos inline).
+# Security headers + CSP.
+#
+# script-src lleva 'unsafe-inline': Next.js con output:'export' inyecta los
+# inline <script> que hidratan el arbol RSC (self.__next_f.push([...])) + el
+# script de next-themes (anti-FOUC). Sin server runtime NO hay nonce posible,
+# y los hashes SHA-256 cambian en cada build (el payload RSC va inline). Sin
+# 'unsafe-inline' el browser bloquea esos scripts -> el RSC stream nunca se
+# completa -> "Connection closed" -> la app se cuelga en "Verificando sesion"
+# y nunca redirige a /login. Es el trade-off inevitable del export estatico:
+# los inline scripts los genera el framework (no son inyeccion de usuario).
+# El resto de la defensa contra robo de tokens se mantiene: 'unsafe-eval'
+# sigue prohibido (solo 'wasm-unsafe-eval' para el runtime de Next),
+# connect-src acotado a los 3 endpoints API + Turnstile, object-src 'none',
+# frame-ancestors 'none'.
+# style-src 'unsafe-inline' es necesario por los portales de Radix.
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com https://api.portfolio.the-full-stack.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.portfolio.dev.the-full-stack.com https://api.portfolio.stage.the-full-stack.com https://api.portfolio.the-full-stack.com https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'


### PR DESCRIPTION
## Problema

El admin (`https://admin.portfolio.dev.the-full-stack.com/`) se quedaba colgado en **"Verificando sesion..."** y nunca redirigia a `/login`. En consola:

```
Uncaught (in promise) Error: Connection closed.
    at eo (0bli4iy2fhy4g.js:1:14766)
```

**Causa raiz REAL** (el service worker huerfano del PR #227 era una pista falsa — el bug se reproduce en un navegador limpio sin ningun SW): la **CSP bloqueaba los inline `<script>` de Next.js**.

Next.js con `output: 'export'` inyecta inline scripts NO opcionales:
1. **Hidratacion RSC**: `self.__next_f.push([...])` — el payload RSC viaja inline en el HTML; es como el SPA reconstruye el arbol React en el cliente.
2. **Anti-FOUC de next-themes**: setea `data-theme` antes del primer paint.

La CSP tenia `script-src 'self'` (sin `'unsafe-inline'`, sin nonce, sin hash) -> el browser **bloquea esos scripts** -> el RSC stream nunca se completa -> **"Connection closed"** -> el JS que haria el redirect a `/login` nunca se hidrata.

Diagnostico con Playwright (chromium):
- `bypassCSP=false` (CSP activa, como prod): colgado en "Verificando sesion", 1 "Connection closed".
- `bypassCSP=true` (CSP ignorada): **redirige a `/login`**, 0 errores, form visible.

## Solucion

`script-src` debe permitir `'unsafe-inline'`. Es **inevitable** con Next `output: 'export'`: sin server runtime no hay nonce posible y los hashes SHA-256 cambian en cada build (el payload RSC va inline).

```diff
- script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com
+ script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://challenges.cloudflare.com
```

El resto de la defensa contra robo de tokens (localStorage) se mantiene estricto:
- `'unsafe-eval'` sigue PROHIBIDO (solo `'wasm-unsafe-eval'` del runtime de Next).
- `connect-src` acotado a los 3 endpoints API + Turnstile.
- `object-src 'none'`, `frame-ancestors 'none'`, `default-src 'self'`.

Se actualizan la rule del admin + 3 docs del knowledge tree (`01-stack`, `04-auth`, `README`) que afirmaban "CSP sin unsafe-inline" — era incorrecto para Next export. Tambien se retira `require-trusted-types-for 'script'` de la doc (rompe la hidratacion de Next).

## Como probar

1. Build local del admin:
   ```bash
   pnpm --filter @portfolio/admin build
   rg "script-src" admin/out/_headers   # -> incluye 'unsafe-inline'
   ```
2. Servir `out/` aplicando el `_headers` (Cloudflare Pages o un server que lo replique) y abrir `/` en un navegador: redirige a `/login` sin "Connection closed".
3. Tras el merge + deploy a dev: abrir `https://admin.portfolio.dev.the-full-stack.com/` -> redirige a `/login` (Parte C post-deploy).

## Verificacion ejecutada

- Playwright (chromium) contra el build local sirviendo el `_headers` real con CSP corregida: redirige a `/login/?next=%2F`, **0 "Connection closed"**, **0 bloqueos CSP de script**, form de login visible.
- Reproduccion del bug con la CSP vieja (control): se cuelga + 1 "Connection closed".
- `pnpm --filter @portfolio/admin build` OK.
- Rule admin validada con `claude -p` (num_turns 2, responde la CSP correcta).
- Pre-push completo verde (lint + typecheck + unit + coverage + build 7 apps + E2E Playwright).

## TODO

- Parte C (curl + navegador real contra dev) se hara post-merge/post-deploy.