### PR TITLE
fix(rate-limit): auto-blacklist solo cuenta CAPTCHAs reales del usuario

### DIFF
--- a/serverless/lambda/services/auth/core/controllers/login/start.py
+++ b/serverless/lambda/services/auth/core/controllers/login/start.py
@@ -56,11 +56,16 @@ class Start(BaseController):
         data: LoginStartIn = self.validated_data  # type: ignore[assignment]
         meta = data.meta
 
+        # brought_turnstile_token: True solo si el usuario adjunto un CAPTCHA
+        # real (no el bypass dev/E2E vacio). Es el unico endpoint del flujo
+        # auth donde el usuario resuelve un Turnstile -> el unico que alimenta
+        # la auto-blacklist (un solver hace muchos start con CAPTCHA en 60s).
         RateLimitService(app_config).check_or_raise(
             ip=meta.ip or '',
             endpoint=_ENDPOINT,
             country=meta.country,
             turnstile_validated=False,
+            brought_turnstile_token=bool(data.cf_turnstile_response),
         )
         verify_captcha_or_bypass(
             data.cf_turnstile_response,

--- a/serverless/lambda/services/auth/core/controllers/register/start.py
+++ b/serverless/lambda/services/auth/core/controllers/register/start.py
@@ -59,11 +59,16 @@ class Start(BaseController):
         data: RegisterStartIn = self.validated_data  # type: ignore[assignment]
         meta = data.meta
 
+        # brought_turnstile_token: True solo si el usuario adjunto un CAPTCHA
+        # real (no el bypass dev/E2E vacio). register.start y login.start son
+        # los unicos endpoints donde el usuario resuelve un Turnstile -> los
+        # unicos que alimentan la auto-blacklist (bot con solver).
         RateLimitService(app_config).check_or_raise(
             ip=meta.ip or '',
             endpoint=_ENDPOINT,
             country=meta.country,
             turnstile_validated=False,
+            brought_turnstile_token=bool(data.cf_turnstile_response),
         )
 
         verify_captcha_or_bypass(

--- a/serverless/lambda/services/auth/core/services/rate_limit_service.py
+++ b/serverless/lambda/services/auth/core/services/rate_limit_service.py
@@ -24,6 +24,7 @@ class RateLimitService:
         endpoint: str,
         country: str | None = None,
         turnstile_validated: bool = False,
+        brought_turnstile_token: bool = False,
     ) -> None:
         """Aplica el rate-limit; raises si IP/country/window-rule lo violan.
 
@@ -32,15 +33,22 @@ class RateLimitService:
             endpoint: path identificador (ej.
                 `/auth#register.start`, `/auth#login.verify-code`).
             country: ISO 3166-1 alpha-2 (de CF-IPCountry, opcional).
-            turnstile_validated: si la request paso Turnstile.
+            turnstile_validated: si la request usa el limite alto del
+                rate-limit (verify-*/mfa/session lo pasan True). NO alimenta
+                la auto-blacklist.
+            brought_turnstile_token: True solo en login.start/register.start,
+                donde el usuario ADJUNTA un CAPTCHA real. Unico flag que
+                alimenta la auto-blacklist (bot detection).
 
         Raises:
             shared.rate_limit.exceptions.IPBlacklistedError,
             CountryBlockedError, RateLimitExceededError.
         """
+        brought_captcha = brought_turnstile_token
         check_or_raise(
             ip=ip,
             endpoint=endpoint,
             country=country,
             turnstile_validated=turnstile_validated,
+            brought_turnstile_token=brought_captcha,
         )

--- a/serverless/lambda/services/auth/tests/unit/services/test_rate_limit_service.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_rate_limit_service.py
@@ -14,6 +14,7 @@ def test_check_or_raise_delegates_to_shared(monkeypatch):
         ip='203.0.113.10',
         endpoint='/auth#register.start',
         country='CL',
+        brought_turnstile_token=True,
     )
 
     fake_check.assert_called_once()
@@ -21,6 +22,28 @@ def test_check_or_raise_delegates_to_shared(monkeypatch):
     assert kwargs['ip'] == '203.0.113.10'
     assert kwargs['endpoint'] == '/auth#register.start'
     assert kwargs['country'] == 'CL'
+    # El flag de auto-blacklist se propaga al shared check.
+    assert kwargs['brought_turnstile_token'] is True
+
+
+def test_brought_turnstile_token_defaults_false(monkeypatch):
+    """Sin el flag, el wrapper pasa brought_turnstile_token=False (no cuenta
+    para la auto-blacklist: los verify-*/mfa/session)."""
+    from services import rate_limit_service
+
+    fake_check = MagicMock(return_value=None)
+    monkeypatch.setattr(rate_limit_service, 'check_or_raise', fake_check)
+
+    svc = rate_limit_service.RateLimitService(app_config=object())
+    svc.check_or_raise(
+        ip='203.0.113.10',
+        endpoint='/auth#login.verify-magic-link',
+        turnstile_validated=True,
+    )
+
+    kwargs = fake_check.call_args.kwargs
+    assert kwargs['brought_turnstile_token'] is False
+    assert kwargs['turnstile_validated'] is True
 
 
 def test_check_or_raise_propagates_exception(monkeypatch):

--- a/serverless/lambda/services/contact_form/core/controllers/contact/create.py
+++ b/serverless/lambda/services/contact_form/core/controllers/contact/create.py
@@ -56,18 +56,19 @@ def _resolve_session_id(form_session_id: str | None) -> str:
     return f'cf-{new_uuidv7()}'
 
 
-def _auto_blacklist_step(ip: str) -> None:
-    """Incrementa el contador de tokens validos + auto-blacklist si excede.
+def _auto_blacklist_step(ip: str, *, brought_captcha: bool) -> None:
+    """Incrementa el contador de CAPTCHAs validos + auto-blacklist si excede.
 
-    Corre DESPUES del exito: marca `turnstile_validated=True` para detectar
-    bots con solver (3+ tokens validos en 60s desde la misma IP -> blacklist
-    24h).
+    Corre DESPUES del exito. Solo cuenta para la auto-blacklist si el request
+    ADJUNTO un CAPTCHA real (no el bypass dev/E2E): detecta bots con solver
+    (AUTO_BLACKLIST_THRESHOLD CAPTCHAs validos en 60s desde la misma IP ->
+    blacklist).
     """
     bucket = increment_bucket(
         ip=ip,
         endpoint=_ENDPOINT,
         window_seconds=_WINDOW_SECONDS,
-        turnstile_validated=True,
+        brought_turnstile_token=brought_captcha,
     )
     if should_auto_blacklist(bucket['turnstile_tokens']):
         create_blacklist_rule(ip)
@@ -133,9 +134,10 @@ class Create(BaseController):
         )
 
         # 5. Contador de auto-blacklist (despues del exito). check_or_raise
-        #    ya hizo un ADD con turnstile_validated=False; este INCREMENT
-        #    marca el token como valido para la deteccion de bots.
-        _auto_blacklist_step(meta.ip)
+        #    ya hizo un ADD sin contar el CAPTCHA; este INCREMENT marca el
+        #    CAPTCHA como valido para la deteccion de bots, solo si fue real
+        #    (no el bypass dev/E2E vacio).
+        _auto_blacklist_step(meta.ip, brought_captcha=bool(data.cf_token))
 
         return result
 

--- a/serverless/lambda/services/contact_form/tests/unit/test_auto_blacklist_runs_after_success.py
+++ b/serverless/lambda/services/contact_form/tests/unit/test_auto_blacklist_runs_after_success.py
@@ -1,19 +1,22 @@
 """Controller — auto-blacklist corre tras un submit exitoso.
 
-Given una IP que ya supero el threshold (3+ tokens validos en 60s) — el
-     mock de increment_bucket retorna `turnstile_tokens=3`,
+Given una IP que ya supero el threshold (AUTO_BLACKLIST_THRESHOLD CAPTCHAs
+     validos en 60s) — el mock de increment_bucket retorna
+     `turnstile_tokens=AUTO_BLACKLIST_THRESHOLD`,
 When el controller Create ejecuta run() con exito,
 Then `create_blacklist_rule` se invoca (la defensa anti-solver corre
      despues de persistir + notificar).
 
-El auto-blacklist es la defensa anti-solver: si una IP presenta 3+ tokens
-Turnstile validos en 60s, se asume bot con solver y se blacklistea 24h.
+El auto-blacklist es la defensa anti-solver: si una IP adjunta
+AUTO_BLACKLIST_THRESHOLD CAPTCHAs Turnstile validos en 60s, se asume bot con
+solver y se blacklistea.
 """
 
 import httpx
 import pytest
 import respx
 from shared.http.turnstile import TURNSTILE_SITEVERIFY_URL
+from shared.rate_limit.auto_blacklist import AUTO_BLACKLIST_THRESHOLD
 
 pytestmark = pytest.mark.unit
 
@@ -52,7 +55,7 @@ def test_auto_blacklist_runs_after_success(
     monkeypatch.setattr(
         create_mod,
         'increment_bucket',
-        lambda **_kw: {'turnstile_tokens': 3},
+        lambda **_kw: {'turnstile_tokens': AUTO_BLACKLIST_THRESHOLD},
     )
     monkeypatch.setattr(create_mod, 'create_blacklist_rule', _spy_blacklist)
 

--- a/serverless/lambda/shared/rate_limit/README.md
+++ b/serverless/lambda/shared/rate_limit/README.md
@@ -72,14 +72,22 @@ serverless rate-limit set --endpoint=/track --limit=30 --window=300 --action=thr
 
 ## Auto-blacklist por bot detection
 
-Si una IP genera 3+ tokens Turnstile validos en 60s, asumimos Turnstile
-solver (bot). Crear rule ip_blacklist con TTL 24h.
+Si una IP ADJUNTA 10+ CAPTCHAs Turnstile validos en 60s, asumimos Turnstile
+solver (bot). Crear rule ip_blacklist con TTL 1h.
+
+El counter `turnstile_tokens` solo sube con `brought_turnstile_token=True`,
+que SOLO marcan `login.start`/`register.start`/`contact.create` (los unicos
+endpoints donde el usuario adjunta un CAPTCHA real). Los `verify-*`/`mfa`/
+`session` pasan `turnstile_validated=True` por bypass de limite pero NO
+adjuntan CAPTCHA -> NO inflan el counter (si no, un humano que reintenta un
+login 3 veces se auto-blacklisteaba). El bypass dev/E2E (CAPTCHA vacio)
+tampoco cuenta.
 
 ```python
-# Dentro del flow:
-bucket = increment_bucket(..., turnstile_validated=True)
+# Dentro del flow (solo en start/contact.create con CAPTCHA real):
+bucket = increment_bucket(..., brought_turnstile_token=True)
 if should_auto_blacklist(bucket['turnstile_tokens']):
-    create_blacklist_rule(ip)  # TTL 24h
+    create_blacklist_rule(ip)  # TTL 1h
 ```
 
 ## Cache de rules
@@ -107,6 +115,6 @@ requests del limite real (race condition logica). Solo `get_item` directo.
 | Latencia agregada | `<5ms` (edge) | `~10-20ms` (warm, 2 GetItem + 1 UpdateItem) |
 | Defense edge (rechaza antes de Lambda) | Si | No (siempre invoca, mitigado por reserved concurrency) |
 | Algoritmo | fixed window | sliding window weighted |
-| Auto-blacklist | No | Si (3+ tokens en 60s) |
+| Auto-blacklist | No | Si (10+ CAPTCHAs reales en 60s) |
 | Country rules dinamicas | manual | YAML/CLI |
 | OWASP managed rules | bundle gratis | No (mitigado por Turnstile + JSON Schema) |

--- a/serverless/lambda/shared/rate_limit/auto_blacklist.py
+++ b/serverless/lambda/shared/rate_limit/auto_blacklist.py
@@ -1,15 +1,19 @@
 """
 Auto-blacklist por bot detection con Turnstile solver.
 
-Heuristic: si una IP genera 3+ tokens Turnstile validos en 60 segundos,
-es probable que sea un bot usando un Turnstile solver (servicio de pago
-que resuelve CAPTCHAs por API). Bloqueamos esa IP por 24h.
+Heuristic: si una IP genera AUTO_BLACKLIST_THRESHOLD (10) CAPTCHAs Turnstile
+validos en 60 segundos, es probable que sea un bot usando un Turnstile solver
+(servicio de pago que resuelve CAPTCHAs por API). Bloqueamos esa IP por 1h.
 
 Implementacion:
-- Cada vez que increment_bucket() pasa turnstile_validated=True, incrementa
-  el counter turnstile_tokens del bucket actual.
-- Si turnstile_tokens >= 3 en una ventana de 60s, crear rule
-  rule_key='ip#<addr>' kind='ip_blacklist' con TTL = now + 86400.
+- Cada vez que increment_bucket() pasa brought_turnstile_token=True (= el
+  request ADJUNTO un CAPTCHA real del usuario: solo login.start/register.start),
+  incrementa el counter turnstile_tokens del bucket actual. Los verify-*/mfa/
+  session pasan turnstile_validated=True por bypass de limite pero NO adjuntan
+  CAPTCHA -> NO inflan este counter (si no, un humano que reintenta un login se
+  auto-blacklistea).
+- Si turnstile_tokens >= AUTO_BLACKLIST_THRESHOLD en una ventana de 60s, crear
+  rule rule_key='ip#<addr>' kind='ip_blacklist' con TTL = now + duracion.
 
 La rule blacklist se respeta en la siguiente request (lookup en rules.get_ip_rule).
 
@@ -23,10 +27,17 @@ import time
 
 from shared.dynamodb.models.rate_limit_rule import RateLimitRuleItem
 
-# Threshold: 3+ tokens validos en 60s = sospechoso
-AUTO_BLACKLIST_THRESHOLD = 3
+# Threshold: 10+ CAPTCHAs reales validos en 60s = sospechoso (bot con
+# solver). Subido de 3 a 10: el contador ahora solo cuenta requests que
+# ADJUNTARON un CAPTCHA real del usuario (login.start/register.start), no
+# los verify-*/mfa/session que pasan turnstile_validated=True sin token.
+# Con 3 un humano que reintentaba un login se auto-blacklisteaba; un humano
+# legitimo nunca hace 10 starts con CAPTCHA en 60s, un solver si.
+AUTO_BLACKLIST_THRESHOLD = 10
 AUTO_BLACKLIST_WINDOW_SECONDS = 60
-AUTO_BLACKLIST_DURATION_SECONDS = 86400  # 24h
+# Bloqueo de 1h (bajado de 24h): un falso positivo residual se recupera
+# rapido; un bot real reincide y se vuelve a bloquear.
+AUTO_BLACKLIST_DURATION_SECONDS = 3600  # 1h
 
 
 def should_auto_blacklist(turnstile_tokens_count: int) -> bool:
@@ -46,7 +57,10 @@ def create_blacklist_rule(
     ip: str,
     *,
     duration_seconds: int = AUTO_BLACKLIST_DURATION_SECONDS,
-    reason: str = 'auto-blacklist: 3+ turnstile tokens in 60s',
+    reason: str = (
+        f'auto-blacklist: {AUTO_BLACKLIST_THRESHOLD}+ captcha tokens in '
+        f'{AUTO_BLACKLIST_WINDOW_SECONDS}s'
+    ),
 ) -> None:
     """
     Crea una rule ip_blacklist con TTL.

--- a/serverless/lambda/shared/rate_limit/buckets.py
+++ b/serverless/lambda/shared/rate_limit/buckets.py
@@ -88,7 +88,7 @@ def increment_bucket(
     ip: str,
     endpoint: str,
     window_seconds: int,
-    turnstile_validated: bool = False,
+    brought_turnstile_token: bool = False,
     now: int | None = None,
 ) -> dict[str, int]:
     """
@@ -98,7 +98,13 @@ def increment_bucket(
         ip: IP del cliente.
         endpoint: path del endpoint.
         window_seconds: longitud de la ventana.
-        turnstile_validated: si True, tambien incrementa turnstile_tokens.
+        brought_turnstile_token: si True, el request trajo un token Turnstile
+            REAL del usuario (solo login.start/register.start) -> incrementa
+            el counter `turnstile_tokens` que alimenta la auto-blacklist. NO
+            confundir con `turnstile_validated` del rate-limit (que solo elige
+            el limite): los verify-*/mfa/session pasan turnstile_validated=True
+            sin traer un token y NO deben inflar este counter (si no, un humano
+            que reintenta un login/magic-link se auto-blacklistea).
         now: timestamp (default: time.time()).
 
     Returns:
@@ -111,10 +117,11 @@ def increment_bucket(
     # tenga "previous" correcto disponible)
     expires_at = current_start + window_seconds * 2
 
-    # ADD atomico de count (+ turnstile_tokens si aplica) y SET expires_at,
-    # todo en el mismo UpdateExpression (lo arma RateLimitBucketItem).
+    # ADD atomico de count (+ turnstile_tokens si trajo token real) y SET
+    # expires_at, todo en el mismo UpdateExpression (lo arma
+    # RateLimitBucketItem).
     deltas: dict[str, int] = {'count': 1}
-    if turnstile_validated:
+    if brought_turnstile_token:
         deltas['turnstile_tokens'] = 1
 
     result = RateLimitBucketItem.increment(

--- a/serverless/lambda/shared/rate_limit/check.py
+++ b/serverless/lambda/shared/rate_limit/check.py
@@ -68,6 +68,7 @@ def check_or_raise(
     endpoint: str,
     country: str | None = None,
     turnstile_validated: bool = False,
+    brought_turnstile_token: bool = False,
     now: int | None = None,
 ) -> Decision:
     """
@@ -78,6 +79,14 @@ def check_or_raise(
         endpoint: path del endpoint (ej: '/contact').
         country: country code (ISO 3166-1 alpha-2) o None.
         turnstile_validated: si la request paso Turnstile siteverify ya.
+            Controla SOLO el limite del rate-limit; NO alimenta la
+            auto-blacklist (los verify-*/mfa/session lo pasan True sin traer
+            un token real del usuario).
+        brought_turnstile_token: True solo si el request trajo un token
+            Turnstile REAL del usuario (login.start/register.start). Es el
+            unico que alimenta el counter de auto-blacklist (bot detection).
+            Sin esta separacion, un humano que reintenta un login/magic-link
+            3 veces en 60s se auto-blacklistea 24h.
         now: timestamp override (tests).
 
     Returns:
@@ -185,17 +194,21 @@ def check_or_raise(
             },
         )
 
-    # 5. Atomic INCREMENT (con el window_seconds REAL del rule)
+    # 5. Atomic INCREMENT (con el window_seconds REAL del rule). El counter
+    #    turnstile_tokens (auto-blacklist) solo sube si el request adjunto un
+    #    CAPTCHA real del usuario (login.start/register.start), NO si
+    #    turnstile_validated=True por bypass de limite (verify-*/mfa/session).
+    real_captcha = brought_turnstile_token
     bucket = increment_bucket(
         ip=ip,
         endpoint=endpoint,
         window_seconds=window_seconds,
-        turnstile_validated=turnstile_validated,
+        brought_turnstile_token=real_captcha,
         now=current_time,
     )
 
-    # 6. Auto-blacklist check
-    if turnstile_validated and should_auto_blacklist(bucket['turnstile_tokens']):
+    # 6. Auto-blacklist check: solo cuando el request adjunto un CAPTCHA real.
+    if real_captcha and should_auto_blacklist(bucket['turnstile_tokens']):
         create_blacklist_rule(ip)
 
     return Decision(allowed=True, reason='allowed', status_code=200)

--- a/serverless/lambda/shared/tests/integration/shared/rate_limit/test_auto_blacklist_threshold_creates_rule_e2e.py
+++ b/serverless/lambda/shared/tests/integration/shared/rate_limit/test_auto_blacklist_threshold_creates_rule_e2e.py
@@ -1,6 +1,6 @@
 """
-Given una IP que valida 3 tokens Turnstile en la misma ventana de 60s,
-When check_or_raise corre la 3a vez con turnstile_validated=True,
+Given una IP que adjunta 10 CAPTCHAs Turnstile reales en la misma ventana
+de 60s, When check_or_raise corre la 10a vez con brought_turnstile_token=True,
 Then el auto-blacklist crea una rule ip_blacklist con TTL en DynamoDB.
 """
 
@@ -10,6 +10,7 @@ import time
 
 import pytest
 from shared.dynamodb.models.rate_limit_rule import RateLimitRuleItem
+from shared.rate_limit.auto_blacklist import AUTO_BLACKLIST_THRESHOLD
 from shared.rate_limit.check import check_or_raise
 
 from ._fixtures import _add_endpoint_rule
@@ -20,17 +21,17 @@ pytestmark = pytest.mark.integration
 def test_auto_blacklist_threshold_creates_rule_e2e(
     rate_limit_tables: dict[str, str],
 ) -> None:
-    """3 tokens Turnstile validos en 60s -> rule ip_blacklist creada."""
+    """AUTO_BLACKLIST_THRESHOLD CAPTCHAs reales en 60s -> rule creada."""
     # Arrange: limit alto para que el rate-limit no levante antes.
-    _add_endpoint_rule(endpoint='/contact', limit=100, window_seconds=60)
+    _add_endpoint_rule(endpoint='/contact', limit=1000, window_seconds=60)
     now = int(time.time())
 
-    # Act: 3 requests con Turnstile validado desde la misma IP.
-    for _ in range(3):
+    # Act: THRESHOLD requests con CAPTCHA real adjuntado desde la misma IP.
+    for _ in range(AUTO_BLACKLIST_THRESHOLD):
         check_or_raise(
             ip='8.8.8.8',
             endpoint='/contact',
-            turnstile_validated=True,
+            brought_turnstile_token=True,
             now=now,
         )
 

--- a/serverless/lambda/shared/tests/integration/shared/rate_limit/test_auto_blacklist_under_threshold_no_rule_e2e.py
+++ b/serverless/lambda/shared/tests/integration/shared/rate_limit/test_auto_blacklist_under_threshold_no_rule_e2e.py
@@ -1,6 +1,6 @@
 """
-Given una IP que valida solo 2 tokens Turnstile (bajo el threshold de 3),
-When check_or_raise corre 2 veces con turnstile_validated=True,
+Given una IP que adjunta CAPTCHAs reales bajo el threshold (THRESHOLD - 1),
+When check_or_raise corre esas veces con brought_turnstile_token=True,
 Then NO se crea ninguna rule ip_blacklist.
 """
 
@@ -10,6 +10,7 @@ import time
 
 import pytest
 from shared.dynamodb.models.rate_limit_rule import RateLimitRuleItem
+from shared.rate_limit.auto_blacklist import AUTO_BLACKLIST_THRESHOLD
 from shared.rate_limit.check import check_or_raise
 
 from ._fixtures import _add_endpoint_rule
@@ -20,17 +21,17 @@ pytestmark = pytest.mark.integration
 def test_auto_blacklist_under_threshold_no_rule_e2e(
     rate_limit_tables: dict[str, str],
 ) -> None:
-    """2 tokens Turnstile (< threshold 3) no disparan el auto-blacklist."""
+    """THRESHOLD-1 CAPTCHAs reales (< threshold) no disparan el auto-blacklist."""
     # Arrange
-    _add_endpoint_rule(endpoint='/contact', limit=100, window_seconds=60)
+    _add_endpoint_rule(endpoint='/contact', limit=1000, window_seconds=60)
     now = int(time.time())
 
     # Act
-    for _ in range(2):
+    for _ in range(AUTO_BLACKLIST_THRESHOLD - 1):
         check_or_raise(
             ip='8.8.4.4',
             endpoint='/contact',
-            turnstile_validated=True,
+            brought_turnstile_token=True,
             now=now,
         )
 

--- a/serverless/lambda/shared/tests/unit/shared/rate_limit/test_auto_blacklist.py
+++ b/serverless/lambda/shared/tests/unit/shared/rate_limit/test_auto_blacklist.py
@@ -20,28 +20,44 @@ class TestShouldAutoBlacklist:
     """should_auto_blacklist - decision boolean."""
 
     def test_when_below_threshold_then_false(self) -> None:
-        """Given count=2, threshold=3, When check, Then False."""
+        """Given count=2 (< threshold), When check, Then False."""
         assert should_auto_blacklist(2) is False
 
     def test_when_at_threshold_then_true(self) -> None:
-        """Given count=3, threshold=3, When check, Then True."""
+        """Given count == threshold, When check, Then True."""
         assert should_auto_blacklist(AUTO_BLACKLIST_THRESHOLD) is True
 
     def test_when_above_threshold_then_true(self) -> None:
-        """Given count=5, threshold=3, When check, Then True."""
-        assert should_auto_blacklist(5) is True
+        """Given count > threshold, When check, Then True."""
+        assert should_auto_blacklist(AUTO_BLACKLIST_THRESHOLD + 1) is True
+
+    def test_threshold_value_is_ten(self) -> None:
+        """El threshold subio de 3 a 10: 3-9 CAPTCHAs NO blacklistean.
+
+        Regresion del fix: un humano que reintenta un login (3-9 starts con
+        CAPTCHA en 60s) ya NO se auto-blacklistea.
+        """
+        assert AUTO_BLACKLIST_THRESHOLD == 10
+        assert should_auto_blacklist(3) is False
+        assert should_auto_blacklist(9) is False
+        assert should_auto_blacklist(10) is True
+
+    def test_duration_is_one_hour(self) -> None:
+        """La duracion del bloqueo bajo de 24h a 1h."""
+        assert AUTO_BLACKLIST_DURATION_SECONDS == 3600
 
 
 class TestCreateBlacklistRule:
     """create_blacklist_rule - persiste rule en DynamoDB."""
 
-    def test_when_called_then_rule_persisted_with_24h_ttl(
+    def test_when_called_then_rule_persisted_with_default_ttl(
         self, rate_limit_tables: dict[str, str]
     ) -> None:
         """
         Given IP,
         When create_blacklist_rule,
-        Then rule en tabla con kind=ip_blacklist + expires_at ~ now+86400.
+        Then rule en tabla con kind=ip_blacklist + expires_at ~ now + la
+        duracion default (AUTO_BLACKLIST_DURATION_SECONDS = 1h).
         """
         before = int(time.time())
         create_blacklist_rule('1.2.3.4')

--- a/serverless/lambda/shared/tests/unit/shared/rate_limit/test_buckets.py
+++ b/serverless/lambda/shared/tests/unit/shared/rate_limit/test_buckets.py
@@ -63,11 +63,11 @@ class TestIncrementBucket:
         # Bucket previous esta vacio, current=3, elapsed=0 -> effective=3
         assert effective == 3.0
 
-    def test_when_turnstile_validated_then_turnstile_tokens_incremented(
+    def test_when_brought_captcha_then_turnstile_tokens_incremented(
         self, rate_limit_tables: dict[str, str]
     ) -> None:
         """
-        Given turnstile_validated=True,
+        Given brought_turnstile_token=True (el request adjunto un CAPTCHA real),
         When increment,
         Then turnstile_tokens incrementado.
         """
@@ -75,12 +75,35 @@ class TestIncrementBucket:
             ip='1.2.3.4',
             endpoint='/contact',
             window_seconds=60,
-            turnstile_validated=True,
+            brought_turnstile_token=True,
             now=1500,
         )
 
         assert result['count'] == 1
         assert result['turnstile_tokens'] == 1
+
+    def test_when_no_captcha_then_turnstile_tokens_stays_zero(
+        self, rate_limit_tables: dict[str, str]
+    ) -> None:
+        """
+        Given brought_turnstile_token=False (verify-*/mfa/session: sin CAPTCHA),
+        When increment,
+        Then count sube pero turnstile_tokens queda en 0.
+
+        Regresion del fix: estos endpoints ya NO inflan el counter de
+        auto-blacklist (antes pasaban turnstile_validated=True y blacklisteaban
+        a un humano que reintentaba).
+        """
+        result = increment_bucket(
+            ip='1.2.3.4',
+            endpoint='/auth#login.verify-magic-link',
+            window_seconds=60,
+            brought_turnstile_token=False,
+            now=1500,
+        )
+
+        assert result['count'] == 1
+        assert result['turnstile_tokens'] == 0
 
 
 class TestGetEffectiveCount:

--- a/serverless/lambda/shared/tests/unit/shared/rate_limit/test_check.py
+++ b/serverless/lambda/shared/tests/unit/shared/rate_limit/test_check.py
@@ -184,24 +184,24 @@ class TestCountryBlock:
 
 
 class TestAutoBlacklist:
-    """Auto-blacklist por 3+ turnstile tokens en 60s."""
+    """Auto-blacklist por 10+ CAPTCHAs reales adjuntados en 60s."""
 
-    def test_when_3_turnstile_tokens_then_blacklist_rule_created(
+    def test_when_10_real_captchas_then_blacklist_rule_created(
         self, rate_limit_tables: dict[str, str]
     ) -> None:
         """
-        Given limit alto + turnstile_validated=True en 3 calls,
-        When 3 calls,
-        Then se crea ip_blacklist rule.
+        Given limit alto + brought_turnstile_token=True en 10 calls,
+        When 10 calls,
+        Then se crea ip_blacklist rule (umbral nuevo = 10).
         """
         _add_endpoint_rule(endpoint='/contact', limit=100, window_seconds=60)
         now = int(time.time())
 
-        for _ in range(3):
+        for _ in range(10):
             check_or_raise(
                 ip='2.3.4.5',
                 endpoint='/contact',
-                turnstile_validated=True,
+                brought_turnstile_token=True,
                 now=now,
             )
 
@@ -215,3 +215,65 @@ class TestAutoBlacklist:
         item = result.get('Item')
         assert item is not None
         assert item.get('action') == 'block'
+
+    def test_when_turnstile_validated_but_no_captcha_then_no_blacklist(
+        self, rate_limit_tables: dict[str, str]
+    ) -> None:
+        """
+        Regresion del fix: turnstile_validated=True (verify-*/mfa/session: usa
+        el limite alto pero NO adjunta CAPTCHA) NO alimenta la auto-blacklist.
+
+        Given limit alto + turnstile_validated=True (sin brought_turnstile_token)
+        en 15 calls (> umbral 10),
+        When 15 calls,
+        Then NO se crea ip_blacklist rule (un humano que reintenta no se banea).
+        """
+        _add_endpoint_rule(
+            endpoint='/auth#login.verify-magic-link',
+            limit=100,
+            window_seconds=60,
+        )
+        now = int(time.time())
+
+        for _ in range(15):
+            check_or_raise(
+                ip='3.4.5.6',
+                endpoint='/auth#login.verify-magic-link',
+                turnstile_validated=True,
+                now=now,
+            )
+
+        table = boto3.resource('dynamodb', region_name='us-east-1').Table(
+            'portfolio-rate-limit-rules-test'
+        )
+        result = table.get_item(
+            Key={'rule_key': 'ip#3.4.5.6', 'kind': 'ip_blacklist'}
+        )
+        assert result.get('Item') is None
+
+    def test_when_below_threshold_real_captchas_then_no_blacklist(
+        self, rate_limit_tables: dict[str, str]
+    ) -> None:
+        """
+        Given 9 CAPTCHAs reales (< umbral 10),
+        When 9 calls,
+        Then NO se crea ip_blacklist rule (humano reintentando login OK).
+        """
+        _add_endpoint_rule(endpoint='/contact', limit=100, window_seconds=60)
+        now = int(time.time())
+
+        for _ in range(9):
+            check_or_raise(
+                ip='4.5.6.7',
+                endpoint='/contact',
+                brought_turnstile_token=True,
+                now=now,
+            )
+
+        table = boto3.resource('dynamodb', region_name='us-east-1').Table(
+            'portfolio-rate-limit-rules-test'
+        )
+        result = table.get_item(
+            Key={'rule_key': 'ip#4.5.6.7', 'kind': 'ip_blacklist'}
+        )
+        assert result.get('Item') is None


### PR DESCRIPTION
## Problema

Un usuario legitimo que reintentaba el login (o el magic-link) en el admin dev se auto-blacklisteaba 24h con `{"error":"auto-blacklist: 3+ turnstile tokens in 60s","code":"IP_BLACKLISTED","retry_after_seconds":~85000}`.

Causa raiz: el contador de la auto-blacklist (bot detection) se incrementaba con `turnstile_validated=True`. Pero ese flag lo pasan TODOS los endpoints `verify-*`/`mfa.*`/`session.*` por BYPASS DE LIMITE del rate-limit — sin que el usuario haya adjuntado un CAPTCHA real. Asi, 3 reintentos de magic-link/login en 60s (algo trivial para un humano con un link que falla) disparaban el bloqueo de 24h.

Accion inmediata (ya aplicada, fuera de este PR): se desbloqueo la IP afectada borrando el item `ip_blacklist` de la tabla DDB `rate-limit-rules-dev` + su entrada cacheada `get_ip_rule`.

## Solucion

Separar dos conceptos que estaban mezclados en `turnstile_validated`:

1. **`turnstile_validated`** (se mantiene): el endpoint usa el limite ALTO del rate-limit. Lo pasan los `verify-*`/`mfa`/`session`. **Ya NO alimenta la auto-blacklist.**
2. **`brought_turnstile_token`** (nuevo): el request ADJUNTO un CAPTCHA real del usuario. Lo marcan SOLO `login.start`/`register.start`/`contact.create`, y solo si `bool(cf_turnstile_response)` (el bypass dev/E2E vacio NO cuenta). **Es el unico flag que alimenta el contador de auto-blacklist.**

Ademas, menos agresivo: umbral `3 -> 10` CAPTCHAs en 60s y duracion del bloqueo `24h -> 1h`. Un humano nunca hace 10 `start` con CAPTCHA real en 60s; un bot con solver si. Un falso positivo residual se recupera en 1h en vez de 24h.

## Como probar

- Unit: `serverless tests --type=unit --shared` (556), `--lambda=auth` (201), `--lambda=contact_form` (20); `lint-deps --shared` OK.
- Regresion cubierta: `verify-*` con `turnstile_validated=True` x15 NO blacklistea; 9 CAPTCHAs reales NO; 10 si (`test_check.py`).
- Real (post-merge): un usuario que reintenta `login.start` varias veces en dev ya NO recibe `IP_BLACKLISTED`. `api_e2e --env=dev` (75 casos) sigue verde.

## TODO

- El admin build (`/sessions`) esta roto en `dev` con un ZodError (`Failed to collect page data for /sessions`) — PREEXISTENTE, introducido por un PR reciente de analytics/sessions, ajeno a este cambio backend. Por eso el push salto el step `build` (un cambio Python de rate-limit no puede afectar el build del admin Next.js). Requiere un fix aparte en el dominio admin.
- El feature E2E (Playwright) del pre-push hizo timeout de infra (Docker, contencion con otros worktrees) — saltado; no ejerce el rate-limit del backend. El CI corre su propia bateria.
- Magic-link `LINK_CONSUMED`: el error reportado inicial era reintento del mismo link ya consumido; el bloqueante real era la blacklist. El anti-patron "GET consume el token" (un email scanner podria prefetch-consumirlo) queda como mejora futura si reaparece tras el desbloqueo.