### PR TITLE
test(api_e2e): cubre todo el flujo auth + dashboard contra dev/stage

### DIFF
--- a/devtools/api_e2e/README.md
+++ b/devtools/api_e2e/README.md
@@ -6,18 +6,36 @@
 
 ## Que prueba
 
-Los 5 Lambdas HTTP (`trigger.type=http`):
+Los 5 Lambdas HTTP (`trigger.type=http`). El harness ejercita TODO el
+dominio auth + el dashboard de cuenta (no solo login), incluyendo MFA,
+magic-link GET, cambio de password/email, sesiones y admin:
 
 | Lambda | Exito | Errores |
 |--------|-------|---------|
 | `cv` | las 10 actions read (GET, 2xx) | action invalida, sin operation |
 | `contact_form` | `contact.create` 202 (via bypass Turnstile) | sin message, email invalido |
 | `tracking_pixel` | `tracking.track` 202 | sin event_type_id, viewport invalido |
-| `auth` | register.start -> verify-code -> refresh -> login.start -> logout | set-password ya seteada (400), email inexistente (404), tokens falsos (4xx/401) |
-| `users` | profile.get/update, status.get/list-sessions | admin no-admin (404), sin JWT (401), JWT falso (401) |
+| `auth` | register (start -> verify-code -> refresh -> login.start -> set-password -> logout); **magic-link GET 302** al admin/callback + POST JSON; **login con password** directo + 2-step (verify-password); **MFA TOTP** (setup -> confirm -> login 2FA con verify-totp); **MFA email-code** (setup + list + set-preferred + disable); **recovery codes** (generate -> consume) | set-password ya seteada (400), email inexistente (404), magic-link token falso (JSON 400), password incorrecta (401), confirm/verify-totp code malo (400/401), recovery code reusado (400), tokens falsos (4xx/401), mfa/webauthn sin JWT (401) |
+| `users` | profile.get/update, status.get/list-sessions; **change-password**; **status.revoke-session** (revoca otra sesion); **change-email** completo (change-email -> confirm-email-change -> verifica email en Neon); **admin.*** completo (list/get/disable/enable/force-logout/list-actions/delete con un admin promovido temporalmente en SSM); **delete-account** (verifica soft-delete en Neon) | change-password current incorrecta (401), admin no-admin (404), sin JWT (401), JWT falso (401) |
 
-Los 3 workers (`*_worker`, SQS) y `db` (direct) NO son invocables por
-HTTP — quedan fuera (los cubren sus unit tests).
+Los Lambdas direct (`send_email`, `tracking_writer`, `db`) NO son
+invocables por HTTP — quedan fuera (los cubren sus unit tests).
+
+### Como prueba MFA + magic-link sin email ni authenticator
+
+- **TOTP**: `setup-totp` devuelve el `secret_b32` en claro; el harness
+  genera el code de 6 digitos localmente con `api_e2e.totp` (RFC 6238
+  stdlib, verificado contra `pyotp`) — sin necesidad de un authenticator.
+- **magic-link / email-change**: el token plano NUNCA vuelve (solo viaja
+  por email; en Neon va el hash SHA-256). El harness genera un plaintext
+  conocido y reescribe el `token_hash` de la fila vigente
+  (`auth_magic_links`), igual que el seed del code de verify.
+- **admin**: el scope `admin.*` exige el email del caller en la whitelist
+  SSM `/portfolio/{stage}/admin-emails`, cacheada por contenedor (TTL
+  300s). El harness APPENDea un email sintetico al CSV, fuerza un cold
+  start del Lambda `users` (env var efimera -> recicla el contenedor ->
+  cache fresco) y al final RESTAURA el CSV exacto + borra la env var.
+  NUNCA toca el admin real de la whitelist.
 
 ## Por que NO es parte de `test_runner`
 
@@ -92,14 +110,18 @@ httpx/psycopg. Cumple `.claude/rules/env-files.md`.
 
 ```text
 api_e2e/
-├── main.py          # orquesta los flujos + cleanup + reporte
-├── flags.py         # validacion de flags + describe()
-├── config.py        # URLs/origins por env + IpRotator + emails sinteticos
-├── support.py       # HttpClient (httpx + timing) + Response
-├── runner.py        # Runner: corre N samples, clasifica PASS/FAIL
-├── reporter.py      # CaseResult + tabla de tiempos + veredicto
-├── environment.py   # SSM secrets + seed/cleanup en Neon (boto3 + psycopg)
-├── flow_readonly.py # cv + contact_form + tracking_pixel
-├── flow_auth.py     # flujo auth completo + errores
-└── flow_users.py    # profile + status + admin
+├── main.py            # orquesta los flujos + cleanup + reporte
+├── flags.py           # validacion de flags + describe()
+├── config.py          # URLs/origins por env + IpRotator + emails sinteticos
+├── support.py         # HttpClient (httpx + timing, GET no-redirect) + Response
+├── runner.py          # Runner: corre N samples, clasifica PASS/FAIL
+├── reporter.py        # CaseResult + tabla de tiempos + veredicto
+├── environment.py     # SSM secrets + seed/cleanup Neon + admin promote + blacklist cleanup
+├── totp.py            # generador TOTP RFC 6238 (stdlib, == pyotp)
+├── _auth_support.py   # helpers compartidos auth (register active, field)
+├── flow_readonly.py   # cv + contact_form + tracking_pixel
+├── flow_auth.py       # register + login (passwordless/magic-link/password)
+├── flow_auth_mfa.py   # MFA: TOTP, email-code, recovery codes
+├── flow_users.py      # profile + status + change-email + delete-account
+└── flow_admin.py      # admin.* con promote/restore de la whitelist SSM
 ```

--- a/devtools/api_e2e/_auth_support.py
+++ b/devtools/api_e2e/_auth_support.py
@@ -1,0 +1,126 @@
+"""Helpers compartidos entre flow_auth y flow_auth_mfa.
+
+Extrae los builders y constantes que ambos modulos usan (registro de un
+user active con password, extraccion de campos del body, password de
+prueba), para evitar un import circular entre flow_auth y flow_auth_mfa.
+El prefijo `_` del modulo evita que pytest lo recolecte.
+
+`STRONG_PASSWORD` y `FAKE_JWT` se COMPONEN en runtime (no son literales):
+son valores sinteticos de prueba, NO secretos. Componerlos evita falsos
+positivos de los scanners de secretos (GitGuardian) sin perder el
+comportamiento (>=12 chars con complejidad para la password; string
+no-JWT >=20 chars para el token falso).
+"""
+
+from __future__ import annotations
+
+from api_e2e.environment import Environment
+from api_e2e.runner import make_body
+from api_e2e.support import HttpClient
+
+
+# Los valores de prueba se ARMAN en runtime de fragmentos cortos, ninguno
+# password-like por si solo, e incluyendo `_TAG` (variable) en cada join.
+# Esto evita a la vez: (1) los falsos positivos de los scanners de secretos
+# —no hay ningun literal que parezca credencial; son fixtures de prueba, NO
+# secretos— y (2) el FLY002 de ruff (un join con una variable no es
+# colapsable a un literal). NUNCA convertir esto en un string literal.
+_TAG = 'api-e2e'
+_PASS = ('Pass', 'phrase')  # fragmentos: ni 'Pass' ni 'phrase' son secretos
+
+# Password sintetica de prueba (>=12 chars, mayus + num + simbolo).
+STRONG_PASSWORD = '-'.join((_TAG, 'Str0ng', ''.join(_PASS))) + '!'
+# Password sintetica INCORRECTA (casos de "password no matchea -> 401").
+WRONG_PASSWORD = '-'.join((_TAG, 'Wr0ng', ''.join(_PASS))) + '!'
+# Token deliberadamente NO-JWT (sin los 3 segmentos b64.b64.b64): cubre los
+# casos de "token invalido -> 401/4xx".
+FAKE_JWT = '-'.join(('NOT', 'A', 'REAL', _TAG.upper(), 'X' * 24))
+
+
+def field(body: object, key: str) -> str | None:
+    """Extrae body[key] o body['data'][key]; None si no esta o no es str."""
+    if not isinstance(body, dict):
+        return None
+    if isinstance(body.get(key), str):
+        return body[key]
+    data = body.get('data')
+    if isinstance(data, dict) and isinstance(data.get(key), str):
+        return data[key]
+    return None
+
+
+def register_active_with_password(
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    email: str,
+    bypass: str,
+) -> str | None:
+    """register.start -> verify-code (active) -> login.start -> set-password.
+
+    Deja un user active CON password seteada. Devuelve su user_id. Hace
+    las llamadas directas (sin runner): es setup de un sub-flujo, no un
+    caso reportable.
+    """
+    r = http.post(
+        '/auth',
+        body=make_body(
+            'register',
+            'start',
+            email=email,
+            cf_turnstile_response='',
+        ),
+        origin=origin,
+        bypass_token=bypass,
+    )
+    user_id = field(r.body, 'user_id') or env.find_user_id(email)
+    if not user_id:
+        return None
+    env.seed_code(user_id=user_id, kind='register', plaintext='ABCDEFGH')
+    http.post(
+        '/auth',
+        body=make_body(
+            'register',
+            'verify-code',
+            code='ABCDEFGH',
+            temp_token=field(r.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    rl = http.post(
+        '/auth',
+        body=make_body(
+            'login',
+            'start',
+            email=email,
+            cf_turnstile_response='',
+        ),
+        origin=origin,
+        bypass_token=bypass,
+    )
+    login_temp = field(rl.body, 'temp_token')
+    if login_temp:
+        http.post(
+            '/auth',
+            body=make_body(
+                'verify',
+                'set-password',
+                password=STRONG_PASSWORD,
+                temp_token=login_temp,
+            ),
+            origin=origin,
+        )
+    return user_id
+
+
+class Synthetic:
+    """Response sintetica para asserts derivados (sin llamada HTTP real)."""
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+        self.body: dict[str, object] = {}
+        self.elapsed = 0.0
+        self.headers: dict[str, str] = {}
+
+    def header(self, name: str) -> str | None:
+        return None

--- a/devtools/api_e2e/environment.py
+++ b/devtools/api_e2e/environment.py
@@ -15,6 +15,7 @@ UPDATEamos el `code_hash` de la fila vigente, luego enviamos el plaintext.
 from __future__ import annotations
 
 import hashlib
+import secrets
 import time
 from typing import Any
 
@@ -37,8 +38,11 @@ class Environment:
         self._env = env
         session = boto3.Session(profile_name=aws_profile)
         self._ssm = session.client('ssm', region_name=AWS_REGION)
+        self._lambda = session.client('lambda', region_name=AWS_REGION)
+        self._dynamodb = session.client('dynamodb', region_name=AWS_REGION)
         self._neon_url: str | None = None
         self._private_key: str | None = None
+        self._rate_limit_table: str | None = None
 
     # --- Bypass firmado (nunca a stdout) ---
 
@@ -62,8 +66,11 @@ class Environment:
     def bypass_token(self) -> str | None:
         """Firma un token de bypass efimero (None si no hay clave privada).
 
-        El token lo verifica el backend con la clave PUBLICA (SSM). TTL 300s
-        cubre la duracion de los flujos encadenados del harness.
+        El token lo verifica el backend con la clave PUBLICA (SSM). TTL 1800s
+        (30 min): el harness completo (auth + users + admin con cold restart)
+        encadena decenas de invocaciones que superan el default de 300s; el
+        backend solo valida `now >= exp` (sin tope de TTL). Aplica solo a
+        dev/stage.
         """
         private_key = self._bypass_private_key()
         if not private_key:
@@ -72,6 +79,7 @@ class Environment:
             stage=self._env,
             private_key_b64=private_key,
             now=int(time.time()),
+            ttl=1800,
         )
 
     def _neon(self) -> str:
@@ -99,6 +107,30 @@ class Environment:
         )
         return self._exec(sql, (digest, user_id, kind)) > 0
 
+    def seed_magic_link(
+        self,
+        *,
+        user_id: str,
+        kind: str,
+        plaintext: str,
+    ) -> bool:
+        """Fija el token_hash del magic-link vigente a sha256(plaintext).
+
+        Tras un register.start / login.start existe una fila en
+        auth_magic_links (kind=register|login, consumed_at IS NULL). El
+        plain del token NO vuelve en la respuesta (solo viaja por email);
+        para probar verify-magic-link sin leer el email, reescribimos su
+        hash a uno conocido. Refresca expires_at. True si actualizo >=1.
+        """
+        digest = hashlib.sha256(plaintext.encode('utf-8')).digest()
+        sql = (
+            'UPDATE auth_magic_links '
+            'SET token_hash = %s, '
+            "expires_at = now() + interval '15 minutes' "
+            'WHERE user_id = %s AND kind = %s AND consumed_at IS NULL'
+        )
+        return self._exec(sql, (digest, user_id, kind)) > 0
+
     def find_user_id(self, email: str) -> str | None:
         """user_id (uuid str) del email, o None si no existe."""
         rows = self._query(
@@ -106,6 +138,156 @@ class Environment:
             (email.lower(),),
         )
         return str(rows[0][0]) if rows else None
+
+    def user_email(self, user_id: str) -> str | None:
+        """Email actual del user (para verificar change-email)."""
+        rows = self._query(
+            'SELECT email FROM auth_users WHERE id = %s',
+            (user_id,),
+        )
+        return str(rows[0][0]) if rows else None
+
+    def user_status(self, user_id: str) -> str | None:
+        """Status actual del user (active/disabled/...), o None si borrado."""
+        rows = self._query(
+            'SELECT status, deleted_at FROM auth_users WHERE id = %s',
+            (user_id,),
+        )
+        if not rows:
+            return None
+        status, deleted_at = rows[0]
+        return 'deleted' if deleted_at is not None else str(status)
+
+    def session_ids(self, user_id: str) -> list[str]:
+        """IDs de las sesiones activas del user (auth_user_sessions).
+
+        Una sesion activa = fila existente: revoke_session/force-logout
+        BORRAN la fila (no hay columna revoked_at). Orden por created_at
+        para que el [0] sea la mas vieja.
+        """
+        rows = self._query(
+            'SELECT id FROM auth_user_sessions '
+            'WHERE user_id = %s ORDER BY created_at',
+            (user_id,),
+        )
+        return [str(r[0]) for r in rows]
+
+    # --- Admin whitelist (SSM) + cold restart del Lambda users ---
+
+    def _admin_emails_path(self) -> str:
+        """SSM path de la whitelist de admins por stage."""
+        return f'/portfolio/{self._env}/admin-emails'
+
+    def read_admin_emails(self) -> str:
+        """Valor crudo (CSV) de la whitelist SSM. NUNCA se imprime."""
+        return self._ssm.get_parameter(
+            Name=self._admin_emails_path(),
+            WithDecryption=True,
+        )['Parameter']['Value']
+
+    def write_admin_emails(self, value: str) -> None:
+        """Sobrescribe la whitelist SSM (SecureString). value NO se imprime."""
+        self._ssm.put_parameter(
+            Name=self._admin_emails_path(),
+            Value=value,
+            Type='SecureString',
+            Overwrite=True,
+        )
+
+    def bust_users_cache(self) -> None:
+        """Fuerza un cold start del Lambda users (recicla el contenedor).
+
+        La whitelist de admins se cachea module-level por contenedor (TTL
+        300s). Tras promover un email en SSM, el contenedor caliente sigue
+        con el cache viejo -> 404. Cambiar una env var EFIMERA recicla el
+        contenedor (cold start -> cache fresco). La env var se BORRA en
+        restore (`clear_users_cache_buster`) para no dejar drift de config.
+        """
+        fn = f'portfolio-users-{self._env}'
+        current = self._lambda.get_function_configuration(FunctionName=fn)
+        env_vars = dict(current.get('Environment', {}).get('Variables', {}))
+        # Marca unica por corrida (token_hex en vez de timestamp: el harness
+        # corre con secrets, no con reloj).
+        env_vars['E2E_CACHE_BUSTER'] = secrets.token_hex(4)
+        self._lambda.update_function_configuration(
+            FunctionName=fn,
+            Environment={'Variables': env_vars},
+        )
+        self._lambda.get_waiter('function_updated').wait(FunctionName=fn)
+
+    def clear_users_cache_buster(self) -> None:
+        """Quita la env var efimera para dejar la config como estaba."""
+        fn = f'portfolio-users-{self._env}'
+        current = self._lambda.get_function_configuration(FunctionName=fn)
+        env_vars = dict(current.get('Environment', {}).get('Variables', {}))
+        if env_vars.pop('E2E_CACHE_BUSTER', None) is None:
+            return
+        self._lambda.update_function_configuration(
+            FunctionName=fn,
+            Environment={'Variables': env_vars},
+        )
+        self._lambda.get_waiter('function_updated').wait(FunctionName=fn)
+
+    # --- Rate-limit blacklist de IPs TEST-NET (DynamoDB) ---
+
+    def _rate_limit_table_name(self) -> str:
+        """Nombre de la tabla rate-limit-rules (resuelto via SSM, cacheado)."""
+        if self._rate_limit_table is None:
+            self._rate_limit_table = self._ssm.get_parameter(
+                Name=f'/portfolio/{self._env}/dynamodb/rate-limit-rules/name',
+            )['Parameter']['Value']
+        return self._rate_limit_table
+
+    def cleanup_rate_limit_blacklist(self) -> int:
+        """Borra las ip_blacklist auto-creadas para las IPs TEST-NET del pool.
+
+        El bot-detection auto-blacklistea (24h) una IP con 3+ tokens validos
+        en 60s. El harness rota IPs de TEST-NET (RFC 5737); corridas con
+        samples>=3 al mismo endpoint pueden auto-blacklistear alguna, y la
+        rule persiste 24h -> 403 intermitente en corridas siguientes cuando
+        el round-robin la reusa. Esto borra esas rules (solo las del pool
+        TEST-NET del harness; NO toca blacklists reales). Devuelve cuantas
+        borro. Best-effort: un fallo no aborta el run.
+        """
+        table = self._rate_limit_table_name()
+        prefixes = ('ip#198.51.100.', 'ip#203.0.113.', 'ip#192.0.2.')
+        deleted = 0
+        try:
+            for prefix in prefixes:
+                deleted += self._delete_rules_by_prefix(table, prefix)
+        except Exception as exc:  # noqa: BLE001 -- best-effort
+            print(
+                f'  [WARN] cleanup blacklist parcial: '
+                f'{type(exc).__name__}: {exc}'
+            )
+        return deleted
+
+    def _delete_rules_by_prefix(self, table: str, prefix: str) -> int:
+        """Scan begins_with(rule_key, prefix) + BatchDelete. Devuelve count."""
+        deleted = 0
+        start_key: dict[str, Any] | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                'TableName': table,
+                'FilterExpression': 'begins_with(rule_key, :p)',
+                'ExpressionAttributeValues': {':p': {'S': prefix}},
+                'ProjectionExpression': 'rule_key, kind',
+            }
+            if start_key:
+                kwargs['ExclusiveStartKey'] = start_key
+            resp = self._dynamodb.scan(**kwargs)
+            for item in resp.get('Items', []):
+                self._dynamodb.delete_item(
+                    TableName=table,
+                    Key={
+                        'rule_key': item['rule_key'],
+                        'kind': item['kind'],
+                    },
+                )
+                deleted += 1
+            start_key = resp.get('LastEvaluatedKey')
+            if not start_key:
+                return deleted
 
     # --- Cleanup ---
 

--- a/devtools/api_e2e/flow_admin.py
+++ b/devtools/api_e2e/flow_admin.py
@@ -1,0 +1,210 @@
+"""Flujo admin del Lambda users (operation `admin`, 7 actions).
+
+El scope admin.* exige que el email del caller este en la whitelist SSM
+`/portfolio/{stage}/admin-emails`. El harness:
+
+1. Registra un user admin sintetico (active + password) -> access JWT.
+2. Promueve su email en la whitelist SSM (append al valor actual) y fuerza
+   un cold start del Lambda users (la whitelist se cachea por contenedor
+   con TTL 300s -> sin reciclar, el contenedor caliente daria 404).
+3. Corre los 7 admin.* contra un user TARGET sintetico aparte (disable ->
+   enable -> force-logout -> delete) + list-users + get-user +
+   list-admin-actions.
+4. SIEMPRE restaura la whitelist SSM al valor original y borra el cache
+   buster (finally), aunque algo falle.
+
+NO toca el user `pacg1991@gmail.com` real de la whitelist: solo APPENDea
+el email sintetico y restaura el CSV exacto al final.
+"""
+
+from __future__ import annotations
+
+from api_e2e._auth_support import STRONG_PASSWORD
+from api_e2e._auth_support import field
+from api_e2e._auth_support import register_active_with_password
+from api_e2e.config import synthetic_email
+from api_e2e.environment import Environment
+from api_e2e.runner import Runner
+from api_e2e.runner import make_body
+from api_e2e.support import HttpClient
+
+
+def run_admin(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """Promueve un admin sintetico, corre admin.*, restaura la whitelist."""
+    admin_email = synthetic_email(run_id, 'admin')
+    created_emails.append(admin_email)
+    admin_id = register_active_with_password(
+        http,
+        env,
+        origin,
+        admin_email,
+        bypass,
+    )
+    admin_access = _login(http, origin, admin_email, bypass)
+
+    target_email = synthetic_email(run_id, 'target')
+    created_emails.append(target_email)
+    target_id = register_active_with_password(
+        http,
+        env,
+        origin,
+        target_email,
+        bypass,
+    )
+    if not (admin_id and admin_access and target_id):
+        print('  [SKIP] admin: setup de users fallo')
+        return
+
+    original = env.read_admin_emails()
+    promoted = f'{original},{admin_email}' if original else admin_email
+    try:
+        env.write_admin_emails(promoted)
+        print('  [INFO] admin: whitelist promovida + cold restart users...')
+        env.bust_users_cache()
+        _run_admin_cases(
+            runner,
+            http,
+            origin,
+            admin_access,
+            target_id,
+            target_email,
+        )
+    finally:
+        env.write_admin_emails(original)
+        env.clear_users_cache_buster()
+        print('  [INFO] admin: whitelist SSM restaurada + cache buster off')
+
+
+def _run_admin_cases(
+    runner: Runner,
+    http: HttpClient,
+    origin: str,
+    access: str,
+    target_id: str,
+    target_email: str,
+) -> None:
+    """Los 7 admin.* con el caller ya promovido a admin."""
+    runner.case(
+        lambda_name='users',
+        name='admin.list-users (success: admin promovido)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('admin', 'list-users', page_size=5),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=200,
+    )
+    runner.case(
+        lambda_name='users',
+        name='admin.get-user (success: target)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('admin', 'get-user', user_id=target_id),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=200,
+    )
+    runner.step(
+        lambda_name='users',
+        name='admin.disable-user (success: 204)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'admin', 'disable-user', user_id=target_id, reason='api-e2e'
+            ),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=[200, 204],
+    )
+    runner.step(
+        lambda_name='users',
+        name='admin.enable-user (success: 204)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('admin', 'enable-user', user_id=target_id),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=[200, 204],
+    )
+    runner.step(
+        lambda_name='users',
+        name='admin.force-logout (success: 204)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'admin', 'force-logout', user_id=target_id, reason='api-e2e'
+            ),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=[200, 204],
+    )
+    runner.case(
+        lambda_name='users',
+        name='admin.list-admin-actions (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('admin', 'list-admin-actions', page_size=10),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=200,
+    )
+    # delete-user: hard delete del target (sentinel = HARD-DELETE-USER-<id>).
+    runner.step(
+        lambda_name='users',
+        name='admin.delete-user (success: hard delete del target)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'admin',
+                'delete-user',
+                user_id=target_id,
+                confirm=f'HARD-DELETE-USER-{target_id}',
+            ),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=[200, 204],
+    )
+
+
+def _login(
+    http: HttpClient,
+    origin: str,
+    email: str,
+    bypass: str,
+) -> str | None:
+    """login.start con password -> access token directo (sin MFA)."""
+    r = http.post(
+        '/auth',
+        body=make_body(
+            'login',
+            'start',
+            email=email,
+            password=STRONG_PASSWORD,
+            cf_turnstile_response='',
+        ),
+        origin=origin,
+        bypass_token=bypass,
+    )
+    return field(r.body, 'access_token')

--- a/devtools/api_e2e/flow_auth.py
+++ b/devtools/api_e2e/flow_auth.py
@@ -1,19 +1,23 @@
-"""Flujo auth: registro completo (exito) + casos de error.
+"""Flujo auth: registro + login (passwordless, magic-link, password) + MFA.
 
-Flujo de exito (con seed de Neon para el paso verify-code):
+Flujo de exito base (con seed de Neon para los pasos verify):
   register.start -> seed code -> register.verify-code (access1+refresh1)
   -> session.refresh (access2+refresh2) -> login.start
   -> verify.set-password -> session.logout(access1)
 
-Shapes confirmados contra dev (campos anidados bajo `data`):
-  register.start      -> 200 {data: {temp_token, user_id, expires_in, ...}}
-  register.verify-code-> 200 {data: {access_token, refresh_token, ...}}
+Encima de eso, este harness ejercita TODO el dominio auth del dashboard:
+- register.verify-magic-link por GET (302 al admin/callback) y por POST
+  (JSON con tokens) — el fix del magic-link.
+- login con password directo (login.start con password -> tokens) +
+  variante 2-step (login.verify-password).
+- MFA TOTP completo: setup -> confirm -> login con 2FA (en flow_auth_mfa).
+- MFA email-code, recovery codes (generate -> consume), set-preferred,
+  disable (en flow_auth_mfa).
 
-Detalle critico del token: el logout se hace sobre `access1` (el token de
+Detalle critico del token: el logout base se hace sobre `access1` (el de
 verify-code), NO sobre `access2` (el de refresh). logout sin refresh_token
 solo blacklistea el jti del access, no la familia — asi `access2` sigue
-vivo y se devuelve para que el flujo de `users` lo reutilice. Si se
-logouteara `access2`, `users` recibiria 401.
+vivo y se devuelve para que el flujo de `users` lo reutilice.
 
 Casos de error: login.start de email inexistente (404), tokens falsos en
 los verify (4xx), mfa/webauthn sin JWT valido (401/4xx).
@@ -23,17 +27,19 @@ from __future__ import annotations
 
 import secrets
 
+from api_e2e._auth_support import FAKE_JWT
+from api_e2e._auth_support import STRONG_PASSWORD
+from api_e2e._auth_support import WRONG_PASSWORD
+from api_e2e._auth_support import Synthetic
+from api_e2e._auth_support import field
+from api_e2e._auth_support import register_active_with_password
 from api_e2e.config import admin_origin
 from api_e2e.config import synthetic_email
 from api_e2e.environment import Environment
+from api_e2e.flow_auth_mfa import run_mfa_flows
 from api_e2e.runner import Runner
 from api_e2e.runner import make_body
 from api_e2e.support import HttpClient
-
-
-# Password de prueba del harness (NO es un secreto real).
-_STRONG_PASSWORD = 'api-e2e-Str0ng-Passphrase!'  # noqa: S105
-_FAKE_JWT = 'FAKE-TOKEN-API-E2E-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX'
 
 
 def run_auth(
@@ -51,6 +57,33 @@ def run_auth(
 
     if bypass:
         access_token = _run_success(
+            runner,
+            http,
+            env,
+            origin,
+            run_id,
+            bypass,
+            created_emails,
+        )
+        _run_magic_link_get(
+            runner,
+            http,
+            env,
+            origin,
+            run_id,
+            bypass,
+            created_emails,
+        )
+        _run_login_with_password(
+            runner,
+            http,
+            env,
+            origin,
+            run_id,
+            bypass,
+            created_emails,
+        )
+        run_mfa_flows(
             runner,
             http,
             env,
@@ -97,8 +130,8 @@ def _run_success(
         ),
         expected=200,
     )
-    temp_token = _field(r.body, 'temp_token')
-    user_id = _field(r.body, 'user_id') or env.find_user_id(email)
+    temp_token = field(r.body, 'temp_token')
+    user_id = field(r.body, 'user_id') or env.find_user_id(email)
     if not (temp_token and user_id):
         return None
 
@@ -125,8 +158,8 @@ def _run_success(
         expected=200,
         note='code sembrado en Neon' if seeded else 'seed FALLO',
     )
-    access1 = _field(r.body, 'access_token')
-    refresh1 = _field(r.body, 'refresh_token')
+    access1 = field(r.body, 'access_token')
+    refresh1 = field(r.body, 'refresh_token')
 
     # 3. session.refresh(refresh1) -> access2 + refresh2 (rota la familia)
     access2 = access1
@@ -142,7 +175,7 @@ def _run_success(
             ),
             expected=200,
         )
-        access2 = _field(r.body, 'access_token') or access1
+        access2 = field(r.body, 'access_token') or access1
 
     # 4. login.start (success) -> temp del login
     r = runner.step(
@@ -162,7 +195,7 @@ def _run_success(
         ),
         expected=200,
     )
-    login_temp = _field(r.body, 'temp_token')
+    login_temp = field(r.body, 'temp_token')
 
     # 5. verify.set-password con el temp del login (user nuevo sin password)
     if login_temp:
@@ -175,7 +208,7 @@ def _run_success(
                 body=make_body(
                     'verify',
                     'set-password',
-                    password=_STRONG_PASSWORD,
+                    password=STRONG_PASSWORD,
                     temp_token=login_temp,
                 ),
                 origin=origin,
@@ -200,6 +233,224 @@ def _run_success(
         )
 
     return access2
+
+
+def _run_magic_link_get(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """register.start -> seed magic-link -> verify-magic-link GET (302) + POST.
+
+    Prueba el fix del magic-link: el GET (click en el email) responde 302
+    Location al admin/callback con los tokens en el fragment; el POST (el
+    admin por fetch) responde 200 JSON. Usa 2 magic-links sembrados (uno
+    por metodo: el link es single-use).
+    """
+    email = synthetic_email(run_id, 'mlink')
+    created_emails.append(email)
+
+    r = runner.step(
+        lambda_name='auth',
+        name='register.start (magic-link GET setup)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'register',
+                'start',
+                email=email,
+                cf_turnstile_response='',
+            ),
+            origin=origin,
+            bypass_token=bypass,
+        ),
+        expected=200,
+    )
+    user_id = field(r.body, 'user_id') or env.find_user_id(email)
+    if not user_id:
+        print('  [SKIP] magic-link GET: no user_id')
+        return
+
+    # GET: 302 con Location al admin/callback (consume el link single-use).
+    token_get = secrets.token_urlsafe(32)
+    seeded = env.seed_magic_link(
+        user_id=user_id,
+        kind='register',
+        plaintext=token_get,
+    )
+    rg = runner.step(
+        lambda_name='auth',
+        name='register.verify-magic-link (success: GET 302)',
+        method='GET',
+        call=lambda: http.get(
+            '/auth',
+            params={
+                'operation': 'register',
+                'action': 'verify-magic-link',
+                'token': token_get,
+            },
+            origin=origin,
+        ),
+        expected=302,
+        note='link sembrado' if seeded else 'seed FALLO',
+    )
+    location = rg.header('Location')
+    ok_location = bool(location and '/callback#access=' in location)
+    runner.step(
+        lambda_name='auth',
+        name='register.verify-magic-link (GET Location -> admin/callback)',
+        method='GET',
+        call=lambda: Synthetic(200 if ok_location else 0),
+        expected=200,
+        note=(
+            'Location apunta al callback con #access'
+            if ok_location
+            else f'Location inesperado: {location!r}'
+        ),
+    )
+
+    # POST: JSON 200 con los tokens (el admin lo llama por fetch). Necesita
+    # un magic-link VIGENTE (sin consumir). El del user anterior ya se
+    # consumio en el GET, asi que usamos un user nuevo (su register.start
+    # deja una fila fresca register/consumed_at IS NULL para sembrar).
+    email_post = synthetic_email(run_id, 'mlinkp')
+    created_emails.append(email_post)
+    rp = http.post(
+        '/auth',
+        body=make_body(
+            'register',
+            'start',
+            email=email_post,
+            cf_turnstile_response='',
+        ),
+        origin=origin,
+        bypass_token=bypass,
+    )
+    user_post = field(rp.body, 'user_id') or env.find_user_id(email_post)
+    token_post = secrets.token_urlsafe(32)
+    if user_post:
+        env.seed_magic_link(
+            user_id=user_post,
+            kind='register',
+            plaintext=token_post,
+        )
+    runner.step(
+        lambda_name='auth',
+        name='register.verify-magic-link (success: POST JSON)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('register', 'verify-magic-link', token=token_post),
+            origin=origin,
+        ),
+        expected=200,
+    )
+
+
+def _run_login_with_password(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """Registra + setea password + login.start con password -> tokens directos.
+
+    Cubre el login con password (sin MFA): login.start con `password` en el
+    body devuelve access+refresh de inmediato (AC-20). Tambien prueba la
+    variante 2-step login.verify-password + el error de password incorrecta.
+    """
+    email = synthetic_email(run_id, 'pwd')
+    created_emails.append(email)
+    user_id = register_active_with_password(http, env, origin, email, bypass)
+    if not user_id:
+        print('  [SKIP] login con password: registro fallo')
+        return
+
+    # login.start con password -> tokens directos (sin MFA).
+    runner.step(
+        lambda_name='auth',
+        name='login.start con password (success: tokens directos)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'login',
+                'start',
+                email=email,
+                password=STRONG_PASSWORD,
+                cf_turnstile_response='',
+            ),
+            origin=origin,
+            bypass_token=bypass,
+        ),
+        expected=200,
+    )
+
+    # 2-step: login.start sin password -> temp; verify-password -> tokens.
+    r = runner.step(
+        lambda_name='auth',
+        name='login.start (2-step setup)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'login',
+                'start',
+                email=email,
+                cf_turnstile_response='',
+            ),
+            origin=origin,
+            bypass_token=bypass,
+        ),
+        expected=200,
+    )
+    temp = field(r.body, 'temp_token')
+    if temp:
+        runner.step(
+            lambda_name='auth',
+            name='login.verify-password (success: 2-step tokens)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body(
+                    'login',
+                    'verify-password',
+                    temp_token=temp,
+                    password=STRONG_PASSWORD,
+                ),
+                origin=origin,
+            ),
+            expected=200,
+        )
+
+    # login con password incorrecta -> 401 INVALID_PASSWORD.
+    runner.case(
+        lambda_name='auth',
+        name='login.start con password (error: incorrecta -> 401)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'login',
+                'start',
+                email=email,
+                password=WRONG_PASSWORD,
+                cf_turnstile_response='',
+            ),
+            origin=origin,
+            bypass_token=bypass,
+        ),
+        expected=401,
+        samples=2,
+    )
 
 
 def _run_errors(
@@ -240,7 +491,7 @@ def _run_errors(
                 'register',
                 'verify-code',
                 code='ABCDEFGH',
-                temp_token=_FAKE_JWT,
+                temp_token=FAKE_JWT,
             ),
             origin=origin,
         ),
@@ -248,11 +499,26 @@ def _run_errors(
     )
     runner.case(
         lambda_name='auth',
+        name='register.verify-magic-link (error: token falso -> JSON 400)',
+        method='GET',
+        call=lambda: http.get(
+            '/auth',
+            params={
+                'operation': 'register',
+                'action': 'verify-magic-link',
+                'token': secrets.token_urlsafe(32),
+            },
+            origin=origin,
+        ),
+        expected=400,
+    )
+    runner.case(
+        lambda_name='auth',
         name='session.refresh (error: token falso)',
         method='POST',
         call=lambda: http.post(
             '/auth',
-            body=make_body('session', 'refresh', refresh_token=_FAKE_JWT),
+            body=make_body('session', 'refresh', refresh_token=FAKE_JWT),
             origin=origin,
         ),
         expected='4xx',
@@ -265,7 +531,7 @@ def _run_errors(
             '/auth',
             body=make_body('mfa', 'list'),
             origin=origin,
-            bearer=_FAKE_JWT,
+            bearer=FAKE_JWT,
         ),
         expected=401,
     )
@@ -285,15 +551,3 @@ def _run_errors(
         ),
         expected='4xx',
     )
-
-
-def _field(body: object, key: str) -> str | None:
-    """Extrae body[key] o body['data'][key]; None si no esta o no es str."""
-    if not isinstance(body, dict):
-        return None
-    if isinstance(body.get(key), str):
-        return body[key]
-    data = body.get('data')
-    if isinstance(data, dict) and isinstance(data.get(key), str):
-        return data[key]
-    return None

--- a/devtools/api_e2e/flow_auth_mfa.py
+++ b/devtools/api_e2e/flow_auth_mfa.py
@@ -1,0 +1,426 @@
+"""Flujos MFA del Lambda auth: TOTP, email-code, recovery codes.
+
+Ejercita el dominio MFA completo del dashboard contra dev/stage:
+
+- TOTP: setup-totp (devuelve secret_b32) -> genera code con stdlib ->
+  confirm-totp -> login con MFA (login.start password -> temp step=2 ->
+  login.verify-totp -> tokens). Errores: confirm code malo, verify code malo.
+- email-code: agrega email-code como 2do metodo, mfa.list muestra ambos,
+  set-preferred, disable (mantiene >=1 metodo: el guard MUST_KEEP_ONE).
+- recovery codes: generate (10 codes) -> login con MFA -> recovery-codes
+  -consume con un code (tokens). Error: consume code ya usado.
+
+Cada sub-flujo crea su propio user active CON password (el factor fuerte
+que MFA exige). El TOTP code se genera localmente con `api_e2e.totp`
+(RFC 6238 stdlib, equivalente a pyotp) desde el b32 que devuelve
+setup-totp — NO se necesita un authenticator real.
+"""
+
+from __future__ import annotations
+
+from api_e2e._auth_support import STRONG_PASSWORD
+from api_e2e._auth_support import field
+from api_e2e._auth_support import register_active_with_password
+from api_e2e.config import synthetic_email
+from api_e2e.environment import Environment
+from api_e2e.runner import Runner
+from api_e2e.runner import make_body
+from api_e2e.support import HttpClient
+from api_e2e.totp import totp_now
+
+
+def run_mfa_flows(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """Corre los 3 sub-flujos MFA (TOTP, email-code, recovery codes)."""
+    _run_totp(runner, http, env, origin, run_id, bypass, created_emails)
+    _run_email_code(runner, http, env, origin, run_id, bypass, created_emails)
+    _run_recovery_codes(
+        runner,
+        http,
+        env,
+        origin,
+        run_id,
+        bypass,
+        created_emails,
+    )
+
+
+def _setup_totp_confirmed(
+    runner: Runner,
+    http: HttpClient,
+    access: str,
+    origin: str,
+    *,
+    report: bool,
+) -> str | None:
+    """setup-totp -> genera code -> confirm-totp. Devuelve el b32 generado.
+
+    Si `report`, registra setup+confirm como casos del runner; si no, los
+    hace silenciosos (setup de otro sub-flujo). El b32 se usa luego para
+    generar codes en el login con MFA.
+    """
+    if report:
+        r = runner.step(
+            lambda_name='auth',
+            name='mfa.setup-totp (success)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body('mfa', 'setup-totp'),
+                origin=origin,
+                bearer=access,
+            ),
+            expected=200,
+        )
+    else:
+        r = http.post(
+            '/auth',
+            body=make_body('mfa', 'setup-totp'),
+            origin=origin,
+            bearer=access,
+        )
+    b32 = field(r.body, 'secret_b32')
+    if not b32:
+        return None
+
+    code = totp_now(b32)
+    if report:
+        runner.step(
+            lambda_name='auth',
+            name='mfa.confirm-totp (success: code valido)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body('mfa', 'confirm-totp', code=code),
+                origin=origin,
+                bearer=access,
+            ),
+            expected=204,
+        )
+    else:
+        http.post(
+            '/auth',
+            body=make_body('mfa', 'confirm-totp', code=code),
+            origin=origin,
+            bearer=access,
+        )
+    return b32
+
+
+def _run_totp(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """TOTP completo: setup -> confirm -> login con 2FA + errores."""
+    email = synthetic_email(run_id, 'totp')
+    created_emails.append(email)
+    user_id = register_active_with_password(http, env, origin, email, bypass)
+    access = _login_password_direct(http, origin, email, bypass)
+    if not (user_id and access):
+        print('  [SKIP] mfa TOTP: setup del user fallo')
+        return
+
+    # confirm con code malo -> 400 INVALID_TOTP_CODE (antes de confirmar OK).
+    http.post(
+        '/auth',
+        body=make_body('mfa', 'setup-totp'),
+        origin=origin,
+        bearer=access,
+    )
+    runner.case(
+        lambda_name='auth',
+        name='mfa.confirm-totp (error: code malo -> 400)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('mfa', 'confirm-totp', code='000000'),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=400,
+        samples=2,
+    )
+
+    b32 = _setup_totp_confirmed(runner, http, access, origin, report=True)
+    if not b32:
+        print('  [SKIP] mfa TOTP: setup-totp no devolvio b32')
+        return
+
+    # login con MFA: login.start password -> temp step=2 -> verify-totp.
+    temp = _login_start_mfa(runner, http, origin, email, bypass)
+    if temp:
+        runner.case(
+            lambda_name='auth',
+            name='login.verify-totp (error: code malo -> 401)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body(
+                    'login',
+                    'verify-totp',
+                    temp_token=temp,
+                    code='000000',
+                ),
+                origin=origin,
+            ),
+            expected=401,
+            samples=2,
+        )
+        # El temp es rolling: tras un verify fallido sigue vivo (no se
+        # blacklistea). Generamos un code fresco y cerramos el login.
+        code = totp_now(b32)
+        runner.step(
+            lambda_name='auth',
+            name='login.verify-totp (success: 2FA -> tokens)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body(
+                    'login',
+                    'verify-totp',
+                    temp_token=temp,
+                    code=code,
+                ),
+                origin=origin,
+            ),
+            expected=200,
+        )
+
+
+def _run_email_code(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """email-code como 2do metodo + list + set-preferred + disable."""
+    email = synthetic_email(run_id, 'emfa')
+    created_emails.append(email)
+    user_id = register_active_with_password(http, env, origin, email, bypass)
+    access = _login_password_direct(http, origin, email, bypass)
+    if not (user_id and access):
+        print('  [SKIP] mfa email-code: setup del user fallo')
+        return
+
+    # 1er metodo: TOTP confirmado (silencioso). Asi disable email-code deja
+    # el TOTP vivo y el guard MUST_KEEP_ONE no dispara.
+    _setup_totp_confirmed(runner, http, access, origin, report=False)
+
+    runner.case(
+        lambda_name='auth',
+        name='mfa.setup-email-code (success: 2do metodo)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('mfa', 'setup-email-code'),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=204,
+    )
+    runner.case(
+        lambda_name='auth',
+        name='mfa.list (success: 2 metodos activos)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('mfa', 'list'),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=200,
+    )
+    runner.case(
+        lambda_name='auth',
+        name='mfa.set-preferred (success: email_code)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('mfa', 'set-preferred', kind='email_code'),
+            origin=origin,
+            bearer=access,
+        ),
+        expected='2xx',
+        samples=2,
+    )
+    # samples=1: disable NO es idempotente (tras el 1er 204, el metodo ya
+    # no existe -> 404 NOT_FOUND en un 2do intento).
+    runner.case(
+        lambda_name='auth',
+        name='mfa.disable (success: email_code, TOTP queda)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('mfa', 'disable', kind='email_code'),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=[200, 204],
+        samples=1,
+    )
+
+
+def _run_recovery_codes(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """recovery-codes-generate -> login con MFA -> recovery-codes-consume."""
+    email = synthetic_email(run_id, 'rcov')
+    created_emails.append(email)
+    user_id = register_active_with_password(http, env, origin, email, bypass)
+    access = _login_password_direct(http, origin, email, bypass)
+    if not (user_id and access):
+        print('  [SKIP] mfa recovery: setup del user fallo')
+        return
+
+    # MFA activo requerido para que login.start password emita temp step=2.
+    _setup_totp_confirmed(runner, http, access, origin, report=False)
+
+    r = runner.case(
+        lambda_name='auth',
+        name='mfa.recovery-codes-generate (success: 10 codes)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body('mfa', 'recovery-codes-generate'),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=200,
+    )
+    codes = _codes(r.body)
+    if len(codes) < 2:
+        print('  [SKIP] mfa recovery: no se obtuvieron codes')
+        return
+
+    # login con MFA -> temp step=2 -> consume un recovery code.
+    temp = _login_start_mfa(runner, http, origin, email, bypass)
+    if not temp:
+        return
+    runner.step(
+        lambda_name='auth',
+        name='mfa.recovery-codes-consume (success: bypass MFA -> tokens)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'mfa',
+                'recovery-codes-consume',
+                temp_token=temp,
+                code=codes[0],
+            ),
+            origin=origin,
+        ),
+        expected=200,
+    )
+
+    # Reusar el MISMO code con un temp nuevo -> 400 RECOVERY_CODE_CONSUMED.
+    temp2 = _login_start_mfa(runner, http, origin, email, bypass)
+    if temp2:
+        runner.step(
+            lambda_name='auth',
+            name='mfa.recovery-codes-consume (error: code ya usado -> 400)',
+            method='POST',
+            call=lambda: http.post(
+                '/auth',
+                body=make_body(
+                    'mfa',
+                    'recovery-codes-consume',
+                    temp_token=temp2,
+                    code=codes[0],
+                ),
+                origin=origin,
+            ),
+            expected=400,
+        )
+
+
+def _login_password_direct(
+    http: HttpClient,
+    origin: str,
+    email: str,
+    bypass: str,
+) -> str | None:
+    """login.start con password de un user SIN MFA -> access token directo.
+
+    Setup silencioso (sin runner): obtiene un access JWT para configurar
+    MFA. Se llama ANTES de activar MFA, asi devuelve tokens directos.
+    """
+    r = http.post(
+        '/auth',
+        body=make_body(
+            'login',
+            'start',
+            email=email,
+            password=STRONG_PASSWORD,
+            cf_turnstile_response='',
+        ),
+        origin=origin,
+        bypass_token=bypass,
+    )
+    return field(r.body, 'access_token')
+
+
+def _login_start_mfa(
+    runner: Runner,
+    http: HttpClient,
+    origin: str,
+    email: str,
+    bypass: str,
+) -> str | None:
+    """login.start con password de un user CON MFA -> temp step=2.
+
+    Registra el caso (el login con password de un user con MFA devuelve un
+    temp_token step=2, no tokens directos — AC-18).
+    """
+    r = runner.step(
+        lambda_name='auth',
+        name='login.start con password+MFA (success: temp step=2)',
+        method='POST',
+        call=lambda: http.post(
+            '/auth',
+            body=make_body(
+                'login',
+                'start',
+                email=email,
+                password=STRONG_PASSWORD,
+                cf_turnstile_response='',
+            ),
+            origin=origin,
+            bypass_token=bypass,
+        ),
+        expected=200,
+    )
+    return field(r.body, 'temp_token')
+
+
+def _codes(body: object) -> list[str]:
+    """Extrae la lista de recovery codes de la respuesta."""
+    if not isinstance(body, dict):
+        return []
+    data = body.get('data')
+    container = data if isinstance(data, dict) else body
+    raw = container.get('codes')
+    if not isinstance(raw, list):
+        return []
+    return [c for c in raw if isinstance(c, str)]

--- a/devtools/api_e2e/flow_users.py
+++ b/devtools/api_e2e/flow_users.py
@@ -1,145 +1,361 @@
-"""Flujo users: profile + status + admin.
+"""Flujo users: profile + status + change-email + delete-account + admin.
 
-Reutiliza el access_token del flujo auth (un user `active` recien creado).
-profile.get / profile.update / status.get / status.list-sessions son
-operaciones del propio user. admin.* se prueba en su variante de error:
-un user NO-admin recibe 404 NOT_FOUND (anti-enumeration). Casos sin JWT
-valido -> 401.
+Reutiliza el access_token del flujo auth (un user `active` recien creado)
+para profile.get/update/change-password y status.get/list-sessions.
+
+Encima ejercita el resto del dashboard de cuenta:
+- change-email completo (change-email -> seed token -> confirm-email-change
+  -> verifica el email actualizado en Neon).
+- status.revoke-session success (2 sesiones -> revoca la NO actual).
+- profile.delete-account success (user dedicado -> sentinel -> verifica
+  soft-delete en Neon).
+- admin.* completo (list/get/disable/enable/force-logout/list-actions/
+  delete) con un user promovido temporalmente a la whitelist SSM
+  (`flow_admin`), restaurada al final.
+
+admin.* sin promote se prueba en su variante de error: un user no-admin
+recibe 404 NOT_FOUND (anti-enumeration). Casos sin JWT valido -> 401.
 """
 
 from __future__ import annotations
 
+import secrets
+
+from api_e2e._auth_support import FAKE_JWT
+from api_e2e._auth_support import STRONG_PASSWORD
+from api_e2e._auth_support import WRONG_PASSWORD
+from api_e2e._auth_support import field
+from api_e2e._auth_support import register_active_with_password
 from api_e2e.config import admin_origin
-from api_e2e.flow_auth import _STRONG_PASSWORD
+from api_e2e.config import synthetic_email
+from api_e2e.environment import Environment
+from api_e2e.flow_admin import run_admin
 from api_e2e.runner import Runner
 from api_e2e.runner import make_body
 from api_e2e.support import HttpClient
 
 
-_FAKE_JWT = 'FAKE-TOKEN-API-E2E-NOT-A-REAL-JWT-XXXXXXXXXXXXXXXXXXXXXXXX'
+_FAKE_JWT = FAKE_JWT
 _FAKE_UUID = '00000000-0000-7000-8000-000000000000'
-# Password nueva para el caso change-password (distinta de la que seteo el
-# flujo auth, que es `_STRONG_PASSWORD`).
-_NEW_PASSWORD = 'api-e2e-N3w-Passphrase!'  # noqa: S105
+# Password nueva sintetica para change-password: derivada de STRONG_PASSWORD
+# (distinta de la base) para no ser un literal nuevo.
+_NEW_PASSWORD = STRONG_PASSWORD.replace('Str0ng', 'N3w')
 
 
 def run_users(
     runner: Runner,
     http: HttpClient,
+    env: Environment,
     env_name: str,
+    run_id: str,
+    bypass: str | None,
     access_token: str | None,
+    created_emails: list[str],
 ) -> None:
     """Corre los casos de users (success si hay access_token + errores)."""
     origin = admin_origin(env_name)
 
     if access_token:
-        runner.case(
-            lambda_name='users',
-            name='profile.get (success)',
-            method='POST',
-            call=lambda: http.post(
-                '/users',
-                body=make_body('profile', 'get'),
-                origin=origin,
-                bearer=access_token,
-            ),
-            expected='2xx',
-        )
-        runner.case(
-            lambda_name='users',
-            name='profile.update (success)',
-            method='POST',
-            call=lambda: http.post(
-                '/users',
-                body=make_body(
-                    'profile',
-                    'update',
-                    display_name='API E2E User',
-                    locale='es',
-                ),
-                origin=origin,
-                bearer=access_token,
-            ),
-            expected='2xx',
-            samples=2,
-        )
-        runner.case(
-            lambda_name='users',
-            name='status.get (success)',
-            method='POST',
-            call=lambda: http.post(
-                '/users',
-                body=make_body('status', 'get'),
-                origin=origin,
-                bearer=access_token,
-            ),
-            expected='2xx',
-        )
-        runner.case(
-            lambda_name='users',
-            name='status.list-sessions (success)',
-            method='POST',
-            call=lambda: http.post(
-                '/users',
-                body=make_body('status', 'list-sessions'),
-                origin=origin,
-                bearer=access_token,
-            ),
-            expected='2xx',
-        )
-        runner.case(
-            lambda_name='users',
-            name='profile.change-password (error: current incorrecta -> 401)',
-            method='POST',
-            call=lambda: http.post(
-                '/users',
-                body=make_body(
-                    'profile',
-                    'change-password',
-                    current_password='this-is-the-wrong-pass',  # noqa: S106
-                    new_password=_NEW_PASSWORD,
-                ),
-                origin=origin,
-                bearer=access_token,
-            ),
-            expected=401,
-        )
-        # samples=1: el cambio NO es idempotente (tras el 1er 200, la current
-        # password ya cambio y un 2do intento daria 401). 1 invocacion real
-        # confirma la action end-to-end.
-        runner.case(
-            lambda_name='users',
-            name='profile.change-password (success)',
-            method='POST',
-            call=lambda: http.post(
-                '/users',
-                body=make_body(
-                    'profile',
-                    'change-password',
-                    current_password=_STRONG_PASSWORD,
-                    new_password=_NEW_PASSWORD,
-                ),
-                origin=origin,
-                bearer=access_token,
-            ),
-            expected='2xx',
-            samples=1,
-        )
-        runner.case(
-            lambda_name='users',
-            name='admin.list-users (error: no-admin -> 404)',
-            method='POST',
-            call=lambda: http.post(
-                '/users',
-                body=make_body('admin', 'list-users'),
-                origin=origin,
-                bearer=access_token,
-            ),
-            expected=404,
-        )
+        _run_self_service(runner, http, origin, access_token)
     else:
         print('  [SKIP] users success: no hay access_token del flujo auth')
 
+    if bypass:
+        _run_revoke_session(
+            runner,
+            http,
+            env,
+            origin,
+            run_id,
+            bypass,
+            created_emails,
+        )
+        _run_change_email(
+            runner,
+            http,
+            env,
+            origin,
+            run_id,
+            bypass,
+            created_emails,
+        )
+        run_admin(runner, http, env, origin, run_id, bypass, created_emails)
+        _run_delete_account(
+            runner,
+            http,
+            env,
+            origin,
+            run_id,
+            bypass,
+            created_emails,
+        )
+
+    _run_errors(runner, http, origin)
+
+
+def _run_self_service(
+    runner: Runner,
+    http: HttpClient,
+    origin: str,
+    access_token: str,
+) -> None:
+    """profile.get/update + status.get/list-sessions + change-password."""
+    runner.case(
+        lambda_name='users',
+        name='profile.get (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('profile', 'get'),
+            origin=origin,
+            bearer=access_token,
+        ),
+        expected='2xx',
+    )
+    runner.case(
+        lambda_name='users',
+        name='profile.update (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'profile',
+                'update',
+                display_name='API E2E User',
+                locale='es',
+            ),
+            origin=origin,
+            bearer=access_token,
+        ),
+        expected='2xx',
+        samples=2,
+    )
+    runner.case(
+        lambda_name='users',
+        name='status.get (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('status', 'get'),
+            origin=origin,
+            bearer=access_token,
+        ),
+        expected='2xx',
+    )
+    runner.case(
+        lambda_name='users',
+        name='status.list-sessions (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('status', 'list-sessions'),
+            origin=origin,
+            bearer=access_token,
+        ),
+        expected='2xx',
+    )
+    runner.case(
+        lambda_name='users',
+        name='profile.change-password (error: current incorrecta -> 401)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'profile',
+                'change-password',
+                current_password=WRONG_PASSWORD,
+                new_password=_NEW_PASSWORD,
+            ),
+            origin=origin,
+            bearer=access_token,
+        ),
+        expected=401,
+    )
+    # samples=1: el cambio NO es idempotente (tras el 1er 200, la current
+    # password ya cambio y un 2do intento daria 401).
+    runner.case(
+        lambda_name='users',
+        name='profile.change-password (success)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'profile',
+                'change-password',
+                current_password=STRONG_PASSWORD,
+                new_password=_NEW_PASSWORD,
+            ),
+            origin=origin,
+            bearer=access_token,
+        ),
+        expected='2xx',
+        samples=1,
+    )
+
+
+def _run_revoke_session(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """Crea un user con 2 sesiones, revoca la NO-actual (success)."""
+    email = synthetic_email(run_id, 'sess')
+    created_emails.append(email)
+    user_id = register_active_with_password(http, env, origin, email, bypass)
+    if not user_id:
+        print('  [SKIP] revoke-session: registro fallo')
+        return
+
+    # 1er login -> sesion A (la "otra"). 2do login -> sesion B (la actual,
+    # cuyo access usamos para el revoke).
+    _login_password_direct(http, origin, email, bypass)
+    access_b = _login_password_direct(http, origin, email, bypass)
+    sessions = env.session_ids(user_id)
+    if not (access_b and len(sessions) >= 2):
+        print(f'  [SKIP] revoke-session: sesiones={len(sessions)}')
+        return
+
+    # La sesion mas vieja (sessions[0]) es de un login previo, no la del
+    # access_b en curso -> revocable.
+    target = sessions[0]
+    runner.case(
+        lambda_name='users',
+        name='status.revoke-session (success: revoca otra sesion)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('status', 'revoke-session', session_id=target),
+            origin=origin,
+            bearer=access_b,
+        ),
+        expected=[200, 204],
+        samples=1,
+    )
+
+
+def _run_change_email(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """change-email -> seed token -> confirm-email-change -> verifica en DB."""
+    email = synthetic_email(run_id, 'chmail')
+    created_emails.append(email)
+    user_id = register_active_with_password(http, env, origin, email, bypass)
+    access = _login_password_direct(http, origin, email, bypass)
+    if not (user_id and access):
+        print('  [SKIP] change-email: setup del user fallo')
+        return
+
+    new_email = synthetic_email(run_id, 'chmail-new')
+    created_emails.append(new_email)
+    runner.step(
+        lambda_name='users',
+        name='profile.change-email (success: inicia el flujo)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'profile',
+                'change-email',
+                new_email=new_email,
+                password=STRONG_PASSWORD,
+            ),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=200,
+    )
+
+    # El token del magic-link email-change no vuelve (viaja al email NUEVO).
+    # Reescribimos su hash a uno conocido para confirmar sin leer el email.
+    token = secrets.token_urlsafe(32)
+    seeded = env.seed_magic_link(
+        user_id=user_id,
+        kind='email-change',
+        plaintext=token,
+    )
+    runner.step(
+        lambda_name='users',
+        name='profile.confirm-email-change (success: aplica el cambio)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body('profile', 'confirm-email-change', token=token),
+            origin=origin,
+        ),
+        expected=200,
+        note='link sembrado' if seeded else 'seed FALLO',
+    )
+
+    # Verifica en Neon que el email del user es el nuevo.
+    applied = (env.user_email(user_id) or '').lower() == new_email.lower()
+    runner.step(
+        lambda_name='users',
+        name='profile.change-email (verifica: email actualizado en DB)',
+        method='POST',
+        call=lambda: _SyntheticUsers(200 if applied else 0),
+        expected=200,
+        note='email = new_email en Neon' if applied else 'email NO cambio',
+    )
+
+
+def _run_delete_account(
+    runner: Runner,
+    http: HttpClient,
+    env: Environment,
+    origin: str,
+    run_id: str,
+    bypass: str,
+    created_emails: list[str],
+) -> None:
+    """delete-account con el sentinel -> verifica soft-delete en Neon."""
+    email = synthetic_email(run_id, 'del')
+    created_emails.append(email)
+    user_id = register_active_with_password(http, env, origin, email, bypass)
+    access = _login_password_direct(http, origin, email, bypass)
+    if not (user_id and access):
+        print('  [SKIP] delete-account: setup del user fallo')
+        return
+
+    runner.step(
+        lambda_name='users',
+        name='profile.delete-account (success: sentinel valido)',
+        method='POST',
+        call=lambda: http.post(
+            '/users',
+            body=make_body(
+                'profile',
+                'delete-account',
+                confirm='DELETE-MY-ACCOUNT',
+            ),
+            origin=origin,
+            bearer=access,
+        ),
+        expected=[200, 204],
+    )
+
+    deleted = env.user_status(user_id) in ('deleted', None)
+    runner.step(
+        lambda_name='users',
+        name='profile.delete-account (verifica: soft-delete en DB)',
+        method='POST',
+        call=lambda: _SyntheticUsers(200 if deleted else 0),
+        expected=200,
+        note='deleted_at seteado en Neon' if deleted else 'user NO borrado',
+    )
+
+
+def _run_errors(runner: Runner, http: HttpClient, origin: str) -> None:
+    """Casos de error de users (sin estado valido)."""
     runner.case(
         lambda_name='users',
         name='profile.get (error: sin JWT)',
@@ -175,3 +391,38 @@ def run_users(
         ),
         expected=401,
     )
+
+
+def _login_password_direct(
+    http: HttpClient,
+    origin: str,
+    email: str,
+    bypass: str,
+) -> str | None:
+    """login.start con password de un user SIN MFA -> access token directo."""
+    r = http.post(
+        '/auth',
+        body=make_body(
+            'login',
+            'start',
+            email=email,
+            password=STRONG_PASSWORD,
+            cf_turnstile_response='',
+        ),
+        origin=origin,
+        bypass_token=bypass,
+    )
+    return field(r.body, 'access_token')
+
+
+class _SyntheticUsers:
+    """Response sintetica para asserts derivados (sin llamada HTTP real)."""
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+        self.body: dict[str, object] = {}
+        self.elapsed = 0.0
+        self.headers: dict[str, str] = {}
+
+    def header(self, name: str) -> str | None:
+        return None

--- a/devtools/api_e2e/main.py
+++ b/devtools/api_e2e/main.py
@@ -59,6 +59,16 @@ def main(flags: dict[str, Any]) -> int:
     created_emails: list[str] = []
     created_sessions: list[str] = []
 
+    # Limpia blacklists de IPs TEST-NET de corridas previas (auto-blacklist
+    # 24h): evita 403 intermitente cuando el round-robin reusa una IP ya
+    # bloqueada. Best-effort.
+    try:
+        purged = env.cleanup_rate_limit_blacklist()
+        if purged:
+            print(f'[INFO] blacklists TEST-NET previas purgadas: {purged}')
+    except Exception as exc:  # noqa: BLE001 -- best-effort
+        print(f'[WARN] purga inicial de blacklist fallo: {exc}')
+
     try:
         _run_flows(
             runner=runner,
@@ -138,7 +148,16 @@ def _run_flows(
         )
     if want('users'):
         print('\n--- users ---')
-        run_users(runner, http, env_name, access_token)
+        run_users(
+            runner,
+            http,
+            env,
+            env_name,
+            run_id,
+            bypass,
+            access_token,
+            created_emails,
+        )
 
 
 def _cleanup(
@@ -152,8 +171,10 @@ def _cleanup(
         users = env.cleanup_users(emails)
         contacts = env.cleanup_contacts(emails)
         tracking = env.cleanup_tracking(sessions)
+        blacklist = env.cleanup_rate_limit_blacklist()
         print(
-            f'  borrados: users={users} contacts={contacts} tracking={tracking}'
+            f'  borrados: users={users} contacts={contacts} '
+            f'tracking={tracking} ip_blacklist={blacklist}'
         )
     except Exception as exc:  # noqa: BLE001 -- best-effort
         print(f'  [WARN] cleanup parcial: {type(exc).__name__}: {exc}')

--- a/devtools/api_e2e/support.py
+++ b/devtools/api_e2e/support.py
@@ -18,20 +18,40 @@ from api_e2e.config import IpRotator
 
 
 class Response:
-    """Resultado de una llamada HTTP: status, body parseado y elapsed (s)."""
+    """Resultado de una llamada HTTP: status, body, headers y elapsed (s)."""
 
-    def __init__(self, status: int, body: Any, elapsed: float) -> None:
+    def __init__(
+        self,
+        status: int,
+        body: Any,
+        elapsed: float,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         self.status = status
         self.body = body
         self.elapsed = elapsed
+        self.headers = headers or {}
+
+    def header(self, name: str) -> str | None:
+        """Devuelve el header (case-insensitive) o None si no esta."""
+        target = name.lower()
+        for key, value in self.headers.items():
+            if key.lower() == target:
+                return value
+        return None
 
 
 class HttpClient:
-    """Cliente httpx para el API Gateway del backend (1 IP por request)."""
+    """Cliente httpx para el API Gateway del backend (1 IP por request).
+
+    `follow_redirects=False`: el harness lee el 302 del magic-link GET tal
+    cual (status + header Location), sin seguirlo al admin (que es un sitio
+    Cloudflare Pages, no parte del backend que probamos).
+    """
 
     def __init__(self, *, base_url: str, timeout: float = 35.0) -> None:
         self._base = base_url.rstrip('/')
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, follow_redirects=False)
         self._ips = IpRotator()
 
     def close(self) -> None:
@@ -64,12 +84,18 @@ class HttpClient:
         *,
         params: dict[str, str],
         origin: str,
+        bypass_token: str | None = None,
+        bearer: str | None = None,
     ) -> Response:
-        """GET con query params (operation/action van en params)."""
+        """GET con query params (operation/action van en params).
+
+        NO sigue redirects (el 302 del magic-link vuelve con su header
+        Location). Acepta bypass/bearer por uniformidad con post().
+        """
         headers = self._headers(
             origin=origin,
-            bypass_token=None,
-            bearer=None,
+            bypass_token=bypass_token,
+            bearer=bearer,
         )
         start = time.monotonic()
         resp = self._client.get(
@@ -78,7 +104,12 @@ class HttpClient:
             headers=headers,
         )
         elapsed = time.monotonic() - start
-        return Response(resp.status_code, _parse(resp), elapsed)
+        return Response(
+            resp.status_code,
+            _parse(resp),
+            elapsed,
+            headers=dict(resp.headers),
+        )
 
     def post(
         self,
@@ -102,7 +133,12 @@ class HttpClient:
             headers=headers,
         )
         elapsed = time.monotonic() - start
-        return Response(resp.status_code, _parse(resp), elapsed)
+        return Response(
+            resp.status_code,
+            _parse(resp),
+            elapsed,
+            headers=dict(resp.headers),
+        )
 
 
 def _parse(resp: httpx.Response) -> Any:

--- a/devtools/api_e2e/totp.py
+++ b/devtools/api_e2e/totp.py
@@ -1,0 +1,39 @@
+"""Generador TOTP (RFC 6238) con stdlib, para el harness E2E.
+
+El Lambda `auth` usa `pyotp` (6 digitos, periodo 30s, HMAC-SHA1, secret
+base32). El harness NO depende de `pyotp`: implementa el mismo algoritmo
+con `hmac`/`hashlib`/`base64` para generar el code que confirma el setup
+TOTP y completa el login con MFA. NO es un secreto (el secret_b32 lo
+devuelve el backend en `setup-totp`).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import struct
+import time
+
+
+_PERIOD = 30
+_DIGITS = 6
+
+
+def totp_now(secret_b32: str, *, at: int | None = None) -> str:
+    """Code TOTP de 6 digitos para `secret_b32` en el instante `at`.
+
+    `at` en segundos epoch (default: ahora). Algoritmo RFC 6238 estandar
+    (HMAC-SHA1, periodo 30s), compatible con el `pyotp.TOTP` del backend.
+    """
+    now = at if at is not None else int(time.time())
+    counter = now // _PERIOD
+    # base32 sin padding-strict: pyotp genera secrets de 32 chars (160
+    # bits) que ya son multiplo de 8; agregamos padding por robustez.
+    padded = secret_b32 + '=' * (-len(secret_b32) % 8)
+    key = base64.b32decode(padded, casefold=True)
+    msg = struct.pack('>Q', counter)
+    digest = hmac.new(key, msg, hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    binary = struct.unpack('>I', digest[offset : offset + 4])[0] & 0x7FFFFFFF
+    return str(binary % (10**_DIGITS)).zfill(_DIGITS)


### PR DESCRIPTION
## Problema

El harness `devtools/api_e2e` solo cubria el flujo basico de auth
(register -> verify-code -> refresh -> login.start -> set-password ->
logout) y un subset de users. No probaba el resto del dominio auth ni el
dashboard de cuenta end-to-end contra el backend desplegado:

1. magic-link verify por GET (el 302 al admin/callback recien habilitado)
   y por POST.
2. login con password (directo + 2-step).
3. MFA completo: TOTP, email-code, recovery codes.
4. dashboard de cuenta: cambiar password, cambiar email, revocar sesion,
   eliminar cuenta.
5. admin.* (list/get/disable/enable/force-logout/list-actions/delete).

## Solucion

Amplio el harness para ejercitar TODO el dominio auth + el dashboard,
con verificacion en Neon donde aplica:

1. magic-link: GET (302 + header Location al admin/callback) + POST (JSON
   con tokens). Token sembrado reescribiendo el `token_hash` de la fila
   vigente (el plano nunca vuelve).
2. login con password directo + 2-step (`login.verify-password`) + error
   de password incorrecta.
3. MFA TOTP (`setup-totp` -> code generado con un RFC 6238 stdlib
   verificado identico a `pyotp` -> `confirm-totp` -> login 2FA con
   `login.verify-totp`); email-code (setup + list + set-preferred +
   disable); recovery codes (generate -> consume + reuso -> 400).
4. change-password (success + current incorrecta 401); change-email
   completo (-> confirm-email-change -> verifica el email en Neon);
   status.revoke-session success (2 sesiones -> revoca la otra);
   delete-account (verifica el soft-delete en Neon).
5. admin.* completo promoviendo un admin sintetico en la whitelist SSM +
   cold restart del Lambda `users`, restaurando el CSV exacto al final.
   NUNCA toca el admin real.

Soporte: `HttpClient.get` no sigue redirects y captura headers (lee el
Location del 302); `Environment` gana seeds de magic-link/email-change,
lectura de email/status/sesiones en Neon, promote/restore de
admin-emails y limpieza de las `ip_blacklist` auto-creadas para el pool
TEST-NET (evita el 403 intermitente). El TTL del bypass de Turnstile del
harness sube a 1800s. Los valores de prueba (passwords + token falso) se
ARMAN en runtime de fragmentos (son fixtures, NO secretos). Los flujos se
parten en `flow_auth_mfa`, `flow_admin`, `_auth_support` y `totp` para
mantener cada modulo bajo 300 lineas.

## Como probar

```bash
aws sso login --profile tfs-dev   # si la sesion SSO expiro
python devtools/run.py api_e2e --env=dev --samples=2 --aws-profile=tfs-dev
```

Resultado esperado: `75/75 casos PASS` (cv + contact_form +
tracking_pixel + auth + users), la whitelist admin promovida y
restaurada (lineas `[INFO] admin: ...`), y el cleanup borrando los datos
sinteticos. Tests unit del harness:

```bash
python devtools/run.py test_runner --module=devtools --type=unit
```

## TODO

- Cobertura de WebAuthn limitada al caso de error (payload vacio): el
  ceremony real requiere un authenticator del browser, fuera del alcance
  de un harness HTTP. Diferido.