### PR TITLE
fix(devtools): remove-permission usa el qualifier :live con SnapStart

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -1392,15 +1392,24 @@ def _wire_http_trigger(
     # lo actualizaria (el Sid ya existe -> noop), dejando el GET sin permiso.
     # `_cleanup_legacy_permissions` NO lo cubre (preserva el `keep_sid`).
     # remove-permission es idempotente (noop si no existe).
+    #
+    # CRITICO con SnapStart: el statement vive en el alias `:live` (el
+    # `add-permission` lleva `--qualifier live`). El `remove-permission`
+    # DEBE usar el MISMO qualifier o borraria el statement del $LATEST
+    # (vacio) y dejaria el del alias intacto -> add-permission no lo
+    # sobrescribe (Sid ya existe) -> queda el SourceArn viejo.
+    remove_args = [
+        'lambda',
+        'remove-permission',
+        '--function-name',
+        rendered.function_name,
+        '--statement-id',
+        target_sid,
+    ]
+    if rendered.snap_start:
+        remove_args += ['--qualifier', _SNAP_START_ALIAS]
     aws(
-        [
-            'lambda',
-            'remove-permission',
-            '--function-name',
-            rendered.function_name,
-            '--statement-id',
-            target_sid,
-        ],
+        remove_args,
         profile=profile,
         region=region,
         check=False,

--- a/devtools/tests/unit/src/serverless/provisioner.py
+++ b/devtools/tests/unit/src/serverless/provisioner.py
@@ -488,6 +488,70 @@ class TestProvisionCreate:
         params = intgr_resp[intgr_resp.index('--response-parameters') + 1]
         assert "'GET,POST,OPTIONS'" in params
 
+    def test_provision_create_snap_start_remove_add_use_qualifier(
+        self, monkeypatch
+    ):
+        """Con snap_start, remove-permission Y add-permission van al alias.
+
+        Regresion real (dev): el remove-permission SIN --qualifier borraba
+        el statement del $LATEST (vacio) y dejaba el del alias `live`
+        intacto; add-permission --qualifier live no lo sobrescribia (Sid
+        ya existe) -> quedaba el SourceArn viejo y el GET sin permiso.
+        """
+        from serverless import provisioner
+        from serverless.aws_cli import AwsResult
+        from serverless.state import Action
+
+        calls = []
+        responses = _default_responses()
+
+        def fake(args, **_kwargs):
+            calls.append(args)
+            key = '.'.join(args[:2])
+            # SnapStart: publish-version retorna Version; get-alias falla
+            # (ResourceNotFound) para forzar create-alias.
+            if key == 'lambda.publish-version':
+                return AwsResult(
+                    returncode=0, stdout='', stderr='', json={'Version': '7'}
+                )
+            if key == 'lambda.get-alias':
+                return AwsResult(
+                    returncode=1, stdout='', stderr='not found', json=None
+                )
+            return AwsResult(
+                returncode=0, stdout='', stderr='', json=responses.get(key)
+            )
+
+        monkeypatch.setattr(provisioner, 'aws', fake)
+        monkeypatch.setattr(provisioner.time, 'sleep', lambda _s: None)
+
+        manifest = _manifest_http()
+        manifest['snap_start'] = True
+        rendered = provisioner.render(manifest, stage='dev')
+        provisioner.provision(
+            rendered,
+            action=Action.CREATE,
+            zip_path=_ZIP_PATH,
+            previous=None,
+            profile=None,
+            region='us-east-1',
+        )
+
+        remove_call = next(
+            c for c in calls if c[:2] == ['lambda', 'remove-permission']
+        )
+        add_call = next(
+            c for c in calls if c[:2] == ['lambda', 'add-permission']
+        )
+        # Ambos llevan --qualifier live y el mismo statement-id -live.
+        assert '--qualifier' in remove_call
+        assert remove_call[remove_call.index('--qualifier') + 1] == 'live'
+        assert remove_call[remove_call.index('--statement-id') + 1] == (
+            'apigw-dev-live'
+        )
+        assert '--qualifier' in add_call
+        assert add_call[add_call.index('--qualifier') + 1] == 'live'
+
     def test_provision_create_records_resources(self, monkeypatch):
         from serverless import provisioner
         from serverless.state import Action


### PR DESCRIPTION
## Problema

Encontrado al verificar el deploy REAL del Lambda `auth` (Parte C del PR #229, magic link GET → 302). Tras el deploy de CI, el statement de permiso del Lambda quedó con el SourceArn viejo `POST/auth` en vez del wildcard `*/auth`:

- el método GET se creó en el API Gateway, pero el Lambda **no tenía permiso** para invocarse vía GET.
- POST seguía funcionando (su SourceArn `POST/auth` lo cubría).

**Causa**: el `remove-permission` que agregué (previo al `add-permission`, para recrear el statement con el wildcard) **no pasaba `--qualifier live`**. Con SnapStart, el statement vive en el alias `:live`. El `remove-permission` sin qualifier borraba el statement del `$LATEST` (vacío) y dejaba intacto el del alias; el `add-permission --qualifier live` no lo sobrescribía (Sid ya existe, `check=False` traga el ConflictException) → quedaba el SourceArn viejo.

## Solución

El `remove-permission` lleva el mismo `--qualifier live` que el `add-permission` cuando `snap_start` está activo. Así borra el statement correcto del alias y el `add-permission` lo recrea con el SourceArn wildcard.

## Verificación

- Fix aplicado a mano en dev (remove + add con qualifier live + wildcard) → GET al magic link real devuelve **302** + `Location: admin/callback#access=...`; POST sigue funcionando; link single-use (segundo GET → 400 LINK_CONSUMED).
- Test nuevo: `provision` CREATE con `snap_start` verifica que `remove-permission` Y `add-permission` llevan `--qualifier live` + statement-id `apigw-dev-live`.
- devtools unit: **976 passed**.
- Pre-push completo verde.

> Este es un fix de seguimiento del PR #229 (magic link GET → 302): sin él, el próximo deploy de CI de un Lambda HTTP con SnapStart dejaría el statement con el SourceArn de método específico viejo.