### PR TITLE
fix(admin): perfil flat en settings + oculta Usuarios a no-admins

### DIFF
--- a/admin/src/features/admin-shell/components/mobile-sidebar.tsx
+++ b/admin/src/features/admin-shell/components/mobile-sidebar.tsx
@@ -12,16 +12,18 @@ import {
 	SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
-import { NAV_ITEMS } from "../lib/nav-items";
+import { useVisibleNavItems } from "../hooks/use-nav-items";
 
 /**
  * @component MobileSidebar
- * @description Navegacion en mobile via Sheet (mismos items que Sidebar).
- *   El trigger (hamburguesa) solo se muestra por debajo de lg.
+ * @description Navegacion en mobile via Sheet (mismos items que Sidebar,
+ *   con el mismo filtro `adminOnly`). El trigger (hamburguesa) solo se
+ *   muestra por debajo de lg.
  */
 export function MobileSidebar() {
 	const pathname = usePathname();
 	const [open, setOpen] = useState(false);
+	const navItems = useVisibleNavItems();
 
 	return (
 		<Sheet open={open} onOpenChange={setOpen}>
@@ -40,7 +42,7 @@ export function MobileSidebar() {
 					Admin
 				</SheetTitle>
 				<nav className="space-y-1 px-3">
-					{NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+					{navItems.map(({ href, label, icon: Icon }) => {
 						const active = pathname === href || pathname.startsWith(`${href}/`);
 						return (
 							<Link

--- a/admin/src/features/admin-shell/components/sidebar.tsx
+++ b/admin/src/features/admin-shell/components/sidebar.tsx
@@ -3,17 +3,18 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { NAV_ITEMS } from "../lib/nav-items";
+import { useVisibleNavItems } from "../hooks/use-nav-items";
 
 /**
  * @component Sidebar
  * @description Navegacion lateral del app shell (desktop). Resalta el item
- *   activo segun el pathname. El item `Usuarios` (adminOnly) se muestra
- *   siempre; la page /users maneja el 404 del backend para no-admin
- *   (anti-enumeration).
+ *   activo segun el pathname. Los items `adminOnly` (ej. `Usuarios`) se
+ *   ocultan a quien no es admin (sondeo `useIsAdmin`); el backend igual
+ *   responde 404 a un no-admin (anti-enumeration), esto solo mejora la UX.
  */
 export function Sidebar() {
 	const pathname = usePathname();
+	const navItems = useVisibleNavItems();
 	return (
 		<aside className="hidden h-screen w-60 shrink-0 border-r bg-card lg:flex lg:flex-col">
 			<div className="p-6">
@@ -22,7 +23,7 @@ export function Sidebar() {
 				</h2>
 			</div>
 			<nav className="flex-1 space-y-1 px-3">
-				{NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+				{navItems.map(({ href, label, icon: Icon }) => {
 					const active = pathname === href || pathname.startsWith(`${href}/`);
 					return (
 						<Link

--- a/admin/src/features/admin-shell/hooks/use-is-admin.ts
+++ b/admin/src/features/admin-shell/hooks/use-is-admin.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { usersAdminClient } from "@/features/users-admin/api/users-admin-client";
+import { ApiError } from "@/lib/api-client";
+
+/**
+ * @module features/admin-shell/hooks/use-is-admin
+ * @description Determina si el usuario autenticado es admin sondeando UNA vez
+ *   `users.admin.list-users` (con `page_size: 1`, payload minimo). El backend
+ *   responde `200` si el email esta en la whitelist SSM, o `404 NOT_FOUND`
+ *   (anti-enumeration) si no. El sidebar usa esto para ocultar los items
+ *   `adminOnly` a quien no es admin (en vez de mostrarlos y dejar que la page
+ *   reciba el 404). El rol no cambia dentro de la sesion -> staleTime largo.
+ */
+
+const ADMIN_PROBE_KEY = ["admin-shell", "is-admin"] as const;
+
+/**
+ * @function useIsAdmin
+ * @description Sonda el rol admin. La query SIEMPRE resuelve a un booleano: un
+ *   `404 NOT_FOUND` (no-admin) se traduce a `false` (NO se propaga como error),
+ *   cualquier OTRO error si se propaga (la query queda en `isError`). Mientras
+ *   `isPending` el rol no esta resuelto: el caller trata "aun no se sabe" como
+ *   "no admin todavia" para no mostrar items que luego se ocultarian.
+ *
+ * @returns `{ isAdmin: boolean, isResolved: boolean }`
+ */
+export function useIsAdmin(): { isAdmin: boolean; isResolved: boolean } {
+	const query = useQuery({
+		queryKey: ADMIN_PROBE_KEY,
+		queryFn: async (): Promise<boolean> => {
+			try {
+				await usersAdminClient.listUsers({ page_size: 1 });
+				return true;
+			} catch (error) {
+				// 404 NOT_FOUND = no-admin (anti-enumeration): no es un fallo, es
+				// la respuesta. Cualquier otro error si se propaga.
+				if (error instanceof ApiError && error.status === 404) {
+					return false;
+				}
+				throw error;
+			}
+		},
+		staleTime: 5 * 60_000,
+		gcTime: 10 * 60_000,
+		retry: false,
+		refetchOnWindowFocus: false,
+	});
+
+	return {
+		isAdmin: query.data === true,
+		isResolved: query.isSuccess,
+	};
+}

--- a/admin/src/features/admin-shell/hooks/use-nav-items.ts
+++ b/admin/src/features/admin-shell/hooks/use-nav-items.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { NAV_ITEMS, type NavItem } from "../lib/nav-items";
+import { useIsAdmin } from "./use-is-admin";
+
+/**
+ * @module features/admin-shell/hooks/use-nav-items
+ * @description Resuelve los items del sidebar visibles para el usuario actual:
+ *   filtra los `adminOnly` cuando el usuario NO es admin (sondeo via
+ *   `useIsAdmin`). Mientras el rol no esta resuelto, los items `adminOnly` se
+ *   ocultan (se asume "no admin" hasta confirmar) para no mostrar un item que
+ *   luego desapareceria. Centraliza el filtro para que Sidebar y MobileSidebar
+ *   compartan la misma logica.
+ */
+
+/**
+ * @function useVisibleNavItems
+ * @description Devuelve los `NAV_ITEMS` que el usuario actual puede ver. Los
+ *   items sin `adminOnly` siempre se incluyen; los `adminOnly` solo si
+ *   `useIsAdmin().isAdmin === true`.
+ *
+ * @returns {readonly NavItem[]} items visibles
+ */
+export function useVisibleNavItems(): readonly NavItem[] {
+	const { isAdmin } = useIsAdmin();
+	return NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
+}

--- a/admin/src/features/settings/hooks/use-profile.ts
+++ b/admin/src/features/settings/hooks/use-profile.ts
@@ -13,8 +13,11 @@ export function useProfile() {
 	return useQuery({
 		queryKey: settingsKeys.profile(),
 		queryFn: async () => {
+			// El backend responde el perfil FLAT: `data` ES el UserProfile (no
+			// hay anidado `data.profile`). apiFetch re-envuelve el body plano en
+			// `{is_valid, code, data}`, asi que aqui `data` ya es el perfil.
 			const { data } = await settingsClient.getProfile();
-			return data.profile;
+			return data;
 		},
 	});
 }

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -74,10 +74,11 @@ export interface WebauthnCredentialsResponse {
 	credentials: WebauthnCredential[];
 }
 
-/** users.profile.get / update */
-export interface ProfileResponse {
-	profile: UserProfile;
-}
+/** users.profile.get / update — el backend responde el perfil FLAT (los
+ *  campos de UserProfile al nivel raiz del `data`, NO anidados en `profile`),
+ *  igual que el resto de las 26 actions (ver shared.lambda_kit.http_dispatch,
+ *  json_response(status, result.data)). */
+export type ProfileResponse = UserProfile;
 
 /** users.status.get */
 export type StatusResponse = AccountStatus;

--- a/admin/tests/mocks/handlers/users.ts
+++ b/admin/tests/mocks/handlers/users.ts
@@ -73,20 +73,20 @@ export const usersHandlers = [
 		const { operation, action, ...data } = body;
 
 		// --- profile ---
+		// El backend responde el perfil FLAT: los campos de UserProfile al
+		// nivel raiz de `data`, NO anidados en `profile` (ver get.py/update.py).
 		if (operation === "profile" && action === "get") {
 			return HttpResponse.json({
 				is_valid: true,
 				code: 0,
-				data: { profile: PROFILE },
+				data: PROFILE,
 			});
 		}
 		if (operation === "profile" && action === "update") {
 			return HttpResponse.json({
 				is_valid: true,
 				code: 0,
-				data: {
-					profile: { ...PROFILE, display_name: data.display_name as string },
-				},
+				data: { ...PROFILE, display_name: data.display_name as string },
 			});
 		}
 		if (operation === "profile" && action === "change-email") {

--- a/admin/tests/unit/features/admin-shell/components/mobile-sidebar.test.tsx
+++ b/admin/tests/unit/features/admin-shell/components/mobile-sidebar.test.tsx
@@ -1,20 +1,34 @@
 import { render, screen, userEvent, waitFor } from "@tests/utils/render";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MobileSidebar } from "@/features/admin-shell/components/mobile-sidebar";
+import { NAV_ITEMS } from "@/features/admin-shell/lib/nav-items";
 
 /**
  * @module tests/unit/features/admin-shell/components/mobile-sidebar
  * @description Verifica el Sheet de navegacion mobile: abre con el trigger,
- *   lista los 4 items, marca el activo segun pathname y cierra al click en un
- *   item.
+ *   lista los items visibles (filtrados por rol admin), marca el activo segun
+ *   pathname y cierra al click en un item.
  */
 
 vi.mock("next/navigation", () => ({
 	usePathname: () => "/settings",
 }));
 
+const useVisibleNavItemsMock = vi.fn();
+vi.mock("@/features/admin-shell/hooks/use-nav-items", () => ({
+	useVisibleNavItems: () => useVisibleNavItemsMock(),
+}));
+
+const ADMIN_ITEMS = NAV_ITEMS; // los 4 (incluye Usuarios adminOnly)
+const NON_ADMIN_ITEMS = NAV_ITEMS.filter((i) => !i.adminOnly); // 3 (sin Usuarios)
+
 describe("MobileSidebar", () => {
-	it("Given el trigger When click Then abre el Sheet y muestra los 4 items", async () => {
+	beforeEach(() => {
+		useVisibleNavItemsMock.mockReset();
+		useVisibleNavItemsMock.mockReturnValue(ADMIN_ITEMS);
+	});
+
+	it("Given un admin When abre el Sheet Then muestra los 4 items", async () => {
 		// Arrange
 		const user = userEvent.setup();
 		render(<MobileSidebar />);
@@ -25,6 +39,21 @@ describe("MobileSidebar", () => {
 		// Assert
 		const links = await screen.findAllByRole("link");
 		expect(links).toHaveLength(4);
+	});
+
+	it("Given un NO-admin When abre el Sheet Then oculta el item Usuarios (3 items)", async () => {
+		// Arrange
+		useVisibleNavItemsMock.mockReturnValue(NON_ADMIN_ITEMS);
+		const user = userEvent.setup();
+		render(<MobileSidebar />);
+
+		// Act
+		await user.click(screen.getByRole("button", { name: /abrir menu/i }));
+
+		// Assert
+		const links = await screen.findAllByRole("link");
+		expect(links).toHaveLength(3);
+		expect(screen.queryByRole("link", { name: /usuarios/i })).toBe(null);
 	});
 
 	it("Given pathname /settings When abierto Then el item Configuracion esta activo", async () => {

--- a/admin/tests/unit/features/admin-shell/components/sidebar.test.tsx
+++ b/admin/tests/unit/features/admin-shell/components/sidebar.test.tsx
@@ -1,12 +1,26 @@
 import { render, screen } from "@tests/utils/render";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "@/features/admin-shell/components/sidebar";
+import { NAV_ITEMS } from "@/features/admin-shell/lib/nav-items";
 
 vi.mock("next/navigation", () => ({
 	usePathname: () => "/settings",
 }));
 
+const useVisibleNavItemsMock = vi.fn();
+vi.mock("@/features/admin-shell/hooks/use-nav-items", () => ({
+	useVisibleNavItems: () => useVisibleNavItemsMock(),
+}));
+
+const ADMIN_ITEMS = NAV_ITEMS; // los 4 (incluye Usuarios adminOnly)
+const NON_ADMIN_ITEMS = NAV_ITEMS.filter((i) => !i.adminOnly); // 3 (sin Usuarios)
+
 describe("Sidebar", () => {
+	beforeEach(() => {
+		useVisibleNavItemsMock.mockReset();
+		useVisibleNavItemsMock.mockReturnValue(ADMIN_ITEMS);
+	});
+
 	it("Given pathname /settings When render Then el item Configuracion esta activo", () => {
 		// Arrange + Act
 		render(<Sidebar />);
@@ -25,12 +39,26 @@ describe("Sidebar", () => {
 		expect(link.className).toContain("text-muted-foreground");
 	});
 
-	it("Given el sidebar When render Then muestra los 4 items de navegacion", () => {
-		// Arrange + Act
+	it("Given un admin When render Then muestra los 4 items (incluye Usuarios)", () => {
+		// Arrange: useVisibleNavItems devuelve los 4 (default del beforeEach)
+		// Act
 		render(<Sidebar />);
 
 		// Assert
 		expect(screen.getAllByRole("link")).toHaveLength(4);
+		expect(screen.getByRole("link", { name: /usuarios/i })).toBeInTheDocument();
+	});
+
+	it("Given un NO-admin When render Then oculta el item Usuarios (3 items)", () => {
+		// Arrange
+		useVisibleNavItemsMock.mockReturnValue(NON_ADMIN_ITEMS);
+
+		// Act
+		render(<Sidebar />);
+
+		// Assert
+		expect(screen.getAllByRole("link")).toHaveLength(3);
+		expect(screen.queryByRole("link", { name: /usuarios/i })).toBe(null);
 	});
 
 	it("Given el sidebar When render Then NO muestra el item Metricas", () => {

--- a/admin/tests/unit/features/admin-shell/hooks/use-is-admin.test.tsx
+++ b/admin/tests/unit/features/admin-shell/hooks/use-is-admin.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { server } from "@tests/mocks/server";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { useIsAdmin } from "@/features/admin-shell/hooks/use-is-admin";
+
+/**
+ * @module tests/unit/features/admin-shell/hooks/use-is-admin
+ * @description Sondeo del rol admin via users.admin.list-users. 200 -> admin;
+ *   404 NOT_FOUND (anti-enumeration) -> no-admin (resuelve a false, NO error);
+ *   otro error -> se propaga (isError).
+ */
+
+const API = "https://api.test.the-full-stack.com";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useIsAdmin", () => {
+	it("Given el backend responde 200 a list-users When sondea Then isAdmin true", async () => {
+		// Arrange: el MSW por defecto devuelve 200 con users.
+
+		// Act
+		const { result } = renderHook(() => useIsAdmin(), { wrapper });
+
+		// Assert
+		await waitFor(() => expect(result.current.isResolved).toBe(true));
+		expect(result.current.isAdmin).toBe(true);
+	});
+
+	it("Given el backend responde 404 NOT_FOUND When sondea Then isAdmin false (no error)", async () => {
+		// Arrange: simula no-admin
+		server.use(
+			http.post(`${API}/users`, () =>
+				HttpResponse.json(
+					{ error: "NOT_FOUND", code: "NOT_FOUND" },
+					{ status: 404 },
+				),
+			),
+		);
+
+		// Act
+		const { result } = renderHook(() => useIsAdmin(), { wrapper });
+
+		// Assert
+		await waitFor(() => expect(result.current.isResolved).toBe(true));
+		expect(result.current.isAdmin).toBe(false);
+	});
+
+	it("Given un error 500 (no 404) When sondea Then NO resuelve a admin (isResolved false)", async () => {
+		// Arrange
+		server.use(
+			http.post(`${API}/users`, () =>
+				HttpResponse.json(
+					{ error: "SERVER_ERROR", code: 5000 },
+					{ status: 500 },
+				),
+			),
+		);
+
+		// Act
+		const { result } = renderHook(() => useIsAdmin(), { wrapper });
+
+		// Assert: el 500 se propaga -> la query queda en error, NO success
+		await waitFor(() => expect(result.current.isResolved).toBe(false));
+		expect(result.current.isAdmin).toBe(false);
+	});
+});

--- a/admin/tests/unit/features/admin-shell/hooks/use-nav-items.test.tsx
+++ b/admin/tests/unit/features/admin-shell/hooks/use-nav-items.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useVisibleNavItems } from "@/features/admin-shell/hooks/use-nav-items";
+
+/**
+ * @module tests/unit/features/admin-shell/hooks/use-nav-items
+ * @description Filtra los items adminOnly del sidebar segun el rol resuelto por
+ *   useIsAdmin: admin -> todos; no-admin -> sin los adminOnly.
+ */
+
+const useIsAdminMock = vi.fn();
+vi.mock("@/features/admin-shell/hooks/use-is-admin", () => ({
+	useIsAdmin: () => useIsAdminMock(),
+}));
+
+afterEach(() => {
+	useIsAdminMock.mockReset();
+});
+
+describe("useVisibleNavItems", () => {
+	it("Given un admin When resuelve Then incluye el item adminOnly Usuarios", () => {
+		// Arrange
+		useIsAdminMock.mockReturnValue({ isAdmin: true, isResolved: true });
+
+		// Act
+		const { result } = renderHook(() => useVisibleNavItems());
+
+		// Assert
+		const hrefs = result.current.map((i) => i.href);
+		expect(hrefs).toEqual(["/settings", "/sessions", "/users", "/cv"]);
+	});
+
+	it("Given un NO-admin When resuelve Then excluye los items adminOnly", () => {
+		// Arrange
+		useIsAdminMock.mockReturnValue({ isAdmin: false, isResolved: true });
+
+		// Act
+		const { result } = renderHook(() => useVisibleNavItems());
+
+		// Assert
+		const hrefs = result.current.map((i) => i.href);
+		expect(hrefs).toEqual(["/settings", "/sessions", "/cv"]);
+		expect(hrefs).not.toContain("/users");
+	});
+
+	it("Given el rol sin resolver When isAdmin false Then oculta los adminOnly (asume no-admin)", () => {
+		// Arrange: aun sondeando -> isAdmin false
+		useIsAdminMock.mockReturnValue({ isAdmin: false, isResolved: false });
+
+		// Act
+		const { result } = renderHook(() => useVisibleNavItems());
+
+		// Assert
+		expect(result.current.map((i) => i.href)).not.toContain("/users");
+	});
+});

--- a/admin/tests/unit/features/settings/components/settings-components-branches.test.tsx
+++ b/admin/tests/unit/features/settings/components/settings-components-branches.test.tsx
@@ -77,17 +77,17 @@ describe("ProfileForm estados", () => {
 				HttpResponse.json({
 					is_valid: true,
 					code: 0,
+					// El backend responde el perfil FLAT (campos al nivel raiz
+					// de `data`, NO anidados en `profile`).
 					data: {
-						profile: {
-							id: "usr_01",
-							email: "sinnombre@test.com",
-							display_name: null,
-							status: "active",
-							locale: "es",
-							timezone: "UTC",
-							marketing_consent: false,
-							created_at: "2026-01-01T00:00:00Z",
-						},
+						id: "usr_01",
+						email: "sinnombre@test.com",
+						display_name: null,
+						status: "active",
+						locale: "es",
+						timezone: "UTC",
+						marketing_consent: false,
+						created_at: "2026-01-01T00:00:00Z",
 					},
 				}),
 			),

--- a/admin/tests/unit/features/settings/hooks/use-profile.test.tsx
+++ b/admin/tests/unit/features/settings/hooks/use-profile.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { server } from "@tests/mocks/server";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useProfile } from "@/features/settings/hooks/use-profile";
+
+/**
+ * @module tests/unit/features/settings/hooks/use-profile
+ * @description Regresion del bug "['settings','profile'] data is undefined": el
+ *   backend responde el perfil FLAT (campos de UserProfile al nivel raiz de
+ *   `data`, NO anidados en `profile`). El hook debe devolver ese `data` tal
+ *   cual. Antes el hook leia `data.profile` (== undefined) y el form caia en
+ *   estado de error.
+ */
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+const API = "https://api.test.the-full-stack.com";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useProfile", () => {
+	it("Given el backend responde el perfil FLAT When la query resuelve Then devuelve el UserProfile desempaquetado", async () => {
+		// Arrange: el MSW por defecto devuelve PROFILE flat (user@test.com).
+
+		// Act
+		const { result } = renderHook(() => useProfile(), { wrapper });
+
+		// Assert: data ES el UserProfile (no undefined, no anidado en .profile)
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual({
+			id: "usr_01",
+			email: "user@test.com",
+			display_name: "Pablo",
+			status: "active",
+			locale: "es",
+			timezone: "America/Santiago",
+			marketing_consent: false,
+			created_at: "2026-01-01T00:00:00Z",
+		});
+	});
+
+	it("Given un perfil con email distinto When resuelve Then expone el email al nivel raiz (no en data.profile)", async () => {
+		// Arrange: override flat con otro email
+		server.use(
+			http.post(`${API}/users`, () =>
+				HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: {
+						id: "usr_99",
+						email: "real@test.com",
+						display_name: null,
+						status: "active",
+						locale: "en",
+						timezone: "UTC",
+						marketing_consent: false,
+						created_at: "2026-06-03T00:00:00Z",
+					},
+				}),
+			),
+		);
+
+		// Act
+		const { result } = renderHook(() => useProfile(), { wrapper });
+
+		// Assert
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data?.email).toBe("real@test.com");
+		expect(result.current.data?.display_name).toBe(null);
+	});
+});


### PR DESCRIPTION
## Problema

Dos bugs del admin (admin.portfolio.dev.the-full-stack.com) contra el backend dev:

1. **profile.get rompe la UI de Settings.** El endpoint `POST /users` con `{operation:'profile', action:'get'}` devuelve HTTP 200 con el perfil correcto, pero la pantalla de Settings muestra `['settings','profile'] data is undefined`. El backend responde el perfil FLAT (campos al nivel raiz de `data`) — igual que las otras 26 actions — pero el tipo `ProfileResponse` y el hook `useProfile` esperaban un anidado `{ profile: {...} }`, asi que `data.profile` era `undefined`.

2. **El item "Usuarios" del sidebar se muestra a quien no es admin.** `POST /users` con `{operation:'admin', action:'list-users'}` responde `404 NOT_FOUND` a un caller que no esta en la whitelist SSM (anti-enumeration, comportamiento correcto). El sidebar declaraba el flag `adminOnly` en nav-items pero NO lo usaba: renderizaba "Usuarios" a todos, y el usuario solo descubria el 404 al entrar a la pantalla.

   - Subproblema de DATO (resuelto fuera del codigo): el email del reporter no estaba en `/portfolio/dev/admin-emails` (solo `pacg1991@gmail.com`).

## Solucion

1. `ProfileResponse` pasa de `{ profile: UserProfile }` a `UserProfile` (flat, como `StatusResponse`); `use-profile.ts` devuelve `data` directo; el handler MSW de `/users` se corrige al shape flat real (antes mockeaba el shape anidado erroneo = falso verde). Test de regresion `use-profile.test.tsx` que asserta el unwrap flat.

2. Nuevo hook `useIsAdmin` (sonda una vez `users.admin.list-users` con `page_size:1`; 200 -> admin, 404 -> no-admin sin propagar error, otro error si se propaga; staleTime 5 min) + `useVisibleNavItems` que filtra los items `adminOnly`. `sidebar` y `mobile-sidebar` consumen el filtro. La page `/users` ya manejaba el 404; esto solo oculta el item para no-admins (UX). Tests de ambos hooks y de ambos componentes con rol admin / no-admin.

   - DATO: `ADMIN_EMAILS` de `docker/env/server/.dev` actualizado a `pacg1991@gmail.com,bypabloc@gmail.com` y sincronizado a SSM `/portfolio/dev/admin-emails` (`serverless sync-secrets --stage=dev`). El Lambda `users` lo reconoce en runtime (cache TTL 5 min, sin redeploy).

## Como probar

- Local: `pnpm --filter @portfolio/admin test` (327 passing) + `typecheck` + `lint` + `build`.
- Settings en dev: abrir `https://admin.portfolio.dev.the-full-stack.com/settings`, loguear -> el perfil carga (email read-only + display_name), ya NO aparece "data is undefined".
- Sidebar: con un email admin (whitelist) el item "Usuarios" aparece; con un email no-admin queda oculto.
- list-users: `POST /users {operation:'admin', action:'list-users'}` con un access JWT de `bypabloc@gmail.com` o `pacg1991@gmail.com` -> 200 (ya en la whitelist SSM de dev).

## TODO

- Cuando exista el backend de metricas (plan b-analytics-api), re-evaluar si el item "Usuarios" necesita mostrarse a no-admins (hoy se oculta).