### PR TITLE
feat(admin): UI de metricas del Lambda analytics (8 features bajo /metrics)

### DIFF
--- a/admin/src/app/(admin)/metrics/contacts/page.tsx
+++ b/admin/src/app/(admin)/metrics/contacts/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Mail } from "lucide-react";
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { ContactByStatusChart } from "@/features/contacts/components/ContactByStatusChart";
+import { ContactByStatusTable } from "@/features/contacts/components/ContactByStatusTable";
+import { ContactListTable } from "@/features/contacts/components/ContactListTable";
+import { ContactStatusFilter } from "@/features/contacts/components/ContactStatusFilter";
+import { useContactList } from "@/features/contacts/hooks/use-contact-list";
+import { useContactsByStatus } from "@/features/contacts/hooks/use-contacts-by-status";
+import type { ContactStatus } from "@/features/contacts/types";
+
+const PAGE_SIZE = 50;
+
+/**
+ * @page MetricsContactsPage
+ * @description Area de contactos (`/metrics/contacts`) con dos tabs: el
+ *   listado crudo paginado (contacts/list, con filtro por estado) y el
+ *   desglose por estado (contacts/by-status, chart + tabla). El rango from/to
+ *   es compartido por la page. Datos PII: no se persisten.
+ */
+export default function MetricsContactsPage() {
+	const { range, setRange } = useMetricsRange();
+	const [page, setPage] = useState(1);
+	const [status, setStatus] = useState<ContactStatus | undefined>(undefined);
+
+	const list = useContactList({
+		...range,
+		page,
+		page_size: PAGE_SIZE,
+		status,
+	});
+	const byStatus = useContactsByStatus(range);
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<Mail className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Contactos</h1>
+				</div>
+				<MetricsDateRange
+					range={range}
+					onChange={(next) => {
+						setPage(1);
+						setRange(next);
+					}}
+				/>
+			</header>
+
+			<Tabs defaultValue="list">
+				<TabsList>
+					<TabsTrigger value="list">Listado</TabsTrigger>
+					<TabsTrigger value="by-status">Por estado</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="list">
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+							<CardTitle>Listado de contactos</CardTitle>
+							<ContactStatusFilter
+								value={status}
+								onChange={(next) => {
+									setPage(1);
+									setStatus(next);
+								}}
+							/>
+						</CardHeader>
+						<CardContent>
+							{list.error ? (
+								<ErrorAlert error={list.error} />
+							) : (
+								<ContactListTable
+									data={list.data}
+									isLoading={list.isLoading}
+									page={page}
+									onPageChange={setPage}
+								/>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+
+				<TabsContent value="by-status">
+					<Card>
+						<CardHeader>
+							<CardTitle>Contactos por estado</CardTitle>
+						</CardHeader>
+						<CardContent className="space-y-6">
+							{byStatus.error ? (
+								<ErrorAlert error={byStatus.error} />
+							) : (
+								<>
+									<ContactByStatusChart
+										data={byStatus.data}
+										isLoading={byStatus.isLoading}
+									/>
+									{!byStatus.isLoading && byStatus.data ? (
+										<ContactByStatusTable items={byStatus.data.items} />
+									) : null}
+								</>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+			</Tabs>
+		</section>
+	);
+}

--- a/admin/src/app/(admin)/metrics/devices/page.tsx
+++ b/admin/src/app/(admin)/metrics/devices/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { MonitorSmartphone } from "lucide-react";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { DeviceBreakdown } from "@/features/devices/components/DeviceBreakdown";
+import { useBreakdown } from "@/features/devices/hooks/use-breakdown";
+
+/**
+ * @page MetricsDevicesPage
+ * @description Vista de metricas de dispositivos (`/metrics/devices`):
+ *   distribucion de sesiones por tipo de dispositivo, navegador y sistema
+ *   operativo (devices/breakdown). El rango from/to es compartido por la page.
+ */
+export default function MetricsDevicesPage() {
+	const { range, setRange } = useMetricsRange();
+	const breakdown = useBreakdown(range);
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<MonitorSmartphone className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Dispositivos</h1>
+				</div>
+				<MetricsDateRange range={range} onChange={setRange} />
+			</header>
+
+			{breakdown.error ? <ErrorAlert error={breakdown.error} /> : null}
+
+			<DeviceBreakdown data={breakdown.data} isLoading={breakdown.isLoading} />
+		</section>
+	);
+}

--- a/admin/src/app/(admin)/metrics/events/page.tsx
+++ b/admin/src/app/(admin)/metrics/events/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { MousePointerClick } from "lucide-react";
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { EventDistributionChart } from "@/features/events/components/EventDistributionChart";
+import { EventDistributionTable } from "@/features/events/components/EventDistributionTable";
+import { EventHeatmap } from "@/features/events/components/EventHeatmap";
+import { EventListTable } from "@/features/events/components/EventListTable";
+import { useDistribution } from "@/features/events/hooks/use-distribution";
+import { useEventList } from "@/features/events/hooks/use-event-list";
+import { useHeatmap } from "@/features/events/hooks/use-heatmap";
+
+const PAGE_SIZE = 50;
+
+/**
+ * @page MetricsEventsPage
+ * @description Area de eventos (`/metrics/events`) con tres tabs: la
+ *   distribucion de tipos de evento (events/distribution, chart + tabla), el
+ *   listado crudo paginado (events/list) y el heatmap dia x hora
+ *   (events/heatmap). El rango from/to es compartido por la page.
+ */
+export default function MetricsEventsPage() {
+	const { range, setRange } = useMetricsRange();
+	const [page, setPage] = useState(1);
+
+	const distribution = useDistribution(range);
+	const list = useEventList({ ...range, page, page_size: PAGE_SIZE });
+	const heatmap = useHeatmap(range);
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<MousePointerClick className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Eventos</h1>
+				</div>
+				<MetricsDateRange
+					range={range}
+					onChange={(next) => {
+						setPage(1);
+						setRange(next);
+					}}
+				/>
+			</header>
+
+			<Tabs defaultValue="distribution">
+				<TabsList>
+					<TabsTrigger value="distribution">Distribucion</TabsTrigger>
+					<TabsTrigger value="list">Listado</TabsTrigger>
+					<TabsTrigger value="heatmap">Heatmap</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="distribution">
+					<Card>
+						<CardHeader>
+							<CardTitle>Distribucion por tipo de evento</CardTitle>
+						</CardHeader>
+						<CardContent className="space-y-6">
+							{distribution.error ? (
+								<ErrorAlert error={distribution.error} />
+							) : (
+								<>
+									<EventDistributionChart
+										data={distribution.data}
+										isLoading={distribution.isLoading}
+									/>
+									{!distribution.isLoading && distribution.data ? (
+										<EventDistributionTable items={distribution.data.items} />
+									) : null}
+								</>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+
+				<TabsContent value="list">
+					<Card>
+						<CardHeader>
+							<CardTitle>Listado de eventos</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{list.error ? (
+								<ErrorAlert error={list.error} />
+							) : (
+								<EventListTable
+									data={list.data}
+									isLoading={list.isLoading}
+									page={page}
+									onPageChange={setPage}
+								/>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+
+				<TabsContent value="heatmap">
+					<Card>
+						<CardHeader>
+							<CardTitle>Eventos por dia y hora</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{heatmap.error ? (
+								<ErrorAlert error={heatmap.error} />
+							) : (
+								<EventHeatmap
+									data={heatmap.data}
+									isLoading={heatmap.isLoading}
+								/>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+			</Tabs>
+		</section>
+	);
+}

--- a/admin/src/app/(admin)/metrics/funnel/page.tsx
+++ b/admin/src/app/(admin)/metrics/funnel/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Filter } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { FunnelChart } from "@/features/funnel/components/FunnelChart";
+import { useConversion } from "@/features/funnel/hooks/use-conversion";
+
+/**
+ * @page FunnelPage
+ * @description Embudo de conversion (`/metrics/funnel`): session -> visit ->
+ *   contact con sus tasas (funnel/conversion). El rango from/to es compartido
+ *   con el resto de las pages de metricas.
+ */
+export default function FunnelPage() {
+	const { range, setRange } = useMetricsRange();
+	const conversion = useConversion(range);
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<Filter className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Embudo de conversion</h1>
+				</div>
+				<MetricsDateRange range={range} onChange={setRange} />
+			</header>
+
+			{conversion.error ? <ErrorAlert error={conversion.error} /> : null}
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Sesiones a contactos</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<FunnelChart
+						data={conversion.data}
+						isLoading={conversion.isLoading}
+					/>
+				</CardContent>
+			</Card>
+		</section>
+	);
+}

--- a/admin/src/app/(admin)/metrics/geo/page.tsx
+++ b/admin/src/app/(admin)/metrics/geo/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Globe } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { GeoCountryChart } from "@/features/geo/components/GeoCountryChart";
+import { GeoCountryTable } from "@/features/geo/components/GeoCountryTable";
+import { useByCountry } from "@/features/geo/hooks/use-by-country";
+
+/**
+ * @page MetricsGeoPage
+ * @description Metricas geograficas (`/metrics/geo`): ranking de paises por
+ *   sesiones (geo/by-country). Grafico con el top 10 + tabla completa. El rango
+ *   from/to es compartido (useMetricsRange).
+ */
+export default function MetricsGeoPage() {
+	const { range, setRange } = useMetricsRange();
+	const byCountry = useByCountry(range);
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<Globe className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Geografia</h1>
+				</div>
+				<MetricsDateRange range={range} onChange={setRange} />
+			</header>
+
+			{byCountry.error ? <ErrorAlert error={byCountry.error} /> : null}
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Top paises por sesiones</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<GeoCountryChart
+						data={byCountry.data}
+						isLoading={byCountry.isLoading}
+					/>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Paises</CardTitle>
+				</CardHeader>
+				<CardContent>
+					{byCountry.error ? (
+						<ErrorAlert error={byCountry.error} />
+					) : (
+						<GeoCountryTable items={byCountry.data?.items ?? []} />
+					)}
+				</CardContent>
+			</Card>
+		</section>
+	);
+}

--- a/admin/src/app/(admin)/metrics/page.tsx
+++ b/admin/src/app/(admin)/metrics/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { BarChart3 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { ActiveNowBadge } from "@/features/analytics/components/ActiveNowBadge";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { OverviewKpis } from "@/features/analytics/components/OverviewKpis";
+import { RetentionChart } from "@/features/analytics/components/RetentionChart";
+import { TimeseriesChart } from "@/features/analytics/components/TimeseriesChart";
+import { TopNichesChart } from "@/features/analytics/components/TopNichesChart";
+import { TopPagesTable } from "@/features/analytics/components/TopPagesTable";
+import { TopReferrersTable } from "@/features/analytics/components/TopReferrersTable";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { useOverview } from "@/features/analytics/hooks/use-overview";
+import { useRetention } from "@/features/analytics/hooks/use-retention";
+import { useTimeseries } from "@/features/analytics/hooks/use-timeseries";
+import { useTopNiches } from "@/features/analytics/hooks/use-top-niches";
+import { useTopPages } from "@/features/analytics/hooks/use-top-pages";
+import { useTopReferrers } from "@/features/analytics/hooks/use-top-referrers";
+
+/**
+ * @page MetricsOverviewPage
+ * @description Raiz del area de metricas (`/metrics`): KPIs (overview),
+ *   contador live (active-now), serie temporal (timeseries) y ranking de
+ *   paginas (top-pages). El rango from/to es compartido por la page.
+ */
+export default function MetricsOverviewPage() {
+	const { range, setRange } = useMetricsRange();
+	const overview = useOverview(range);
+	const timeseries = useTimeseries({ ...range, bucket: "day" });
+	const topPages = useTopPages(range);
+	const topReferrers = useTopReferrers(range);
+	const topNiches = useTopNiches(range);
+	const retention = useRetention(range);
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<BarChart3 className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Metricas</h1>
+					<ActiveNowBadge />
+				</div>
+				<MetricsDateRange range={range} onChange={setRange} />
+			</header>
+
+			{overview.error ? <ErrorAlert error={overview.error} /> : null}
+
+			<OverviewKpis data={overview.data} isLoading={overview.isLoading} />
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Eventos en el tiempo</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<TimeseriesChart
+						data={timeseries.data}
+						isLoading={timeseries.isLoading}
+					/>
+				</CardContent>
+			</Card>
+
+			<div className="grid gap-6 lg:grid-cols-2">
+				<Card>
+					<CardHeader>
+						<CardTitle>Paginas mas vistas</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{topPages.error ? (
+							<ErrorAlert error={topPages.error} />
+						) : (
+							<TopPagesTable items={topPages.data?.items ?? []} />
+						)}
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<CardTitle>Top referrers</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{topReferrers.error ? (
+							<ErrorAlert error={topReferrers.error} />
+						) : (
+							<TopReferrersTable
+								label="Referrer"
+								items={topReferrers.data?.referrers ?? []}
+							/>
+						)}
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<CardTitle>Top niches</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{topNiches.error ? (
+							<ErrorAlert error={topNiches.error} />
+						) : (
+							<TopNichesChart
+								data={topNiches.data}
+								isLoading={topNiches.isLoading}
+							/>
+						)}
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<CardTitle>Retencion</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{retention.error ? (
+							<ErrorAlert error={retention.error} />
+						) : (
+							<RetentionChart
+								data={retention.data}
+								isLoading={retention.isLoading}
+							/>
+						)}
+					</CardContent>
+				</Card>
+			</div>
+		</section>
+	);
+}

--- a/admin/src/app/(admin)/metrics/sessions/detail/page.tsx
+++ b/admin/src/app/(admin)/metrics/sessions/detail/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { SessionDetailView } from "@/features/sessions/components/SessionDetailView";
+
+/**
+ * @page MetricsSessionDetailPage
+ * @description Detalle de una sesion de visitante. Ruta ESTATICA
+ *   (`/metrics/sessions/detail?id=<session_id>`) en vez de dinamica `[id]`:
+ *   `output: 'export'` no admite rutas dinamicas sin params conocidos en
+ *   build. El id viaja como query param y se lee client-side con
+ *   `useSearchParams` (dentro de Suspense, obligatorio en export).
+ */
+function SessionDetailContent() {
+	const params = useSearchParams();
+	const sessionId = params.get("id") ?? "";
+	return <SessionDetailView sessionId={sessionId} />;
+}
+
+export default function MetricsSessionDetailPage() {
+	return (
+		<Suspense fallback={null}>
+			<SessionDetailContent />
+		</Suspense>
+	);
+}

--- a/admin/src/app/(admin)/metrics/sessions/page.tsx
+++ b/admin/src/app/(admin)/metrics/sessions/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Users } from "lucide-react";
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { SessionFilters } from "@/features/sessions/components/SessionFilters";
+import { SessionsPagination } from "@/features/sessions/components/SessionsPagination";
+import { SessionsTable } from "@/features/sessions/components/SessionsTable";
+import { useSessionList } from "@/features/sessions/hooks/use-session-list";
+
+const PAGE_SIZE = 25;
+
+/**
+ * @page MetricsSessionsPage
+ * @description Listado paginado de sesiones de visitantes (sessions/list).
+ *   Comparte el rango from/to con el resto del area de metricas. Filtros
+ *   opcionales por device_type y browser; al cambiar un filtro o el rango se
+ *   vuelve a la pagina 1.
+ */
+export default function MetricsSessionsPage() {
+	const { range, setRange } = useMetricsRange();
+	const [page, setPage] = useState(1);
+	const [deviceType, setDeviceType] = useState<string | undefined>();
+	const [browser, setBrowser] = useState<string | undefined>();
+
+	const sessions = useSessionList({
+		...range,
+		page,
+		page_size: PAGE_SIZE,
+		device_type: deviceType,
+		browser,
+	});
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<Users className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Sesiones</h1>
+				</div>
+				<MetricsDateRange
+					range={range}
+					onChange={(next) => {
+						setPage(1);
+						setRange(next);
+					}}
+				/>
+			</header>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Sesiones de visitantes</CardTitle>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<SessionFilters
+						deviceType={deviceType}
+						browser={browser}
+						onDeviceTypeChange={(value) => {
+							setPage(1);
+							setDeviceType(value);
+						}}
+						onBrowserChange={(value) => {
+							setPage(1);
+							setBrowser(value);
+						}}
+					/>
+
+					{sessions.error ? (
+						<ErrorAlert
+							error={sessions.error}
+							onRetry={() => sessions.refetch()}
+						/>
+					) : (
+						<>
+							<SessionsTable
+								items={sessions.data?.items ?? []}
+								isLoading={sessions.isLoading}
+							/>
+							<SessionsPagination
+								page={sessions.data?.page ?? page}
+								pageSize={sessions.data?.page_size ?? PAGE_SIZE}
+								total={sessions.data?.total ?? 0}
+								hasMore={sessions.data?.has_more ?? false}
+								isLoading={sessions.isLoading || sessions.isFetching}
+								onPageChange={setPage}
+							/>
+						</>
+					)}
+				</CardContent>
+			</Card>
+		</section>
+	);
+}

--- a/admin/src/app/(admin)/metrics/visits/page.tsx
+++ b/admin/src/app/(admin)/metrics/visits/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Eye } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+import { LandingPagesTable } from "@/features/visits/components/LandingPagesTable";
+import { VisitsTable } from "@/features/visits/components/VisitsTable";
+import { useLandingPages } from "@/features/visits/hooks/use-landing-pages";
+import { useVisitsList } from "@/features/visits/hooks/use-visits-list";
+
+const PAGE_SIZE = 20;
+
+/**
+ * @page MetricsVisitsPage
+ * @description Area de visitas (`/metrics/visits`) con dos tabs: el listado
+ *   paginado de visitas (visits/list) y el ranking de landing pages
+ *   (visits/landing-pages). El rango from/to es compartido por la page.
+ */
+export default function MetricsVisitsPage() {
+	const { range, setRange } = useMetricsRange();
+	const [page, setPage] = useState(1);
+
+	const list = useVisitsList({ ...range, page, page_size: PAGE_SIZE });
+	const landingPages = useLandingPages(range);
+
+	const total = list.data?.total ?? 0;
+	const hasMore = list.data?.has_more ?? false;
+
+	return (
+		<section className="space-y-6">
+			<header className="flex flex-wrap items-center justify-between gap-3">
+				<div className="flex items-center gap-3">
+					<Eye className="h-5 w-5 text-muted-foreground" />
+					<h1 className="text-2xl font-semibold">Visitas</h1>
+				</div>
+				<MetricsDateRange
+					range={range}
+					onChange={(next) => {
+						setPage(1);
+						setRange(next);
+					}}
+				/>
+			</header>
+
+			<Tabs defaultValue="list">
+				<TabsList>
+					<TabsTrigger value="list">Listado</TabsTrigger>
+					<TabsTrigger value="landing">Landing pages</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="list">
+					<Card>
+						<CardHeader>
+							<CardTitle>Listado de visitas</CardTitle>
+						</CardHeader>
+						<CardContent className="space-y-4">
+							{list.error ? (
+								<ErrorAlert error={list.error} />
+							) : list.isLoading ? (
+								<Skeleton className="h-72 w-full" />
+							) : (
+								<>
+									<VisitsTable items={list.data?.items ?? []} />
+									<div className="flex items-center justify-between">
+										<p className="text-sm text-muted-foreground">
+											Pagina {page} · {total} visitas
+										</p>
+										<div className="flex gap-2">
+											<Button
+												variant="outline"
+												size="sm"
+												disabled={page <= 1}
+												onClick={() => setPage((p) => Math.max(1, p - 1))}
+											>
+												Anterior
+											</Button>
+											<Button
+												variant="outline"
+												size="sm"
+												disabled={!hasMore}
+												onClick={() => setPage((p) => p + 1)}
+											>
+												Cargar mas
+											</Button>
+										</div>
+									</div>
+								</>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+
+				<TabsContent value="landing">
+					<Card>
+						<CardHeader>
+							<CardTitle>Landing pages</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{landingPages.error ? (
+								<ErrorAlert error={landingPages.error} />
+							) : landingPages.isLoading ? (
+								<Skeleton className="h-72 w-full" />
+							) : (
+								<LandingPagesTable items={landingPages.data?.items ?? []} />
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+			</Tabs>
+		</section>
+	);
+}

--- a/admin/src/features/admin-shell/lib/nav-items.ts
+++ b/admin/src/features/admin-shell/lib/nav-items.ts
@@ -1,4 +1,5 @@
 import {
+	BarChart3,
 	FileText,
 	type LucideIcon,
 	Monitor,
@@ -12,11 +13,11 @@ import { ROUTES } from "@/lib/routes";
  * @description Items del sidebar del app shell. `adminOnly` oculta el item a
  *   usuarios no-admin.
  *
- *   El slot `metrics` (ROUTES.admin.metrics) NO se lista todavia: las pantallas
- *   de metricas las monta el plan b-analytics-api y la page /metrics aun no
- *   existe (un link rompe la navegacion con un 404 del SPA fallback). Cuando
- *   ese plan monte la page, re-agregar
- *   `{ href: ROUTES.admin.metrics, label: "Metricas", icon: BarChart3 }`.
+ *   El area de metricas (Lambda analytics, plan b-analytics-api) entra por el
+ *   item `Metricas` (ROUTES.admin.metrics). Las sub-secciones del tracking de
+ *   visitantes cuelgan de /metrics/* (sessions, events, visits, geo, devices,
+ *   funnel, contacts) y se navegan desde la page /metrics; el sidebar solo
+ *   expone la raiz para no saturarlo.
  */
 export interface NavItem {
 	href: string;
@@ -26,6 +27,7 @@ export interface NavItem {
 }
 
 export const NAV_ITEMS: readonly NavItem[] = [
+	{ href: ROUTES.admin.metrics, label: "Metricas", icon: BarChart3 },
 	{ href: ROUTES.admin.settings, label: "Configuracion", icon: Settings },
 	{ href: ROUTES.admin.sessions, label: "Mis sesiones", icon: Monitor },
 	{ href: ROUTES.admin.users, label: "Usuarios", icon: Users, adminOnly: true },

--- a/admin/src/features/analytics/api/analytics-client.ts
+++ b/admin/src/features/analytics/api/analytics-client.ts
@@ -1,0 +1,43 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type {
+	ActiveNowResponse,
+	DateRangeParams,
+	OverviewResponse,
+	RetentionResponse,
+	TimeseriesParams,
+	TimeseriesResponse,
+	TopNichesResponse,
+	TopPagesParams,
+	TopPagesResponse,
+	TopReferrersResponse,
+} from "../types";
+
+/**
+ * @module features/analytics/api/analytics-client
+ * @description Cliente tipado de la operation `analytics` del Lambda
+ *   `analytics`. Cada fn hace `GET /analytics?operation=analytics&action=...`
+ *   via `fetchMetric` (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const analyticsClient = {
+	overview: (params: DateRangeParams) =>
+		fetchMetric<OverviewResponse>("analytics", "overview", { ...params }),
+
+	timeseries: (params: TimeseriesParams) =>
+		fetchMetric<TimeseriesResponse>("analytics", "timeseries", { ...params }),
+
+	topPages: (params: TopPagesParams) =>
+		fetchMetric<TopPagesResponse>("analytics", "top-pages", { ...params }),
+
+	topReferrers: (params: DateRangeParams) =>
+		fetchMetric<TopReferrersResponse>("analytics", "top-referrers", {
+			...params,
+		}),
+
+	topNiches: (params: DateRangeParams) =>
+		fetchMetric<TopNichesResponse>("analytics", "top-niches", { ...params }),
+
+	activeNow: () => fetchMetric<ActiveNowResponse>("analytics", "active-now"),
+
+	retention: (params: DateRangeParams) =>
+		fetchMetric<RetentionResponse>("analytics", "retention", { ...params }),
+};

--- a/admin/src/features/analytics/api/query-keys.ts
+++ b/admin/src/features/analytics/api/query-keys.ts
@@ -1,0 +1,27 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type {
+	DateRangeParams,
+	TimeseriesParams,
+	TopPagesParams,
+} from "../types";
+
+/**
+ * @module features/analytics/api/query-keys
+ * @description Query keys del dominio `analytics`, derivadas del namespace raiz
+ *   `['metrics', 'analytics', <action>, params]`.
+ */
+export const analyticsKeys = {
+	overview: (params: DateRangeParams) =>
+		metricsKey("analytics", "overview", params),
+	timeseries: (params: TimeseriesParams) =>
+		metricsKey("analytics", "timeseries", params),
+	topPages: (params: TopPagesParams) =>
+		metricsKey("analytics", "top-pages", params),
+	topReferrers: (params: DateRangeParams) =>
+		metricsKey("analytics", "top-referrers", params),
+	topNiches: (params: DateRangeParams) =>
+		metricsKey("analytics", "top-niches", params),
+	activeNow: () => metricsKey("analytics", "active-now"),
+	retention: (params: DateRangeParams) =>
+		metricsKey("analytics", "retention", params),
+};

--- a/admin/src/features/analytics/components/ActiveNowBadge.tsx
+++ b/admin/src/features/analytics/components/ActiveNowBadge.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Radio } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { useActiveNow } from "../hooks/use-active-now";
+
+/**
+ * @component ActiveNowBadge
+ * @description Contador live de sesiones activas (analytics/active-now), con
+ *   refetch cada 15s. Punto verde pulsante + conteo. Si falla o carga, muestra
+ *   un guion sin romper el layout.
+ */
+export function ActiveNowBadge() {
+	const { data, isLoading, isError } = useActiveNow();
+	const count = isLoading || isError || !data ? "–" : data.active_sessions;
+
+	return (
+		<Badge variant="secondary" className="gap-2">
+			<span className="relative flex h-2 w-2">
+				<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
+				<span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+			</span>
+			<Radio className="h-3.5 w-3.5" />
+			<span>
+				{count}{" "}
+				{typeof count === "number" && count === 1 ? "activo" : "activos"}
+			</span>
+		</Badge>
+	);
+}

--- a/admin/src/features/analytics/components/MetricsDateRange.tsx
+++ b/admin/src/features/analytics/components/MetricsDateRange.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { DateRange } from "react-day-picker";
+import { DateRangePicker } from "@/components/ui/date-range-picker";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @component MetricsDateRange
+ * @description Wrapper del DateRangePicker para el rango de metricas: adapta
+ *   entre los strings `YYYY-MM-DD` (params del backend) y los `Date` que usa
+ *   el picker (react-day-picker). Al elegir un rango completo, lo propaga como
+ *   `{from, to}` strings.
+ *
+ * @props {DateRangeParams} range - rango actual (from/to YYYY-MM-DD)
+ * @props {(range: DateRangeParams) => void} onChange - callback con strings
+ */
+function toDate(s?: string): Date | undefined {
+	if (!s) return undefined;
+	const d = new Date(`${s}T00:00:00`);
+	return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+function toIso(d?: Date): string | undefined {
+	if (!d) return undefined;
+	return d.toISOString().slice(0, 10);
+}
+
+export function MetricsDateRange({
+	range,
+	onChange,
+}: {
+	range: DateRangeParams;
+	onChange: (range: DateRangeParams) => void;
+}) {
+	const value: DateRange | undefined = range.from
+		? { from: toDate(range.from), to: toDate(range.to) }
+		: undefined;
+
+	return (
+		<DateRangePicker
+			value={value}
+			onChange={(next) => {
+				if (next?.from && next?.to) {
+					onChange({ from: toIso(next.from), to: toIso(next.to) });
+				}
+			}}
+		/>
+	);
+}

--- a/admin/src/features/analytics/components/OverviewKpis.tsx
+++ b/admin/src/features/analytics/components/OverviewKpis.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import {
+	Activity,
+	Clock,
+	Eye,
+	Mail,
+	MousePointerClick,
+	TrendingDown,
+	Users,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { OverviewResponse } from "../types";
+
+/**
+ * @component OverviewKpis
+ * @description Grid de KPI cards de analytics/overview: sessions, visits,
+ *   events, contacts, unique_visitors, avg_visit_duration_sec, bounce_rate.
+ *   Muestra skeletons mientras carga.
+ *
+ * @props {OverviewResponse} [data] - KPIs del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+interface KpiDef {
+	key: keyof OverviewResponse;
+	label: string;
+	icon: LucideIcon;
+	format: (v: number) => string;
+}
+
+function fmtInt(v: number): string {
+	return new Intl.NumberFormat("es").format(Math.round(v));
+}
+
+function fmtDuration(sec: number): string {
+	const s = Math.round(sec);
+	if (s < 60) return `${s}s`;
+	const m = Math.floor(s / 60);
+	if (m < 60) return `${m}m ${s % 60}s`;
+	const h = Math.floor(m / 60);
+	return `${h}h ${m % 60}m`;
+}
+
+function fmtPct(v: number): string {
+	return `${(v * 100).toFixed(1)}%`;
+}
+
+const KPIS: readonly KpiDef[] = [
+	{ key: "sessions", label: "Sesiones", icon: Users, format: fmtInt },
+	{ key: "visits", label: "Visitas", icon: Eye, format: fmtInt },
+	{ key: "events", label: "Eventos", icon: MousePointerClick, format: fmtInt },
+	{ key: "contacts", label: "Contactos", icon: Mail, format: fmtInt },
+	{
+		key: "unique_visitors",
+		label: "Visitantes unicos",
+		icon: Activity,
+		format: fmtInt,
+	},
+	{
+		key: "avg_visit_duration_sec",
+		label: "Duracion media",
+		icon: Clock,
+		format: fmtDuration,
+	},
+	{
+		key: "bounce_rate",
+		label: "Tasa de rebote",
+		icon: TrendingDown,
+		format: fmtPct,
+	},
+];
+
+export function OverviewKpis({
+	data,
+	isLoading,
+}: {
+	data?: OverviewResponse;
+	isLoading: boolean;
+}) {
+	return (
+		<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+			{KPIS.map((kpi) => {
+				const Icon = kpi.icon;
+				return (
+					<Card key={kpi.key}>
+						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+							<CardTitle className="text-sm font-medium text-muted-foreground">
+								{kpi.label}
+							</CardTitle>
+							<Icon className="h-4 w-4 text-muted-foreground" />
+						</CardHeader>
+						<CardContent>
+							{isLoading || !data ? (
+								<Skeleton className="h-7 w-20" />
+							) : (
+								<p className="text-2xl font-semibold">
+									{kpi.format(data[kpi.key] as number)}
+								</p>
+							)}
+						</CardContent>
+					</Card>
+				);
+			})}
+		</div>
+	);
+}

--- a/admin/src/features/analytics/components/RetentionChart.tsx
+++ b/admin/src/features/analytics/components/RetentionChart.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { RetentionResponse } from "../types";
+
+/**
+ * @component RetentionChart
+ * @description New vs returning visitors (analytics/retention) como PieChart de
+ *   Recharts + tasa de retorno. Skeleton mientras carga.
+ *
+ * @props {RetentionResponse} [data] - retencion del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+export function RetentionChart({
+	data,
+	isLoading,
+}: {
+	data?: RetentionResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-64 w-full" />;
+	}
+
+	const slices = [
+		{ name: "Nuevos", value: data.new_visitors, fill: "var(--primary)" },
+		{
+			name: "Recurrentes",
+			value: data.returning_visitors,
+			fill: "var(--muted-foreground)",
+		},
+	];
+
+	return (
+		<div className="flex flex-col items-center gap-3">
+			<ResponsiveContainer width="100%" height={224}>
+				<PieChart>
+					<Pie
+						data={slices}
+						dataKey="value"
+						nameKey="name"
+						innerRadius={50}
+						outerRadius={80}
+						paddingAngle={2}
+					>
+						{slices.map((slice) => (
+							<Cell key={slice.name} fill={slice.fill} />
+						))}
+					</Pie>
+					<Tooltip
+						contentStyle={{
+							background: "var(--popover)",
+							border: "1px solid var(--border)",
+							borderRadius: 8,
+							fontSize: 12,
+						}}
+					/>
+				</PieChart>
+			</ResponsiveContainer>
+			<p className="text-sm text-muted-foreground">
+				Tasa de retorno:{" "}
+				<span className="font-semibold text-foreground">
+					{(data.returning_rate * 100).toFixed(1)}%
+				</span>
+			</p>
+		</div>
+	);
+}

--- a/admin/src/features/analytics/components/TimeseriesChart.tsx
+++ b/admin/src/features/analytics/components/TimeseriesChart.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+	CartesianGrid,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { TimeseriesResponse } from "../types";
+
+/**
+ * @component TimeseriesChart
+ * @description Serie temporal de eventos (analytics/timeseries) como LineChart
+ *   de Recharts. Colores via CSS vars del DS (`--primary`). Skeleton mientras
+ *   carga; mensaje si no hay puntos.
+ *
+ * @props {TimeseriesResponse} [data] - serie del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+export function TimeseriesChart({
+	data,
+	isLoading,
+}: {
+	data?: TimeseriesResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-72 w-full" />;
+	}
+	if (data.points.length === 0) {
+		return (
+			<div className="flex h-72 items-center justify-center text-sm text-muted-foreground">
+				Sin datos en el rango seleccionado.
+			</div>
+		);
+	}
+
+	const chartData = data.points.map((p) => ({
+		ts: p.timestamp.slice(0, 10),
+		count: p.count,
+	}));
+
+	return (
+		<ResponsiveContainer width="100%" height={288}>
+			<LineChart
+				data={chartData}
+				margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+			>
+				<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+				<XAxis
+					dataKey="ts"
+					tick={{ fontSize: 12 }}
+					className="text-muted-foreground"
+				/>
+				<YAxis tick={{ fontSize: 12 }} allowDecimals={false} width={40} />
+				<Tooltip
+					contentStyle={{
+						background: "var(--popover)",
+						border: "1px solid var(--border)",
+						borderRadius: 8,
+						fontSize: 12,
+					}}
+				/>
+				<Line
+					type="monotone"
+					dataKey="count"
+					stroke="var(--primary)"
+					strokeWidth={2}
+					dot={false}
+				/>
+			</LineChart>
+		</ResponsiveContainer>
+	);
+}

--- a/admin/src/features/analytics/components/TopNichesChart.tsx
+++ b/admin/src/features/analytics/components/TopNichesChart.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { TopNichesResponse } from "../types";
+
+/**
+ * @component TopNichesChart
+ * @description Ranking de niches por visitas (analytics/top-niches) como
+ *   BarChart de Recharts. Skeleton mientras carga; mensaje si vacio.
+ *
+ * @props {TopNichesResponse} [data] - ranking del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+export function TopNichesChart({
+	data,
+	isLoading,
+}: {
+	data?: TopNichesResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-64 w-full" />;
+	}
+	if (data.items.length === 0) {
+		return (
+			<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+				Sin datos en el rango seleccionado.
+			</div>
+		);
+	}
+
+	return (
+		<ResponsiveContainer width="100%" height={256}>
+			<BarChart
+				data={data.items}
+				margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+			>
+				<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+				<XAxis dataKey="niche" tick={{ fontSize: 12 }} />
+				<YAxis tick={{ fontSize: 12 }} allowDecimals={false} width={40} />
+				<Tooltip
+					contentStyle={{
+						background: "var(--popover)",
+						border: "1px solid var(--border)",
+						borderRadius: 8,
+						fontSize: 12,
+					}}
+				/>
+				<Bar dataKey="visits" fill="var(--primary)" radius={[4, 4, 0, 0]} />
+			</BarChart>
+		</ResponsiveContainer>
+	);
+}

--- a/admin/src/features/analytics/components/TopPagesTable.tsx
+++ b/admin/src/features/analytics/components/TopPagesTable.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import type { TopPageItem } from "../types";
+
+/**
+ * @component TopPagesTable
+ * @description Ranking de paginas (analytics/top-pages): page_path + events +
+ *   unique_visitors + unique_visits.
+ *
+ * @props {TopPageItem[]} items - filas del ranking
+ */
+export function TopPagesTable({ items }: { items: TopPageItem[] }) {
+	if (items.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin paginas en el rango seleccionado.
+			</p>
+		);
+	}
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Pagina</TableHead>
+					<TableHead className="text-right">Eventos</TableHead>
+					<TableHead className="text-right">Visitantes</TableHead>
+					<TableHead className="text-right">Visitas</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{items.map((item) => (
+					<TableRow key={item.page_path}>
+						<TableCell className="font-mono text-xs">
+							{item.page_path}
+						</TableCell>
+						<TableCell className="text-right">{item.events}</TableCell>
+						<TableCell className="text-right">{item.unique_visitors}</TableCell>
+						<TableCell className="text-right">{item.unique_visits}</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/admin/src/features/analytics/components/TopReferrersTable.tsx
+++ b/admin/src/features/analytics/components/TopReferrersTable.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import type { RankItem } from "../types";
+
+/**
+ * @component TopReferrersTable
+ * @description Ranking generico (referrers o UTM) de analytics/top-referrers:
+ *   etiqueta + visitas. La columna de etiqueta se resuelve del primer campo
+ *   no-numerico presente en el item.
+ *
+ * @props {string} label - encabezado de la columna de etiqueta
+ * @props {RankItem[]} items - filas del ranking
+ */
+function rowLabel(item: RankItem): string {
+	return (
+		item.referrer ??
+		item.utm_source ??
+		item.utm_medium ??
+		item.utm_campaign ??
+		"(desconocido)"
+	);
+}
+
+export function TopReferrersTable({
+	label,
+	items,
+}: {
+	label: string;
+	items: RankItem[];
+}) {
+	if (items.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin datos en el rango seleccionado.
+			</p>
+		);
+	}
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>{label}</TableHead>
+					<TableHead className="text-right">Visitas</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{items.map((item) => (
+					<TableRow key={rowLabel(item)}>
+						<TableCell className="font-mono text-xs">
+							{rowLabel(item)}
+						</TableCell>
+						<TableCell className="text-right">{item.visits}</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/admin/src/features/analytics/hooks/use-active-now.ts
+++ b/admin/src/features/analytics/hooks/use-active-now.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+
+/**
+ * @function useActiveNow
+ * @description Contador live de sesiones activas (analytics/active-now).
+ *   staleTime 10s + refetchInterval 15s (live; TTL backend 10s). NO depende
+ *   del rango de fechas.
+ */
+export function useActiveNow() {
+	return useQuery({
+		queryKey: analyticsKeys.activeNow(),
+		queryFn: () => analyticsClient.activeNow(),
+		staleTime: 10_000,
+		refetchInterval: 15_000,
+	});
+}

--- a/admin/src/features/analytics/hooks/use-metrics-range.ts
+++ b/admin/src/features/analytics/hooks/use-metrics-range.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function isoDate
+ * @description Formatea un Date a `YYYY-MM-DD` (UTC) para los params from/to.
+ */
+function isoDate(d: Date): string {
+	return d.toISOString().slice(0, 10);
+}
+
+/**
+ * @function useMetricsRange
+ * @description Estado del rango de fechas compartido por las pages de metricas.
+ *   Default: ultimos 30 dias (matchea el default del backend). El backend
+ *   rechaza rangos > 90 dias (400); el DateRangePicker debe acotar a 90d.
+ *
+ * @returns `{ range, setRange }` donde range es `{from, to}` (YYYY-MM-DD).
+ */
+export function useMetricsRange(): {
+	range: DateRangeParams;
+	setRange: (range: DateRangeParams) => void;
+} {
+	const [range, setRange] = useState<DateRangeParams>(() => {
+		const to = new Date();
+		const from = new Date();
+		from.setDate(from.getDate() - 30);
+		return { from: isoDate(from), to: isoDate(to) };
+	});
+	return { range, setRange };
+}

--- a/admin/src/features/analytics/hooks/use-overview.ts
+++ b/admin/src/features/analytics/hooks/use-overview.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useOverview
+ * @description KPIs top-level (analytics/overview). staleTime 60s (matchea el
+ *   TTL de cache del backend para las queries agregadas).
+ * @param range - rango de fechas (from/to)
+ */
+export function useOverview(range: DateRangeParams) {
+	return useQuery({
+		queryKey: analyticsKeys.overview(range),
+		queryFn: () => analyticsClient.overview(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/analytics/hooks/use-retention.ts
+++ b/admin/src/features/analytics/hooks/use-retention.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useRetention
+ * @description New vs returning visitors (analytics/retention). staleTime 60s.
+ * @param range - rango de fechas
+ */
+export function useRetention(range: DateRangeParams) {
+	return useQuery({
+		queryKey: analyticsKeys.retention(range),
+		queryFn: () => analyticsClient.retention(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/analytics/hooks/use-timeseries.ts
+++ b/admin/src/features/analytics/hooks/use-timeseries.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+import type { TimeseriesParams } from "../types";
+
+/**
+ * @function useTimeseries
+ * @description Serie temporal de eventos (analytics/timeseries). staleTime 60s.
+ * @param params - rango + bucket (day|hour|week) + filtros opcionales
+ */
+export function useTimeseries(params: TimeseriesParams) {
+	return useQuery({
+		queryKey: analyticsKeys.timeseries(params),
+		queryFn: () => analyticsClient.timeseries(params),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/analytics/hooks/use-top-niches.ts
+++ b/admin/src/features/analytics/hooks/use-top-niches.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useTopNiches
+ * @description Ranking de niches por visitas (analytics/top-niches). staleTime 60s.
+ * @param range - rango de fechas
+ */
+export function useTopNiches(range: DateRangeParams) {
+	return useQuery({
+		queryKey: analyticsKeys.topNiches(range),
+		queryFn: () => analyticsClient.topNiches(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/analytics/hooks/use-top-pages.ts
+++ b/admin/src/features/analytics/hooks/use-top-pages.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+import type { TopPagesParams } from "../types";
+
+/**
+ * @function useTopPages
+ * @description Ranking de paginas mas vistas (analytics/top-pages). staleTime 60s.
+ * @param params - rango + limit + niche opcional
+ */
+export function useTopPages(params: TopPagesParams) {
+	return useQuery({
+		queryKey: analyticsKeys.topPages(params),
+		queryFn: () => analyticsClient.topPages(params),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/analytics/hooks/use-top-referrers.ts
+++ b/admin/src/features/analytics/hooks/use-top-referrers.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useTopReferrers
+ * @description Rankings de referrers + UTM (analytics/top-referrers). staleTime 60s.
+ * @param range - rango de fechas
+ */
+export function useTopReferrers(range: DateRangeParams) {
+	return useQuery({
+		queryKey: analyticsKeys.topReferrers(range),
+		queryFn: () => analyticsClient.topReferrers(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/analytics/types.ts
+++ b/admin/src/features/analytics/types.ts
@@ -1,0 +1,106 @@
+/**
+ * @module features/analytics/types
+ * @description Shapes de las respuestas del Lambda `analytics` (operation
+ *   `analytics`): overview, timeseries, top-pages, top-referrers, top-niches,
+ *   active-now, retention. Espejan el `data` que devuelve cada endpoint.
+ */
+
+/** Rango de fechas que comparten todos los endpoints de metricas. */
+export interface DateRangeParams {
+	from?: string;
+	to?: string;
+}
+
+/** analytics/overview — 7 KPIs top-level. */
+export interface OverviewResponse {
+	sessions: number;
+	visits: number;
+	events: number;
+	contacts: number;
+	unique_visitors: number;
+	avg_visit_duration_sec: number;
+	bounce_rate: number;
+	from: string;
+	to: string;
+}
+
+/** Un punto de la serie temporal. */
+export interface TimeseriesPoint {
+	timestamp: string;
+	count: number;
+}
+
+/** analytics/timeseries — serie temporal de eventos. */
+export interface TimeseriesResponse {
+	bucket: string;
+	points: TimeseriesPoint[];
+	from: string;
+	to: string;
+	filters: { niche: string | null; event_type: string | null };
+}
+
+export interface TimeseriesParams extends DateRangeParams {
+	bucket?: "day" | "hour" | "week";
+	niche?: string;
+	event_type?: string;
+}
+
+/** Una pagina rankeada (top-pages). */
+export interface TopPageItem {
+	page_path: string;
+	events: number;
+	unique_visitors: number;
+	unique_visits: number;
+}
+
+export interface TopPagesResponse {
+	items: TopPageItem[];
+}
+
+export interface TopPagesParams extends DateRangeParams {
+	limit?: number;
+	niche?: string;
+}
+
+/** Un referrer rankeado. */
+export interface RankItem {
+	referrer?: string;
+	utm_source?: string;
+	utm_medium?: string;
+	utm_campaign?: string;
+	visits: number;
+	unique_visitors?: number;
+}
+
+export interface TopReferrersResponse {
+	referrers: RankItem[];
+	utm_sources: RankItem[];
+	utm_mediums: RankItem[];
+	utm_campaigns: RankItem[];
+}
+
+/** Un niche rankeado. */
+export interface TopNicheItem {
+	niche: string;
+	visits: number;
+	unique_visitors: number;
+}
+
+export interface TopNichesResponse {
+	items: TopNicheItem[];
+}
+
+/** analytics/active-now — contador live de sesiones activas. */
+export interface ActiveNowResponse {
+	active_sessions: number;
+	threshold_minutes: number;
+	as_of: string;
+}
+
+/** analytics/retention — new vs returning. */
+export interface RetentionResponse {
+	new_visitors: number;
+	returning_visitors: number;
+	total: number;
+	returning_rate: number;
+}

--- a/admin/src/features/contacts/api/contacts-client.ts
+++ b/admin/src/features/contacts/api/contacts-client.ts
@@ -1,0 +1,33 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type {
+	ContactByStatusResponse,
+	ContactListParams,
+	ContactListResponse,
+	DateRangeParams,
+} from "../types";
+
+/**
+ * @module features/contacts/api/contacts-client
+ * @description Cliente tipado de la operation `contacts` del Lambda
+ *   `analytics`. Cada fn hace `GET /analytics?operation=contacts&action=...`
+ *   via `fetchMetric` (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const contactsClient = {
+	// El backend de `list` requiere `offset` ademas de page/page_size: se
+	// deriva como (page - 1) * page_size.
+	list: (params: ContactListParams) => {
+		const page = params.page ?? 1;
+		const pageSize = params.page_size ?? 50;
+		return fetchMetric<ContactListResponse>("contacts", "list", {
+			...params,
+			page,
+			page_size: pageSize,
+			offset: (page - 1) * pageSize,
+		});
+	},
+
+	byStatus: (params: DateRangeParams) =>
+		fetchMetric<ContactByStatusResponse>("contacts", "by-status", {
+			...params,
+		}),
+};

--- a/admin/src/features/contacts/api/query-keys.ts
+++ b/admin/src/features/contacts/api/query-keys.ts
@@ -1,0 +1,14 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type { ContactListParams, DateRangeParams } from "../types";
+
+/**
+ * @module features/contacts/api/query-keys
+ * @description Query keys del dominio `contacts`, derivadas del namespace raiz
+ *   `['metrics', 'contacts', <action>, params]`. Al ser feature PII, el
+ *   prefijo `contacts` la excluye del persister.
+ */
+export const contactsKeys = {
+	list: (params: ContactListParams) => metricsKey("contacts", "list", params),
+	byStatus: (params: DateRangeParams) =>
+		metricsKey("contacts", "by-status", params),
+};

--- a/admin/src/features/contacts/components/ContactByStatusChart.tsx
+++ b/admin/src/features/contacts/components/ContactByStatusChart.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ContactByStatusResponse } from "../types";
+
+/**
+ * @component ContactByStatusChart
+ * @description Desglose de contactos por estado (contacts/by-status) como
+ *   PieChart de Recharts. Colores via CSS vars del DS. Skeleton mientras
+ *   carga; mensaje si vacio.
+ *
+ * @props {ContactByStatusResponse} [data] - desglose del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+const SLICE_COLORS: readonly string[] = [
+	"var(--primary)",
+	"var(--muted-foreground)",
+	"var(--chart-3, var(--secondary))",
+	"var(--chart-4, var(--accent))",
+	"var(--destructive)",
+];
+
+export function ContactByStatusChart({
+	data,
+	isLoading,
+}: {
+	data?: ContactByStatusResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-64 w-full" />;
+	}
+	if (data.items.length === 0) {
+		return (
+			<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+				Sin contactos en el rango seleccionado.
+			</div>
+		);
+	}
+
+	return (
+		<ResponsiveContainer width="100%" height={256}>
+			<PieChart>
+				<Pie
+					data={data.items}
+					dataKey="count"
+					nameKey="status"
+					innerRadius={50}
+					outerRadius={88}
+					paddingAngle={2}
+				>
+					{data.items.map((item, i) => (
+						<Cell
+							key={item.status}
+							fill={SLICE_COLORS[i % SLICE_COLORS.length]}
+						/>
+					))}
+				</Pie>
+				<Tooltip
+					contentStyle={{
+						background: "var(--popover)",
+						border: "1px solid var(--border)",
+						borderRadius: 8,
+						fontSize: 12,
+					}}
+				/>
+			</PieChart>
+		</ResponsiveContainer>
+	);
+}

--- a/admin/src/features/contacts/components/ContactByStatusTable.tsx
+++ b/admin/src/features/contacts/components/ContactByStatusTable.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import type { ContactStatusItem } from "../types";
+
+/**
+ * @component ContactByStatusTable
+ * @description Desglose de contactos por estado (contacts/by-status): status +
+ *   count + pct. Acompana al PieChart con el porcentaje exacto por fila.
+ *
+ * @props {ContactStatusItem[]} items - filas del desglose
+ */
+export function ContactByStatusTable({
+	items,
+}: {
+	items: ContactStatusItem[];
+}) {
+	if (items.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin contactos en el rango seleccionado.
+			</p>
+		);
+	}
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Estado</TableHead>
+					<TableHead className="text-right">Cantidad</TableHead>
+					<TableHead className="text-right">%</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{items.map((item) => (
+					<TableRow key={item.status}>
+						<TableCell className="font-mono text-xs">{item.status}</TableCell>
+						<TableCell className="text-right">{item.count}</TableCell>
+						<TableCell className="text-right">
+							{(item.pct * 100).toFixed(1)}%
+						</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/admin/src/features/contacts/components/ContactListTable.tsx
+++ b/admin/src/features/contacts/components/ContactListTable.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { formatDate } from "@/lib/format/date";
+import type { ContactListResponse } from "../types";
+import { ContactStatusBadge } from "./ContactStatusBadge";
+
+const SKELETON_ROWS = ["sk1", "sk2", "sk3", "sk4", "sk5"] as const;
+const SKELETON_CELLS = ["c1", "c2", "c3", "c4", "c5", "c6"] as const;
+
+/**
+ * @component ContactListTable
+ * @description Listado crudo paginado de contactos (contacts/list). Columnas:
+ *   created_at, name, email, status (Badge), niche, company. Pagina con
+ *   botones anterior/siguiente sobre el estado `page` (controlado por la
+ *   page). Muestra `total` y `has_more`. Skeleton mientras carga.
+ *
+ * @props {ContactListResponse} [data] - pagina de contactos del backend
+ * @props {boolean} isLoading - estado de carga
+ * @props {number} page - pagina actual (1-based)
+ * @props {(page: number) => void} onPageChange - cambia de pagina
+ */
+export function ContactListTable({
+	data,
+	isLoading,
+	page,
+	onPageChange,
+}: {
+	data?: ContactListResponse;
+	isLoading: boolean;
+	page: number;
+	onPageChange: (page: number) => void;
+}) {
+	const items = data?.items ?? [];
+	const hasMore = data?.has_more ?? false;
+	const total = data?.total ?? 0;
+
+	return (
+		<div className="space-y-4">
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Fecha</TableHead>
+							<TableHead>Nombre</TableHead>
+							<TableHead>Email</TableHead>
+							<TableHead>Estado</TableHead>
+							<TableHead>Niche</TableHead>
+							<TableHead>Empresa</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading ? (
+							SKELETON_ROWS.map((rowKey) => (
+								<TableRow key={rowKey}>
+									{SKELETON_CELLS.map((cellKey) => (
+										<TableCell key={`${rowKey}-${cellKey}`}>
+											<Skeleton className="h-5 w-full" />
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						) : items.length === 0 ? (
+							<TableRow>
+								<TableCell
+									colSpan={6}
+									className="h-24 text-center text-muted-foreground"
+								>
+									Sin contactos en el rango seleccionado.
+								</TableCell>
+							</TableRow>
+						) : (
+							items.map((row) => (
+								<TableRow key={row.id}>
+									<TableCell className="whitespace-nowrap text-xs">
+										{formatDate(row.created_at)}
+									</TableCell>
+									<TableCell className="font-medium">{row.name}</TableCell>
+									<TableCell className="font-mono text-xs">
+										{row.email}
+									</TableCell>
+									<TableCell>
+										<ContactStatusBadge status={row.status} />
+									</TableCell>
+									<TableCell>
+										<Badge variant="secondary">{row.niche}</Badge>
+									</TableCell>
+									<TableCell className="text-muted-foreground">
+										{row.company ?? "-"}
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			<div className="flex items-center justify-between">
+				<p className="text-sm text-muted-foreground">
+					Pagina {page}
+					{total > 0 ? ` · ${total} contactos en total` : ""}
+				</p>
+				<div className="flex gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={page <= 1 || isLoading}
+						onClick={() => onPageChange(page - 1)}
+					>
+						Anterior
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={!hasMore || isLoading}
+						onClick={() => onPageChange(page + 1)}
+					>
+						Siguiente
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/admin/src/features/contacts/components/ContactStatusBadge.tsx
+++ b/admin/src/features/contacts/components/ContactStatusBadge.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { ContactStatus } from "../types";
+
+/**
+ * @component ContactStatusBadge
+ * @description Badge del estado de un contacto con variante segun el estado
+ *   del embudo (new -> converted = progreso, rejected = destructivo).
+ *
+ * @props {ContactStatus} status - estado del contacto
+ */
+type BadgeVariant = "default" | "secondary" | "outline" | "destructive";
+
+const STATUS_LABEL: Record<ContactStatus, string> = {
+	new: "Nuevo",
+	contacted: "Contactado",
+	qualified: "Calificado",
+	converted: "Convertido",
+	rejected: "Rechazado",
+};
+
+const STATUS_VARIANT: Record<ContactStatus, BadgeVariant> = {
+	new: "default",
+	contacted: "secondary",
+	qualified: "secondary",
+	converted: "default",
+	rejected: "destructive",
+};
+
+export function ContactStatusBadge({ status }: { status: ContactStatus }) {
+	return (
+		<Badge variant={STATUS_VARIANT[status] ?? "outline"}>
+			{STATUS_LABEL[status] ?? status}
+		</Badge>
+	);
+}

--- a/admin/src/features/contacts/components/ContactStatusFilter.tsx
+++ b/admin/src/features/contacts/components/ContactStatusFilter.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import type { ContactStatus } from "../types";
+
+/**
+ * @component ContactStatusFilter
+ * @description Select para filtrar el listado de contactos por estado. El
+ *   valor `all` (centinela del UI) significa "sin filtro" y se mapea a
+ *   `undefined` hacia el backend.
+ *
+ * @props {ContactStatus | undefined} value - estado seleccionado (o sin filtro)
+ * @props {(status: ContactStatus | undefined) => void} onChange - callback
+ */
+const ALL = "all";
+
+const STATUS_OPTIONS: readonly { value: ContactStatus; label: string }[] = [
+	{ value: "new", label: "Nuevo" },
+	{ value: "contacted", label: "Contactado" },
+	{ value: "qualified", label: "Calificado" },
+	{ value: "converted", label: "Convertido" },
+	{ value: "rejected", label: "Rechazado" },
+];
+
+export function ContactStatusFilter({
+	value,
+	onChange,
+}: {
+	value: ContactStatus | undefined;
+	onChange: (status: ContactStatus | undefined) => void;
+}) {
+	return (
+		<Select
+			value={value ?? ALL}
+			onValueChange={(next) =>
+				onChange(next === ALL ? undefined : (next as ContactStatus))
+			}
+		>
+			<SelectTrigger size="sm" className="w-44">
+				<SelectValue placeholder="Todos los estados" />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value={ALL}>Todos los estados</SelectItem>
+				{STATUS_OPTIONS.map((opt) => (
+					<SelectItem key={opt.value} value={opt.value}>
+						{opt.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/admin/src/features/contacts/hooks/use-contact-list.ts
+++ b/admin/src/features/contacts/hooks/use-contact-list.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { contactsClient } from "../api/contacts-client";
+import { contactsKeys } from "../api/query-keys";
+import type { ContactListParams } from "../types";
+
+/**
+ * @function useContactList
+ * @description Listado crudo paginado de contactos (contacts/list). staleTime
+ *   30s (listado crudo, no agregado; PII no persistida). Filtra por status y
+ *   niche cuando se proveen.
+ * @param params - rango + paginacion + filtros (status, niche)
+ */
+export function useContactList(params: ContactListParams) {
+	return useQuery({
+		queryKey: contactsKeys.list(params),
+		queryFn: () => contactsClient.list(params),
+		staleTime: 30_000,
+	});
+}

--- a/admin/src/features/contacts/hooks/use-contacts-by-status.ts
+++ b/admin/src/features/contacts/hooks/use-contacts-by-status.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { contactsClient } from "../api/contacts-client";
+import { contactsKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useContactsByStatus
+ * @description Desglose de contactos por estado (contacts/by-status).
+ *   staleTime 60s (metrica agregada, matchea el TTL de cache del backend).
+ * @param range - rango de fechas (from/to)
+ */
+export function useContactsByStatus(range: DateRangeParams) {
+	return useQuery({
+		queryKey: contactsKeys.byStatus(range),
+		queryFn: () => contactsClient.byStatus(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/contacts/index.ts
+++ b/admin/src/features/contacts/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @module features/contacts
+ * @description API publica de la feature de metricas `contacts` (operation
+ *   `contacts` del Lambda `analytics`): list, by-status. Es una feature PII.
+ */
+
+export { contactsClient } from "./api/contacts-client";
+export { contactsKeys } from "./api/query-keys";
+export { ContactByStatusChart } from "./components/ContactByStatusChart";
+export { ContactByStatusTable } from "./components/ContactByStatusTable";
+export { ContactListTable } from "./components/ContactListTable";
+export { ContactStatusBadge } from "./components/ContactStatusBadge";
+export { ContactStatusFilter } from "./components/ContactStatusFilter";
+export { useContactList } from "./hooks/use-contact-list";
+export { useContactsByStatus } from "./hooks/use-contacts-by-status";
+export type {
+	ContactByStatusResponse,
+	ContactListParams,
+	ContactListResponse,
+	ContactRow,
+	ContactStatus,
+	ContactStatusItem,
+	DateRangeParams,
+} from "./types";

--- a/admin/src/features/contacts/types.ts
+++ b/admin/src/features/contacts/types.ts
@@ -1,0 +1,66 @@
+/**
+ * @module features/contacts/types
+ * @description Shapes de las respuestas del Lambda `analytics` (operation
+ *   `contacts`): list, by-status. Espejan el `data` que devuelve cada
+ *   endpoint. Es una feature PII: el `queryKey[1] === 'contacts'` ya la
+ *   excluye del persister (ver metrics-query-keys).
+ */
+
+import type { DateRangeParams } from "@/features/analytics/types";
+
+export type { DateRangeParams };
+
+/** Estados validos de un contacto en el embudo. */
+export type ContactStatus =
+	| "new"
+	| "contacted"
+	| "qualified"
+	| "converted"
+	| "rejected";
+
+/** Una fila cruda de contacto (contacts/list) — contiene PII. */
+export interface ContactRow {
+	id: string;
+	created_at: string;
+	name: string;
+	email: string;
+	message: string;
+	company: string | null;
+	role: string | null;
+	service_type: string | null;
+	budget: string | null;
+	timeline: string | null;
+	niche: string;
+	status: ContactStatus;
+	session_id: string | null;
+}
+
+/** contacts/list — listado crudo paginado de contactos. */
+export interface ContactListResponse {
+	items: ContactRow[];
+	page: number;
+	page_size: number;
+	total: number;
+	has_more: boolean;
+}
+
+/** Params del listado paginado de contactos (contacts/list). */
+export interface ContactListParams extends DateRangeParams {
+	page?: number;
+	page_size?: number;
+	offset?: number;
+	status?: ContactStatus;
+	niche?: string;
+}
+
+/** Una fila del desglose por estado (contacts/by-status). */
+export interface ContactStatusItem {
+	status: string;
+	count: number;
+	pct: number;
+}
+
+/** contacts/by-status — desglose de contactos por estado. */
+export interface ContactByStatusResponse {
+	items: ContactStatusItem[];
+}

--- a/admin/src/features/devices/api/devices-client.ts
+++ b/admin/src/features/devices/api/devices-client.ts
@@ -1,0 +1,13 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type { BreakdownParams, BreakdownResponse } from "../types";
+
+/**
+ * @module features/devices/api/devices-client
+ * @description Cliente tipado de la operation `devices` del Lambda `analytics`.
+ *   Cada fn hace `GET /analytics?operation=devices&action=...` via
+ *   `fetchMetric` (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const devicesClient = {
+	breakdown: (params: BreakdownParams) =>
+		fetchMetric<BreakdownResponse>("devices", "breakdown", { ...params }),
+};

--- a/admin/src/features/devices/api/query-keys.ts
+++ b/admin/src/features/devices/api/query-keys.ts
@@ -1,0 +1,12 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type { BreakdownParams } from "../types";
+
+/**
+ * @module features/devices/api/query-keys
+ * @description Query keys del dominio `devices`, derivadas del namespace raiz
+ *   `['metrics', 'devices', <action>, params]`.
+ */
+export const devicesKeys = {
+	breakdown: (params: BreakdownParams) =>
+		metricsKey("devices", "breakdown", params),
+};

--- a/admin/src/features/devices/components/DeviceBreakdown.tsx
+++ b/admin/src/features/devices/components/DeviceBreakdown.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { BreakdownResponse } from "../types";
+import { DistributionChart } from "./DistributionChart";
+
+/**
+ * @component DeviceBreakdown
+ * @description Las 3 distribuciones de devices/breakdown (tipos de dispositivo,
+ *   navegadores, sistemas operativos) como BarCharts lado a lado, cada uno en
+ *   su Card. Ordenado desc por sessions dentro de cada chart.
+ *
+ * @props {BreakdownResponse} [data] - distribuciones del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+export function DeviceBreakdown({
+	data,
+	isLoading,
+}: {
+	data?: BreakdownResponse;
+	isLoading: boolean;
+}) {
+	return (
+		<div className="grid gap-6 lg:grid-cols-3">
+			<Card>
+				<CardHeader>
+					<CardTitle>Tipos de dispositivo</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<DistributionChart
+						data={data?.device_types}
+						nameKey="device_type"
+						isLoading={isLoading}
+					/>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Navegadores</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<DistributionChart
+						data={data?.browsers}
+						nameKey="browser"
+						isLoading={isLoading}
+					/>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Sistemas operativos</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<DistributionChart
+						data={data?.os}
+						nameKey="os"
+						isLoading={isLoading}
+					/>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/admin/src/features/devices/components/DistributionChart.tsx
+++ b/admin/src/features/devices/components/DistributionChart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * @component DistributionChart
+ * @description BarChart generico de una distribucion de sesiones (devices
+ *   breakdown): normaliza la fila `{<nameKey>: string, sessions: number}` a
+ *   `{label, sessions}` y la ordena desc por sessions. Skeleton mientras carga;
+ *   mensaje si vacio.
+ *
+ * @props {Array<Record<string, string | number>>} [data] - filas crudas
+ * @props {string} nameKey - clave de la primera columna (device_type/browser/os)
+ * @props {boolean} isLoading - estado de carga
+ */
+export function DistributionChart<T extends { sessions: number }>({
+	data,
+	nameKey,
+	isLoading,
+}: {
+	data?: T[];
+	nameKey: keyof T;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-64 w-full" />;
+	}
+	if (data.length === 0) {
+		return (
+			<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+				Sin datos en el rango seleccionado.
+			</div>
+		);
+	}
+
+	const chartData = [...data]
+		.sort((a, b) => b.sessions - a.sessions)
+		.map((row) => ({
+			label: String(row[nameKey] ?? "-"),
+			sessions: row.sessions,
+		}));
+
+	return (
+		<ResponsiveContainer width="100%" height={256}>
+			<BarChart
+				data={chartData}
+				margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+			>
+				<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+				<XAxis dataKey="label" tick={{ fontSize: 12 }} />
+				<YAxis tick={{ fontSize: 12 }} allowDecimals={false} width={40} />
+				<Tooltip
+					contentStyle={{
+						background: "var(--popover)",
+						border: "1px solid var(--border)",
+						borderRadius: 8,
+						fontSize: 12,
+					}}
+				/>
+				<Bar dataKey="sessions" fill="var(--primary)" radius={[4, 4, 0, 0]} />
+			</BarChart>
+		</ResponsiveContainer>
+	);
+}

--- a/admin/src/features/devices/hooks/use-breakdown.ts
+++ b/admin/src/features/devices/hooks/use-breakdown.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { devicesClient } from "../api/devices-client";
+import { devicesKeys } from "../api/query-keys";
+import type { BreakdownParams } from "../types";
+
+/**
+ * @function useBreakdown
+ * @description Distribucion de sesiones por tipo de dispositivo, navegador y
+ *   sistema operativo (devices/breakdown). staleTime 60s (agregada, matchea el
+ *   TTL de cache del backend).
+ * @param range - rango de fechas (from/to)
+ */
+export function useBreakdown(range: BreakdownParams) {
+	return useQuery({
+		queryKey: devicesKeys.breakdown(range),
+		queryFn: () => devicesClient.breakdown(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/devices/index.ts
+++ b/admin/src/features/devices/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @module features/devices
+ * @description API publica de la feature `devices` (UI de metricas de la
+ *   operation `devices` del Lambda `analytics`).
+ */
+export { devicesClient } from "./api/devices-client";
+export { devicesKeys } from "./api/query-keys";
+export { DeviceBreakdown } from "./components/DeviceBreakdown";
+export { DistributionChart } from "./components/DistributionChart";
+export { useBreakdown } from "./hooks/use-breakdown";
+export type {
+	BreakdownParams,
+	BreakdownResponse,
+	BrowserDist,
+	DateRangeParams,
+	DeviceTypeDist,
+	OsDist,
+} from "./types";

--- a/admin/src/features/devices/types.ts
+++ b/admin/src/features/devices/types.ts
@@ -1,0 +1,39 @@
+/**
+ * @module features/devices/types
+ * @description Shapes de las respuestas de la operation `devices` del Lambda
+ *   `analytics`: breakdown (distribucion por tipo de dispositivo, navegador y
+ *   sistema operativo). Espejan el `data` que devuelve cada endpoint.
+ */
+
+/** Rango de fechas compartido por los endpoints de metricas. */
+export interface DateRangeParams {
+	from?: string;
+	to?: string;
+}
+
+/** Una fila de distribucion por tipo de dispositivo. */
+export interface DeviceTypeDist {
+	device_type: string;
+	sessions: number;
+}
+
+/** Una fila de distribucion por navegador. */
+export interface BrowserDist {
+	browser: string;
+	sessions: number;
+}
+
+/** Una fila de distribucion por sistema operativo. */
+export interface OsDist {
+	os: string;
+	sessions: number;
+}
+
+/** devices/breakdown — 3 distribuciones de sesiones. */
+export interface BreakdownResponse {
+	device_types: DeviceTypeDist[];
+	browsers: BrowserDist[];
+	os: OsDist[];
+}
+
+export type BreakdownParams = DateRangeParams;

--- a/admin/src/features/events/api/events-client.ts
+++ b/admin/src/features/events/api/events-client.ts
@@ -1,0 +1,37 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type {
+	DateRangeParams,
+	EventDistributionResponse,
+	EventListParams,
+	EventListResponse,
+	HeatmapResponse,
+} from "../types";
+
+/**
+ * @module features/events/api/events-client
+ * @description Cliente tipado de la operation `events` del Lambda `analytics`.
+ *   Cada fn hace `GET /analytics?operation=events&action=...` via `fetchMetric`
+ *   (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const eventsClient = {
+	distribution: (params: DateRangeParams) =>
+		fetchMetric<EventDistributionResponse>("events", "distribution", {
+			...params,
+		}),
+
+	// El backend de `list` requiere `offset` ademas de page/page_size: se
+	// deriva como (page - 1) * page_size.
+	list: (params: EventListParams) => {
+		const page = params.page ?? 1;
+		const pageSize = params.page_size ?? 50;
+		return fetchMetric<EventListResponse>("events", "list", {
+			...params,
+			page,
+			page_size: pageSize,
+			offset: (page - 1) * pageSize,
+		});
+	},
+
+	heatmap: (params: DateRangeParams) =>
+		fetchMetric<HeatmapResponse>("events", "heatmap", { ...params }),
+};

--- a/admin/src/features/events/api/query-keys.ts
+++ b/admin/src/features/events/api/query-keys.ts
@@ -1,0 +1,14 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type { DateRangeParams, EventListParams } from "../types";
+
+/**
+ * @module features/events/api/query-keys
+ * @description Query keys del dominio `events`, derivadas del namespace raiz
+ *   `['metrics', 'events', <action>, params]`.
+ */
+export const eventsKeys = {
+	distribution: (params: DateRangeParams) =>
+		metricsKey("events", "distribution", params),
+	list: (params: EventListParams) => metricsKey("events", "list", params),
+	heatmap: (params: DateRangeParams) => metricsKey("events", "heatmap", params),
+};

--- a/admin/src/features/events/components/EventDistributionChart.tsx
+++ b/admin/src/features/events/components/EventDistributionChart.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { EventDistributionResponse } from "../types";
+
+/**
+ * @component EventDistributionChart
+ * @description Ranking de tipos de evento por frecuencia (events/distribution)
+ *   como BarChart de Recharts (dataKey count, xAxis event_type). Skeleton
+ *   mientras carga; mensaje si vacio.
+ *
+ * @props {EventDistributionResponse} [data] - distribucion del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+export function EventDistributionChart({
+	data,
+	isLoading,
+}: {
+	data?: EventDistributionResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-64 w-full" />;
+	}
+	if (data.items.length === 0) {
+		return (
+			<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+				Sin eventos en el rango seleccionado.
+			</div>
+		);
+	}
+
+	return (
+		<ResponsiveContainer width="100%" height={256}>
+			<BarChart
+				data={data.items}
+				margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+			>
+				<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+				<XAxis dataKey="event_type" tick={{ fontSize: 12 }} />
+				<YAxis tick={{ fontSize: 12 }} allowDecimals={false} width={40} />
+				<Tooltip
+					contentStyle={{
+						background: "var(--popover)",
+						border: "1px solid var(--border)",
+						borderRadius: 8,
+						fontSize: 12,
+					}}
+				/>
+				<Bar dataKey="count" fill="var(--primary)" radius={[4, 4, 0, 0]} />
+			</BarChart>
+		</ResponsiveContainer>
+	);
+}

--- a/admin/src/features/events/components/EventDistributionTable.tsx
+++ b/admin/src/features/events/components/EventDistributionTable.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import type { EventDistributionItem } from "../types";
+
+/**
+ * @component EventDistributionTable
+ * @description Ranking de tipos de evento (events/distribution): event_type +
+ *   count + pct. Acompana al BarChart con el porcentaje exacto por fila.
+ *
+ * @props {EventDistributionItem[]} items - filas del ranking
+ */
+export function EventDistributionTable({
+	items,
+}: {
+	items: EventDistributionItem[];
+}) {
+	if (items.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin eventos en el rango seleccionado.
+			</p>
+		);
+	}
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Tipo de evento</TableHead>
+					<TableHead className="text-right">Cantidad</TableHead>
+					<TableHead className="text-right">%</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{items.map((item) => (
+					<TableRow key={item.event_type}>
+						<TableCell className="font-mono text-xs">
+							{item.event_type}
+						</TableCell>
+						<TableCell className="text-right">{item.count}</TableCell>
+						<TableCell className="text-right">
+							{(item.pct * 100).toFixed(1)}%
+						</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/admin/src/features/events/components/EventHeatmap.tsx
+++ b/admin/src/features/events/components/EventHeatmap.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import type { HeatmapResponse } from "../types";
+
+/**
+ * @component EventHeatmap
+ * @description Grilla 7x24 (dias de semana x horas) de eventos (events/heatmap).
+ *   Filas = dias (Lun..Dom, ISO 1-7), columnas = horas 0-23. Cada celda se
+ *   colorea con opacidad proporcional a su `count` (mas eventos = mas opaco)
+ *   usando `--primary`. Skeleton mientras carga; mensaje si vacio.
+ *
+ * @props {HeatmapResponse} [data] - celdas del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+const DAY_LABELS = ["Lun", "Mar", "Mie", "Jue", "Vie", "Sab", "Dom"] as const;
+const HOURS = Array.from({ length: 24 }, (_, h) => h);
+
+export function EventHeatmap({
+	data,
+	isLoading,
+}: {
+	data?: HeatmapResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-72 w-full" />;
+	}
+	if (data.cells.length === 0) {
+		return (
+			<div className="flex h-72 items-center justify-center text-sm text-muted-foreground">
+				Sin eventos en el rango seleccionado.
+			</div>
+		);
+	}
+
+	// Indexa las celdas por (dow, hour) para lookup O(1) + calcula el maximo
+	// para normalizar la intensidad.
+	const counts = new Map<string, number>();
+	let max = 0;
+	for (const cell of data.cells) {
+		counts.set(`${cell.dow}-${cell.hour}`, cell.count);
+		if (cell.count > max) max = cell.count;
+	}
+
+	function intensity(count: number): number {
+		if (max === 0 || count === 0) return 0;
+		// Minimo 0.12 para que una celda con datos sea visible, hasta 1.
+		return 0.12 + 0.88 * (count / max);
+	}
+
+	return (
+		<div className="overflow-x-auto">
+			<div className="inline-block min-w-full">
+				<div className="flex">
+					<div className="w-10 shrink-0" />
+					{HOURS.map((hour) => (
+						<div
+							key={`head-${hour}`}
+							className="w-6 shrink-0 text-center text-[10px] text-muted-foreground"
+						>
+							{hour % 3 === 0 ? hour : ""}
+						</div>
+					))}
+				</div>
+				{DAY_LABELS.map((label, idx) => {
+					const dow = idx + 1;
+					return (
+						<div key={label} className="flex items-center">
+							<div className="w-10 shrink-0 pr-2 text-right text-xs text-muted-foreground">
+								{label}
+							</div>
+							{HOURS.map((hour) => {
+								const count = counts.get(`${dow}-${hour}`) ?? 0;
+								return (
+									<div
+										key={`${dow}-${hour}`}
+										title={`${label} ${String(hour).padStart(2, "0")}:00 — ${count} eventos`}
+										className="m-px h-6 w-6 shrink-0 rounded-sm border border-border/40"
+										style={{
+											backgroundColor: "var(--primary)",
+											opacity: intensity(count),
+										}}
+									/>
+								);
+							})}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/admin/src/features/events/components/EventListTable.tsx
+++ b/admin/src/features/events/components/EventListTable.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { formatDate } from "@/lib/format/date";
+import type { EventListResponse } from "../types";
+
+const SKELETON_ROWS = ["sk1", "sk2", "sk3", "sk4", "sk5"] as const;
+const SKELETON_CELLS = ["c1", "c2", "c3", "c4", "c5"] as const;
+
+/**
+ * @component EventListTable
+ * @description Listado crudo paginado de eventos (events/list). Columnas:
+ *   created_at, event_type, page_path, niche, session_id. Pagina con botones
+ *   anterior/siguiente sobre el estado `page` (controlado por la page). Muestra
+ *   `total` y `has_more`. Skeleton mientras carga.
+ *
+ * @props {EventListResponse} [data] - pagina de eventos del backend
+ * @props {boolean} isLoading - estado de carga
+ * @props {number} page - pagina actual (1-based)
+ * @props {(page: number) => void} onPageChange - cambia de pagina
+ */
+export function EventListTable({
+	data,
+	isLoading,
+	page,
+	onPageChange,
+}: {
+	data?: EventListResponse;
+	isLoading: boolean;
+	page: number;
+	onPageChange: (page: number) => void;
+}) {
+	const items = data?.items ?? [];
+	const hasMore = data?.has_more ?? false;
+	const total = data?.total ?? 0;
+
+	return (
+		<div className="space-y-4">
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Fecha</TableHead>
+							<TableHead>Tipo</TableHead>
+							<TableHead>Pagina</TableHead>
+							<TableHead>Niche</TableHead>
+							<TableHead>Sesion</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading ? (
+							SKELETON_ROWS.map((rowKey) => (
+								<TableRow key={rowKey}>
+									{SKELETON_CELLS.map((cellKey) => (
+										<TableCell key={`${rowKey}-${cellKey}`}>
+											<Skeleton className="h-5 w-full" />
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						) : items.length === 0 ? (
+							<TableRow>
+								<TableCell
+									colSpan={5}
+									className="h-24 text-center text-muted-foreground"
+								>
+									Sin eventos en el rango seleccionado.
+								</TableCell>
+							</TableRow>
+						) : (
+							items.map((row) => (
+								<TableRow key={`${row.visit_id}-${row.created_at}`}>
+									<TableCell className="whitespace-nowrap text-xs">
+										{formatDate(row.created_at)}
+									</TableCell>
+									<TableCell className="font-mono text-xs">
+										{row.event_type}
+									</TableCell>
+									<TableCell className="font-mono text-xs">
+										{row.page_path}
+									</TableCell>
+									<TableCell>
+										<Badge variant="secondary">{row.niche}</Badge>
+									</TableCell>
+									<TableCell className="font-mono text-xs text-muted-foreground">
+										{row.session_id}
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			<div className="flex items-center justify-between">
+				<p className="text-sm text-muted-foreground">
+					Pagina {page}
+					{total > 0 ? ` · ${total} eventos en total` : ""}
+				</p>
+				<div className="flex gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={page <= 1 || isLoading}
+						onClick={() => onPageChange(page - 1)}
+					>
+						Anterior
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={!hasMore || isLoading}
+						onClick={() => onPageChange(page + 1)}
+					>
+						Siguiente
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/admin/src/features/events/hooks/use-distribution.ts
+++ b/admin/src/features/events/hooks/use-distribution.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { eventsClient } from "../api/events-client";
+import { eventsKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useDistribution
+ * @description Ranking de tipos de evento por frecuencia (events/distribution).
+ *   staleTime 60s (matchea el TTL de cache del backend para las agregadas).
+ * @param range - rango de fechas (from/to)
+ */
+export function useDistribution(range: DateRangeParams) {
+	return useQuery({
+		queryKey: eventsKeys.distribution(range),
+		queryFn: () => eventsClient.distribution(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/events/hooks/use-event-list.ts
+++ b/admin/src/features/events/hooks/use-event-list.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { eventsClient } from "../api/events-client";
+import { eventsKeys } from "../api/query-keys";
+import type { EventListParams } from "../types";
+
+/**
+ * @function useEventList
+ * @description Listado crudo paginado de eventos (events/list). staleTime 30s
+ *   (listado crudo, no agregado).
+ * @param params - rango + paginacion + filtros (niche, event_type, ...)
+ */
+export function useEventList(params: EventListParams) {
+	return useQuery({
+		queryKey: eventsKeys.list(params),
+		queryFn: () => eventsClient.list(params),
+		staleTime: 30_000,
+	});
+}

--- a/admin/src/features/events/hooks/use-heatmap.ts
+++ b/admin/src/features/events/hooks/use-heatmap.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { eventsClient } from "../api/events-client";
+import { eventsKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useHeatmap
+ * @description Distribucion de eventos por dia de semana x hora
+ *   (events/heatmap). staleTime 60s (agregada).
+ * @param range - rango de fechas (from/to)
+ */
+export function useHeatmap(range: DateRangeParams) {
+	return useQuery({
+		queryKey: eventsKeys.heatmap(range),
+		queryFn: () => eventsClient.heatmap(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/events/index.ts
+++ b/admin/src/features/events/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @module features/events
+ * @description API publica de la feature de metricas `events` (operation
+ *   `events` del Lambda `analytics`): distribution, list, heatmap.
+ */
+
+export { eventsClient } from "./api/events-client";
+export { eventsKeys } from "./api/query-keys";
+export { EventDistributionChart } from "./components/EventDistributionChart";
+export { EventDistributionTable } from "./components/EventDistributionTable";
+export { EventHeatmap } from "./components/EventHeatmap";
+export { EventListTable } from "./components/EventListTable";
+export { useDistribution } from "./hooks/use-distribution";
+export { useEventList } from "./hooks/use-event-list";
+export { useHeatmap } from "./hooks/use-heatmap";
+export type {
+	DateRangeParams,
+	EventDistributionItem,
+	EventDistributionResponse,
+	EventListParams,
+	EventListResponse,
+	EventRow,
+	HeatmapCell,
+	HeatmapResponse,
+} from "./types";

--- a/admin/src/features/events/types.ts
+++ b/admin/src/features/events/types.ts
@@ -1,0 +1,67 @@
+/**
+ * @module features/events/types
+ * @description Shapes de las respuestas del Lambda `analytics` (operation
+ *   `events`): distribution, list, heatmap. Espejan el `data` que devuelve
+ *   cada endpoint.
+ */
+
+import type { DateRangeParams } from "@/features/analytics/types";
+
+export type { DateRangeParams };
+
+/** Una fila del ranking de tipos de evento (events/distribution). */
+export interface EventDistributionItem {
+	event_type: string;
+	count: number;
+	pct: number;
+}
+
+/** events/distribution — ranking de tipos de evento por frecuencia. */
+export interface EventDistributionResponse {
+	items: EventDistributionItem[];
+}
+
+/** Una fila cruda de evento (events/list). */
+export interface EventRow {
+	created_at: string;
+	visit_id: string;
+	page_id: string;
+	session_id: string;
+	page_path: string;
+	niche: string;
+	viewport_width: number;
+	viewport_height: number;
+	event_type: string;
+	event_props: Record<string, unknown>;
+}
+
+/** events/list — listado crudo paginado de eventos. */
+export interface EventListResponse {
+	items: EventRow[];
+	page: number;
+	page_size: number;
+	total: number;
+	has_more: boolean;
+}
+
+/** Params del listado paginado de eventos (events/list). */
+export interface EventListParams extends DateRangeParams {
+	page?: number;
+	page_size?: number;
+	niche?: string;
+	event_type?: string;
+	session_id?: string;
+	page_path?: string;
+}
+
+/** Una celda del heatmap (events/heatmap). */
+export interface HeatmapCell {
+	dow: number;
+	hour: number;
+	count: number;
+}
+
+/** events/heatmap — distribucion de eventos por dia de semana x hora. */
+export interface HeatmapResponse {
+	cells: HeatmapCell[];
+}

--- a/admin/src/features/funnel/api/funnel-client.ts
+++ b/admin/src/features/funnel/api/funnel-client.ts
@@ -1,0 +1,15 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type { DateRangeParams, FunnelConversionResponse } from "../types";
+
+/**
+ * @module features/funnel/api/funnel-client
+ * @description Cliente tipado de la operation `funnel` del Lambda `analytics`.
+ *   Cada fn hace `GET /analytics?operation=funnel&action=...` via `fetchMetric`
+ *   (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const funnelClient = {
+	conversion: (params: DateRangeParams) =>
+		fetchMetric<FunnelConversionResponse>("funnel", "conversion", {
+			...params,
+		}),
+};

--- a/admin/src/features/funnel/api/query-keys.ts
+++ b/admin/src/features/funnel/api/query-keys.ts
@@ -1,0 +1,12 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @module features/funnel/api/query-keys
+ * @description Query keys del dominio `funnel`, derivadas del namespace raiz
+ *   `['metrics', 'funnel', <action>, params]`.
+ */
+export const funnelKeys = {
+	conversion: (params: DateRangeParams) =>
+		metricsKey("funnel", "conversion", params),
+};

--- a/admin/src/features/funnel/components/FunnelChart.tsx
+++ b/admin/src/features/funnel/components/FunnelChart.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { Mail, MousePointerClick, Users } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { FunnelConversionResponse } from "../types";
+
+/**
+ * @component FunnelChart
+ * @description Embudo visual de conversion (funnel/conversion): 3 barras
+ *   horizontales decrecientes (sessions -> visits -> contacts) con el width
+ *   proporcional al numero de sesiones (etapa raiz). Entre etapas muestra la
+ *   tasa de conversion formateada como porcentaje. Skeleton mientras carga;
+ *   mensaje si no hay sesiones en el rango.
+ *
+ * @props {FunnelConversionResponse} [data] - embudo del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+interface StageDef {
+	key: "sessions" | "visits" | "contacts";
+	label: string;
+	icon: LucideIcon;
+}
+
+const STAGES: readonly StageDef[] = [
+	{ key: "sessions", label: "Sesiones", icon: Users },
+	{ key: "visits", label: "Visitas", icon: MousePointerClick },
+	{ key: "contacts", label: "Contactos", icon: Mail },
+];
+
+function fmtInt(v: number): string {
+	return new Intl.NumberFormat("es").format(Math.round(v));
+}
+
+function fmtPct(v: number): string {
+	return `${(v * 100).toFixed(1)}%`;
+}
+
+export function FunnelChart({
+	data,
+	isLoading,
+}: {
+	data?: FunnelConversionResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return (
+			<div className="space-y-4">
+				<Skeleton className="h-12 w-full" />
+				<Skeleton className="h-12 w-3/4" />
+				<Skeleton className="h-12 w-1/2" />
+			</div>
+		);
+	}
+
+	if (data.sessions === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin sesiones en el rango seleccionado.
+			</p>
+		);
+	}
+
+	const stageRates: Record<string, number> = {
+		visits: data.session_to_visit_rate,
+		contacts: data.visit_to_contact_rate,
+	};
+
+	return (
+		<div className="space-y-2">
+			{STAGES.map((stage, index) => {
+				const Icon = stage.icon;
+				const value = data[stage.key];
+				const width = data.sessions > 0 ? (value / data.sessions) * 100 : 0;
+				return (
+					<div key={stage.key} className="space-y-2">
+						{index > 0 ? (
+							<p className="text-center text-xs text-muted-foreground">
+								{fmtPct(stageRates[stage.key] ?? 0)} de conversion
+							</p>
+						) : null}
+						<div
+							className="flex h-12 items-center justify-between rounded-md bg-primary px-4 text-primary-foreground"
+							style={{ width: `${Math.max(width, 18)}%` }}
+						>
+							<span className="flex items-center gap-2 text-sm font-medium">
+								<Icon className="h-4 w-4" />
+								{stage.label}
+							</span>
+							<span className="text-sm font-semibold tabular-nums">
+								{fmtInt(value)}
+							</span>
+						</div>
+					</div>
+				);
+			})}
+			<p className="pt-2 text-center text-xs text-muted-foreground">
+				Conversion total (sesion a contacto):{" "}
+				<span className="font-medium text-foreground">
+					{fmtPct(data.session_to_contact_rate)}
+				</span>
+			</p>
+		</div>
+	);
+}

--- a/admin/src/features/funnel/hooks/use-conversion.ts
+++ b/admin/src/features/funnel/hooks/use-conversion.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { funnelClient } from "../api/funnel-client";
+import { funnelKeys } from "../api/query-keys";
+import type { DateRangeParams } from "../types";
+
+/**
+ * @function useConversion
+ * @description Embudo de conversion (funnel/conversion): session -> visit ->
+ *   contact con sus tasas. staleTime 60s (matchea el TTL de cache del backend
+ *   para las queries agregadas).
+ * @param range - rango de fechas (from/to)
+ */
+export function useConversion(range: DateRangeParams) {
+	return useQuery({
+		queryKey: funnelKeys.conversion(range),
+		queryFn: () => funnelClient.conversion(range),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/funnel/types.ts
+++ b/admin/src/features/funnel/types.ts
@@ -1,0 +1,24 @@
+/**
+ * @module features/funnel/types
+ * @description Shapes de las respuestas del Lambda `analytics` (operation
+ *   `funnel`): conversion. Espejan el `data` que devuelve cada endpoint.
+ */
+
+/** Rango de fechas que comparten los endpoints de funnel. */
+export interface DateRangeParams {
+	from?: string;
+	to?: string;
+}
+
+/**
+ * funnel/conversion — embudo session -> visit -> contact con sus tasas.
+ * Los `*_rate` vienen en [0, 1] (proporcion); se formatean a % en la UI.
+ */
+export interface FunnelConversionResponse {
+	sessions: number;
+	visits: number;
+	contacts: number;
+	session_to_visit_rate: number;
+	visit_to_contact_rate: number;
+	session_to_contact_rate: number;
+}

--- a/admin/src/features/geo/api/geo-client.ts
+++ b/admin/src/features/geo/api/geo-client.ts
@@ -1,0 +1,13 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type { GeoByCountryParams, GeoByCountryResponse } from "../types";
+
+/**
+ * @module features/geo/api/geo-client
+ * @description Cliente tipado de la operation `geo` del Lambda `analytics`.
+ *   Cada fn hace `GET /analytics?operation=geo&action=...` via `fetchMetric`
+ *   (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const geoClient = {
+	byCountry: (params: GeoByCountryParams) =>
+		fetchMetric<GeoByCountryResponse>("geo", "by-country", { ...params }),
+};

--- a/admin/src/features/geo/api/query-keys.ts
+++ b/admin/src/features/geo/api/query-keys.ts
@@ -1,0 +1,12 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type { GeoByCountryParams } from "../types";
+
+/**
+ * @module features/geo/api/query-keys
+ * @description Query keys del dominio `geo`, derivadas del namespace raiz
+ *   `['metrics', 'geo', <action>, params]`.
+ */
+export const geoKeys = {
+	byCountry: (params: GeoByCountryParams) =>
+		metricsKey("geo", "by-country", params),
+};

--- a/admin/src/features/geo/components/GeoCountryChart.tsx
+++ b/admin/src/features/geo/components/GeoCountryChart.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { GeoByCountryResponse } from "../types";
+
+/**
+ * @component GeoCountryChart
+ * @description Top 10 paises por sesiones (geo/by-country) como BarChart de
+ *   Recharts. Skeleton mientras carga; mensaje si vacio.
+ *
+ * @props {GeoByCountryResponse} [data] - ranking del backend
+ * @props {boolean} isLoading - estado de carga
+ */
+export function GeoCountryChart({
+	data,
+	isLoading,
+}: {
+	data?: GeoByCountryResponse;
+	isLoading: boolean;
+}) {
+	if (isLoading || !data) {
+		return <Skeleton className="h-64 w-full" />;
+	}
+	if (data.items.length === 0) {
+		return (
+			<div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+				Sin datos en el rango seleccionado.
+			</div>
+		);
+	}
+
+	const top = [...data.items]
+		.sort((a, b) => b.sessions - a.sessions)
+		.slice(0, 10);
+
+	return (
+		<ResponsiveContainer width="100%" height={256}>
+			<BarChart data={top} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+				<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+				<XAxis dataKey="country" tick={{ fontSize: 12 }} />
+				<YAxis tick={{ fontSize: 12 }} allowDecimals={false} width={40} />
+				<Tooltip
+					contentStyle={{
+						background: "var(--popover)",
+						border: "1px solid var(--border)",
+						borderRadius: 8,
+						fontSize: 12,
+					}}
+				/>
+				<Bar dataKey="sessions" fill="var(--primary)" radius={[4, 4, 0, 0]} />
+			</BarChart>
+		</ResponsiveContainer>
+	);
+}

--- a/admin/src/features/geo/components/GeoCountryTable.tsx
+++ b/admin/src/features/geo/components/GeoCountryTable.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import type { GeoCountryItem } from "../types";
+
+/**
+ * @component GeoCountryTable
+ * @description Ranking de paises (geo/by-country): country (ISO-2) + sessions +
+ *   visits + events. Las filas llegan ya ordenadas por sessions desc del
+ *   backend; igual se reordena en cliente para robustez.
+ *
+ * @props {GeoCountryItem[]} items - filas del ranking
+ */
+function fmtInt(v: number): string {
+	return new Intl.NumberFormat("es").format(Math.round(v));
+}
+
+export function GeoCountryTable({ items }: { items: GeoCountryItem[] }) {
+	if (items.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin paises en el rango seleccionado.
+			</p>
+		);
+	}
+	const rows = [...items].sort((a, b) => b.sessions - a.sessions);
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Pais</TableHead>
+					<TableHead className="text-right">Sesiones</TableHead>
+					<TableHead className="text-right">Visitas</TableHead>
+					<TableHead className="text-right">Eventos</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{rows.map((item) => (
+					<TableRow key={item.country}>
+						<TableCell className="font-mono text-xs uppercase">
+							{item.country}
+						</TableCell>
+						<TableCell className="text-right">
+							{fmtInt(item.sessions)}
+						</TableCell>
+						<TableCell className="text-right">{fmtInt(item.visits)}</TableCell>
+						<TableCell className="text-right">{fmtInt(item.events)}</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/admin/src/features/geo/hooks/use-by-country.ts
+++ b/admin/src/features/geo/hooks/use-by-country.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { geoClient } from "../api/geo-client";
+import { geoKeys } from "../api/query-keys";
+import type { GeoByCountryParams } from "../types";
+
+/**
+ * @function useByCountry
+ * @description Ranking de paises por sesiones (geo/by-country). staleTime 60s
+ *   (matchea el TTL de cache del backend para las queries agregadas).
+ * @param params - rango de fechas (from/to) + limite de filas
+ */
+export function useByCountry(params: GeoByCountryParams) {
+	return useQuery({
+		queryKey: geoKeys.byCountry(params),
+		queryFn: () => geoClient.byCountry(params),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/geo/index.ts
+++ b/admin/src/features/geo/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @module features/geo
+ * @description API publica de la feature `geo` (metricas geograficas).
+ */
+export { geoClient } from "./api/geo-client";
+export { geoKeys } from "./api/query-keys";
+export { GeoCountryChart } from "./components/GeoCountryChart";
+export { GeoCountryTable } from "./components/GeoCountryTable";
+export { useByCountry } from "./hooks/use-by-country";
+export type {
+	GeoByCountryParams,
+	GeoByCountryResponse,
+	GeoCountryItem,
+} from "./types";

--- a/admin/src/features/geo/types.ts
+++ b/admin/src/features/geo/types.ts
@@ -1,0 +1,27 @@
+import type { DateRangeParams } from "@/features/analytics/types";
+
+/**
+ * @module features/geo/types
+ * @description Shapes de las respuestas del Lambda `analytics` (operation
+ *   `geo`): by-country. Espejan el `data` que devuelve el endpoint.
+ */
+
+/** Una fila del ranking por pais (geo/by-country). */
+export interface GeoCountryItem {
+	/** Codigo ISO-3166-1 alpha-2 del pais, o 'XX' si desconocido. */
+	country: string;
+	sessions: number;
+	visits: number;
+	events: number;
+}
+
+/** geo/by-country — ranking de paises por sesiones. */
+export interface GeoByCountryResponse {
+	items: GeoCountryItem[];
+	total: number;
+}
+
+/** Params de geo/by-country: rango + limite de filas. */
+export interface GeoByCountryParams extends DateRangeParams {
+	limit?: number;
+}

--- a/admin/src/features/sessions/api/query-keys.ts
+++ b/admin/src/features/sessions/api/query-keys.ts
@@ -1,0 +1,14 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type { SessionDetailParams, SessionListParams } from "../types";
+
+/**
+ * @module features/sessions/api/query-keys
+ * @description Query keys del dominio `sessions` (tracking de visitantes),
+ *   derivadas del namespace raiz `['metrics', 'sessions', <action>, params]`.
+ *   `sessions` es PII -> el persister NO persiste estas queries.
+ */
+export const sessionsKeys = {
+	list: (params: SessionListParams) => metricsKey("sessions", "list", params),
+	detail: (params: SessionDetailParams) =>
+		metricsKey("sessions", "detail", params),
+};

--- a/admin/src/features/sessions/api/sessions-client.ts
+++ b/admin/src/features/sessions/api/sessions-client.ts
@@ -1,0 +1,21 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type {
+	SessionDetailParams,
+	SessionDetailResponse,
+	SessionListParams,
+	SessionListResponse,
+} from "../types";
+
+/**
+ * @module features/sessions/api/sessions-client
+ * @description Cliente tipado de la operation `sessions` del Lambda
+ *   `analytics`. Cada fn hace `GET /analytics?operation=sessions&action=...`
+ *   via `fetchMetric` (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const sessionsClient = {
+	list: (params: SessionListParams) =>
+		fetchMetric<SessionListResponse>("sessions", "list", { ...params }),
+
+	detail: (params: SessionDetailParams) =>
+		fetchMetric<SessionDetailResponse>("sessions", "detail", { ...params }),
+};

--- a/admin/src/features/sessions/components/SessionDetailView.tsx
+++ b/admin/src/features/sessions/components/SessionDetailView.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { ArrowLeft, SearchX } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SessionVisitsTable } from "@/features/sessions/components/SessionVisitsTable";
+import { useSessionDetail } from "@/features/sessions/hooks/use-session-detail";
+import { ApiError } from "@/lib/api-client";
+import { formatDate } from "@/lib/format/date";
+import { ROUTES } from "@/lib/routes";
+
+/**
+ * @component SessionDetailView
+ * @description Detalle de una sesion de visitante (sessions/detail): resumen de
+ *   la sesion + total de eventos + tabla de visitas. Recibe el `sessionId` como
+ *   prop (la page lo lee del path con useParams). Un 404 del backend (sesion
+ *   inexistente) muestra un EmptyState.
+ *
+ * @props {string} sessionId - id de la sesion a mostrar
+ */
+export function SessionDetailView({ sessionId }: { sessionId: string }) {
+	const detail = useSessionDetail({ session_id: sessionId });
+
+	const isNotFound =
+		detail.error instanceof ApiError && detail.error.status === 404;
+
+	return (
+		<section className="space-y-6">
+			<header className="flex items-center gap-3">
+				<Button variant="ghost" size="sm" asChild>
+					<Link href={ROUTES.admin.metricsSessions}>
+						<ArrowLeft className="h-4 w-4" />
+						Volver
+					</Link>
+				</Button>
+				<h1 className="font-mono text-lg font-semibold">{sessionId}</h1>
+			</header>
+
+			{isNotFound ? (
+				<EmptyState
+					icon={SearchX}
+					title="Sesion no encontrada"
+					description="La sesion solicitada no existe o esta fuera del periodo de retencion."
+					action={
+						<Button variant="outline" asChild>
+							<Link href={ROUTES.admin.metricsSessions}>
+								Ver todas las sesiones
+							</Link>
+						</Button>
+					}
+				/>
+			) : detail.error ? (
+				<ErrorAlert error={detail.error} onRetry={() => detail.refetch()} />
+			) : (
+				<>
+					<div className="grid gap-4 md:grid-cols-3">
+						<Card>
+							<CardHeader className="pb-2">
+								<CardTitle className="text-sm font-medium text-muted-foreground">
+									Visitas
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								{detail.isLoading || !detail.data ? (
+									<Skeleton className="h-7 w-16" />
+								) : (
+									<p className="text-2xl font-semibold">
+										{detail.data.session.visits_count}
+									</p>
+								)}
+							</CardContent>
+						</Card>
+						<Card>
+							<CardHeader className="pb-2">
+								<CardTitle className="text-sm font-medium text-muted-foreground">
+									Eventos
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								{detail.isLoading || !detail.data ? (
+									<Skeleton className="h-7 w-16" />
+								) : (
+									<p className="text-2xl font-semibold">
+										{detail.data.events_count}
+									</p>
+								)}
+							</CardContent>
+						</Card>
+						<Card>
+							<CardHeader className="pb-2">
+								<CardTitle className="text-sm font-medium text-muted-foreground">
+									Dispositivo
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								{detail.isLoading || !detail.data ? (
+									<Skeleton className="h-7 w-24" />
+								) : (
+									<Badge variant="secondary">
+										{detail.data.session.device_type}
+									</Badge>
+								)}
+							</CardContent>
+						</Card>
+					</div>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Resumen de la sesion</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{detail.isLoading || !detail.data ? (
+								<div className="grid gap-3 sm:grid-cols-2">
+									{["f1", "f2", "f3", "f4"].map((fieldKey) => (
+										<Skeleton key={fieldKey} className="h-5 w-full" />
+									))}
+								</div>
+							) : (
+								<dl className="grid gap-3 text-sm sm:grid-cols-2">
+									<div>
+										<dt className="text-muted-foreground">Navegador</dt>
+										<dd>
+											{detail.data.session.browser}{" "}
+											{detail.data.session.browser_version}
+										</dd>
+									</div>
+									<div>
+										<dt className="text-muted-foreground">Sistema operativo</dt>
+										<dd>{detail.data.session.os}</dd>
+									</div>
+									<div>
+										<dt className="text-muted-foreground">Primera vez</dt>
+										<dd>{formatDate(detail.data.session.first_seen_at)}</dd>
+									</div>
+									<div>
+										<dt className="text-muted-foreground">Ultima vez</dt>
+										<dd>{formatDate(detail.data.session.last_seen_at)}</dd>
+									</div>
+								</dl>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Visitas</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{detail.isLoading || !detail.data ? (
+								<Skeleton className="h-40 w-full" />
+							) : (
+								<SessionVisitsTable visits={detail.data.visits} />
+							)}
+						</CardContent>
+					</Card>
+				</>
+			)}
+		</section>
+	);
+}

--- a/admin/src/features/sessions/components/SessionFilters.tsx
+++ b/admin/src/features/sessions/components/SessionFilters.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * @component SessionFilters
+ * @description Filtros opcionales del listado de sesiones: device_type y
+ *   browser. El valor `_all` representa "sin filtro" (se traduce a undefined
+ *   en la page para no enviar el param).
+ *
+ * @props {string} [deviceType] - filtro de device_type activo
+ * @props {string} [browser] - filtro de browser activo
+ * @props {(value?: string) => void} onDeviceTypeChange - cambia device_type
+ * @props {(value?: string) => void} onBrowserChange - cambia browser
+ */
+const ALL = "_all";
+
+const DEVICE_TYPES: readonly string[] = ["desktop", "mobile", "tablet", "bot"];
+
+const BROWSERS: readonly string[] = [
+	"Chrome",
+	"Firefox",
+	"Safari",
+	"Edge",
+	"Opera",
+];
+
+export function SessionFilters({
+	deviceType,
+	browser,
+	onDeviceTypeChange,
+	onBrowserChange,
+}: {
+	deviceType?: string;
+	browser?: string;
+	onDeviceTypeChange: (value?: string) => void;
+	onBrowserChange: (value?: string) => void;
+}) {
+	return (
+		<div className="flex flex-wrap items-center gap-3">
+			<Select
+				value={deviceType ?? ALL}
+				onValueChange={(v) => onDeviceTypeChange(v === ALL ? undefined : v)}
+			>
+				<SelectTrigger className="w-40">
+					<SelectValue placeholder="Dispositivo" />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value={ALL}>Todos los dispositivos</SelectItem>
+					{DEVICE_TYPES.map((type) => (
+						<SelectItem key={type} value={type}>
+							{type}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+
+			<Select
+				value={browser ?? ALL}
+				onValueChange={(v) => onBrowserChange(v === ALL ? undefined : v)}
+			>
+				<SelectTrigger className="w-40">
+					<SelectValue placeholder="Navegador" />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value={ALL}>Todos los navegadores</SelectItem>
+					{BROWSERS.map((b) => (
+						<SelectItem key={b} value={b}>
+							{b}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	);
+}

--- a/admin/src/features/sessions/components/SessionVisitsTable.tsx
+++ b/admin/src/features/sessions/components/SessionVisitsTable.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { formatDate } from "@/lib/format/date";
+import type { VisitRow } from "../types";
+
+/**
+ * @component SessionVisitsTable
+ * @description Tabla de visitas de una sesion (sessions/detail.visits).
+ *   Columnas: started_at, landing_page_path, niche, referrer, country,
+ *   utm_source/medium/campaign y event_count.
+ *
+ * @props {VisitRow[]} visits - filas de visitas de la sesion
+ */
+export function SessionVisitsTable({ visits }: { visits: VisitRow[] }) {
+	if (visits.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Esta sesion no tiene visitas registradas.
+			</p>
+		);
+	}
+	return (
+		<div className="rounded-md border">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Inicio</TableHead>
+						<TableHead>Landing</TableHead>
+						<TableHead>Niche</TableHead>
+						<TableHead>Referrer</TableHead>
+						<TableHead>Pais</TableHead>
+						<TableHead>UTM</TableHead>
+						<TableHead className="text-right">Eventos</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{visits.map((visit) => {
+						const utm = [visit.utm_source, visit.utm_medium, visit.utm_campaign]
+							.filter(Boolean)
+							.join(" / ");
+						return (
+							<TableRow key={visit.visit_id}>
+								<TableCell className="text-muted-foreground">
+									{formatDate(visit.started_at)}
+								</TableCell>
+								<TableCell className="font-mono text-xs">
+									{visit.landing_page_path || "-"}
+								</TableCell>
+								<TableCell>{visit.niche || "-"}</TableCell>
+								<TableCell className="max-w-48 truncate text-xs text-muted-foreground">
+									{visit.referrer || "-"}
+								</TableCell>
+								<TableCell>{visit.country || "-"}</TableCell>
+								<TableCell className="text-xs text-muted-foreground">
+									{utm || "-"}
+								</TableCell>
+								<TableCell className="text-right">
+									{visit.event_count}
+								</TableCell>
+							</TableRow>
+						);
+					})}
+				</TableBody>
+			</Table>
+		</div>
+	);
+}

--- a/admin/src/features/sessions/components/SessionsPagination.tsx
+++ b/admin/src/features/sessions/components/SessionsPagination.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * @component SessionsPagination
+ * @description Controles de paginacion del listado de sesiones: "Anterior" /
+ *   "Siguiente" + el rango mostrado (page/total). El boton siguiente se
+ *   deshabilita cuando `has_more` es false; el anterior cuando `page <= 1`.
+ *
+ * @props {number} page - pagina actual (1-based)
+ * @props {number} pageSize - tamano de pagina
+ * @props {number} total - total de sesiones
+ * @props {boolean} hasMore - hay mas paginas despues de la actual
+ * @props {boolean} isLoading - deshabilita los botones mientras carga
+ * @props {(page: number) => void} onPageChange - cambia de pagina
+ */
+export function SessionsPagination({
+	page,
+	pageSize,
+	total,
+	hasMore,
+	isLoading,
+	onPageChange,
+}: {
+	page: number;
+	pageSize: number;
+	total: number;
+	hasMore: boolean;
+	isLoading: boolean;
+	onPageChange: (page: number) => void;
+}) {
+	const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+	const to = Math.min(page * pageSize, total);
+
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<p className="text-sm text-muted-foreground">
+				{from}-{to} de {total}
+			</p>
+			<div className="flex items-center gap-2">
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={page <= 1 || isLoading}
+					onClick={() => onPageChange(page - 1)}
+				>
+					Anterior
+				</Button>
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={!hasMore || isLoading}
+					onClick={() => onPageChange(page + 1)}
+				>
+					Siguiente
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/admin/src/features/sessions/components/SessionsTable.tsx
+++ b/admin/src/features/sessions/components/SessionsTable.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { formatDate } from "@/lib/format/date";
+import { ROUTES } from "@/lib/routes";
+import type { SessionRow } from "../types";
+
+const SKELETON_ROWS = ["sk1", "sk2", "sk3", "sk4", "sk5"] as const;
+const SKELETON_CELLS = ["c1", "c2", "c3", "c4", "c5", "c6"] as const;
+
+/**
+ * @component SessionsTable
+ * @description Tabla del listado de sesiones de visitantes (sessions/list).
+ *   Columnas: session_id (mono, link al detalle), browser, os, device_type
+ *   (badge), visits_count, last_seen_at (formateado). Muestra skeleton rows
+ *   mientras carga y un mensaje cuando no hay filas.
+ *
+ * @props {SessionRow[]} items - filas de sesiones
+ * @props {boolean} isLoading - estado de carga
+ */
+export function SessionsTable({
+	items,
+	isLoading,
+}: {
+	items: SessionRow[];
+	isLoading: boolean;
+}) {
+	return (
+		<div className="rounded-md border">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Sesion</TableHead>
+						<TableHead>Navegador</TableHead>
+						<TableHead>SO</TableHead>
+						<TableHead>Dispositivo</TableHead>
+						<TableHead className="text-right">Visitas</TableHead>
+						<TableHead>Ultima vez</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{isLoading ? (
+						SKELETON_ROWS.map((rowKey) => (
+							<TableRow key={rowKey}>
+								{SKELETON_CELLS.map((cellKey) => (
+									<TableCell key={`${rowKey}-${cellKey}`}>
+										<Skeleton className="h-5 w-full" />
+									</TableCell>
+								))}
+							</TableRow>
+						))
+					) : items.length === 0 ? (
+						<TableRow>
+							<TableCell
+								colSpan={6}
+								className="h-24 text-center text-muted-foreground"
+							>
+								Sin sesiones en el rango seleccionado.
+							</TableCell>
+						</TableRow>
+					) : (
+						items.map((row) => (
+							<TableRow key={row.session_id}>
+								<TableCell className="font-mono text-xs">
+									<Link
+										href={ROUTES.admin.metricsSessionDetail(row.session_id)}
+										className="text-primary hover:underline"
+									>
+										{row.session_id}
+									</Link>
+								</TableCell>
+								<TableCell>
+									{row.browser}
+									{row.browser_version ? (
+										<span className="text-muted-foreground">
+											{" "}
+											{row.browser_version}
+										</span>
+									) : null}
+								</TableCell>
+								<TableCell>{row.os}</TableCell>
+								<TableCell>
+									<Badge variant="secondary">{row.device_type}</Badge>
+								</TableCell>
+								<TableCell className="text-right">{row.visits_count}</TableCell>
+								<TableCell className="text-muted-foreground">
+									{formatDate(row.last_seen_at)}
+								</TableCell>
+							</TableRow>
+						))
+					)}
+				</TableBody>
+			</Table>
+		</div>
+	);
+}

--- a/admin/src/features/sessions/hooks/use-session-detail.ts
+++ b/admin/src/features/sessions/hooks/use-session-detail.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { sessionsKeys } from "../api/query-keys";
+import { sessionsClient } from "../api/sessions-client";
+import type { SessionDetailParams } from "../types";
+
+/**
+ * @function useSessionDetail
+ * @description Detalle de una sesion de visitante (sessions/detail): sesion +
+ *   visitas + events_count. staleTime 0 (siempre fresh). Solo dispara cuando
+ *   hay un session_id no vacio.
+ * @param params - `{session_id}` de la sesion a inspeccionar
+ */
+export function useSessionDetail(params: SessionDetailParams) {
+	return useQuery({
+		queryKey: sessionsKeys.detail(params),
+		queryFn: () => sessionsClient.detail(params),
+		staleTime: 0,
+		enabled: Boolean(params.session_id),
+	});
+}

--- a/admin/src/features/sessions/hooks/use-session-list.ts
+++ b/admin/src/features/sessions/hooks/use-session-list.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { sessionsKeys } from "../api/query-keys";
+import { sessionsClient } from "../api/sessions-client";
+import type { SessionListParams } from "../types";
+
+/**
+ * @function useSessionList
+ * @description Listado paginado de sesiones de visitantes (sessions/list).
+ *   staleTime 30s (listado crudo). Es PII: la query no se persiste.
+ * @param params - rango from/to + page/page_size + filtros device_type/browser
+ */
+export function useSessionList(params: SessionListParams) {
+	return useQuery({
+		queryKey: sessionsKeys.list(params),
+		queryFn: () => sessionsClient.list(params),
+		staleTime: 30_000,
+	});
+}

--- a/admin/src/features/sessions/index.ts
+++ b/admin/src/features/sessions/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @module features/sessions
+ * @description API publica de la feature `sessions` (tracking de visitantes,
+ *   operation `sessions` del Lambda `analytics`). Re-exporta el cliente, las
+ *   query keys, los hooks, los componentes y los tipos.
+ */
+
+export { sessionsKeys } from "./api/query-keys";
+export { sessionsClient } from "./api/sessions-client";
+export { SessionFilters } from "./components/SessionFilters";
+export { SessionsPagination } from "./components/SessionsPagination";
+export { SessionsTable } from "./components/SessionsTable";
+export { SessionVisitsTable } from "./components/SessionVisitsTable";
+export { useSessionDetail } from "./hooks/use-session-detail";
+export { useSessionList } from "./hooks/use-session-list";
+export type {
+	SessionDetailParams,
+	SessionDetailResponse,
+	SessionListParams,
+	SessionListResponse,
+	SessionRow,
+	VisitRow,
+} from "./types";

--- a/admin/src/features/sessions/types.ts
+++ b/admin/src/features/sessions/types.ts
@@ -1,0 +1,66 @@
+/**
+ * @module features/sessions/types
+ * @description Shapes de las respuestas del Lambda `analytics` (operation
+ *   `sessions`): tracking de VISITANTES (NO `sessions-mgmt` de auth). Espejan
+ *   el `data` que devuelve cada endpoint (list paginado + detail). Es PII, por
+ *   eso el queryKey[1] === 'sessions' queda excluido del persister.
+ */
+
+/** Una fila de la lista de sesiones de visitantes (sessions/list). */
+export interface SessionRow {
+	session_id: string;
+	first_seen_at: string;
+	last_seen_at: string;
+	browser: string;
+	browser_version: string;
+	os: string;
+	device_type: string;
+	visits_count: number;
+}
+
+/** sessions/list — listado paginado de sesiones (PII, staleTime 30s). */
+export interface SessionListResponse {
+	items: SessionRow[];
+	page: number;
+	page_size: number;
+	total: number;
+	has_more: boolean;
+}
+
+/** Params del listado paginado de sesiones (con filtros opcionales). */
+export interface SessionListParams {
+	from?: string;
+	to?: string;
+	page?: number;
+	page_size?: number;
+	device_type?: string;
+	browser?: string;
+}
+
+/** Una visita asociada a una sesion (sessions/detail). */
+export interface VisitRow {
+	visit_id: string;
+	started_at: string;
+	ended_at: string;
+	event_count: number;
+	ip: string;
+	country: string;
+	utm_source: string;
+	utm_medium: string;
+	utm_campaign: string;
+	referrer: string;
+	landing_page_path: string;
+	niche: string;
+}
+
+/** sessions/detail — sesion + sus visitas + total de eventos (staleTime 0). */
+export interface SessionDetailResponse {
+	session: SessionRow;
+	visits: VisitRow[];
+	events_count: number;
+}
+
+/** Params del detalle de una sesion. */
+export interface SessionDetailParams {
+	session_id: string;
+}

--- a/admin/src/features/visits/api/query-keys.ts
+++ b/admin/src/features/visits/api/query-keys.ts
@@ -1,0 +1,13 @@
+import { metricsKey } from "@/lib/metrics-query-keys";
+import type { LandingPagesParams, VisitsListParams } from "../types";
+
+/**
+ * @module features/visits/api/query-keys
+ * @description Query keys del dominio `visits`, derivadas del namespace raiz
+ *   `['metrics', 'visits', <action>, params]`.
+ */
+export const visitsKeys = {
+	list: (params: VisitsListParams) => metricsKey("visits", "list", params),
+	landingPages: (params: LandingPagesParams) =>
+		metricsKey("visits", "landing-pages", params),
+};

--- a/admin/src/features/visits/api/visits-client.ts
+++ b/admin/src/features/visits/api/visits-client.ts
@@ -1,0 +1,21 @@
+import { fetchMetric } from "@/lib/metrics-client";
+import type {
+	LandingPagesParams,
+	LandingPagesResponse,
+	VisitsListParams,
+	VisitsListResponse,
+} from "../types";
+
+/**
+ * @module features/visits/api/visits-client
+ * @description Cliente tipado de la operation `visits` del Lambda `analytics`.
+ *   Cada fn hace `GET /analytics?operation=visits&action=...` via `fetchMetric`
+ *   (adjunta el Bearer + refresh) y devuelve el `data`.
+ */
+export const visitsClient = {
+	list: (params: VisitsListParams) =>
+		fetchMetric<VisitsListResponse>("visits", "list", { ...params }),
+
+	landingPages: (params: LandingPagesParams) =>
+		fetchMetric<LandingPagesResponse>("visits", "landing-pages", { ...params }),
+};

--- a/admin/src/features/visits/components/LandingPagesTable.tsx
+++ b/admin/src/features/visits/components/LandingPagesTable.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import type { LandingPageItem } from "../types";
+
+/**
+ * @component LandingPagesTable
+ * @description Ranking de landing pages (visits/landing-pages): landing_page_path
+ *   + visits + unique_visitors, ordenado por visits desc (el backend ya lo
+ *   entrega ordenado).
+ *
+ * @props {LandingPageItem[]} items - filas del ranking
+ */
+export function LandingPagesTable({ items }: { items: LandingPageItem[] }) {
+	if (items.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin landing pages en el rango seleccionado.
+			</p>
+		);
+	}
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Landing page</TableHead>
+					<TableHead className="text-right">Visitas</TableHead>
+					<TableHead className="text-right">Visitantes</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{items.map((item) => (
+					<TableRow key={item.landing_page_path}>
+						<TableCell className="font-mono text-xs">
+							{item.landing_page_path}
+						</TableCell>
+						<TableCell className="text-right">{item.visits}</TableCell>
+						<TableCell className="text-right">{item.unique_visitors}</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/admin/src/features/visits/components/VisitsTable.tsx
+++ b/admin/src/features/visits/components/VisitsTable.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { formatDate } from "@/lib/format/date";
+import type { VisitRow } from "../types";
+
+/**
+ * @component VisitsTable
+ * @description Tabla del listado de visitas (visits/list): started_at, country,
+ *   niche, referrer, landing_page_path, event_count. Vacio muestra un mensaje.
+ *
+ * @props {VisitRow[]} items - filas de visitas
+ */
+export function VisitsTable({ items }: { items: VisitRow[] }) {
+	if (items.length === 0) {
+		return (
+			<p className="py-6 text-center text-sm text-muted-foreground">
+				Sin visitas en el rango seleccionado.
+			</p>
+		);
+	}
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Inicio</TableHead>
+					<TableHead>Pais</TableHead>
+					<TableHead>Niche</TableHead>
+					<TableHead>Referrer</TableHead>
+					<TableHead>Landing</TableHead>
+					<TableHead className="text-right">Eventos</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{items.map((item) => (
+					<TableRow key={item.visit_id}>
+						<TableCell className="whitespace-nowrap">
+							{formatDate(item.started_at)}
+						</TableCell>
+						<TableCell>{item.country ?? "-"}</TableCell>
+						<TableCell>
+							{item.niche ? (
+								<Badge variant="secondary">{item.niche}</Badge>
+							) : (
+								"-"
+							)}
+						</TableCell>
+						<TableCell className="max-w-[16rem] truncate text-xs text-muted-foreground">
+							{item.referrer ?? "-"}
+						</TableCell>
+						<TableCell className="max-w-[16rem] truncate font-mono text-xs">
+							{item.landing_page_path ?? "-"}
+						</TableCell>
+						<TableCell className="text-right">{item.event_count}</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	);
+}

--- a/admin/src/features/visits/hooks/use-landing-pages.ts
+++ b/admin/src/features/visits/hooks/use-landing-pages.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { visitsKeys } from "../api/query-keys";
+import { visitsClient } from "../api/visits-client";
+import type { LandingPagesParams } from "../types";
+
+/**
+ * @function useLandingPages
+ * @description Ranking de landing pages por visitas (visits/landing-pages).
+ *   staleTime 60s (ranking agregado, matchea el TTL de cache del backend).
+ * @param params - rango (from/to) + limit
+ */
+export function useLandingPages(params: LandingPagesParams) {
+	return useQuery({
+		queryKey: visitsKeys.landingPages(params),
+		queryFn: () => visitsClient.landingPages(params),
+		staleTime: 60_000,
+	});
+}

--- a/admin/src/features/visits/hooks/use-visits-list.ts
+++ b/admin/src/features/visits/hooks/use-visits-list.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { visitsKeys } from "../api/query-keys";
+import { visitsClient } from "../api/visits-client";
+import type { VisitsListParams } from "../types";
+
+/**
+ * @function useVisitsList
+ * @description Listado paginado de visitas (visits/list). staleTime 30s
+ *   (listado crudo). El backend requiere `offset = (page - 1) * page_size`:
+ *   se deriva aqui a partir de `page`/`page_size` para que la page solo
+ *   maneje el numero de pagina.
+ * @param params - rango + paginacion (page, page_size) + filtros (niche, country)
+ */
+export function useVisitsList(params: VisitsListParams) {
+	const page = params.page ?? 1;
+	const pageSize = params.page_size ?? 20;
+	const offset = (page - 1) * pageSize;
+	const query: VisitsListParams = {
+		...params,
+		page,
+		page_size: pageSize,
+		offset,
+	};
+	return useQuery({
+		queryKey: visitsKeys.list(query),
+		queryFn: () => visitsClient.list(query),
+		staleTime: 30_000,
+	});
+}

--- a/admin/src/features/visits/index.ts
+++ b/admin/src/features/visits/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @module features/visits
+ * @description API publica de la feature `visits` (operation `visits` del
+ *   Lambda `analytics`): listado paginado de visitas + ranking de landing pages.
+ */
+
+export { visitsKeys } from "./api/query-keys";
+export { visitsClient } from "./api/visits-client";
+export { LandingPagesTable } from "./components/LandingPagesTable";
+export { VisitsTable } from "./components/VisitsTable";
+export { useLandingPages } from "./hooks/use-landing-pages";
+export { useVisitsList } from "./hooks/use-visits-list";
+export type {
+	LandingPageItem,
+	LandingPagesParams,
+	LandingPagesResponse,
+	VisitRow,
+	VisitsListParams,
+	VisitsListResponse,
+} from "./types";

--- a/admin/src/features/visits/types.ts
+++ b/admin/src/features/visits/types.ts
@@ -1,0 +1,60 @@
+/**
+ * @module features/visits/types
+ * @description Shapes de las respuestas del Lambda `analytics` (operation
+ *   `visits`): list (paginado) y landing-pages (ranking agregado). Espejan el
+ *   `data` que devuelve cada endpoint.
+ */
+
+import type { DateRangeParams } from "@/features/analytics/types";
+
+/** visits/list — params del listado paginado. Requiere `offset`. */
+export interface VisitsListParams extends DateRangeParams {
+	page?: number;
+	page_size?: number;
+	offset?: number;
+	niche?: string;
+	country?: string;
+}
+
+/** Una fila del listado de visitas. */
+export interface VisitRow {
+	visit_id: string;
+	session_id: string;
+	started_at: string;
+	ended_at: string | null;
+	event_count: number;
+	ip: string | null;
+	country: string | null;
+	utm_source: string | null;
+	utm_medium: string | null;
+	utm_campaign: string | null;
+	referrer: string | null;
+	landing_page_path: string | null;
+	niche: string | null;
+}
+
+/** visits/list — pagina de visitas. */
+export interface VisitsListResponse {
+	items: VisitRow[];
+	page: number;
+	page_size: number;
+	total: number;
+	has_more: boolean;
+}
+
+/** visits/landing-pages — params del ranking de landing pages. */
+export interface LandingPagesParams extends DateRangeParams {
+	limit?: number;
+}
+
+/** Una landing page rankeada. */
+export interface LandingPageItem {
+	landing_page_path: string;
+	visits: number;
+	unique_visitors: number;
+}
+
+/** visits/landing-pages — ranking de landing pages. */
+export interface LandingPagesResponse {
+	items: LandingPageItem[];
+}

--- a/admin/src/lib/metrics-client.ts
+++ b/admin/src/lib/metrics-client.ts
@@ -1,0 +1,50 @@
+import { apiFetch } from "@/lib/api-client";
+import type { Envelope } from "@/types/api";
+
+/**
+ * @module lib/metrics-client
+ * @description Helper GET compartido por todas las features de metricas que
+ *   consumen el Lambda `analytics` (`GET /analytics?operation=...&action=...`).
+ *
+ *   A diferencia del resto del admin (POST `/auth` y `/users` con body
+ *   `{operation, action, data}`), el Lambda `analytics` es GET con query
+ *   params: `operation` y `action` van en el query string, igual que el
+ *   resto del payload. El access JWT viaja en el header `Authorization`
+ *   (lo agrega `apiFetch`), NUNCA en query params.
+ *
+ *   El backend responde FLAT; `apiFetch` lo re-envuelve en
+ *   `Envelope<T> = {is_valid, code, data}`. Aqui se devuelve el `data`.
+ */
+
+/** Valores admitidos en el query string de un GET de metricas. */
+export type MetricParam = string | number | boolean | null | undefined;
+
+/**
+ * @function fetchMetric
+ * @description Hace `GET /analytics` con `operation`/`action` + params como
+ *   query string, adjunta el Bearer (via apiFetch) y devuelve el `data` del
+ *   Envelope tipado. Omite los params `null`/`undefined`/`""`.
+ *
+ * @param operation - dominio de metricas (`analytics`, `events`, ...)
+ * @param action - accion (`overview`, `list`, `by-country`, ...)
+ * @param params - resto de los query params (from, to, page, filtros, ...)
+ * @returns el `data` de la respuesta, tipado como `T`
+ */
+export async function fetchMetric<T>(
+	operation: string,
+	action: string,
+	params: Record<string, MetricParam> = {},
+): Promise<T> {
+	const search = new URLSearchParams();
+	search.set("operation", operation);
+	search.set("action", action);
+	for (const [key, value] of Object.entries(params)) {
+		if (value === null || value === undefined || value === "") continue;
+		search.set(key, String(value));
+	}
+	const envelope = await apiFetch<Envelope<T>>(
+		`/analytics?${search.toString()}`,
+		{ method: "GET" },
+	);
+	return envelope.data;
+}

--- a/admin/src/lib/metrics-query-keys.ts
+++ b/admin/src/lib/metrics-query-keys.ts
@@ -1,0 +1,36 @@
+/**
+ * @module lib/metrics-query-keys
+ * @description Namespace raiz de las query keys de TODAS las features de
+ *   metricas (`['metrics', <feature>, <action>, params]`). Cada feature
+ *   deriva su factory de aqui para que la invalidacion coordinada y la
+ *   exclusion del persister (data con PII) funcionen por prefijo.
+ *
+ *   El persister NO persiste queries cuyo `queryKey[0] === 'metrics'` y la
+ *   feature es de PII (`contacts`, `sessions`): ver query-provider. El resto
+ *   (agregadas) si se persiste (24h) para una UX rapida al recargar.
+ */
+
+/** Prefijo raiz de todas las queries de metricas. */
+export const METRICS_KEY = "metrics" as const;
+
+/**
+ * @function metricsKey
+ * @description Construye una query key bajo el namespace `metrics`:
+ *   `['metrics', feature, action, params?]`.
+ *
+ * @param feature - dominio (`analytics`, `events`, `sessions`, ...)
+ * @param action - accion (`overview`, `list`, `by-country`, ...)
+ * @param params - params de la query (range, paginacion, filtros)
+ */
+export function metricsKey<P extends object>(
+	feature: string,
+	action: string,
+	params?: P,
+): readonly unknown[] {
+	return params === undefined
+		? [METRICS_KEY, feature, action]
+		: [METRICS_KEY, feature, action, params];
+}
+
+/** Features de metricas con PII: no se persisten en el query persister. */
+export const METRICS_PII_FEATURES: readonly string[] = ["contacts", "sessions"];

--- a/admin/src/lib/routes.ts
+++ b/admin/src/lib/routes.ts
@@ -16,6 +16,18 @@ export const ROUTES = {
 	admin: {
 		root: "/",
 		metrics: "/metrics",
+		// Area de metricas del visitante (Lambda analytics). Todo bajo
+		// /metrics/* para NO colisionar con /sessions (Mis sesiones de auth).
+		metricsTimeseries: "/metrics/timeseries",
+		metricsSessions: "/metrics/sessions",
+		metricsSessionDetail: (id: string) =>
+			`/metrics/sessions/detail?id=${encodeURIComponent(id)}`,
+		metricsEvents: "/metrics/events",
+		metricsVisits: "/metrics/visits",
+		metricsGeo: "/metrics/geo",
+		metricsDevices: "/metrics/devices",
+		metricsFunnel: "/metrics/funnel",
+		metricsContacts: "/metrics/contacts",
 		settings: "/settings",
 		settingsSecurity: "/settings/security",
 		sessions: "/sessions",

--- a/admin/src/providers/query-provider.tsx
+++ b/admin/src/providers/query-provider.tsx
@@ -6,6 +6,7 @@ import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client
 import { compress, decompress } from "lz-string";
 import { type ReactNode, useState } from "react";
 import { ApiError } from "@/lib/api-client";
+import { METRICS_PII_FEATURES } from "@/lib/metrics-query-keys";
 
 /**
  * @component QueryProvider
@@ -59,6 +60,14 @@ export function QueryProvider({ children }: { children: ReactNode }) {
 						const key = query.queryKey[0];
 						// No persistir datos sensibles (usuarios admin, sesiones)
 						if (key === "admin") return false;
+						// Metricas con PII (contacts, sessions de tracking): no
+						// persistir. Las agregadas si (UX rapida al recargar).
+						if (
+							key === "metrics" &&
+							METRICS_PII_FEATURES.includes(query.queryKey[1] as string)
+						) {
+							return false;
+						}
 						return true;
 					},
 				},

--- a/admin/tests/mocks/browser.ts
+++ b/admin/tests/mocks/browser.ts
@@ -1,6 +1,11 @@
 import { setupWorker } from "msw/browser";
 import { authHandlers } from "./handlers/auth";
+import { metricsHandlers } from "./handlers/metrics";
 import { usersHandlers } from "./handlers/users";
 
 /** @module tests/mocks/browser — setupWorker (browser dev con NEXT_PUBLIC_USE_MSW). */
-export const worker = setupWorker(...authHandlers, ...usersHandlers);
+export const worker = setupWorker(
+	...authHandlers,
+	...usersHandlers,
+	...metricsHandlers,
+);

--- a/admin/tests/mocks/handlers/metrics.ts
+++ b/admin/tests/mocks/handlers/metrics.ts
@@ -1,0 +1,227 @@
+import { HttpResponse, http } from "msw";
+
+/**
+ * @module tests/mocks/handlers/metrics
+ * @description MSW handler del Lambda `analytics` (`GET /analytics?operation=
+ *   ...&action=...`). Responde un payload FLAT por (operation, action) — el
+ *   api-client lo re-envuelve en `{is_valid, code, data}`. Cubre las 19 actions
+ *   de las 8 features de metricas con data sintetica determinista.
+ */
+
+const API = "https://api.test.the-full-stack.com";
+
+const FIXTURES: Record<string, Record<string, unknown>> = {
+	"analytics:overview": {
+		sessions: 100,
+		visits: 80,
+		events: 500,
+		contacts: 5,
+		unique_visitors: 75,
+		avg_visit_duration_sec: 45.5,
+		bounce_rate: 0.15,
+		from: "2026-04-27",
+		to: "2026-05-28",
+	},
+	"analytics:timeseries": {
+		bucket: "day",
+		points: [
+			{ timestamp: "2026-05-01", count: 10 },
+			{ timestamp: "2026-05-02", count: 20 },
+		],
+		from: "2026-04-27",
+		to: "2026-05-28",
+		filters: { niche: null, event_type: null },
+	},
+	"analytics:top-pages": {
+		items: [
+			{ page_path: "/", events: 50, unique_visitors: 30, unique_visits: 40 },
+		],
+	},
+	"analytics:top-referrers": {
+		referrers: [{ referrer: "(direct)", visits: 40, unique_visitors: 30 }],
+		utm_sources: [{ utm_source: "google", visits: 10 }],
+		utm_mediums: [{ utm_medium: "cpc", visits: 5 }],
+		utm_campaigns: [{ utm_campaign: "launch", visits: 3 }],
+	},
+	"analytics:top-niches": {
+		items: [{ niche: "fintech", visits: 30, unique_visitors: 20 }],
+	},
+	"analytics:active-now": {
+		active_sessions: 3,
+		threshold_minutes: 5,
+		as_of: "2026-05-28T12:00:00+00:00",
+	},
+	"analytics:retention": {
+		new_visitors: 60,
+		returning_visitors: 15,
+		total: 75,
+		returning_rate: 0.2,
+	},
+	"events:distribution": {
+		items: [
+			{ event_type: "page_view", count: 300, pct: 60.0 },
+			{ event_type: "click", count: 200, pct: 40.0 },
+		],
+	},
+	"events:list": {
+		items: [
+			{
+				created_at: "2026-05-20T10:00:00Z",
+				visit_id: "vis_1",
+				page_id: "pg_1",
+				session_id: "sess_1",
+				page_path: "/",
+				niche: "fintech",
+				viewport_width: 1920,
+				viewport_height: 1080,
+				event_type: "page_view",
+				event_props: {},
+			},
+		],
+		page: 1,
+		page_size: 50,
+		total: 1,
+		has_more: false,
+	},
+	"events:heatmap": {
+		cells: [
+			{ dow: 1, hour: 9, count: 12 },
+			{ dow: 3, hour: 14, count: 8 },
+		],
+	},
+	"sessions:list": {
+		items: [
+			{
+				session_id: "sess_1",
+				first_seen_at: "2026-05-01T10:00:00Z",
+				last_seen_at: "2026-05-20T10:00:00Z",
+				browser: "Chrome",
+				browser_version: "120",
+				os: "Linux",
+				device_type: "desktop",
+				visits_count: 4,
+			},
+		],
+		page: 1,
+		page_size: 20,
+		total: 1,
+		has_more: false,
+	},
+	"sessions:detail": {
+		session: {
+			session_id: "sess_1",
+			first_seen_at: "2026-05-01T10:00:00Z",
+			last_seen_at: "2026-05-20T10:00:00Z",
+			browser: "Chrome",
+			browser_version: "120",
+			os: "Linux",
+			device_type: "desktop",
+			visits_count: 2,
+		},
+		visits: [
+			{
+				visit_id: "vis_1",
+				started_at: "2026-05-01T10:00:00Z",
+				ended_at: "2026-05-01T10:05:00Z",
+				event_count: 3,
+				ip: "1.2.3.4",
+				country: "AR",
+				utm_source: null,
+				utm_medium: null,
+				utm_campaign: null,
+				referrer: null,
+				landing_page_path: "/",
+				niche: "fintech",
+			},
+		],
+		events_count: 6,
+	},
+	"visits:list": {
+		items: [
+			{
+				visit_id: "vis_1",
+				session_id: "sess_1",
+				started_at: "2026-05-01T10:00:00Z",
+				ended_at: "2026-05-01T10:05:00Z",
+				event_count: 3,
+				ip: "1.2.3.4",
+				country: "AR",
+				utm_source: null,
+				utm_medium: null,
+				utm_campaign: null,
+				referrer: "(direct)",
+				landing_page_path: "/",
+				niche: "fintech",
+			},
+		],
+		page: 1,
+		page_size: 20,
+		total: 1,
+		has_more: false,
+	},
+	"visits:landing-pages": {
+		items: [{ landing_page_path: "/", visits: 40, unique_visitors: 30 }],
+	},
+	"geo:by-country": {
+		items: [{ country: "AR", sessions: 30, visits: 40, events: 100 }],
+		total: 30,
+	},
+	"devices:breakdown": {
+		device_types: [{ device_type: "desktop", sessions: 50 }],
+		browsers: [{ browser: "Chrome", sessions: 40 }],
+		os: [{ os: "Linux", sessions: 35 }],
+	},
+	"funnel:conversion": {
+		sessions: 100,
+		visits: 80,
+		contacts: 5,
+		session_to_visit_rate: 0.8,
+		visit_to_contact_rate: 0.063,
+		session_to_contact_rate: 0.05,
+	},
+	"contacts:list": {
+		items: [
+			{
+				id: "ct_1",
+				created_at: "2026-05-20T10:00:00Z",
+				name: "Ada",
+				email: "ada@example.com",
+				message: "Hola",
+				company: "Acme",
+				role: "CTO",
+				service_type: "consulting",
+				budget: "10k",
+				timeline: "Q3",
+				niche: "fintech",
+				status: "new",
+				session_id: "sess_1",
+			},
+		],
+		page: 1,
+		page_size: 50,
+		total: 1,
+		has_more: false,
+	},
+	"contacts:by-status": {
+		items: [
+			{ status: "new", count: 8, pct: 80.0 },
+			{ status: "converted", count: 2, pct: 20.0 },
+		],
+	},
+};
+
+export const metricsHandlers = [
+	http.get(`${API}/analytics`, ({ request }) => {
+		const url = new URL(request.url);
+		const operation = url.searchParams.get("operation") ?? "";
+		const action = url.searchParams.get("action") ?? "";
+		const fixture = FIXTURES[`${operation}:${action}`];
+		if (fixture === undefined) {
+			return HttpResponse.json(
+				{ error: "unknown", code: 1000 },
+				{ status: 400 },
+			);
+		}
+		return HttpResponse.json(fixture, { status: 200 });
+	}),
+];

--- a/admin/tests/mocks/server.ts
+++ b/admin/tests/mocks/server.ts
@@ -1,6 +1,11 @@
 import { setupServer } from "msw/node";
 import { authHandlers } from "./handlers/auth";
+import { metricsHandlers } from "./handlers/metrics";
 import { usersHandlers } from "./handlers/users";
 
 /** @module tests/mocks/server — setupServer (Node) para Vitest. */
-export const server = setupServer(...authHandlers, ...usersHandlers);
+export const server = setupServer(
+	...authHandlers,
+	...usersHandlers,
+	...metricsHandlers,
+);

--- a/admin/tests/unit/features/admin-shell/components/mobile-sidebar.test.tsx
+++ b/admin/tests/unit/features/admin-shell/components/mobile-sidebar.test.tsx
@@ -28,7 +28,7 @@ describe("MobileSidebar", () => {
 		useVisibleNavItemsMock.mockReturnValue(ADMIN_ITEMS);
 	});
 
-	it("Given un admin When abre el Sheet Then muestra los 4 items", async () => {
+	it("Given un admin When abre el Sheet Then muestra los 5 items", async () => {
 		// Arrange
 		const user = userEvent.setup();
 		render(<MobileSidebar />);
@@ -38,10 +38,10 @@ describe("MobileSidebar", () => {
 
 		// Assert
 		const links = await screen.findAllByRole("link");
-		expect(links).toHaveLength(4);
+		expect(links).toHaveLength(5);
 	});
 
-	it("Given un NO-admin When abre el Sheet Then oculta el item Usuarios (3 items)", async () => {
+	it("Given un NO-admin When abre el Sheet Then oculta el item Usuarios (4 items)", async () => {
 		// Arrange
 		useVisibleNavItemsMock.mockReturnValue(NON_ADMIN_ITEMS);
 		const user = userEvent.setup();
@@ -52,7 +52,7 @@ describe("MobileSidebar", () => {
 
 		// Assert
 		const links = await screen.findAllByRole("link");
-		expect(links).toHaveLength(3);
+		expect(links).toHaveLength(4);
 		expect(screen.queryByRole("link", { name: /usuarios/i })).toBe(null);
 	});
 
@@ -82,17 +82,18 @@ describe("MobileSidebar", () => {
 		expect(link.className).toContain("text-muted-foreground");
 	});
 
-	it("Given el Sheet abierto Then NO muestra el item Metricas", async () => {
+	it("Given el Sheet abierto Then muestra el item Metricas", async () => {
 		// Arrange
 		const user = userEvent.setup();
 		render(<MobileSidebar />);
 
 		// Act
 		await user.click(screen.getByRole("button", { name: /abrir menu/i }));
-		await screen.findByRole("link", { name: /configuracion/i });
 
 		// Assert
-		expect(screen.queryByRole("link", { name: /metricas/i })).toBe(null);
+		expect(
+			await screen.findByRole("link", { name: /metricas/i }),
+		).toBeInTheDocument();
 	});
 
 	it("Given el Sheet abierto When click en un item Then cierra el Sheet", async () => {

--- a/admin/tests/unit/features/admin-shell/components/sidebar.test.tsx
+++ b/admin/tests/unit/features/admin-shell/components/sidebar.test.tsx
@@ -39,17 +39,17 @@ describe("Sidebar", () => {
 		expect(link.className).toContain("text-muted-foreground");
 	});
 
-	it("Given un admin When render Then muestra los 4 items (incluye Usuarios)", () => {
-		// Arrange: useVisibleNavItems devuelve los 4 (default del beforeEach)
+	it("Given un admin When render Then muestra los 5 items (incluye Usuarios)", () => {
+		// Arrange: useVisibleNavItems devuelve los 5 (default del beforeEach)
 		// Act
 		render(<Sidebar />);
 
 		// Assert
-		expect(screen.getAllByRole("link")).toHaveLength(4);
+		expect(screen.getAllByRole("link")).toHaveLength(5);
 		expect(screen.getByRole("link", { name: /usuarios/i })).toBeInTheDocument();
 	});
 
-	it("Given un NO-admin When render Then oculta el item Usuarios (3 items)", () => {
+	it("Given un NO-admin When render Then oculta el item Usuarios (4 items)", () => {
 		// Arrange
 		useVisibleNavItemsMock.mockReturnValue(NON_ADMIN_ITEMS);
 
@@ -57,15 +57,15 @@ describe("Sidebar", () => {
 		render(<Sidebar />);
 
 		// Assert
-		expect(screen.getAllByRole("link")).toHaveLength(3);
+		expect(screen.getAllByRole("link")).toHaveLength(4);
 		expect(screen.queryByRole("link", { name: /usuarios/i })).toBe(null);
 	});
 
-	it("Given el sidebar When render Then NO muestra el item Metricas", () => {
+	it("Given el sidebar When render Then muestra el item Metricas", () => {
 		// Arrange + Act
 		render(<Sidebar />);
 
 		// Assert
-		expect(screen.queryByRole("link", { name: /metricas/i })).toBe(null);
+		expect(screen.getByRole("link", { name: /metricas/i })).toBeInTheDocument();
 	});
 });

--- a/admin/tests/unit/features/admin-shell/hooks/use-nav-items.test.tsx
+++ b/admin/tests/unit/features/admin-shell/hooks/use-nav-items.test.tsx
@@ -27,7 +27,13 @@ describe("useVisibleNavItems", () => {
 
 		// Assert
 		const hrefs = result.current.map((i) => i.href);
-		expect(hrefs).toEqual(["/settings", "/sessions", "/users", "/cv"]);
+		expect(hrefs).toEqual([
+			"/metrics",
+			"/settings",
+			"/sessions",
+			"/users",
+			"/cv",
+		]);
 	});
 
 	it("Given un NO-admin When resuelve Then excluye los items adminOnly", () => {
@@ -39,7 +45,7 @@ describe("useVisibleNavItems", () => {
 
 		// Assert
 		const hrefs = result.current.map((i) => i.href);
-		expect(hrefs).toEqual(["/settings", "/sessions", "/cv"]);
+		expect(hrefs).toEqual(["/metrics", "/settings", "/sessions", "/cv"]);
 		expect(hrefs).not.toContain("/users");
 	});
 

--- a/admin/tests/unit/features/admin-shell/lib/nav-items.test.ts
+++ b/admin/tests/unit/features/admin-shell/lib/nav-items.test.ts
@@ -3,30 +3,36 @@ import { NAV_ITEMS } from "@/features/admin-shell/lib/nav-items";
 
 /**
  * @module tests/unit/features/admin-shell/lib/nav-items
- * @description Verifica los items del sidebar. Regresion del bug 4: el slot
- *   `metrics` NO se lista hasta que el plan b-analytics-api monte la page
- *   /metrics (un link rompe la navegacion con un 404 del SPA fallback).
+ * @description Verifica los items del sidebar. Tras el plan b-analytics-api la
+ *   raiz del area de metricas (`/metrics`) ES un item del sidebar (la page ya
+ *   existe); las sub-secciones de /metrics/* se navegan desde esa page.
  */
 
 describe("NAV_ITEMS", () => {
-	it("Given los items When se inspeccionan Then ninguno apunta a /metrics", () => {
+	it("Given los items When se inspeccionan Then incluye /metrics como raiz", () => {
 		// Arrange + Act
 		const hrefs = NAV_ITEMS.map((item) => item.href);
 
 		// Assert
-		expect(hrefs).not.toContain("/metrics");
+		expect(hrefs).toContain("/metrics");
 	});
 
-	it("Given los items When se cuentan Then hay 4 (sin Metricas)", () => {
+	it("Given los items When se cuentan Then hay 5 (con Metricas)", () => {
 		// Arrange + Act + Assert
-		expect(NAV_ITEMS).toHaveLength(4);
+		expect(NAV_ITEMS).toHaveLength(5);
 	});
 
-	it("Given los items When se listan Then son settings, sessions, users, cv", () => {
+	it("Given los items When se listan Then son metrics, settings, sessions, users, cv", () => {
 		// Arrange + Act
 		const hrefs = NAV_ITEMS.map((item) => item.href);
 
 		// Assert
-		expect(hrefs).toEqual(["/settings", "/sessions", "/users", "/cv"]);
+		expect(hrefs).toEqual([
+			"/metrics",
+			"/settings",
+			"/sessions",
+			"/users",
+			"/cv",
+		]);
 	});
 });

--- a/admin/tests/unit/features/analytics/ActiveNowBadge.test.tsx
+++ b/admin/tests/unit/features/analytics/ActiveNowBadge.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { makeJwt } from "@tests/mocks/jwt";
+import { server } from "@tests/mocks/server";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ActiveNowBadge } from "@/features/analytics/components/ActiveNowBadge";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/ActiveNowBadge
+ * @description ActiveNowBadge: contador live (useActiveNow). Muestra un guion
+ *   mientras carga o si falla; el conteo + plural/singular cuando hay data.
+ *   Wrapper propio con retry:false + refetchInterval off para que el branch
+ *   de error resuelva sin esperar reintentos. El conteo y el plural viven en
+ *   el mismo <span>, por eso se asertan contra el textContent normalizado.
+ */
+
+const API = "https://api.test.the-full-stack.com";
+
+function Wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, refetchInterval: false },
+		},
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("ActiveNowBadge", () => {
+	it("Given el render inicial When aun no resolvio Then muestra un guion en plural", () => {
+		// Arrange + Act
+		const { container } = render(<ActiveNowBadge />, { wrapper: Wrapper });
+
+		// Assert: estado loading -> "– activos"
+		expect(container.textContent?.replace(/\s+/g, " ")).toContain("– activos");
+	});
+
+	it("Given el fixture (3 sesiones) When la query resuelve Then muestra el conteo en plural", async () => {
+		// Arrange + Act
+		const { container } = render(<ActiveNowBadge />, { wrapper: Wrapper });
+
+		// Assert
+		await waitFor(() => {
+			expect(container.textContent?.replace(/\s+/g, " ")).toContain(
+				"3 activos",
+			);
+		});
+	});
+
+	it("Given exactamente 1 sesion activa When la query resuelve Then usa el singular", async () => {
+		// Arrange
+		server.use(
+			http.get(`${API}/analytics`, () =>
+				HttpResponse.json(
+					{ active_sessions: 1, threshold_minutes: 5, as_of: "x" },
+					{ status: 200 },
+				),
+			),
+		);
+
+		// Act
+		const { container } = render(<ActiveNowBadge />, { wrapper: Wrapper });
+
+		// Assert
+		await waitFor(() => {
+			expect(container.textContent?.replace(/\s+/g, " ")).toContain("1 activo");
+		});
+		expect(container.textContent?.replace(/\s+/g, " ")).not.toContain(
+			"1 activos",
+		);
+	});
+
+	it("Given un error del backend When la query falla Then muestra un guion", async () => {
+		// Arrange
+		server.use(
+			http.get(`${API}/analytics`, () =>
+				HttpResponse.json({ error: "boom", code: 5000 }, { status: 500 }),
+			),
+		);
+
+		// Act
+		const { container } = render(<ActiveNowBadge />, { wrapper: Wrapper });
+
+		// Assert
+		await waitFor(() => {
+			expect(container.textContent?.replace(/\s+/g, " ")).toContain(
+				"– activos",
+			);
+		});
+	});
+});

--- a/admin/tests/unit/features/analytics/MetricsDateRange.test.tsx
+++ b/admin/tests/unit/features/analytics/MetricsDateRange.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@tests/utils/render";
+import type { DateRange } from "react-day-picker";
+import { describe, expect, it, vi } from "vitest";
+import { MetricsDateRange } from "@/features/analytics/components/MetricsDateRange";
+
+/**
+ * @module tests/unit/features/analytics/MetricsDateRange
+ * @description MetricsDateRange: adapta entre los strings YYYY-MM-DD (params del
+ *   backend) y los Date del DateRangePicker. Se mockea el DateRangePicker para
+ *   exponer su `value` (que MetricsDateRange computa) y disparar su `onChange`
+ *   de forma determinista, sin depender del calendario real.
+ */
+
+/** Captura del ultimo `value` recibido + dispara el onChange controlado. */
+let lastValue: DateRange | undefined;
+let lastOnChange: ((range: DateRange | undefined) => void) | undefined;
+
+vi.mock("@/components/ui/date-range-picker", () => ({
+	DateRangePicker: ({
+		value,
+		onChange,
+	}: {
+		value: DateRange | undefined;
+		onChange: (range: DateRange | undefined) => void;
+	}) => {
+		lastValue = value;
+		lastOnChange = onChange;
+		return (
+			<div data-testid="picker">
+				{value?.from
+					? `from:${value.from.toISOString().slice(0, 10)}`
+					: "no-value"}
+			</div>
+		);
+	},
+}));
+
+describe("MetricsDateRange", () => {
+	it("Given un rango con from/to When se renderiza Then pasa Dates parseados al picker", () => {
+		// Arrange + Act
+		render(
+			<MetricsDateRange
+				range={{ from: "2026-04-27", to: "2026-05-28" }}
+				onChange={() => {}}
+			/>,
+		);
+
+		// Assert: el value derivado expone el from convertido a Date
+		expect(screen.getByTestId("picker")).toHaveTextContent("from:2026-04-27");
+		expect(lastValue?.from).toBeInstanceOf(Date);
+		expect(lastValue?.to).toBeInstanceOf(Date);
+	});
+
+	it("Given un rango sin from When se renderiza Then el value del picker es undefined", () => {
+		// Arrange + Act
+		render(<MetricsDateRange range={{}} onChange={() => {}} />);
+
+		// Assert
+		expect(screen.getByTestId("picker")).toHaveTextContent("no-value");
+		expect(lastValue).toBeUndefined();
+	});
+
+	it("Given el picker emite un rango completo When onChange Then propaga los strings ISO", () => {
+		// Arrange
+		const onChange = vi.fn();
+		render(<MetricsDateRange range={{}} onChange={onChange} />);
+
+		// Act: simula que el calendario eligio un rango from+to
+		lastOnChange?.({
+			from: new Date("2026-01-01T00:00:00Z"),
+			to: new Date("2026-01-31T00:00:00Z"),
+		});
+
+		// Assert
+		expect(onChange).toHaveBeenCalledWith({
+			from: "2026-01-01",
+			to: "2026-01-31",
+		});
+	});
+
+	it("Given el picker emite un rango incompleto (solo from) When onChange Then NO propaga", () => {
+		// Arrange
+		const onChange = vi.fn();
+		render(<MetricsDateRange range={{}} onChange={onChange} />);
+
+		// Act: solo from, sin to -> el guard no propaga
+		lastOnChange?.({ from: new Date("2026-01-01T00:00:00Z"), to: undefined });
+
+		// Assert
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("Given el picker emite un rango incompleto (solo to) When onChange Then NO propaga", () => {
+		// Arrange
+		const onChange = vi.fn();
+		render(<MetricsDateRange range={{}} onChange={onChange} />);
+
+		// Act: solo to, sin from -> el guard `next?.from && next?.to` no propaga
+		lastOnChange?.({
+			from: undefined as unknown as Date,
+			to: new Date("2026-01-31T00:00:00Z"),
+		});
+
+		// Assert
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("Given el picker emite undefined When onChange Then NO propaga", () => {
+		// Arrange
+		const onChange = vi.fn();
+		render(<MetricsDateRange range={{}} onChange={onChange} />);
+
+		// Act: el calendario se limpia -> next undefined
+		lastOnChange?.(undefined);
+
+		// Assert
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("Given un range con from invalido When se renderiza Then toDate retorna undefined (NaN guard)", () => {
+		// Arrange + Act: 'no-es-fecha' produce un Date NaN -> toDate -> undefined.
+		// `range.from` truthy entra a la rama del value, pero el from parseado es
+		// undefined (cubre el branch Number.isNaN de toDate, lineas 18-20).
+		render(
+			<MetricsDateRange
+				range={{ from: "no-es-fecha", to: "tampoco" }}
+				onChange={() => {}}
+			/>,
+		);
+
+		// Assert: value existe (from era truthy) pero ambos Dates son undefined
+		expect(screen.getByTestId("picker")).toHaveTextContent("no-value");
+		expect(lastValue).toEqual({ from: undefined, to: undefined });
+	});
+});

--- a/admin/tests/unit/features/analytics/OverviewKpis.test.tsx
+++ b/admin/tests/unit/features/analytics/OverviewKpis.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { OverviewKpis } from "@/features/analytics/components/OverviewKpis";
+import type { OverviewResponse } from "@/features/analytics/types";
+
+/**
+ * @module tests/unit/features/analytics/OverviewKpis
+ * @description OverviewKpis: grid de 7 KPI cards. Skeleton mientras carga;
+ *   con data formatea int / duracion / porcentaje.
+ */
+
+const DATA: OverviewResponse = {
+	sessions: 12345,
+	visits: 80,
+	events: 500,
+	contacts: 5,
+	unique_visitors: 75,
+	avg_visit_duration_sec: 3725, // 1h 2m
+	bounce_rate: 0.156,
+	from: "2026-04-27",
+	to: "2026-05-28",
+};
+
+describe("OverviewKpis", () => {
+	it("Given isLoading true When se renderiza Then muestra las 7 etiquetas (estado skeleton)", () => {
+		// Arrange + Act
+		render(<OverviewKpis isLoading={true} />);
+
+		// Assert: las etiquetas siempre se renderizan; el valor es skeleton
+		expect(screen.getByText("Sesiones")).toBeInTheDocument();
+		expect(screen.getByText("Tasa de rebote")).toBeInTheDocument();
+		expect(screen.queryByText("12.345")).not.toBeInTheDocument();
+	});
+
+	it("Given data sin loading When se renderiza Then formatea los enteros con separador de miles", () => {
+		// Arrange + Act
+		render(<OverviewKpis data={DATA} isLoading={false} />);
+
+		// Assert: 12345 -> "12.345" (grouping es a partir de 5 digitos)
+		expect(screen.getByText("12.345")).toBeInTheDocument();
+		expect(screen.getByText("75")).toBeInTheDocument();
+	});
+
+	it("Given una duracion > 1h When se renderiza Then la formatea como horas y minutos", () => {
+		// Arrange + Act
+		render(<OverviewKpis data={DATA} isLoading={false} />);
+
+		// Assert: 3725s -> 1h 2m
+		expect(screen.getByText("1h 2m")).toBeInTheDocument();
+	});
+
+	it("Given un bounce_rate When se renderiza Then lo formatea como porcentaje", () => {
+		// Arrange + Act
+		render(<OverviewKpis data={DATA} isLoading={false} />);
+
+		// Assert: 0.156 -> 15.6%
+		expect(screen.getByText("15.6%")).toBeInTheDocument();
+	});
+
+	it("Given una duracion < 1m When se renderiza Then la formatea en segundos", () => {
+		// Arrange
+		const data: OverviewResponse = { ...DATA, avg_visit_duration_sec: 45 };
+
+		// Act
+		render(<OverviewKpis data={data} isLoading={false} />);
+
+		// Assert
+		expect(screen.getByText("45s")).toBeInTheDocument();
+	});
+
+	it("Given una duracion de minutos When se renderiza Then la formatea en minutos y segundos", () => {
+		// Arrange
+		const data: OverviewResponse = { ...DATA, avg_visit_duration_sec: 125 };
+
+		// Act
+		render(<OverviewKpis data={data} isLoading={false} />);
+
+		// Assert: 125s -> 2m 5s
+		expect(screen.getByText("2m 5s")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/analytics/RetentionChart.test.tsx
+++ b/admin/tests/unit/features/analytics/RetentionChart.test.tsx
@@ -1,0 +1,57 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { RetentionChart } from "@/features/analytics/components/RetentionChart";
+import type { RetentionResponse } from "@/features/analytics/types";
+
+/**
+ * @module tests/unit/features/analytics/RetentionChart
+ * @description PieChart de Recharts + tasa de retorno. Cubre el branch loading
+ *   (skeleton) y el de data (arma los slices + monta el ResponsiveContainer +
+ *   formatea la tasa). El label "Tasa de retorno:" comparte <p> con el <span>
+ *   del valor: el valor SI es su propio elemento, el label se valida por
+ *   substring del container. SVG no se asserta (happy-dom).
+ */
+
+const DATA: RetentionResponse = {
+	new_visitors: 60,
+	returning_visitors: 15,
+	total: 75,
+	returning_rate: 0.2,
+};
+
+describe("RetentionChart", () => {
+	it("Given isLoading true When se renderiza Then muestra el skeleton sin la tasa", () => {
+		// Arrange + Act
+		const { container } = render(
+			<RetentionChart isLoading={true} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-64")).not.toBeNull();
+		expect(container.textContent).not.toContain("Tasa de retorno:");
+	});
+
+	it("Given data undefined y isLoading false When se renderiza Then sigue mostrando skeleton", () => {
+		// Arrange + Act
+		const { container } = render(
+			<RetentionChart isLoading={false} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-64")).not.toBeNull();
+	});
+
+	it("Given data When se renderiza Then monta el chart y muestra la tasa formateada", () => {
+		// Arrange + Act
+		const { container, getByText } = render(
+			<RetentionChart isLoading={false} data={DATA} />,
+		);
+
+		// Assert: 0.2 -> 20.0% (el valor es su propio <span>) + wrapper Recharts
+		expect(container.textContent).toContain("Tasa de retorno:");
+		expect(getByText("20.0%")).toBeInTheDocument();
+		expect(
+			container.querySelector(".recharts-responsive-container"),
+		).not.toBeNull();
+	});
+});

--- a/admin/tests/unit/features/analytics/TimeseriesChart.test.tsx
+++ b/admin/tests/unit/features/analytics/TimeseriesChart.test.tsx
@@ -1,0 +1,73 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { TimeseriesChart } from "@/features/analytics/components/TimeseriesChart";
+import type { TimeseriesResponse } from "@/features/analytics/types";
+
+/**
+ * @module tests/unit/features/analytics/TimeseriesChart
+ * @description LineChart de Recharts. Cubre los 3 branches: loading (skeleton),
+ *   vacio (mensaje) y con data (monta el ResponsiveContainer + ejecuta la
+ *   transformacion de puntos). En happy-dom el SVG no se pinta con dimensiones
+ *   reales -> no se asserta sobre el SVG, solo el contenedor / branches.
+ */
+
+const DATA: TimeseriesResponse = {
+	bucket: "day",
+	points: [
+		{ timestamp: "2026-05-01T00:00:00Z", count: 10 },
+		{ timestamp: "2026-05-02T00:00:00Z", count: 20 },
+	],
+	from: "2026-04-27",
+	to: "2026-05-28",
+	filters: { niche: null, event_type: null },
+};
+
+describe("TimeseriesChart", () => {
+	it("Given isLoading true When se renderiza Then muestra el skeleton (sin mensaje vacio)", () => {
+		// Arrange + Act
+		const { container, queryByText } = render(
+			<TimeseriesChart isLoading={true} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-72")).not.toBeNull();
+		expect(queryByText("Sin datos en el rango seleccionado.")).toBeNull();
+	});
+
+	it("Given data undefined y isLoading false When se renderiza Then sigue mostrando skeleton", () => {
+		// Arrange + Act
+		const { container } = render(
+			<TimeseriesChart isLoading={false} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-72")).not.toBeNull();
+	});
+
+	it("Given data con 0 puntos When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange
+		const empty: TimeseriesResponse = { ...DATA, points: [] };
+
+		// Act
+		const { getByText } = render(
+			<TimeseriesChart isLoading={false} data={empty} />,
+		);
+
+		// Assert
+		expect(
+			getByText("Sin datos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given data con puntos When se renderiza Then monta el ResponsiveContainer sin crashear", () => {
+		// Arrange + Act
+		const { container } = render(
+			<TimeseriesChart isLoading={false} data={DATA} />,
+		);
+
+		// Assert: el wrapper de Recharts existe (la transformacion .map ya corrio)
+		expect(
+			container.querySelector(".recharts-responsive-container"),
+		).not.toBeNull();
+	});
+});

--- a/admin/tests/unit/features/analytics/TopNichesChart.test.tsx
+++ b/admin/tests/unit/features/analytics/TopNichesChart.test.tsx
@@ -1,0 +1,65 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { TopNichesChart } from "@/features/analytics/components/TopNichesChart";
+import type { TopNichesResponse } from "@/features/analytics/types";
+
+/**
+ * @module tests/unit/features/analytics/TopNichesChart
+ * @description BarChart de Recharts. Cubre los 3 branches: loading (skeleton),
+ *   vacio (mensaje) y con data (monta el ResponsiveContainer). En happy-dom el
+ *   SVG no se pinta con dimensiones reales -> no se asserta sobre el SVG.
+ */
+
+const DATA: TopNichesResponse = {
+	items: [
+		{ niche: "fintech", visits: 30, unique_visitors: 20 },
+		{ niche: "architect", visits: 15, unique_visitors: 10 },
+	],
+};
+
+describe("TopNichesChart", () => {
+	it("Given isLoading true When se renderiza Then muestra el skeleton (sin mensaje vacio)", () => {
+		// Arrange + Act
+		const { container, queryByText } = render(
+			<TopNichesChart isLoading={true} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-64")).not.toBeNull();
+		expect(queryByText("Sin datos en el rango seleccionado.")).toBeNull();
+	});
+
+	it("Given data undefined y isLoading false When se renderiza Then sigue mostrando skeleton", () => {
+		// Arrange + Act
+		const { container } = render(
+			<TopNichesChart isLoading={false} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-64")).not.toBeNull();
+	});
+
+	it("Given items vacios When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<TopNichesChart isLoading={false} data={{ items: [] }} />,
+		);
+
+		// Assert
+		expect(
+			getByText("Sin datos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given items con data When se renderiza Then monta el ResponsiveContainer sin crashear", () => {
+		// Arrange + Act
+		const { container } = render(
+			<TopNichesChart isLoading={false} data={DATA} />,
+		);
+
+		// Assert
+		expect(
+			container.querySelector(".recharts-responsive-container"),
+		).not.toBeNull();
+	});
+});

--- a/admin/tests/unit/features/analytics/TopPagesTable.test.tsx
+++ b/admin/tests/unit/features/analytics/TopPagesTable.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { TopPagesTable } from "@/features/analytics/components/TopPagesTable";
+import type { TopPageItem } from "@/features/analytics/types";
+
+/**
+ * @module tests/unit/features/analytics/TopPagesTable
+ * @description TopPagesTable: tabla de ranking de paginas. Mensaje vacio si no
+ *   hay items; una fila por pagina con sus 3 metricas.
+ */
+
+const ITEMS: TopPageItem[] = [
+	{ page_path: "/", events: 50, unique_visitors: 30, unique_visits: 40 },
+	{
+		page_path: "/projects",
+		events: 25,
+		unique_visitors: 18,
+		unique_visits: 20,
+	},
+];
+
+describe("TopPagesTable", () => {
+	it("Given items When se renderiza Then muestra una fila por pagina con sus metricas", () => {
+		// Arrange + Act
+		render(<TopPagesTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("/")).toBeInTheDocument();
+		expect(screen.getByText("/projects")).toBeInTheDocument();
+		expect(screen.getByText("50")).toBeInTheDocument();
+		expect(screen.getByText("18")).toBeInTheDocument();
+	});
+
+	it("Given items When se renderiza Then muestra los encabezados de columna", () => {
+		// Arrange + Act
+		render(<TopPagesTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("Pagina")).toBeInTheDocument();
+		expect(screen.getByText("Eventos")).toBeInTheDocument();
+		expect(screen.getByText("Visitantes")).toBeInTheDocument();
+		expect(screen.getByText("Visitas")).toBeInTheDocument();
+	});
+
+	it("Given items vacios When se renderiza Then muestra el mensaje vacio y ninguna tabla", () => {
+		// Arrange + Act
+		render(<TopPagesTable items={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin paginas en el rango seleccionado."),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/analytics/TopReferrersTable.test.tsx
+++ b/admin/tests/unit/features/analytics/TopReferrersTable.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { TopReferrersTable } from "@/features/analytics/components/TopReferrersTable";
+import type { RankItem } from "@/features/analytics/types";
+
+/**
+ * @module tests/unit/features/analytics/TopReferrersTable
+ * @description TopReferrersTable: tabla generica de ranking. La etiqueta de la
+ *   fila se resuelve del primer campo no-numerico (referrer / utm_*) presente,
+ *   con fallback "(desconocido)". Mensaje vacio si no hay items.
+ */
+
+describe("TopReferrersTable", () => {
+	it("Given referrers When se renderiza Then usa el campo referrer como etiqueta", () => {
+		// Arrange
+		const items: RankItem[] = [
+			{ referrer: "(direct)", visits: 40, unique_visitors: 30 },
+		];
+
+		// Act
+		render(<TopReferrersTable label="Referrer" items={items} />);
+
+		// Assert
+		expect(screen.getByText("Referrer")).toBeInTheDocument();
+		expect(screen.getByText("(direct)")).toBeInTheDocument();
+		expect(screen.getByText("40")).toBeInTheDocument();
+	});
+
+	it("Given utm_source When no hay referrer Then usa utm_source como etiqueta", () => {
+		// Arrange
+		const items: RankItem[] = [{ utm_source: "google", visits: 10 }];
+
+		// Act
+		render(<TopReferrersTable label="Fuente" items={items} />);
+
+		// Assert
+		expect(screen.getByText("google")).toBeInTheDocument();
+	});
+
+	it("Given utm_medium When no hay referrer ni source Then usa utm_medium", () => {
+		// Arrange
+		const items: RankItem[] = [{ utm_medium: "cpc", visits: 5 }];
+
+		// Act
+		render(<TopReferrersTable label="Medio" items={items} />);
+
+		// Assert
+		expect(screen.getByText("cpc")).toBeInTheDocument();
+	});
+
+	it("Given utm_campaign When es el unico campo Then usa utm_campaign", () => {
+		// Arrange
+		const items: RankItem[] = [{ utm_campaign: "launch", visits: 3 }];
+
+		// Act
+		render(<TopReferrersTable label="Campaña" items={items} />);
+
+		// Assert
+		expect(screen.getByText("launch")).toBeInTheDocument();
+	});
+
+	it("Given un item sin ningun campo etiqueta When se renderiza Then usa el fallback", () => {
+		// Arrange
+		const items: RankItem[] = [{ visits: 1 }];
+
+		// Act
+		render(<TopReferrersTable label="X" items={items} />);
+
+		// Assert
+		expect(screen.getByText("(desconocido)")).toBeInTheDocument();
+	});
+
+	it("Given items vacios When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<TopReferrersTable label="Referrer" items={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin datos en el rango seleccionado."),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/analytics/analytics-client.test.tsx
+++ b/admin/tests/unit/features/analytics/analytics-client.test.tsx
@@ -1,0 +1,120 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { analyticsClient } from "@/features/analytics/api/analytics-client";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/analytics-client
+ * @description analyticsClient: cada fn hace GET /analytics?operation=analytics
+ *   &action=... via fetchMetric y devuelve el `data` desempaquetado del
+ *   Envelope. Los asserts usan la data sintetica del MSW handler de metrics.
+ */
+
+const RANGE = { from: "2026-04-27", to: "2026-05-28" };
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("analyticsClient.overview", () => {
+	it("Given un rango When overview Then devuelve los 7 KPIs del fixture", async () => {
+		// Act
+		const data = await analyticsClient.overview(RANGE);
+
+		// Assert
+		expect(data).toEqual({
+			sessions: 100,
+			visits: 80,
+			events: 500,
+			contacts: 5,
+			unique_visitors: 75,
+			avg_visit_duration_sec: 45.5,
+			bounce_rate: 0.15,
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+	});
+});
+
+describe("analyticsClient.timeseries", () => {
+	it("Given un rango + bucket When timeseries Then devuelve bucket day + 2 puntos", async () => {
+		// Act
+		const data = await analyticsClient.timeseries({ ...RANGE, bucket: "day" });
+
+		// Assert
+		expect(data.bucket).toBe("day");
+		expect(data.points).toEqual([
+			{ timestamp: "2026-05-01", count: 10 },
+			{ timestamp: "2026-05-02", count: 20 },
+		]);
+		expect(data.filters).toEqual({ niche: null, event_type: null });
+	});
+});
+
+describe("analyticsClient.topPages", () => {
+	it("Given un rango + limit When topPages Then devuelve el item del fixture", async () => {
+		// Act
+		const data = await analyticsClient.topPages({ ...RANGE, limit: 10 });
+
+		// Assert
+		expect(data.items).toEqual([
+			{ page_path: "/", events: 50, unique_visitors: 30, unique_visits: 40 },
+		]);
+	});
+});
+
+describe("analyticsClient.topReferrers", () => {
+	it("Given un rango When topReferrers Then devuelve referrers + UTM rankings", async () => {
+		// Act
+		const data = await analyticsClient.topReferrers(RANGE);
+
+		// Assert
+		expect(data.referrers).toEqual([
+			{ referrer: "(direct)", visits: 40, unique_visitors: 30 },
+		]);
+		expect(data.utm_sources).toEqual([{ utm_source: "google", visits: 10 }]);
+		expect(data.utm_mediums).toEqual([{ utm_medium: "cpc", visits: 5 }]);
+		expect(data.utm_campaigns).toEqual([{ utm_campaign: "launch", visits: 3 }]);
+	});
+});
+
+describe("analyticsClient.topNiches", () => {
+	it("Given un rango When topNiches Then devuelve el ranking de niches", async () => {
+		// Act
+		const data = await analyticsClient.topNiches(RANGE);
+
+		// Assert
+		expect(data.items).toEqual([
+			{ niche: "fintech", visits: 30, unique_visitors: 20 },
+		]);
+	});
+});
+
+describe("analyticsClient.activeNow", () => {
+	it("Given sin params When activeNow Then devuelve el contador live", async () => {
+		// Act
+		const data = await analyticsClient.activeNow();
+
+		// Assert
+		expect(data).toEqual({
+			active_sessions: 3,
+			threshold_minutes: 5,
+			as_of: "2026-05-28T12:00:00+00:00",
+		});
+	});
+});
+
+describe("analyticsClient.retention", () => {
+	it("Given un rango When retention Then devuelve new vs returning", async () => {
+		// Act
+		const data = await analyticsClient.retention(RANGE);
+
+		// Assert
+		expect(data).toEqual({
+			new_visitors: 60,
+			returning_visitors: 15,
+			total: 75,
+			returning_rate: 0.2,
+		});
+	});
+});

--- a/admin/tests/unit/features/analytics/use-active-now.test.tsx
+++ b/admin/tests/unit/features/analytics/use-active-now.test.tsx
@@ -1,0 +1,44 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useActiveNow } from "@/features/analytics/hooks/use-active-now";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-active-now
+ * @description useActiveNow: resuelve analytics/active-now (live, sin rango) y
+ *   devuelve el contador de sesiones activas del fixture MSW.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useActiveNow", () => {
+	it("Given sin params When la query resuelve Then devuelve el contador live", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useActiveNow(), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.active_sessions).toBe(3);
+		expect(result.current.data?.threshold_minutes).toBe(5);
+	});
+});

--- a/admin/tests/unit/features/analytics/use-metrics-range.test.tsx
+++ b/admin/tests/unit/features/analytics/use-metrics-range.test.tsx
@@ -1,0 +1,48 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
+
+/**
+ * @module tests/unit/features/analytics/use-metrics-range
+ * @description useMetricsRange: estado del rango de fechas. Default = ultimos
+ *   30 dias (from/to en YYYY-MM-DD). setRange reemplaza el rango.
+ */
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+describe("useMetricsRange", () => {
+	it("Given el render inicial When se monta Then el default cubre 30 dias en formato ISO", () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useMetricsRange());
+		const { from, to } = result.current.range;
+
+		// Assert: ambos son YYYY-MM-DD
+		expect(from).toMatch(ISO_DATE);
+		expect(to).toMatch(ISO_DATE);
+
+		// Assert: la diferencia entre from y to es ~30 dias. El hook calcula from
+		// en hora LOCAL (setDate(-30)) y luego corta a fecha UTC; un cambio de DST
+		// dentro de la ventana puede desplazar la fecha UTC en 1 dia, por eso se
+		// acepta el conjunto exacto {29,30,31} en vez de un valor unico fragil.
+		const fromMs = new Date(`${from}T00:00:00Z`).getTime();
+		const toMs = new Date(`${to}T00:00:00Z`).getTime();
+		const days = (toMs - fromMs) / (1000 * 60 * 60 * 24);
+		expect([29, 30, 31]).toContain(days);
+	});
+
+	it("Given un rango nuevo When se llama setRange Then el range se reemplaza", () => {
+		// Arrange
+		const { result } = renderHook(() => useMetricsRange());
+
+		// Act
+		act(() => {
+			result.current.setRange({ from: "2026-01-01", to: "2026-01-31" });
+		});
+
+		// Assert
+		expect(result.current.range).toEqual({
+			from: "2026-01-01",
+			to: "2026-01-31",
+		});
+	});
+});

--- a/admin/tests/unit/features/analytics/use-overview.test.tsx
+++ b/admin/tests/unit/features/analytics/use-overview.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useOverview } from "@/features/analytics/hooks/use-overview";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-overview
+ * @description useOverview: resuelve analytics/overview y devuelve los 7 KPIs
+ *   desempaquetados del Envelope (data sintetica del MSW handler de metrics).
+ */
+
+const RANGE = { from: "2026-04-27", to: "2026-05-28" };
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useOverview", () => {
+	it("Given un rango When la query resuelve Then devuelve los KPIs del fixture", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useOverview(RANGE), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.sessions).toBe(100);
+		expect(result.current.data?.bounce_rate).toBe(0.15);
+	});
+});

--- a/admin/tests/unit/features/analytics/use-retention.test.tsx
+++ b/admin/tests/unit/features/analytics/use-retention.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRetention } from "@/features/analytics/hooks/use-retention";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-retention
+ * @description useRetention: resuelve analytics/retention y devuelve new vs
+ *   returning del fixture MSW.
+ */
+
+const RANGE = { from: "2026-04-27", to: "2026-05-28" };
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useRetention", () => {
+	it("Given un rango When la query resuelve Then devuelve new vs returning", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useRetention(RANGE), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.new_visitors).toBe(60);
+		expect(result.current.data?.returning_rate).toBe(0.2);
+	});
+});

--- a/admin/tests/unit/features/analytics/use-timeseries.test.tsx
+++ b/admin/tests/unit/features/analytics/use-timeseries.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTimeseries } from "@/features/analytics/hooks/use-timeseries";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-timeseries
+ * @description useTimeseries: resuelve analytics/timeseries y devuelve la serie
+ *   de puntos del fixture MSW.
+ */
+
+const PARAMS = {
+	from: "2026-04-27",
+	to: "2026-05-28",
+	bucket: "day" as const,
+};
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useTimeseries", () => {
+	it("Given un rango + bucket When la query resuelve Then devuelve los 2 puntos", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useTimeseries(PARAMS), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.bucket).toBe("day");
+		expect(result.current.data?.points).toHaveLength(2);
+		expect(result.current.data?.points[0]?.count).toBe(10);
+	});
+});

--- a/admin/tests/unit/features/analytics/use-top-niches.test.tsx
+++ b/admin/tests/unit/features/analytics/use-top-niches.test.tsx
@@ -1,0 +1,47 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTopNiches } from "@/features/analytics/hooks/use-top-niches";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-top-niches
+ * @description useTopNiches: resuelve analytics/top-niches y devuelve el ranking
+ *   de niches del fixture MSW.
+ */
+
+const RANGE = { from: "2026-04-27", to: "2026-05-28" };
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useTopNiches", () => {
+	it("Given un rango When la query resuelve Then devuelve el ranking de niches", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useTopNiches(RANGE), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items).toHaveLength(1);
+		expect(result.current.data?.items[0]?.niche).toBe("fintech");
+		expect(result.current.data?.items[0]?.visits).toBe(30);
+	});
+});

--- a/admin/tests/unit/features/analytics/use-top-pages.test.tsx
+++ b/admin/tests/unit/features/analytics/use-top-pages.test.tsx
@@ -1,0 +1,47 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTopPages } from "@/features/analytics/hooks/use-top-pages";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-top-pages
+ * @description useTopPages: resuelve analytics/top-pages y devuelve el ranking
+ *   de paginas del fixture MSW.
+ */
+
+const PARAMS = { from: "2026-04-27", to: "2026-05-28", limit: 10 };
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useTopPages", () => {
+	it("Given un rango + limit When la query resuelve Then devuelve el item del ranking", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useTopPages(PARAMS), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items).toHaveLength(1);
+		expect(result.current.data?.items[0]?.page_path).toBe("/");
+		expect(result.current.data?.items[0]?.events).toBe(50);
+	});
+});

--- a/admin/tests/unit/features/analytics/use-top-referrers.test.tsx
+++ b/admin/tests/unit/features/analytics/use-top-referrers.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTopReferrers } from "@/features/analytics/hooks/use-top-referrers";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-top-referrers
+ * @description useTopReferrers: resuelve analytics/top-referrers y devuelve los
+ *   rankings de referrers + UTM del fixture MSW.
+ */
+
+const RANGE = { from: "2026-04-27", to: "2026-05-28" };
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useTopReferrers", () => {
+	it("Given un rango When la query resuelve Then devuelve referrers + UTM", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useTopReferrers(RANGE), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.referrers[0]?.referrer).toBe("(direct)");
+		expect(result.current.data?.utm_sources[0]?.utm_source).toBe("google");
+	});
+});

--- a/admin/tests/unit/features/contacts/ContactByStatusChart.test.tsx
+++ b/admin/tests/unit/features/contacts/ContactByStatusChart.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { ContactByStatusChart } from "@/features/contacts/components/ContactByStatusChart";
+import type { ContactByStatusResponse } from "@/features/contacts/types";
+
+/**
+ * @module tests/unit/features/contacts/ContactByStatusChart
+ * @description ContactByStatusChart: PieChart de Recharts del desglose por
+ *   estado. Cubre los 3 branches: loading (Skeleton), vacio (mensaje) y con
+ *   data. Recharts NO renderiza el SVG con dimensiones 0 en happy-dom, asi
+ *   que el branch con data solo verifica que el codigo de transformacion
+ *   (map de Cells) corre sin crashear.
+ */
+
+const DATA: ContactByStatusResponse = {
+	items: [
+		{ status: "new", count: 8, pct: 0.8 },
+		{ status: "converted", count: 2, pct: 0.2 },
+	],
+};
+
+describe("ContactByStatusChart", () => {
+	it("Given isLoading true When se renderiza Then muestra el skeleton (no el mensaje vacio)", () => {
+		// Arrange + Act
+		const { container } = render(
+			<ContactByStatusChart data={DATA} isLoading={true} />,
+		);
+
+		// Assert: el skeleton (.h-64) se monta y no muestra el mensaje de vacio
+		expect(container.querySelector(".h-64")).not.toBeNull();
+		expect(
+			screen.queryByText("Sin contactos en el rango seleccionado."),
+		).not.toBeInTheDocument();
+	});
+
+	it("Given data undefined When isLoading false Then cae al skeleton (no el mensaje vacio)", () => {
+		// Arrange + Act
+		const { container } = render(
+			<ContactByStatusChart data={undefined} isLoading={false} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-64")).not.toBeNull();
+		expect(
+			screen.queryByText("Sin contactos en el rango seleccionado."),
+		).not.toBeInTheDocument();
+	});
+
+	it("Given items vacios When isLoading false Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<ContactByStatusChart data={{ items: [] }} isLoading={false} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin contactos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given data con items When se renderiza Then no crashea y no muestra el mensaje vacio", () => {
+		// Arrange + Act
+		const { container } = render(
+			<ContactByStatusChart data={DATA} isLoading={false} />,
+		);
+
+		// Assert: corrio el map de Cells (sin crash); no es el branch vacio
+		expect(
+			screen.queryByText("Sin contactos en el rango seleccionado."),
+		).not.toBeInTheDocument();
+		expect(container.querySelector(".recharts-responsive-container")).not.toBe(
+			null,
+		);
+	});
+});

--- a/admin/tests/unit/features/contacts/ContactByStatusTable.test.tsx
+++ b/admin/tests/unit/features/contacts/ContactByStatusTable.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { ContactByStatusTable } from "@/features/contacts/components/ContactByStatusTable";
+import type { ContactStatusItem } from "@/features/contacts/types";
+
+/**
+ * @module tests/unit/features/contacts/ContactByStatusTable
+ * @description ContactByStatusTable: render del desglose por estado (status +
+ *   count + pct formateado a 1 decimal). Cubre estado vacio y con data.
+ */
+
+const ITEMS: ContactStatusItem[] = [
+	{ status: "new", count: 8, pct: 0.8 },
+	{ status: "converted", count: 2, pct: 0.2 },
+];
+
+describe("ContactByStatusTable", () => {
+	it("Given items vacios When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<ContactByStatusTable items={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin contactos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given items When se renderiza Then muestra una fila por estado", () => {
+		// Arrange + Act
+		render(<ContactByStatusTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("new")).toBeInTheDocument();
+		expect(screen.getByText("converted")).toBeInTheDocument();
+		expect(screen.getByText("8")).toBeInTheDocument();
+		expect(screen.getByText("2")).toBeInTheDocument();
+	});
+
+	it("Given un pct de 0.8 When se renderiza Then muestra 80.0%", () => {
+		// Arrange + Act
+		render(<ContactByStatusTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("80.0%")).toBeInTheDocument();
+		expect(screen.getByText("20.0%")).toBeInTheDocument();
+	});
+
+	it("Given items When se renderiza Then muestra los headers Estado/Cantidad/%", () => {
+		// Arrange + Act
+		render(<ContactByStatusTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("Estado")).toBeInTheDocument();
+		expect(screen.getByText("Cantidad")).toBeInTheDocument();
+		expect(screen.getByText("%")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/contacts/ContactListTable.test.tsx
+++ b/admin/tests/unit/features/contacts/ContactListTable.test.tsx
@@ -1,0 +1,242 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, within } from "@tests/utils/render";
+import { describe, expect, it, vi } from "vitest";
+import { ContactListTable } from "@/features/contacts/components/ContactListTable";
+import type { ContactListResponse } from "@/features/contacts/types";
+
+/**
+ * @module tests/unit/features/contacts/ContactListTable
+ * @description ContactListTable: render del listado crudo paginado. Cubre
+ *   loading (skeleton), vacio, con data (filas) y la paginacion (disabled de
+ *   anterior/siguiente + callbacks onPageChange).
+ */
+
+const DATA: ContactListResponse = {
+	items: [
+		{
+			id: "ct_1",
+			created_at: "2026-05-20T10:00:00Z",
+			name: "Ada",
+			email: "ada@example.com",
+			message: "Hola",
+			company: "Acme",
+			role: "CTO",
+			service_type: "consulting",
+			budget: "10k",
+			timeline: "Q3",
+			niche: "fintech",
+			status: "new",
+			session_id: "sess_1",
+		},
+		{
+			id: "ct_2",
+			created_at: "2026-05-21T10:00:00Z",
+			name: "Linus",
+			email: "linus@example.com",
+			message: "Hey",
+			company: null,
+			role: null,
+			service_type: null,
+			budget: null,
+			timeline: null,
+			niche: "architect",
+			status: "converted",
+			session_id: null,
+		},
+	],
+	page: 2,
+	page_size: 50,
+	total: 120,
+	has_more: true,
+};
+
+describe("ContactListTable", () => {
+	it("Given isLoading true When se renderiza Then muestra skeletons y NO filas de datos", () => {
+		// Arrange + Act
+		render(
+			<ContactListTable
+				data={undefined}
+				isLoading={true}
+				page={1}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(screen.queryByText("Ada")).not.toBeInTheDocument();
+		expect(screen.getByText("Fecha")).toBeInTheDocument();
+	});
+
+	it("Given items vacios When isLoading false Then muestra el mensaje vacio", () => {
+		// Arrange
+		const empty: ContactListResponse = {
+			items: [],
+			page: 1,
+			page_size: 50,
+			total: 0,
+			has_more: false,
+		};
+
+		// Act
+		render(
+			<ContactListTable
+				data={empty}
+				isLoading={false}
+				page={1}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(
+			screen.getByText("Sin contactos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given data con items When se renderiza Then muestra nombre, email, niche y company", () => {
+		// Arrange + Act
+		render(
+			<ContactListTable
+				data={DATA}
+				isLoading={false}
+				page={2}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByText("Ada")).toBeInTheDocument();
+		expect(screen.getByText("ada@example.com")).toBeInTheDocument();
+		expect(screen.getByText("Linus")).toBeInTheDocument();
+		expect(screen.getByText("Acme")).toBeInTheDocument();
+	});
+
+	it("Given una company null When se renderiza Then muestra '-' en esa celda", () => {
+		// Arrange + Act
+		render(
+			<ContactListTable
+				data={DATA}
+				isLoading={false}
+				page={2}
+				onPageChange={vi.fn()}
+			/>,
+		);
+		const row = screen.getByText("Linus").closest("tr");
+		if (!row) throw new Error("fila de Linus no encontrada");
+
+		// Assert
+		expect(within(row).getByText("-")).toBeInTheDocument();
+	});
+
+	it("Given page 2 con total When se renderiza Then muestra el resumen de pagina y total", () => {
+		// Arrange + Act
+		render(
+			<ContactListTable
+				data={DATA}
+				isLoading={false}
+				page={2}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(
+			screen.getByText("Pagina 2 · 120 contactos en total"),
+		).toBeInTheDocument();
+	});
+
+	it("Given page 1 When se renderiza Then el boton Anterior esta deshabilitado", () => {
+		// Arrange
+		const firstPage: ContactListResponse = { ...DATA, page: 1, has_more: true };
+
+		// Act
+		render(
+			<ContactListTable
+				data={firstPage}
+				isLoading={false}
+				page={1}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByRole("button", { name: "Anterior" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Siguiente" })).toBeEnabled();
+	});
+
+	it("Given has_more false When se renderiza Then el boton Siguiente esta deshabilitado", () => {
+		// Arrange
+		const lastPage: ContactListResponse = { ...DATA, has_more: false };
+
+		// Act
+		render(
+			<ContactListTable
+				data={lastPage}
+				isLoading={false}
+				page={2}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByRole("button", { name: "Siguiente" })).toBeDisabled();
+	});
+
+	it("Given click en Siguiente When se habilita Then llama onPageChange con page+1", async () => {
+		// Arrange
+		const onPageChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<ContactListTable
+				data={DATA}
+				isLoading={false}
+				page={2}
+				onPageChange={onPageChange}
+			/>,
+		);
+
+		// Act
+		await user.click(screen.getByRole("button", { name: "Siguiente" }));
+
+		// Assert
+		expect(onPageChange).toHaveBeenCalledWith(3);
+	});
+
+	it("Given click en Anterior When se habilita Then llama onPageChange con page-1", async () => {
+		// Arrange
+		const onPageChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<ContactListTable
+				data={DATA}
+				isLoading={false}
+				page={2}
+				onPageChange={onPageChange}
+			/>,
+		);
+
+		// Act
+		await user.click(screen.getByRole("button", { name: "Anterior" }));
+
+		// Assert
+		expect(onPageChange).toHaveBeenCalledWith(1);
+	});
+
+	it("Given data undefined When isLoading false Then cae a items vacios y total 0", () => {
+		// Arrange + Act
+		render(
+			<ContactListTable
+				data={undefined}
+				isLoading={false}
+				page={1}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert: sin total muestra solo "Pagina 1" (sin sufijo de total)
+		expect(screen.getByText("Pagina 1")).toBeInTheDocument();
+		expect(
+			screen.getByText("Sin contactos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/contacts/ContactStatusBadge.test.tsx
+++ b/admin/tests/unit/features/contacts/ContactStatusBadge.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { ContactStatusBadge } from "@/features/contacts/components/ContactStatusBadge";
+import type { ContactStatus } from "@/features/contacts/types";
+
+/**
+ * @module tests/unit/features/contacts/ContactStatusBadge
+ * @description ContactStatusBadge: muestra el label en espanol del estado del
+ *   embudo segun el mapa STATUS_LABEL. Cubre los 5 estados validos.
+ */
+
+describe("ContactStatusBadge", () => {
+	it.each<[ContactStatus, string]>([
+		["new", "Nuevo"],
+		["contacted", "Contactado"],
+		["qualified", "Calificado"],
+		["converted", "Convertido"],
+		["rejected", "Rechazado"],
+	])("Given status %s When se renderiza Then muestra el label %s", (status, label) => {
+		// Arrange + Act
+		render(<ContactStatusBadge status={status} />);
+
+		// Assert
+		expect(screen.getByText(label)).toBeInTheDocument();
+	});
+
+	it("Given un status fuera del union When se renderiza Then cae al fallback (valor crudo)", () => {
+		// Arrange + Act: cast deliberado para ejercitar los branch ?? defensivos.
+		render(<ContactStatusBadge status={"archived" as ContactStatus} />);
+
+		// Assert: sin label mapeado -> muestra el valor crudo.
+		expect(screen.getByText("archived")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/contacts/ContactStatusFilter.test.tsx
+++ b/admin/tests/unit/features/contacts/ContactStatusFilter.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ContactStatusFilter } from "@/features/contacts/components/ContactStatusFilter";
+
+/**
+ * @module tests/unit/features/contacts/ContactStatusFilter
+ * @description ContactStatusFilter: select de estado. value undefined cae al
+ *   centinela `all`; un value concreto se refleja en el Select. El onChange
+ *   mapea `all` -> undefined y un estado concreto -> ese ContactStatus.
+ *
+ *   El shadcn Select (Radix) usa portal + pointer events poco fiables en
+ *   happy-dom, asi que se mockea para exponer su `value` y disparar su
+ *   `onValueChange` de forma determinista (mismo patron que MetricsDateRange).
+ */
+
+/** Captura del ultimo `value` recibido + dispara el onValueChange controlado. */
+let lastValue: string | undefined;
+let lastOnValueChange: ((next: string) => void) | undefined;
+
+vi.mock("@/components/ui/select", () => ({
+	Select: ({
+		value,
+		onValueChange,
+		children,
+	}: {
+		value: string;
+		onValueChange: (next: string) => void;
+		children: ReactNode;
+	}) => {
+		lastValue = value;
+		lastOnValueChange = onValueChange;
+		return <div data-testid="select">{children}</div>;
+	},
+	SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+	SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
+		<div data-value={value}>{children}</div>
+	),
+	SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+	SelectValue: ({ placeholder }: { placeholder?: string }) => (
+		<span>{placeholder}</span>
+	),
+}));
+
+beforeEach(() => {
+	lastValue = undefined;
+	lastOnValueChange = undefined;
+});
+
+describe("ContactStatusFilter", () => {
+	it("Given value undefined When se renderiza Then el Select recibe el centinela `all`", () => {
+		// Arrange + Act
+		render(<ContactStatusFilter value={undefined} onChange={vi.fn()} />);
+
+		// Assert
+		expect(lastValue).toBe("all");
+	});
+
+	it("Given value 'converted' When se renderiza Then el Select recibe ese estado", () => {
+		// Arrange + Act
+		render(<ContactStatusFilter value="converted" onChange={vi.fn()} />);
+
+		// Assert
+		expect(lastValue).toBe("converted");
+	});
+
+	it("Given el Select emite un estado concreto When onValueChange Then onChange recibe ese ContactStatus", () => {
+		// Arrange
+		const onChange = vi.fn();
+		render(<ContactStatusFilter value={undefined} onChange={onChange} />);
+
+		// Act
+		lastOnValueChange?.("qualified");
+
+		// Assert
+		expect(onChange).toHaveBeenCalledWith("qualified");
+	});
+
+	it("Given el Select emite el centinela `all` When onValueChange Then onChange recibe undefined", () => {
+		// Arrange
+		const onChange = vi.fn();
+		render(<ContactStatusFilter value="new" onChange={onChange} />);
+
+		// Act
+		lastOnValueChange?.("all");
+
+		// Assert
+		expect(onChange).toHaveBeenCalledWith(undefined);
+	});
+
+	it("Given se renderiza When se listan las opciones Then incluye los 5 estados + Todos", () => {
+		// Arrange + Act
+		render(<ContactStatusFilter value={undefined} onChange={vi.fn()} />);
+
+		// Assert: el map de STATUS_OPTIONS + el item ALL + el placeholder. "Todos
+		// los estados" aparece 2 veces (SelectValue placeholder + SelectItem ALL).
+		expect(screen.getAllByText("Todos los estados")).toHaveLength(2);
+		expect(screen.getByText("Nuevo")).toBeInTheDocument();
+		expect(screen.getByText("Contactado")).toBeInTheDocument();
+		expect(screen.getByText("Calificado")).toBeInTheDocument();
+		expect(screen.getByText("Convertido")).toBeInTheDocument();
+		expect(screen.getByText("Rechazado")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/contacts/contacts-client.test.tsx
+++ b/admin/tests/unit/features/contacts/contacts-client.test.tsx
@@ -1,0 +1,83 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { contactsClient } from "@/features/contacts/api/contacts-client";
+
+/**
+ * @module tests/unit/features/contacts/contacts-client
+ * @description contactsClient.list y .byStatus: hacen GET /analytics?operation=
+ *   contacts&action=... via fetchMetric y devuelven el `data`. La data viene
+ *   del MSW handler (tests/mocks/handlers/metrics).
+ */
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("contactsClient.list", () => {
+	it("Given page+page_size por defecto When list Then devuelve el listado del fixture", async () => {
+		// Act
+		const data = await contactsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+
+		// Assert
+		expect(data.total).toBe(1);
+		expect(data.page).toBe(1);
+		expect(data.page_size).toBe(50);
+		expect(data.has_more).toBe(false);
+		expect(data.items).toHaveLength(1);
+		expect(data.items[0]?.id).toBe("ct_1");
+		expect(data.items[0]?.name).toBe("Ada");
+		expect(data.items[0]?.email).toBe("ada@example.com");
+		expect(data.items[0]?.status).toBe("new");
+		expect(data.items[0]?.niche).toBe("fintech");
+	});
+
+	it("Given page=3 y page_size=20 When list Then deriva offset=(page-1)*page_size", async () => {
+		// Act: el fixture es estatico, pero el client debe resolver sin romper
+		const data = await contactsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+			page: 3,
+			page_size: 20,
+		});
+
+		// Assert: el offset derivado (40) no rompe el fetch; devuelve el data
+		expect(data.items).toHaveLength(1);
+		expect(data.total).toBe(1);
+	});
+
+	it("Given status y niche When list Then los pasa como filtros sin romper", async () => {
+		// Act
+		const data = await contactsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+			status: "new",
+			niche: "fintech",
+		});
+
+		// Assert
+		expect(data.items[0]?.status).toBe("new");
+	});
+});
+
+describe("contactsClient.byStatus", () => {
+	it("Given un rango valido When byStatus Then devuelve el desglose por estado", async () => {
+		// Act
+		const data = await contactsClient.byStatus({
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+
+		// Assert
+		expect(data.items).toHaveLength(2);
+		expect(data.items[0]).toEqual({ status: "new", count: 8, pct: 80.0 });
+		expect(data.items[1]).toEqual({
+			status: "converted",
+			count: 2,
+			pct: 20.0,
+		});
+	});
+});

--- a/admin/tests/unit/features/contacts/use-contact-list.test.tsx
+++ b/admin/tests/unit/features/contacts/use-contact-list.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useContactList } from "@/features/contacts/hooks/use-contact-list";
+
+/**
+ * @module tests/unit/features/contacts/use-contact-list
+ * @description useContactList: listado crudo paginado de contactos
+ *   (contacts/list). Desempaqueta el envelope del Lambda `analytics` y devuelve
+ *   la pagina del fixture MSW.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useContactList", () => {
+	it("Given un rango valido When la query resuelve Then devuelve la pagina de contactos", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useContactList({ from: "2026-04-27", to: "2026-05-28" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.total).toBe(1);
+		expect(result.current.data?.items).toHaveLength(1);
+		expect(result.current.data?.items[0]?.name).toBe("Ada");
+		expect(result.current.data?.items[0]?.email).toBe("ada@example.com");
+		expect(result.current.data?.items[0]?.status).toBe("new");
+	});
+
+	it("Given filtros status y niche When la query resuelve Then sigue devolviendo el data", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() =>
+				useContactList({
+					from: "2026-04-27",
+					to: "2026-05-28",
+					status: "new",
+					niche: "fintech",
+				}),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.has_more).toBe(false);
+	});
+});

--- a/admin/tests/unit/features/contacts/use-contacts-by-status.test.tsx
+++ b/admin/tests/unit/features/contacts/use-contacts-by-status.test.tsx
@@ -1,0 +1,55 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useContactsByStatus } from "@/features/contacts/hooks/use-contacts-by-status";
+
+/**
+ * @module tests/unit/features/contacts/use-contacts-by-status
+ * @description useContactsByStatus: desglose de contactos por estado
+ *   (contacts/by-status). Desempaqueta el envelope del Lambda `analytics` y
+ *   devuelve los items del fixture MSW.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useContactsByStatus", () => {
+	it("Given un rango valido When la query resuelve Then devuelve el desglose por estado", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useContactsByStatus({ from: "2026-04-27", to: "2026-05-28" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items).toHaveLength(2);
+		expect(result.current.data?.items[0]).toEqual({
+			status: "new",
+			count: 8,
+			pct: 80.0,
+		});
+		expect(result.current.data?.items[1]).toEqual({
+			status: "converted",
+			count: 2,
+			pct: 20.0,
+		});
+	});
+});

--- a/admin/tests/unit/features/devices/DeviceBreakdown.test.tsx
+++ b/admin/tests/unit/features/devices/DeviceBreakdown.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { DeviceBreakdown } from "@/features/devices/components/DeviceBreakdown";
+import type { BreakdownResponse } from "@/features/devices/types";
+
+/**
+ * @module tests/unit/features/devices/DeviceBreakdown
+ * @description Las 3 Cards (tipos de dispositivo, navegadores, sistemas
+ *   operativos) con su DistributionChart. Cubre el estado loading (3 skeletons +
+ *   titulos) y el estado con data (3 ResponsiveContainer de Recharts).
+ */
+
+const DATA: BreakdownResponse = {
+	device_types: [{ device_type: "desktop", sessions: 50 }],
+	browsers: [{ browser: "Chrome", sessions: 40 }],
+	os: [{ os: "Linux", sessions: 35 }],
+};
+
+describe("DeviceBreakdown", () => {
+	it("Given cualquier estado When se renderiza Then muestra los 3 titulos de Card", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<DeviceBreakdown data={DATA} isLoading={false} />,
+		);
+
+		// Assert
+		expect(getByText("Tipos de dispositivo")).toBeInTheDocument();
+		expect(getByText("Navegadores")).toBeInTheDocument();
+		expect(getByText("Sistemas operativos")).toBeInTheDocument();
+	});
+
+	it("Given isLoading true When se renderiza Then muestra 3 skeletons (uno por chart)", () => {
+		// Arrange + Act
+		const { container } = render(
+			<DeviceBreakdown data={undefined} isLoading={true} />,
+		);
+
+		// Assert: cada DistributionChart en loading renderiza un Skeleton .h-64
+		expect(container.querySelectorAll(".h-64")).toHaveLength(3);
+	});
+
+	it("Given data When se renderiza Then monta los 3 ResponsiveContainer de Recharts", () => {
+		// Arrange + Act
+		const { container } = render(
+			<DeviceBreakdown data={DATA} isLoading={false} />,
+		);
+
+		// Assert: un wrapper de Recharts por cada una de las 3 distribuciones
+		expect(
+			container.querySelectorAll(".recharts-responsive-container"),
+		).toHaveLength(3);
+	});
+});

--- a/admin/tests/unit/features/devices/DistributionChart.test.tsx
+++ b/admin/tests/unit/features/devices/DistributionChart.test.tsx
@@ -1,0 +1,101 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { DistributionChart } from "@/features/devices/components/DistributionChart";
+import type { DeviceTypeDist } from "@/features/devices/types";
+
+/**
+ * @module tests/unit/features/devices/DistributionChart
+ * @description BarChart generico de una distribucion de sesiones. Cubre los 3
+ *   branches: loading (skeleton), undefined/vacio (mensaje) y con data (no
+ *   crashea + ejecuta la transformacion/sort). En happy-dom el SVG no renderiza
+ *   con dimensiones reales -> no se asserta sobre el SVG, solo el contenedor /
+ *   branches.
+ */
+
+const DATA: DeviceTypeDist[] = [
+	{ device_type: "mobile", sessions: 20 },
+	{ device_type: "desktop", sessions: 50 },
+];
+
+describe("DistributionChart", () => {
+	it("Given isLoading true When se renderiza Then muestra el skeleton (sin mensaje vacio)", () => {
+		// Arrange + Act
+		const { container, queryByText } = render(
+			<DistributionChart<DeviceTypeDist>
+				isLoading={true}
+				nameKey="device_type"
+			/>,
+		);
+
+		// Assert: el skeleton es un div con la clase de tamano; no hay mensaje vacio
+		expect(container.querySelector(".h-64")).not.toBeNull();
+		expect(queryByText("Sin datos en el rango seleccionado.")).toBeNull();
+	});
+
+	it("Given data undefined y isLoading false When se renderiza Then sigue mostrando skeleton", () => {
+		// Arrange + Act
+		const { container } = render(
+			<DistributionChart<DeviceTypeDist>
+				isLoading={false}
+				nameKey="device_type"
+				data={undefined}
+			/>,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-64")).not.toBeNull();
+	});
+
+	it("Given data vacia When se renderiza Then muestra el mensaje de vacio", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<DistributionChart<DeviceTypeDist>
+				isLoading={false}
+				nameKey="device_type"
+				data={[]}
+			/>,
+		);
+
+		// Assert
+		expect(
+			getByText("Sin datos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given filas con data When se renderiza Then monta el ResponsiveContainer sin crashear", () => {
+		// Arrange + Act
+		const { container } = render(
+			<DistributionChart<DeviceTypeDist>
+				isLoading={false}
+				nameKey="device_type"
+				data={DATA}
+			/>,
+		);
+
+		// Assert: el wrapper de Recharts existe; no se assertan paths del SVG
+		expect(
+			container.querySelector(".recharts-responsive-container"),
+		).not.toBeNull();
+	});
+
+	it("Given una fila sin valor en nameKey When se renderiza Then cae al fallback sin crashear", () => {
+		// Arrange: el valor de nameKey es undefined -> el .map usa '-' como label
+		const rows = [
+			{ device_type: undefined, sessions: 5 },
+		] as unknown as DeviceTypeDist[];
+
+		// Act
+		const { container } = render(
+			<DistributionChart<DeviceTypeDist>
+				isLoading={false}
+				nameKey="device_type"
+				data={rows}
+			/>,
+		);
+
+		// Assert
+		expect(
+			container.querySelector(".recharts-responsive-container"),
+		).not.toBeNull();
+	});
+});

--- a/admin/tests/unit/features/devices/devices-client.test.ts
+++ b/admin/tests/unit/features/devices/devices-client.test.ts
@@ -1,0 +1,46 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { devicesClient } from "@/features/devices/api/devices-client";
+
+/**
+ * @module tests/unit/features/devices/devices-client
+ * @description devicesClient: cada fn hace GET /analytics?operation=devices&
+ *   action=... via fetchMetric y devuelve el data. Usa el MSW handler de
+ *   /analytics (handlers/metrics).
+ */
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("devicesClient.breakdown", () => {
+	it("Given un rango valido When breakdown Then devuelve las 3 distribuciones del fixture", async () => {
+		// Act
+		const data = await devicesClient.breakdown({
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+
+		// Assert
+		expect(data.device_types).toHaveLength(1);
+		expect(data.device_types[0]).toEqual({
+			device_type: "desktop",
+			sessions: 50,
+		});
+		expect(data.browsers).toHaveLength(1);
+		expect(data.browsers[0]).toEqual({ browser: "Chrome", sessions: 40 });
+		expect(data.os).toHaveLength(1);
+		expect(data.os[0]).toEqual({ os: "Linux", sessions: 35 });
+	});
+
+	it("Given un rango sin from/to When breakdown Then resuelve igual (params omitidos)", async () => {
+		// Act
+		const data = await devicesClient.breakdown({});
+
+		// Assert
+		expect(data.device_types[0]?.device_type).toBe("desktop");
+		expect(data.browsers[0]?.browser).toBe("Chrome");
+		expect(data.os[0]?.os).toBe("Linux");
+	});
+});

--- a/admin/tests/unit/features/devices/use-breakdown.test.tsx
+++ b/admin/tests/unit/features/devices/use-breakdown.test.tsx
@@ -1,0 +1,51 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useBreakdown } from "@/features/devices/hooks/use-breakdown";
+
+/**
+ * @module tests/unit/features/devices/use-breakdown
+ * @description useBreakdown: distribucion de sesiones por dispositivo, navegador
+ *   y sistema operativo (devices/breakdown). Desempaqueta el envelope y devuelve
+ *   las 3 distribuciones del fixture MSW.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useBreakdown", () => {
+	it("Given un rango valido When la query resuelve Then devuelve las 3 distribuciones del fixture", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useBreakdown({ from: "2026-04-27", to: "2026-05-28" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.device_types).toHaveLength(1);
+		expect(result.current.data?.device_types[0]?.device_type).toBe("desktop");
+		expect(result.current.data?.device_types[0]?.sessions).toBe(50);
+		expect(result.current.data?.browsers[0]?.browser).toBe("Chrome");
+		expect(result.current.data?.browsers[0]?.sessions).toBe(40);
+		expect(result.current.data?.os[0]?.os).toBe("Linux");
+		expect(result.current.data?.os[0]?.sessions).toBe(35);
+	});
+});

--- a/admin/tests/unit/features/events/EventDistributionChart.test.tsx
+++ b/admin/tests/unit/features/events/EventDistributionChart.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { EventDistributionChart } from "@/features/events/components/EventDistributionChart";
+import type { EventDistributionResponse } from "@/features/events/types";
+
+/**
+ * @module tests/unit/features/events/EventDistributionChart
+ * @description BarChart de Recharts del ranking de tipos de evento. Cubre los 3
+ *   branches: loading (skeleton), vacio (mensaje) y con data (no crashea +
+ *   ejecuta la transformacion). En happy-dom el SVG no renderiza con dimensiones
+ *   reales -> no se asserta sobre el SVG, solo el contenedor / branches.
+ */
+
+const DATA: EventDistributionResponse = {
+	items: [
+		{ event_type: "page_view", count: 300, pct: 0.6 },
+		{ event_type: "click", count: 200, pct: 0.4 },
+	],
+};
+
+describe("EventDistributionChart", () => {
+	it("Given isLoading true When se renderiza Then muestra el skeleton (sin mensaje vacio)", () => {
+		// Arrange + Act
+		const { container, queryByText } = render(
+			<EventDistributionChart isLoading={true} />,
+		);
+
+		// Assert: el skeleton es un div con la clase de tamano; no hay mensaje vacio
+		expect(container.querySelector(".h-64")).not.toBeNull();
+		expect(queryByText("Sin eventos en el rango seleccionado.")).toBeNull();
+	});
+
+	it("Given data undefined y isLoading false When se renderiza Then sigue mostrando skeleton", () => {
+		// Arrange + Act
+		const { container } = render(
+			<EventDistributionChart isLoading={false} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-64")).not.toBeNull();
+	});
+
+	it("Given items vacios When se renderiza Then muestra el mensaje de vacio", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<EventDistributionChart isLoading={false} data={{ items: [] }} />,
+		);
+
+		// Assert
+		expect(
+			getByText("Sin eventos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given items con data When se renderiza Then monta el ResponsiveContainer sin crashear", () => {
+		// Arrange + Act
+		const { container } = render(
+			<EventDistributionChart isLoading={false} data={DATA} />,
+		);
+
+		// Assert: el wrapper de Recharts existe; no se assertan paths del SVG
+		expect(
+			container.querySelector(".recharts-responsive-container"),
+		).not.toBeNull();
+	});
+});

--- a/admin/tests/unit/features/events/EventDistributionTable.test.tsx
+++ b/admin/tests/unit/features/events/EventDistributionTable.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { EventDistributionTable } from "@/features/events/components/EventDistributionTable";
+import type { EventDistributionItem } from "@/features/events/types";
+
+/**
+ * @module tests/unit/features/events/EventDistributionTable
+ * @description Tabla del ranking de tipos de evento: event_type + count + pct.
+ *   Cubre el branch vacio (mensaje) y el branch con filas (renderiza cada fila
+ *   con el pct formateado a 1 decimal).
+ */
+
+const ITEMS: EventDistributionItem[] = [
+	{ event_type: "page_view", count: 300, pct: 0.6 },
+	{ event_type: "click", count: 200, pct: 0.401 },
+];
+
+describe("EventDistributionTable", () => {
+	it("Given items vacios When se renderiza Then muestra el mensaje de vacio", () => {
+		// Arrange + Act
+		render(<EventDistributionTable items={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin eventos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given 2 filas When se renderiza Then muestra los event_type y counts", () => {
+		// Arrange + Act
+		render(<EventDistributionTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("page_view")).toBeInTheDocument();
+		expect(screen.getByText("click")).toBeInTheDocument();
+		expect(screen.getByText("300")).toBeInTheDocument();
+		expect(screen.getByText("200")).toBeInTheDocument();
+	});
+
+	it("Given un pct 0.6 When se renderiza Then lo formatea como 60.0%", () => {
+		// Arrange + Act
+		render(<EventDistributionTable items={ITEMS} />);
+
+		// Assert: pct * 100 con 1 decimal
+		expect(screen.getByText("60.0%")).toBeInTheDocument();
+		expect(screen.getByText("40.1%")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/events/EventHeatmap.test.tsx
+++ b/admin/tests/unit/features/events/EventHeatmap.test.tsx
@@ -1,0 +1,96 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { EventHeatmap } from "@/features/events/components/EventHeatmap";
+import type { HeatmapResponse } from "@/features/events/types";
+
+/**
+ * @module tests/unit/features/events/EventHeatmap
+ * @description Grilla 7x24 de eventos (events/heatmap). Cubre loading (skeleton),
+ *   vacio (mensaje), con data (calcula intensidad por celda) y el caso borde
+ *   max=0 (todas las celdas con count 0 -> opacidad 0).
+ */
+
+const DATA: HeatmapResponse = {
+	cells: [
+		{ dow: 1, hour: 9, count: 12 },
+		{ dow: 3, hour: 14, count: 8 },
+	],
+};
+
+describe("EventHeatmap", () => {
+	it("Given isLoading true When se renderiza Then muestra el skeleton", () => {
+		// Arrange + Act
+		const { container, queryByText } = render(
+			<EventHeatmap isLoading={true} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-72")).not.toBeNull();
+		expect(queryByText("Sin eventos en el rango seleccionado.")).toBeNull();
+	});
+
+	it("Given data undefined y isLoading false When se renderiza Then sigue mostrando skeleton", () => {
+		// Arrange + Act
+		const { container } = render(
+			<EventHeatmap isLoading={false} data={undefined} />,
+		);
+
+		// Assert
+		expect(container.querySelector(".h-72")).not.toBeNull();
+	});
+
+	it("Given celdas vacias When se renderiza Then muestra el mensaje de vacio", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<EventHeatmap isLoading={false} data={{ cells: [] }} />,
+		);
+
+		// Assert
+		expect(
+			getByText("Sin eventos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given celdas con data When se renderiza Then muestra los 7 labels de dia", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<EventHeatmap isLoading={false} data={DATA} />,
+		);
+
+		// Assert: los labels de dia de semana
+		for (const label of ["Lun", "Mar", "Mie", "Jue", "Vie", "Sab", "Dom"]) {
+			expect(getByText(label)).toBeInTheDocument();
+		}
+	});
+
+	it("Given una celda con count When se renderiza Then su title incluye el conteo de eventos", () => {
+		// Arrange + Act
+		const { getByTitle } = render(
+			<EventHeatmap isLoading={false} data={DATA} />,
+		);
+
+		// Assert: la celda (dow=1=Lun, hour=9) lleva su title con el count
+		expect(getByTitle("Lun 09:00 — 12 eventos")).toBeInTheDocument();
+		// Y una celda sin dato cae al fallback count 0
+		expect(getByTitle("Lun 00:00 — 0 eventos")).toBeInTheDocument();
+	});
+
+	it("Given todas las celdas con count 0 When se renderiza Then no crashea (max=0 -> opacidad 0)", () => {
+		// Arrange: cells presentes (no vacio) pero todas con count 0 -> branch max=0
+		const zeros: HeatmapResponse = {
+			cells: [
+				{ dow: 1, hour: 0, count: 0 },
+				{ dow: 2, hour: 1, count: 0 },
+			],
+		};
+
+		// Act
+		const { getByTitle } = render(
+			<EventHeatmap isLoading={false} data={zeros} />,
+		);
+
+		// Assert: la grilla se monta y la celda con count 0 lleva opacidad 0
+		const cell = getByTitle("Lun 00:00 — 0 eventos");
+		expect(cell).toHaveStyle({ opacity: "0" });
+	});
+});

--- a/admin/tests/unit/features/events/EventListTable.test.tsx
+++ b/admin/tests/unit/features/events/EventListTable.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, userEvent, within } from "@tests/utils/render";
+import { describe, expect, it, vi } from "vitest";
+import { EventListTable } from "@/features/events/components/EventListTable";
+import type { EventListResponse } from "@/features/events/types";
+
+/**
+ * @module tests/unit/features/events/EventListTable
+ * @description Listado crudo paginado de eventos. Cubre loading (skeleton rows),
+ *   vacio (mensaje), con data (filas + badge niche), paginacion (botones
+ *   anterior/siguiente con disabled segun page/has_more) y onPageChange.
+ */
+
+const DATA: EventListResponse = {
+	items: [
+		{
+			created_at: "2026-05-20T10:00:00Z",
+			visit_id: "vis_1",
+			page_id: "pg_1",
+			session_id: "sess_1",
+			page_path: "/projects",
+			niche: "fintech",
+			viewport_width: 1920,
+			viewport_height: 1080,
+			event_type: "page_view",
+			event_props: {},
+		},
+	],
+	page: 1,
+	page_size: 50,
+	total: 1,
+	has_more: false,
+};
+
+describe("EventListTable", () => {
+	it("Given isLoading true When se renderiza Then muestra filas skeleton y deshabilita la paginacion", () => {
+		// Arrange + Act
+		const { container } = render(
+			<EventListTable
+				data={undefined}
+				isLoading={true}
+				page={1}
+				onPageChange={() => {}}
+			/>,
+		);
+
+		// Assert: hay skeletons y ambos botones de paginacion deshabilitados
+		expect(container.querySelectorAll(".h-5").length).toBeGreaterThan(0);
+		expect(screen.getByRole("button", { name: "Anterior" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Siguiente" })).toBeDisabled();
+	});
+
+	it("Given items vacios When no carga Then muestra el mensaje de vacio", () => {
+		// Arrange + Act
+		render(
+			<EventListTable
+				data={{ items: [], page: 1, page_size: 50, total: 0, has_more: false }}
+				isLoading={false}
+				page={1}
+				onPageChange={() => {}}
+			/>,
+		);
+
+		// Assert
+		expect(
+			screen.getByText("Sin eventos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given una pagina con un evento When se renderiza Then muestra el tipo, path y niche", () => {
+		// Arrange + Act
+		render(
+			<EventListTable
+				data={DATA}
+				isLoading={false}
+				page={1}
+				onPageChange={() => {}}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByText("page_view")).toBeInTheDocument();
+		expect(screen.getByText("/projects")).toBeInTheDocument();
+		expect(screen.getByText("fintech")).toBeInTheDocument();
+		expect(screen.getByText("sess_1")).toBeInTheDocument();
+		expect(
+			screen.getByText("Pagina 1 · 1 eventos en total"),
+		).toBeInTheDocument();
+	});
+
+	it("Given page 1 When se renderiza Then el boton Anterior esta deshabilitado", () => {
+		// Arrange + Act
+		render(
+			<EventListTable
+				data={DATA}
+				isLoading={false}
+				page={1}
+				onPageChange={() => {}}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByRole("button", { name: "Anterior" })).toBeDisabled();
+	});
+
+	it("Given has_more false When se renderiza Then el boton Siguiente esta deshabilitado", () => {
+		// Arrange + Act
+		render(
+			<EventListTable
+				data={DATA}
+				isLoading={false}
+				page={1}
+				onPageChange={() => {}}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByRole("button", { name: "Siguiente" })).toBeDisabled();
+	});
+
+	it("Given page 2 con has_more When click Siguiente Then llama onPageChange con la pagina siguiente", async () => {
+		// Arrange
+		const onPageChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<EventListTable
+				data={{ ...DATA, page: 2, total: 100, has_more: true }}
+				isLoading={false}
+				page={2}
+				onPageChange={onPageChange}
+			/>,
+		);
+
+		// Act
+		await user.click(screen.getByRole("button", { name: "Siguiente" }));
+
+		// Assert
+		expect(onPageChange).toHaveBeenCalledWith(3);
+	});
+
+	it("Given page 2 When click Anterior Then llama onPageChange con la pagina previa", async () => {
+		// Arrange
+		const onPageChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<EventListTable
+				data={{ ...DATA, page: 2, total: 100, has_more: true }}
+				isLoading={false}
+				page={2}
+				onPageChange={onPageChange}
+			/>,
+		);
+
+		// Act
+		await user.click(screen.getByRole("button", { name: "Anterior" }));
+
+		// Assert
+		expect(onPageChange).toHaveBeenCalledWith(1);
+	});
+
+	it("Given data undefined When no carga Then usa los defaults (vacio + paginacion deshabilitada)", () => {
+		// Arrange + Act: data?.items ?? [] -> vacio; has_more ?? false; total ?? 0
+		render(
+			<EventListTable
+				data={undefined}
+				isLoading={false}
+				page={1}
+				onPageChange={() => {}}
+			/>,
+		);
+
+		// Assert
+		expect(
+			screen.getByText("Sin eventos en el rango seleccionado."),
+		).toBeInTheDocument();
+		expect(screen.getByText("Pagina 1")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Siguiente" })).toBeDisabled();
+	});
+
+	it("Given filas con data When se renderiza Then la celda de fecha no esta vacia", () => {
+		// Arrange + Act
+		render(
+			<EventListTable
+				data={DATA}
+				isLoading={false}
+				page={1}
+				onPageChange={() => {}}
+			/>,
+		);
+		const row = screen.getByText("page_view").closest("tr");
+		if (!row) throw new Error("fila del evento no encontrada");
+
+		// Assert: la primera celda (fecha) tiene contenido formateado (no '-')
+		const firstCell = within(row).getAllByRole("cell")[0];
+		expect(firstCell?.textContent).not.toBe("");
+		expect(firstCell?.textContent).not.toBe("-");
+	});
+});

--- a/admin/tests/unit/features/events/events-client.test.ts
+++ b/admin/tests/unit/features/events/events-client.test.ts
@@ -1,0 +1,95 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { eventsClient } from "@/features/events/api/events-client";
+
+/**
+ * @module tests/unit/features/events/events-client
+ * @description eventsClient: cada fn hace GET /analytics?operation=events&
+ *   action=... via fetchMetric y devuelve el data. list deriva offset desde
+ *   page/page_size. Usa el MSW handler de /analytics (handlers/metrics).
+ */
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("eventsClient.distribution", () => {
+	it("Given un rango valido When distribution Then devuelve el ranking del fixture", async () => {
+		// Act
+		const data = await eventsClient.distribution({
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+
+		// Assert
+		expect(data.items).toHaveLength(2);
+		expect(data.items[0]?.event_type).toBe("page_view");
+		expect(data.items[0]?.count).toBe(300);
+		expect(data.items[1]?.event_type).toBe("click");
+		expect(data.items[1]?.count).toBe(200);
+	});
+});
+
+describe("eventsClient.list", () => {
+	it("Given page/page_size explicitos When list Then devuelve la pagina del fixture", async () => {
+		// Act
+		const data = await eventsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+			page: 1,
+			page_size: 50,
+		});
+
+		// Assert
+		expect(data.items).toHaveLength(1);
+		expect(data.items[0]?.visit_id).toBe("vis_1");
+		expect(data.items[0]?.event_type).toBe("page_view");
+		expect(data.page).toBe(1);
+		expect(data.page_size).toBe(50);
+		expect(data.total).toBe(1);
+		expect(data.has_more).toBe(false);
+	});
+
+	it("Given page/page_size omitidos When list Then usa los defaults page=1 page_size=50", async () => {
+		// Act: sin page/page_size el cliente deriva page=1, page_size=50, offset=0
+		const data = await eventsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+
+		// Assert
+		expect(data.page).toBe(1);
+		expect(data.page_size).toBe(50);
+		expect(data.items[0]?.session_id).toBe("sess_1");
+	});
+
+	it("Given page=3 page_size=20 When list Then el offset derivado es (page-1)*page_size", async () => {
+		// Act: el offset no aparece en la respuesta (el fixture es fijo); el test
+		// confirma que con offset derivado el request resuelve sin romper.
+		const data = await eventsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+			page: 3,
+			page_size: 20,
+		});
+
+		// Assert
+		expect(data.total).toBe(1);
+	});
+});
+
+describe("eventsClient.heatmap", () => {
+	it("Given un rango valido When heatmap Then devuelve las celdas del fixture", async () => {
+		// Act
+		const data = await eventsClient.heatmap({
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+
+		// Assert
+		expect(data.cells).toHaveLength(2);
+		expect(data.cells[0]).toEqual({ dow: 1, hour: 9, count: 12 });
+		expect(data.cells[1]).toEqual({ dow: 3, hour: 14, count: 8 });
+	});
+});

--- a/admin/tests/unit/features/events/use-distribution.test.tsx
+++ b/admin/tests/unit/features/events/use-distribution.test.tsx
@@ -1,0 +1,47 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useDistribution } from "@/features/events/hooks/use-distribution";
+
+/**
+ * @module tests/unit/features/events/use-distribution
+ * @description useDistribution: ranking de tipos de evento (events/distribution).
+ *   Desempaqueta el envelope y devuelve { items } del fixture MSW.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useDistribution", () => {
+	it("Given un rango valido When la query resuelve Then devuelve el ranking del fixture", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useDistribution({ from: "2026-04-27", to: "2026-05-28" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items).toHaveLength(2);
+		expect(result.current.data?.items[0]?.event_type).toBe("page_view");
+		expect(result.current.data?.items[0]?.count).toBe(300);
+		expect(result.current.data?.items[1]?.event_type).toBe("click");
+	});
+});

--- a/admin/tests/unit/features/events/use-event-list.test.tsx
+++ b/admin/tests/unit/features/events/use-event-list.test.tsx
@@ -1,0 +1,55 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useEventList } from "@/features/events/hooks/use-event-list";
+
+/**
+ * @module tests/unit/features/events/use-event-list
+ * @description useEventList: listado crudo paginado de eventos (events/list).
+ *   Desempaqueta el envelope y devuelve la pagina del fixture MSW.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useEventList", () => {
+	it("Given un rango + paginacion When la query resuelve Then devuelve la pagina del fixture", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() =>
+				useEventList({
+					from: "2026-04-27",
+					to: "2026-05-28",
+					page: 1,
+					page_size: 50,
+				}),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items).toHaveLength(1);
+		expect(result.current.data?.items[0]?.visit_id).toBe("vis_1");
+		expect(result.current.data?.page).toBe(1);
+		expect(result.current.data?.page_size).toBe(50);
+		expect(result.current.data?.total).toBe(1);
+		expect(result.current.data?.has_more).toBe(false);
+	});
+});

--- a/admin/tests/unit/features/events/use-heatmap.test.tsx
+++ b/admin/tests/unit/features/events/use-heatmap.test.tsx
@@ -1,0 +1,54 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useHeatmap } from "@/features/events/hooks/use-heatmap";
+
+/**
+ * @module tests/unit/features/events/use-heatmap
+ * @description useHeatmap: distribucion de eventos por dia de semana x hora
+ *   (events/heatmap). Desempaqueta el envelope y devuelve { cells } del fixture.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useHeatmap", () => {
+	it("Given un rango valido When la query resuelve Then devuelve las celdas del fixture", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useHeatmap({ from: "2026-04-27", to: "2026-05-28" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.cells).toHaveLength(2);
+		expect(result.current.data?.cells[0]).toEqual({
+			dow: 1,
+			hour: 9,
+			count: 12,
+		});
+		expect(result.current.data?.cells[1]).toEqual({
+			dow: 3,
+			hour: 14,
+			count: 8,
+		});
+	});
+});

--- a/admin/tests/unit/features/funnel/FunnelChart.test.tsx
+++ b/admin/tests/unit/features/funnel/FunnelChart.test.tsx
@@ -1,0 +1,108 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { FunnelChart } from "@/features/funnel/components/FunnelChart";
+import type { FunnelConversionResponse } from "@/features/funnel/types";
+
+/**
+ * @module tests/unit/features/funnel/FunnelChart
+ * @description FunnelChart: cubre los 3 branches (loading -> skeleton,
+ *   sessions=0 -> mensaje vacio, con data -> 3 barras + tasas). No usa Recharts:
+ *   el render es DOM plano (divs), por lo que se asertan los labels y valores
+ *   formateados directamente.
+ */
+
+const RESPONSE: FunnelConversionResponse = {
+	sessions: 100,
+	visits: 80,
+	contacts: 5,
+	session_to_visit_rate: 0.8,
+	visit_to_contact_rate: 0.063,
+	session_to_contact_rate: 0.05,
+};
+
+describe("FunnelChart", () => {
+	it("Given isLoading=true When se renderiza Then muestra el skeleton", () => {
+		// Arrange + Act
+		const { container } = render(<FunnelChart isLoading={true} />);
+
+		// Assert: el skeleton son 3 divs con data-slot="skeleton"
+		expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(
+			3,
+		);
+	});
+
+	it("Given data undefined When isLoading=false Then tambien muestra el skeleton", () => {
+		// Arrange + Act
+		const { container } = render(<FunnelChart isLoading={false} />);
+
+		// Assert
+		expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+	});
+
+	it("Given sessions=0 When se renderiza Then muestra el mensaje de rango sin sesiones", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<FunnelChart
+				data={{
+					sessions: 0,
+					visits: 0,
+					contacts: 0,
+					session_to_visit_rate: 0,
+					visit_to_contact_rate: 0,
+					session_to_contact_rate: 0,
+				}}
+				isLoading={false}
+			/>,
+		);
+
+		// Assert
+		expect(
+			getByText("Sin sesiones en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given data con sesiones When se renderiza Then muestra los 3 labels de etapa", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<FunnelChart data={RESPONSE} isLoading={false} />,
+		);
+
+		// Assert
+		expect(getByText("Sesiones")).toBeInTheDocument();
+		expect(getByText("Visitas")).toBeInTheDocument();
+		expect(getByText("Contactos")).toBeInTheDocument();
+	});
+
+	it("Given data con sesiones When se renderiza Then formatea los valores enteros de cada etapa", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<FunnelChart data={RESPONSE} isLoading={false} />,
+		);
+
+		// Assert: fmtInt -> Intl.NumberFormat('es')
+		expect(getByText("100")).toBeInTheDocument();
+		expect(getByText("80")).toBeInTheDocument();
+		expect(getByText("5")).toBeInTheDocument();
+	});
+
+	it("Given data con tasas When se renderiza Then muestra las tasas de conversion entre etapas", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<FunnelChart data={RESPONSE} isLoading={false} />,
+		);
+
+		// Assert: fmtPct(0.8)=80.0%, fmtPct(0.063)=6.3% como tasas intermedias
+		expect(getByText("80.0% de conversion")).toBeInTheDocument();
+		expect(getByText("6.3% de conversion")).toBeInTheDocument();
+	});
+
+	it("Given data con conversion total When se renderiza Then muestra session_to_contact_rate formateada", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<FunnelChart data={RESPONSE} isLoading={false} />,
+		);
+
+		// Assert: fmtPct(0.05) = 5.0% en el pie del embudo
+		expect(getByText("5.0%")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/funnel/funnel-client.test.tsx
+++ b/admin/tests/unit/features/funnel/funnel-client.test.tsx
@@ -1,0 +1,44 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { funnelClient } from "@/features/funnel/api/funnel-client";
+
+/**
+ * @module tests/unit/features/funnel/funnel-client
+ * @description funnelClient.conversion: hace GET /analytics?operation=funnel&
+ *   action=conversion via fetchMetric y devuelve el data. Usa el MSW handler
+ *   de /analytics (fixture funnel:conversion).
+ */
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("funnelClient.conversion", () => {
+	it("Given un rango valido When conversion Then devuelve el embudo del fixture", async () => {
+		// Act
+		const data = await funnelClient.conversion({
+			from: "2026-04-27",
+			to: "2026-05-27",
+		});
+
+		// Assert
+		expect(data).toEqual({
+			sessions: 100,
+			visits: 80,
+			contacts: 5,
+			session_to_visit_rate: 0.8,
+			visit_to_contact_rate: 0.063,
+			session_to_contact_rate: 0.05,
+		});
+	});
+
+	it("Given params vacios When conversion Then sigue devolviendo el shape del fixture", async () => {
+		// Act
+		const data = await funnelClient.conversion({});
+
+		// Assert
+		expect(data.sessions).toBe(100);
+		expect(data.session_to_contact_rate).toBe(0.05);
+	});
+});

--- a/admin/tests/unit/features/funnel/use-conversion.test.tsx
+++ b/admin/tests/unit/features/funnel/use-conversion.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useConversion } from "@/features/funnel/hooks/use-conversion";
+
+/**
+ * @module tests/unit/features/funnel/use-conversion
+ * @description useConversion: useQuery contra funnel/conversion. Resuelve con el
+ *   data del Lambda `analytics` (fixture MSW funnel:conversion).
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useConversion", () => {
+	it("Given un rango valido When la query resuelve Then devuelve el embudo de conversion", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useConversion({ from: "2026-04-27", to: "2026-05-27" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data).toEqual({
+			sessions: 100,
+			visits: 80,
+			contacts: 5,
+			session_to_visit_rate: 0.8,
+			visit_to_contact_rate: 0.063,
+			session_to_contact_rate: 0.05,
+		});
+	});
+
+	it("Given un rango sin parametros When la query resuelve Then devuelve las tasas", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useConversion({}), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.session_to_visit_rate).toBe(0.8);
+	});
+});

--- a/admin/tests/unit/features/geo/geo-client.test.tsx
+++ b/admin/tests/unit/features/geo/geo-client.test.tsx
@@ -1,0 +1,48 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { geoClient } from "@/features/geo/api/geo-client";
+
+/**
+ * @module tests/unit/features/geo/geo-client
+ * @description geoClient.byCountry: hace GET /analytics?operation=geo&
+ *   action=by-country via fetchMetric y devuelve el data. Usa el MSW handler
+ *   de /analytics (fixture geo:by-country).
+ */
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("geoClient.byCountry", () => {
+	it("Given un rango valido When byCountry Then devuelve items + total del fixture", async () => {
+		// Act
+		const data = await geoClient.byCountry({
+			from: "2026-04-27",
+			to: "2026-05-27",
+		});
+
+		// Assert
+		expect(data.total).toBe(30);
+		expect(data.items).toHaveLength(1);
+		expect(data.items[0]).toEqual({
+			country: "AR",
+			sessions: 30,
+			visits: 40,
+			events: 100,
+		});
+	});
+
+	it("Given un limit explicito When byCountry Then sigue devolviendo el shape del fixture", async () => {
+		// Act
+		const data = await geoClient.byCountry({
+			from: "2026-04-27",
+			to: "2026-05-27",
+			limit: 10,
+		});
+
+		// Assert
+		expect(data.items[0]?.country).toBe("AR");
+		expect(data.total).toBe(30);
+	});
+});

--- a/admin/tests/unit/features/geo/geo-country-chart.test.tsx
+++ b/admin/tests/unit/features/geo/geo-country-chart.test.tsx
@@ -1,0 +1,82 @@
+import { render } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { GeoCountryChart } from "@/features/geo/components/GeoCountryChart";
+import type {
+	GeoByCountryResponse,
+	GeoCountryItem,
+} from "@/features/geo/types";
+
+/**
+ * @module tests/unit/features/geo/geo-country-chart
+ * @description GeoCountryChart: cubre los 3 branches (loading -> skeleton,
+ *   vacio -> mensaje, con data -> BarChart). Recharts no pinta el SVG con
+ *   dimensiones 0 en happy-dom: se verifica que no crashea y el codigo de
+ *   transformacion (sort + slice top 10) se ejecuta.
+ */
+
+const RESPONSE: GeoByCountryResponse = {
+	items: [
+		{ country: "AR", sessions: 30, visits: 40, events: 100 },
+		{ country: "CL", sessions: 90, visits: 120, events: 300 },
+	],
+	total: 120,
+};
+
+describe("GeoCountryChart", () => {
+	it("Given isLoading=true When se renderiza Then muestra el skeleton", () => {
+		// Arrange + Act
+		const { container } = render(<GeoCountryChart isLoading={true} />);
+
+		// Assert: skeleton es un div con data-slot="skeleton"
+		expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+	});
+
+	it("Given data undefined When isLoading=false Then tambien muestra el skeleton", () => {
+		// Arrange + Act
+		const { container } = render(<GeoCountryChart isLoading={false} />);
+
+		// Assert
+		expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+	});
+
+	it("Given items vacio When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		const { getByText } = render(
+			<GeoCountryChart data={{ items: [], total: 0 }} isLoading={false} />,
+		);
+
+		// Assert
+		expect(
+			getByText("Sin datos en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given data con paises When se renderiza Then no crashea y monta el contenedor del chart", () => {
+		// Arrange + Act
+		const { container } = render(
+			<GeoCountryChart data={RESPONSE} isLoading={false} />,
+		);
+
+		// Assert: ResponsiveContainer renderiza su wrapper; no muestra mensaje vacio
+		expect(
+			container.querySelector(".recharts-responsive-container"),
+		).not.toBeNull();
+	});
+
+	it("Given mas de 10 paises When se renderiza Then ejecuta el slice top 10 sin crashear", () => {
+		// Arrange: 12 paises -> el codigo corta a 10
+		const many: GeoCountryItem[] = Array.from({ length: 12 }, (_, i) => ({
+			country: `C${i}`,
+			sessions: i + 1,
+			visits: i + 2,
+			events: i + 3,
+		}));
+
+		// Act + Assert: el render no lanza con la rama de transformacion
+		expect(() =>
+			render(
+				<GeoCountryChart data={{ items: many, total: 78 }} isLoading={false} />,
+			),
+		).not.toThrow();
+	});
+});

--- a/admin/tests/unit/features/geo/geo-country-table.test.tsx
+++ b/admin/tests/unit/features/geo/geo-country-table.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, within } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { GeoCountryTable } from "@/features/geo/components/GeoCountryTable";
+import type { GeoCountryItem } from "@/features/geo/types";
+
+/**
+ * @module tests/unit/features/geo/geo-country-table
+ * @description Render del ranking de paises: filas con country + sessions +
+ *   visits + events formateados, reordenadas por sessions desc, y mensaje
+ *   vacio cuando items=[].
+ */
+
+const ITEMS: GeoCountryItem[] = [
+	{ country: "AR", sessions: 30, visits: 40, events: 100 },
+	{ country: "CL", sessions: 1500, visits: 1800, events: 5000 },
+];
+
+describe("GeoCountryTable", () => {
+	it("Given 2 paises When se renderiza Then muestra ambos codigos ISO-2", () => {
+		// Arrange + Act
+		render(<GeoCountryTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("AR")).toBeInTheDocument();
+		expect(screen.getByText("CL")).toBeInTheDocument();
+	});
+
+	it("Given filas desordenadas When se renderiza Then la de mas sessions queda primera", () => {
+		// Arrange + Act
+		render(<GeoCountryTable items={ITEMS} />);
+		const dataRows = screen
+			.getAllByRole("row")
+			.filter((row) => within(row).queryByText(/AR|CL/));
+
+		// Assert: CL (1500) antes que AR (30)
+		expect(
+			within(dataRows[0] as HTMLElement).getByText("CL"),
+		).toBeInTheDocument();
+		expect(
+			within(dataRows[1] as HTMLElement).getByText("AR"),
+		).toBeInTheDocument();
+	});
+
+	it("Given valores numericos When se renderiza Then formatea los miles con Intl es", () => {
+		// Arrange + Act
+		render(<GeoCountryTable items={ITEMS} />);
+
+		// Assert: el componente usa Intl.NumberFormat('es'); se calcula el
+		// valor esperado con el mismo formateador (agnostico al ICU del runtime).
+		const fmt = new Intl.NumberFormat("es");
+		expect(screen.getByText(fmt.format(1500))).toBeInTheDocument();
+		expect(screen.getByText(fmt.format(5000))).toBeInTheDocument();
+	});
+
+	it("Given una fila When se renderiza Then muestra sessions, visits y events de ese pais", () => {
+		// Arrange + Act
+		render(<GeoCountryTable items={[ITEMS[0] as GeoCountryItem]} />);
+		const row = screen.getByText("AR").closest("tr");
+		if (!row) throw new Error("fila AR no encontrada");
+
+		// Assert
+		expect(within(row).getByText("30")).toBeInTheDocument();
+		expect(within(row).getByText("40")).toBeInTheDocument();
+		expect(within(row).getByText("100")).toBeInTheDocument();
+	});
+
+	it("Given items vacio When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<GeoCountryTable items={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin paises en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given los encabezados When se renderiza Then muestra las 4 columnas", () => {
+		// Arrange + Act
+		render(<GeoCountryTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("Pais")).toBeInTheDocument();
+		expect(screen.getByText("Sesiones")).toBeInTheDocument();
+		expect(screen.getByText("Visitas")).toBeInTheDocument();
+		expect(screen.getByText("Eventos")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/geo/use-by-country.test.tsx
+++ b/admin/tests/unit/features/geo/use-by-country.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useByCountry } from "@/features/geo/hooks/use-by-country";
+
+/**
+ * @module tests/unit/features/geo/use-by-country
+ * @description useByCountry: useQuery contra geo/by-country. Resuelve con el
+ *   data del Lambda `analytics` (fixture MSW geo:by-country).
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useByCountry", () => {
+	it("Given un rango valido When la query resuelve Then devuelve items + total", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useByCountry({ from: "2026-04-27", to: "2026-05-27" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data).toEqual({
+			items: [{ country: "AR", sessions: 30, visits: 40, events: 100 }],
+			total: 30,
+		});
+	});
+
+	it("Given un limit explicito When la query resuelve Then devuelve el ranking", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useByCountry({ from: "2026-04-27", to: "2026-05-27", limit: 5 }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items[0]?.country).toBe("AR");
+	});
+});

--- a/admin/tests/unit/features/sessions/session-detail-view.test.tsx
+++ b/admin/tests/unit/features/sessions/session-detail-view.test.tsx
@@ -1,0 +1,166 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { server } from "@tests/mocks/server";
+import { render, screen, userEvent, waitFor } from "@tests/utils/render";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { SessionDetailView } from "@/features/sessions/components/SessionDetailView";
+
+/**
+ * @module tests/unit/features/sessions/session-detail-view
+ * @description Detalle de una sesion: con data muestra visitas/eventos/
+ *   dispositivo + resumen + tabla de visitas; un 404 muestra el EmptyState; un
+ *   error generico muestra el ErrorAlert. Usa el MSW handler de /analytics
+ *   (override por caso para 404/500).
+ */
+
+const API = "https://api.test.the-full-stack.com";
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("SessionDetailView", () => {
+	it("Given un sessionId valido When la query resuelve Then muestra eventos, dispositivo y resumen", async () => {
+		// Arrange + Act
+		render(<SessionDetailView sessionId="sess_1" />);
+
+		// Assert: el header muestra el id desde el primer render
+		expect(screen.getByRole("heading", { name: "sess_1" })).toBeInTheDocument();
+		// events_count=6 del fixture
+		await waitFor(() => {
+			expect(screen.getByText("6")).toBeInTheDocument();
+		});
+		// visits_count=2 del fixture
+		expect(screen.getByText("2")).toBeInTheDocument();
+		expect(screen.getByText("Sistema operativo")).toBeInTheDocument();
+		expect(screen.getByText("Linux")).toBeInTheDocument();
+		// la tabla de visitas renderiza la unica visita (landing '/')
+		expect(screen.getByText("/")).toBeInTheDocument();
+	});
+
+	it("Given un boton Volver When se renderiza Then enlaza al listado de sesiones", () => {
+		// Arrange + Act
+		render(<SessionDetailView sessionId="sess_1" />);
+
+		// Assert
+		const back = screen.getByRole("link", { name: /Volver/ });
+		expect(back).toHaveAttribute("href", "/metrics/sessions");
+	});
+
+	it("Given un 404 del backend When la query falla Then muestra el EmptyState de sesion no encontrada", async () => {
+		// Arrange: override -> 404
+		server.use(
+			http.get(`${API}/analytics`, () =>
+				HttpResponse.json(
+					{ error: "NOT_FOUND", code: 4040, message: "No existe" },
+					{ status: 404 },
+				),
+			),
+		);
+
+		// Act
+		render(<SessionDetailView sessionId="sess_missing" />);
+
+		// Assert
+		await waitFor(() => {
+			expect(screen.getByText("Sesion no encontrada")).toBeInTheDocument();
+		});
+		expect(
+			screen.getByRole("link", { name: "Ver todas las sesiones" }),
+		).toBeInTheDocument();
+	});
+
+	it("Given un error 500 del backend When la query falla Then muestra el ErrorAlert con reintento", async () => {
+		// Arrange: override -> 500
+		server.use(
+			http.get(`${API}/analytics`, () =>
+				HttpResponse.json(
+					{ error: "INTERNAL", code: 6000, message: "Error interno" },
+					{ status: 500 },
+				),
+			),
+		);
+
+		// Act
+		render(<SessionDetailView sessionId="sess_1" />);
+
+		// Assert
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent("Error interno");
+		expect(
+			screen.getByRole("button", { name: "Reintentar" }),
+		).toBeInTheDocument();
+	});
+
+	it("Given el ErrorAlert con reintento When se clickea Reintentar Then refetch re-consulta y muestra la data", async () => {
+		// Arrange: primer request 500, los siguientes 200 (la 2da consulta proviene
+		// del refetch del onRetry inline -> invoca detail.refetch()).
+		let calls = 0;
+		server.use(
+			http.get(`${API}/analytics`, () => {
+				calls += 1;
+				if (calls === 1) {
+					return HttpResponse.json(
+						{ error: "INTERNAL", code: 6000, message: "Error interno" },
+						{ status: 500 },
+					);
+				}
+				return HttpResponse.json(
+					{
+						session: {
+							session_id: "sess_1",
+							first_seen_at: "2026-05-01T10:00:00Z",
+							last_seen_at: "2026-05-20T10:00:00Z",
+							browser: "Chrome",
+							browser_version: "120",
+							os: "Linux",
+							device_type: "desktop",
+							visits_count: 2,
+						},
+						visits: [],
+						events_count: 6,
+					},
+					{ status: 200 },
+				);
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: aparece el error -> click en Reintentar dispara el onRetry inline
+		render(<SessionDetailView sessionId="sess_1" />);
+		const retry = await screen.findByRole("button", { name: "Reintentar" });
+		await user.click(retry);
+
+		// Assert: tras el refetch exitoso desaparece el error y aparece la data
+		await waitFor(() => {
+			expect(screen.getByText("Sistema operativo")).toBeInTheDocument();
+		});
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(calls).toBe(2);
+	});
+
+	it("Given la query en vuelo When aun no resuelve Then muestra los skeletons (sin error ni data)", () => {
+		// Arrange: handler que nunca responde -> la query queda pending, forzando el
+		// estado isLoading del primer render (skeletons).
+		server.use(
+			http.get(`${API}/analytics`, () => new Promise<Response>(() => {})),
+		);
+
+		// Act
+		const { container } = render(
+			<SessionDetailView sessionId="sess_pending" />,
+		);
+
+		// Assert: el header ya esta; los Skeleton (animate-pulse) se renderizan y no
+		// hay error ni la data del fixture todavia.
+		expect(
+			screen.getByRole("heading", { name: "sess_pending" }),
+		).toBeInTheDocument();
+		expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
+			0,
+		);
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+		expect(screen.queryByText("Sistema operativo")).not.toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/sessions/session-filters.test.tsx
+++ b/admin/tests/unit/features/sessions/session-filters.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionFilters } from "@/features/sessions/components/SessionFilters";
+
+/**
+ * @module tests/unit/features/sessions/session-filters
+ * @description SessionFilters: dos Selects (device_type, browser). El valor
+ *   centinela `_all` representa "sin filtro": al renderizar, un value undefined
+ *   cae a `_all`; al emitirse, `_all` -> undefined y un valor concreto se
+ *   propaga tal cual.
+ *
+ *   El shadcn Select (Radix) usa portal + pointer events poco fiables en
+ *   happy-dom, asi que se mockea cada Select para exponer su `value` y disparar
+ *   su `onValueChange` de forma determinista (mismo patron que
+ *   ContactStatusFilter / MetricsDateRange). Se capturan AMBOS Selects en orden:
+ *   [0] = device_type, [1] = browser.
+ */
+
+/** Captura del value + onValueChange de cada Select, en orden de render. */
+let capturedValues: string[] = [];
+let capturedOnValueChange: ((next: string) => void)[] = [];
+
+vi.mock("@/components/ui/select", () => ({
+	Select: ({
+		value,
+		onValueChange,
+		children,
+	}: {
+		value: string;
+		onValueChange: (next: string) => void;
+		children: ReactNode;
+	}) => {
+		capturedValues.push(value);
+		capturedOnValueChange.push(onValueChange);
+		return <div data-testid="select">{children}</div>;
+	},
+	SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+	SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
+		<div data-value={value}>{children}</div>
+	),
+	SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+	SelectValue: ({ placeholder }: { placeholder?: string }) => (
+		<span>{placeholder}</span>
+	),
+}));
+
+beforeEach(() => {
+	capturedValues = [];
+	capturedOnValueChange = [];
+});
+
+describe("SessionFilters", () => {
+	it("Given deviceType y browser undefined When se renderiza Then ambos Selects reciben el centinela `_all`", () => {
+		// Arrange + Act
+		render(
+			<SessionFilters
+				deviceType={undefined}
+				browser={undefined}
+				onDeviceTypeChange={vi.fn()}
+				onBrowserChange={vi.fn()}
+			/>,
+		);
+
+		// Assert: [0] = device_type, [1] = browser
+		expect(capturedValues).toEqual(["_all", "_all"]);
+	});
+
+	it("Given deviceType y browser concretos When se renderiza Then cada Select recibe su value", () => {
+		// Arrange + Act
+		render(
+			<SessionFilters
+				deviceType="mobile"
+				browser="Firefox"
+				onDeviceTypeChange={vi.fn()}
+				onBrowserChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(capturedValues).toEqual(["mobile", "Firefox"]);
+	});
+
+	it("Given el Select de dispositivo emite un valor concreto When onValueChange Then onDeviceTypeChange recibe ese valor", () => {
+		// Arrange
+		const onDeviceTypeChange = vi.fn();
+		render(
+			<SessionFilters
+				deviceType={undefined}
+				browser={undefined}
+				onDeviceTypeChange={onDeviceTypeChange}
+				onBrowserChange={vi.fn()}
+			/>,
+		);
+
+		// Act: el primer Select es device_type
+		capturedOnValueChange[0]?.("tablet");
+
+		// Assert
+		expect(onDeviceTypeChange).toHaveBeenCalledWith("tablet");
+	});
+
+	it("Given el Select de dispositivo emite el centinela `_all` When onValueChange Then onDeviceTypeChange recibe undefined", () => {
+		// Arrange
+		const onDeviceTypeChange = vi.fn();
+		render(
+			<SessionFilters
+				deviceType="desktop"
+				browser={undefined}
+				onDeviceTypeChange={onDeviceTypeChange}
+				onBrowserChange={vi.fn()}
+			/>,
+		);
+
+		// Act
+		capturedOnValueChange[0]?.("_all");
+
+		// Assert
+		expect(onDeviceTypeChange).toHaveBeenCalledWith(undefined);
+	});
+
+	it("Given el Select de navegador emite un valor concreto When onValueChange Then onBrowserChange recibe ese valor", () => {
+		// Arrange
+		const onBrowserChange = vi.fn();
+		render(
+			<SessionFilters
+				deviceType={undefined}
+				browser={undefined}
+				onDeviceTypeChange={vi.fn()}
+				onBrowserChange={onBrowserChange}
+			/>,
+		);
+
+		// Act: el segundo Select es browser
+		capturedOnValueChange[1]?.("Safari");
+
+		// Assert
+		expect(onBrowserChange).toHaveBeenCalledWith("Safari");
+	});
+
+	it("Given el Select de navegador emite el centinela `_all` When onValueChange Then onBrowserChange recibe undefined", () => {
+		// Arrange
+		const onBrowserChange = vi.fn();
+		render(
+			<SessionFilters
+				deviceType={undefined}
+				browser="Chrome"
+				onDeviceTypeChange={vi.fn()}
+				onBrowserChange={onBrowserChange}
+			/>,
+		);
+
+		// Act
+		capturedOnValueChange[1]?.("_all");
+
+		// Assert
+		expect(onBrowserChange).toHaveBeenCalledWith(undefined);
+	});
+
+	it("Given se renderiza When se listan las opciones Then incluye los 4 dispositivos, los 5 navegadores y los placeholders/centinelas", () => {
+		// Arrange + Act
+		render(
+			<SessionFilters
+				deviceType={undefined}
+				browser={undefined}
+				onDeviceTypeChange={vi.fn()}
+				onBrowserChange={vi.fn()}
+			/>,
+		);
+
+		// Assert: placeholders (SelectValue)
+		expect(screen.getByText("Dispositivo")).toBeInTheDocument();
+		expect(screen.getByText("Navegador")).toBeInTheDocument();
+		// centinelas (SelectItem ALL)
+		expect(screen.getByText("Todos los dispositivos")).toBeInTheDocument();
+		expect(screen.getByText("Todos los navegadores")).toBeInTheDocument();
+		// 4 device types
+		expect(screen.getByText("desktop")).toBeInTheDocument();
+		expect(screen.getByText("mobile")).toBeInTheDocument();
+		expect(screen.getByText("tablet")).toBeInTheDocument();
+		expect(screen.getByText("bot")).toBeInTheDocument();
+		// 5 browsers
+		expect(screen.getByText("Chrome")).toBeInTheDocument();
+		expect(screen.getByText("Firefox")).toBeInTheDocument();
+		expect(screen.getByText("Safari")).toBeInTheDocument();
+		expect(screen.getByText("Edge")).toBeInTheDocument();
+		expect(screen.getByText("Opera")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/sessions/session-visits-table.test.tsx
+++ b/admin/tests/unit/features/sessions/session-visits-table.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, within } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { SessionVisitsTable } from "@/features/sessions/components/SessionVisitsTable";
+import type { VisitRow } from "@/features/sessions/types";
+
+/**
+ * @module tests/unit/features/sessions/session-visits-table
+ * @description Render de la tabla de visitas de una sesion: mensaje vacio sin
+ *   visitas; con visitas muestra landing, niche, pais y la combinacion UTM
+ *   (source/medium/campaign). Cubre los fallbacks "-" de campos vacios.
+ */
+
+const VISIT: VisitRow = {
+	visit_id: "vis_1",
+	started_at: "2026-05-01T10:00:00Z",
+	ended_at: "2026-05-01T10:05:00Z",
+	event_count: 3,
+	ip: "1.2.3.4",
+	country: "AR",
+	utm_source: "google",
+	utm_medium: "cpc",
+	utm_campaign: "launch",
+	referrer: "https://google.com",
+	landing_page_path: "/",
+	niche: "fintech",
+};
+
+describe("SessionVisitsTable", () => {
+	it("Given sin visitas When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<SessionVisitsTable visits={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Esta sesion no tiene visitas registradas."),
+		).toBeInTheDocument();
+	});
+
+	it("Given una visita con UTM completos When se renderiza Then muestra landing, niche, pais y UTM unidos", () => {
+		// Arrange + Act
+		render(<SessionVisitsTable visits={[VISIT]} />);
+
+		// Assert
+		expect(screen.getByText("/")).toBeInTheDocument();
+		expect(screen.getByText("fintech")).toBeInTheDocument();
+		expect(screen.getByText("AR")).toBeInTheDocument();
+		expect(screen.getByText("google / cpc / launch")).toBeInTheDocument();
+		expect(screen.getByText("3")).toBeInTheDocument();
+	});
+
+	it("Given una visita sin UTM, niche ni landing When se renderiza Then esos campos caen al fallback '-'", () => {
+		// Arrange: landing, niche, referrer, country y los 3 utm vacios
+		const empty: VisitRow = {
+			...VISIT,
+			landing_page_path: "",
+			niche: "",
+			referrer: "",
+			country: "",
+			utm_source: "",
+			utm_medium: "",
+			utm_campaign: "",
+		};
+
+		// Act
+		render(<SessionVisitsTable visits={[empty]} />);
+		const row = screen.getByText("3").closest("tr");
+		if (!row) throw new Error("fila de la visita vacia no encontrada");
+
+		// Assert: landing, niche, referrer, pais y UTM -> 5 celdas con "-"
+		const dashes = within(row).getAllByText("-");
+		expect(dashes).toHaveLength(5);
+	});
+});

--- a/admin/tests/unit/features/sessions/sessions-client.test.tsx
+++ b/admin/tests/unit/features/sessions/sessions-client.test.tsx
@@ -1,0 +1,85 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { server } from "@tests/mocks/server";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { sessionsClient } from "@/features/sessions/api/sessions-client";
+
+/**
+ * @module tests/unit/features/sessions/sessions-client
+ * @description sessionsClient.list y .detail: GET /analytics?operation=sessions
+ *   &action=... via fetchMetric (Bearer + envelope) y devuelven el `data`. Los
+ *   asserts usan el fixture MSW (tests/mocks/handlers/metrics).
+ */
+
+const API = "https://api.test.the-full-stack.com";
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("sessionsClient.list", () => {
+	it("Given params validos When list Then devuelve el listado paginado del fixture", async () => {
+		// Act
+		const data = await sessionsClient.list({
+			from: "2026-05-01",
+			to: "2026-05-28",
+			page: 1,
+			page_size: 20,
+		});
+
+		// Assert
+		expect(data.total).toBe(1);
+		expect(data.page).toBe(1);
+		expect(data.page_size).toBe(20);
+		expect(data.has_more).toBe(false);
+		expect(data.items).toHaveLength(1);
+		expect(data.items[0]?.session_id).toBe("sess_1");
+		expect(data.items[0]?.browser).toBe("Chrome");
+		expect(data.items[0]?.visits_count).toBe(4);
+	});
+
+	it("Given operation+action=sessions:list When list Then llama el endpoint con esos query params", async () => {
+		// Arrange: captura los query params que recibe el handler
+		let captured: { operation: string | null; action: string | null } = {
+			operation: null,
+			action: null,
+		};
+		server.use(
+			http.get(`${API}/analytics`, ({ request }) => {
+				const url = new URL(request.url);
+				captured = {
+					operation: url.searchParams.get("operation"),
+					action: url.searchParams.get("action"),
+				};
+				return HttpResponse.json(
+					{ items: [], page: 2, page_size: 20, total: 0, has_more: false },
+					{ status: 200 },
+				);
+			}),
+		);
+
+		// Act
+		const data = await sessionsClient.list({ page: 2, device_type: "mobile" });
+
+		// Assert
+		expect(captured.operation).toBe("sessions");
+		expect(captured.action).toBe("list");
+		expect(data.page).toBe(2);
+	});
+});
+
+describe("sessionsClient.detail", () => {
+	it("Given un session_id When detail Then devuelve sesion + visitas + events_count del fixture", async () => {
+		// Act
+		const data = await sessionsClient.detail({ session_id: "sess_1" });
+
+		// Assert
+		expect(data.session.session_id).toBe("sess_1");
+		expect(data.session.visits_count).toBe(2);
+		expect(data.events_count).toBe(6);
+		expect(data.visits).toHaveLength(1);
+		expect(data.visits[0]?.visit_id).toBe("vis_1");
+		expect(data.visits[0]?.country).toBe("AR");
+	});
+});

--- a/admin/tests/unit/features/sessions/sessions-pagination.test.tsx
+++ b/admin/tests/unit/features/sessions/sessions-pagination.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, userEvent } from "@tests/utils/render";
+import { describe, expect, it, vi } from "vitest";
+import { SessionsPagination } from "@/features/sessions/components/SessionsPagination";
+
+/**
+ * @module tests/unit/features/sessions/sessions-pagination
+ * @description Controles de paginacion: rango mostrado, botones anterior/
+ *   siguiente y sus estados disabled (page<=1, !hasMore, isLoading).
+ */
+
+describe("SessionsPagination", () => {
+	it("Given page 1 de 100 When render Then muestra el rango y deshabilita Anterior", () => {
+		// Arrange + Act
+		render(
+			<SessionsPagination
+				page={1}
+				pageSize={20}
+				total={100}
+				hasMore={true}
+				isLoading={false}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByText("1-20 de 100")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /anterior/i })).toBeDisabled();
+		expect(
+			screen.getByRole("button", { name: /siguiente/i }),
+		).not.toBeDisabled();
+	});
+
+	it("Given total 0 When render Then el rango arranca en 0", () => {
+		// Arrange + Act
+		render(
+			<SessionsPagination
+				page={1}
+				pageSize={20}
+				total={0}
+				hasMore={false}
+				isLoading={false}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByText("0-0 de 0")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /siguiente/i })).toBeDisabled();
+	});
+
+	it("Given isLoading When render Then ambos botones deshabilitados", () => {
+		// Arrange + Act
+		render(
+			<SessionsPagination
+				page={2}
+				pageSize={20}
+				total={100}
+				hasMore={true}
+				isLoading={true}
+				onPageChange={vi.fn()}
+			/>,
+		);
+
+		// Assert
+		expect(screen.getByRole("button", { name: /anterior/i })).toBeDisabled();
+		expect(screen.getByRole("button", { name: /siguiente/i })).toBeDisabled();
+	});
+
+	it("Given click en Siguiente When habilitado Then llama onPageChange con page+1", async () => {
+		// Arrange
+		const onPageChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<SessionsPagination
+				page={2}
+				pageSize={20}
+				total={100}
+				hasMore={true}
+				isLoading={false}
+				onPageChange={onPageChange}
+			/>,
+		);
+
+		// Act
+		await user.click(screen.getByRole("button", { name: /siguiente/i }));
+		await user.click(screen.getByRole("button", { name: /anterior/i }));
+
+		// Assert
+		expect(onPageChange).toHaveBeenNthCalledWith(1, 3);
+		expect(onPageChange).toHaveBeenNthCalledWith(2, 1);
+	});
+});

--- a/admin/tests/unit/features/sessions/sessions-table.test.tsx
+++ b/admin/tests/unit/features/sessions/sessions-table.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { SessionsTable } from "@/features/sessions/components/SessionsTable";
+import type { SessionRow } from "@/features/sessions/types";
+
+/**
+ * @module tests/unit/features/sessions/sessions-table
+ * @description Render del listado de sesiones: skeleton mientras carga, mensaje
+ *   vacio sin filas, filas con link al detalle + badge de dispositivo. Cubre el
+ *   branch del browser_version presente vs ausente.
+ */
+
+const ROW: SessionRow = {
+	session_id: "sess_1",
+	first_seen_at: "2026-05-01T10:00:00Z",
+	last_seen_at: "2026-05-20T10:00:00Z",
+	browser: "Chrome",
+	browser_version: "120",
+	os: "Linux",
+	device_type: "desktop",
+	visits_count: 4,
+};
+
+describe("SessionsTable", () => {
+	it("Given isLoading true When se renderiza Then muestra los headers de la tabla", () => {
+		// Arrange + Act
+		render(<SessionsTable items={[]} isLoading />);
+
+		// Assert: header siempre visible; sin mensaje vacio mientras carga
+		expect(screen.getByText("Sesion")).toBeInTheDocument();
+		expect(screen.getByText("Navegador")).toBeInTheDocument();
+		expect(
+			screen.queryByText("Sin sesiones en el rango seleccionado."),
+		).toBeNull();
+	});
+
+	it("Given items vacios y isLoading false When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<SessionsTable items={[]} isLoading={false} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin sesiones en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given una fila con browser_version When se renderiza Then muestra session_id, version, os, dispositivo y visitas", () => {
+		// Arrange + Act
+		render(<SessionsTable items={[ROW]} isLoading={false} />);
+
+		// Assert
+		const link = screen.getByRole("link", { name: "sess_1" });
+		expect(link).toHaveAttribute("href", "/metrics/sessions/detail?id=sess_1");
+		expect(screen.getByText("120")).toBeInTheDocument();
+		expect(screen.getByText("Linux")).toBeInTheDocument();
+		expect(screen.getByText("desktop")).toBeInTheDocument();
+		expect(screen.getByText("4")).toBeInTheDocument();
+	});
+
+	it("Given una fila sin browser_version When se renderiza Then no muestra el span de version", () => {
+		// Arrange
+		const noVersion: SessionRow = { ...ROW, browser_version: "" };
+
+		// Act
+		render(<SessionsTable items={[noVersion]} isLoading={false} />);
+
+		// Assert: solo el nombre del navegador, sin version
+		expect(screen.getByText("Chrome")).toBeInTheDocument();
+		expect(screen.queryByText("120")).toBeNull();
+	});
+});

--- a/admin/tests/unit/features/sessions/use-session-detail.test.tsx
+++ b/admin/tests/unit/features/sessions/use-session-detail.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useSessionDetail } from "@/features/sessions/hooks/use-session-detail";
+
+/**
+ * @module tests/unit/features/sessions/use-session-detail
+ * @description useSessionDetail: detalle de una sesion de visitante
+ *   (sessions/detail). Solo dispara con un session_id no vacio (enabled). El
+ *   MSW handler de /analytics provee el `data`.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useSessionDetail", () => {
+	it("Given un session_id valido When la query resuelve Then devuelve sesion + visitas + events_count", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useSessionDetail({ session_id: "sess_1" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.session.session_id).toBe("sess_1");
+		expect(result.current.data?.events_count).toBe(6);
+		expect(result.current.data?.visits).toHaveLength(1);
+	});
+
+	it("Given un session_id vacio When se monta Then la query queda deshabilitada (no dispara)", () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useSessionDetail({ session_id: "" }), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert: enabled=false (Tanstack v5) -> fetchStatus idle, status
+		// pending, NO isLoading (no hay fetch en vuelo), sin data.
+		expect(result.current.fetchStatus).toBe("idle");
+		expect(result.current.isPending).toBe(true);
+		expect(result.current.isLoading).toBe(false);
+		expect(result.current.data).toBeUndefined();
+	});
+});

--- a/admin/tests/unit/features/sessions/use-session-list.test.tsx
+++ b/admin/tests/unit/features/sessions/use-session-list.test.tsx
@@ -1,0 +1,48 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useSessionList } from "@/features/sessions/hooks/use-session-list";
+
+/**
+ * @module tests/unit/features/sessions/use-session-list
+ * @description useSessionList: listado paginado de sesiones de visitantes
+ *   (sessions/list). Resuelve via el MSW handler de /analytics y devuelve el
+ *   `data` desempaquetado.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useSessionList", () => {
+	it("Given params validos When la query resuelve Then devuelve el listado paginado del fixture", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useSessionList({ from: "2026-05-01", to: "2026-05-28", page: 1 }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.total).toBe(1);
+		expect(result.current.data?.items).toHaveLength(1);
+		expect(result.current.data?.items[0]?.session_id).toBe("sess_1");
+		expect(result.current.data?.items[0]?.visits_count).toBe(4);
+	});
+});

--- a/admin/tests/unit/features/visits/LandingPagesTable.test.tsx
+++ b/admin/tests/unit/features/visits/LandingPagesTable.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { LandingPagesTable } from "@/features/visits/components/LandingPagesTable";
+import type { LandingPageItem } from "@/features/visits/types";
+
+/**
+ * @module tests/unit/features/visits/LandingPagesTable
+ * @description Render del ranking de landing pages: path + visits +
+ *   unique_visitors por fila, headers y mensaje vacio.
+ */
+
+const ITEMS: LandingPageItem[] = [
+	{ landing_page_path: "/", visits: 40, unique_visitors: 30 },
+	{ landing_page_path: "/projects", visits: 25, unique_visitors: 18 },
+];
+
+describe("LandingPagesTable", () => {
+	it("Given un array vacio When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<LandingPagesTable items={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin landing pages en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given dos landing pages When se renderiza Then muestra ambos paths", () => {
+		// Arrange + Act
+		render(<LandingPagesTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("/")).toBeInTheDocument();
+		expect(screen.getByText("/projects")).toBeInTheDocument();
+	});
+
+	it("Given una landing page When se renderiza Then muestra sus visits y unique_visitors", () => {
+		// Arrange + Act
+		render(<LandingPagesTable items={[ITEMS[0] as LandingPageItem]} />);
+
+		// Assert
+		expect(screen.getByText("40")).toBeInTheDocument();
+		expect(screen.getByText("30")).toBeInTheDocument();
+	});
+
+	it("Given data When se renderiza Then muestra los headers de la tabla", () => {
+		// Arrange + Act
+		render(<LandingPagesTable items={ITEMS} />);
+
+		// Assert
+		expect(screen.getByText("Landing page")).toBeInTheDocument();
+		expect(screen.getByText("Visitas")).toBeInTheDocument();
+		expect(screen.getByText("Visitantes")).toBeInTheDocument();
+	});
+});

--- a/admin/tests/unit/features/visits/VisitsTable.test.tsx
+++ b/admin/tests/unit/features/visits/VisitsTable.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, within } from "@tests/utils/render";
+import { describe, expect, it } from "vitest";
+import { VisitsTable } from "@/features/visits/components/VisitsTable";
+import type { VisitRow } from "@/features/visits/types";
+
+/**
+ * @module tests/unit/features/visits/VisitsTable
+ * @description Render de la tabla de visitas: filas con country/niche/referrer/
+ *   landing/event_count, fallback "-" en nullables y mensaje vacio.
+ */
+
+const ROW: VisitRow = {
+	visit_id: "vis_1",
+	session_id: "sess_1",
+	started_at: "2026-05-01T10:00:00Z",
+	ended_at: "2026-05-01T10:05:00Z",
+	event_count: 3,
+	ip: "1.2.3.4",
+	country: "AR",
+	utm_source: null,
+	utm_medium: null,
+	utm_campaign: null,
+	referrer: "(direct)",
+	landing_page_path: "/blog",
+	niche: "fintech",
+};
+
+describe("VisitsTable", () => {
+	it("Given un array vacio When se renderiza Then muestra el mensaje vacio", () => {
+		// Arrange + Act
+		render(<VisitsTable items={[]} />);
+
+		// Assert
+		expect(
+			screen.getByText("Sin visitas en el rango seleccionado."),
+		).toBeInTheDocument();
+	});
+
+	it("Given una visita When se renderiza Then muestra sus columnas con data", () => {
+		// Arrange + Act
+		render(<VisitsTable items={[ROW]} />);
+
+		// Assert
+		expect(screen.getByText("AR")).toBeInTheDocument();
+		expect(screen.getByText("fintech")).toBeInTheDocument();
+		expect(screen.getByText("(direct)")).toBeInTheDocument();
+		expect(screen.getByText("/blog")).toBeInTheDocument();
+		expect(screen.getByText("3")).toBeInTheDocument();
+	});
+
+	it("Given los headers de la tabla When se renderiza con data Then los muestra", () => {
+		// Arrange + Act
+		render(<VisitsTable items={[ROW]} />);
+
+		// Assert
+		expect(screen.getByText("Inicio")).toBeInTheDocument();
+		expect(screen.getByText("Pais")).toBeInTheDocument();
+		expect(screen.getByText("Niche")).toBeInTheDocument();
+		expect(screen.getByText("Referrer")).toBeInTheDocument();
+		expect(screen.getByText("Landing")).toBeInTheDocument();
+		expect(screen.getByText("Eventos")).toBeInTheDocument();
+	});
+
+	it('Given una visita con country/niche/referrer/landing nulos When se renderiza Then muestra "-" en esas celdas', () => {
+		// Arrange
+		const nullRow: VisitRow = {
+			...ROW,
+			visit_id: "vis_null",
+			country: null,
+			niche: null,
+			referrer: null,
+			landing_page_path: null,
+		};
+
+		// Act
+		render(<VisitsTable items={[nullRow]} />);
+		const row = screen.getByText("3").closest("tr");
+		if (!row) throw new Error("fila de la visita null no encontrada");
+
+		// Assert: country, niche, referrer, landing caen al fallback "-"
+		const dashes = within(row).getAllByText("-");
+		expect(dashes).toHaveLength(4);
+	});
+});

--- a/admin/tests/unit/features/visits/use-landing-pages.test.tsx
+++ b/admin/tests/unit/features/visits/use-landing-pages.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useLandingPages } from "@/features/visits/hooks/use-landing-pages";
+
+/**
+ * @module tests/unit/features/visits/use-landing-pages
+ * @description useLandingPages: devuelve el ranking de landing pages
+ *   (visits/landing-pages) desempaquetado del envelope.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useLandingPages", () => {
+	it("Given un rango + limit When la query resuelve Then devuelve el ranking de landing pages", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() =>
+				useLandingPages({
+					from: "2026-04-27",
+					to: "2026-05-28",
+					limit: 10,
+				}),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items).toHaveLength(1);
+		expect(result.current.data?.items[0]?.landing_page_path).toBe("/");
+		expect(result.current.data?.items[0]?.visits).toBe(40);
+		expect(result.current.data?.items[0]?.unique_visitors).toBe(30);
+	});
+
+	it("Given solo el rango sin limit When la query resuelve Then resuelve igual", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() => useLandingPages({ from: "2026-04-27", to: "2026-05-28" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items[0]?.visits).toBe(40);
+	});
+});

--- a/admin/tests/unit/features/visits/use-visits-list.test.tsx
+++ b/admin/tests/unit/features/visits/use-visits-list.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { useVisitsList } from "@/features/visits/hooks/use-visits-list";
+
+/**
+ * @module tests/unit/features/visits/use-visits-list
+ * @description useVisitsList: deriva offset desde page/page_size y devuelve la
+ *   pagina de visitas (visits/list) desempaquetada del envelope.
+ */
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useVisitsList", () => {
+	it("Given un rango + page When la query resuelve Then devuelve la pagina de visitas", async () => {
+		// Arrange + Act
+		const { result } = renderHook(
+			() =>
+				useVisitsList({
+					from: "2026-04-27",
+					to: "2026-05-28",
+					page: 1,
+					page_size: 20,
+				}),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.total).toBe(1);
+		expect(result.current.data?.items).toHaveLength(1);
+		expect(result.current.data?.items[0]?.visit_id).toBe("vis_1");
+	});
+
+	it("Given params sin page ni page_size When la query resuelve Then usa los defaults y resuelve", async () => {
+		// Arrange + Act: page=1, page_size=20, offset=0 derivados por defecto
+		const { result } = renderHook(
+			() => useVisitsList({ from: "2026-04-27", to: "2026-05-28" }),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.page).toBe(1);
+		expect(result.current.data?.page_size).toBe(20);
+		expect(result.current.data?.has_more).toBe(false);
+	});
+
+	it("Given page=3 con page_size=10 When la query resuelve Then deriva offset=20 sin romper", async () => {
+		// Arrange + Act: el offset derivado (page-1)*page_size se pasa al client
+		const { result } = renderHook(
+			() =>
+				useVisitsList({
+					from: "2026-04-27",
+					to: "2026-05-28",
+					page: 3,
+					page_size: 10,
+				}),
+			{ wrapper: makeWrapper() },
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		expect(result.current.data?.items[0]?.session_id).toBe("sess_1");
+	});
+});

--- a/admin/tests/unit/features/visits/visits-client.test.tsx
+++ b/admin/tests/unit/features/visits/visits-client.test.tsx
@@ -1,0 +1,71 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { visitsClient } from "@/features/visits/api/visits-client";
+
+/**
+ * @module tests/unit/features/visits/visits-client
+ * @description visitsClient.list y visitsClient.landingPages: cada fn hace
+ *   `GET /analytics?operation=visits&action=...` via fetchMetric y devuelve el
+ *   `data`. Usa el MSW handler de /analytics (tests/mocks/handlers/metrics).
+ */
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("visitsClient.list", () => {
+	it("Given un rango + paginacion When list Then devuelve la pagina de visitas", async () => {
+		// Act
+		const data = await visitsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+			page: 1,
+			page_size: 20,
+			offset: 0,
+		});
+
+		// Assert
+		expect(data.total).toBe(1);
+		expect(data.page).toBe(1);
+		expect(data.page_size).toBe(20);
+		expect(data.has_more).toBe(false);
+		expect(data.items).toHaveLength(1);
+	});
+
+	it("Given el fixture de visits/list When list Then la fila tiene el shape esperado", async () => {
+		// Act
+		const data = await visitsClient.list({
+			from: "2026-04-27",
+			to: "2026-05-28",
+		});
+
+		// Assert
+		const row = data.items[0];
+		expect(row?.visit_id).toBe("vis_1");
+		expect(row?.session_id).toBe("sess_1");
+		expect(row?.started_at).toBe("2026-05-01T10:00:00Z");
+		expect(row?.event_count).toBe(3);
+		expect(row?.country).toBe("AR");
+		expect(row?.referrer).toBe("(direct)");
+		expect(row?.landing_page_path).toBe("/");
+		expect(row?.niche).toBe("fintech");
+	});
+});
+
+describe("visitsClient.landingPages", () => {
+	it("Given un rango When landingPages Then devuelve el ranking de landing pages", async () => {
+		// Act
+		const data = await visitsClient.landingPages({
+			from: "2026-04-27",
+			to: "2026-05-28",
+			limit: 10,
+		});
+
+		// Assert
+		expect(data.items).toHaveLength(1);
+		expect(data.items[0]?.landing_page_path).toBe("/");
+		expect(data.items[0]?.visits).toBe(40);
+		expect(data.items[0]?.unique_visitors).toBe(30);
+	});
+});

--- a/admin/tests/unit/lib/metrics-client.test.ts
+++ b/admin/tests/unit/lib/metrics-client.test.ts
@@ -1,0 +1,48 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import { fetchMetric } from "@/lib/metrics-client";
+
+/**
+ * @module tests/unit/lib/metrics-client
+ * @description fetchMetric: arma el query string con operation/action + params,
+ *   omite los vacios, adjunta el Bearer y devuelve el `data` del Envelope.
+ *   Usa el MSW handler de /analytics (tests/mocks/handlers/metrics).
+ */
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("fetchMetric", () => {
+	it("Given operation+action validos When fetch Then devuelve el data del Envelope", async () => {
+		// Act
+		const data = await fetchMetric<{ sessions: number }>(
+			"analytics",
+			"overview",
+			{ from: "2026-04-27", to: "2026-05-27" },
+		);
+
+		// Assert
+		expect(data.sessions).toBe(100);
+	});
+
+	it("Given un action desconocido When fetch Then lanza ApiError 400", async () => {
+		// Act + Assert
+		await expect(
+			fetchMetric("analytics", "no-existe", {}),
+		).rejects.toMatchObject({ status: 400 });
+	});
+
+	it("Given params vacios/null When fetch Then los omite del query string", async () => {
+		// Act: el handler responde igual; el test verifica que no rompe con vacios
+		const data = await fetchMetric<{ active_sessions: number }>(
+			"analytics",
+			"active-now",
+			{ from: "", to: undefined, niche: null },
+		);
+
+		// Assert
+		expect(data.active_sessions).toBe(3);
+	});
+});


### PR DESCRIPTION
## Problema

1. El Lambda `analytics` (mergeado en PR #237) expone metricas de visitantes (sessions/visits/events/contacts) via `GET /analytics`, pero el admin no tenia UI para consumirlas — el area de metricas eran placeholders.

## Solucion

UI completa de metricas en `admin/`, una feature por dominio del backend (Hybrid Atomic Design), montada en el app shell del admin bajo `/metrics/*`:

1. **lib compartida**: `metrics-client` (GET `/analytics` con Bearer via el `apiFetch` existente + refresh rotation), `metrics-query-keys` (namespace `['metrics', ...]` + exclusion del persister para PII), `query-provider` no persiste `contacts`/`sessions` (PII), `routes` `/metrics/*`.
2. **8 features** (api client tipado + query-keys + hooks Tanstack Query + components + page):
   - `analytics`: overview (KPIs), timeseries, top-pages/referrers/niches, active-now (live 15s), retention — charts Recharts (Line/Bar/Pie).
   - `sessions` (tracking de visitantes): list + detail (`?id=`).
   - `events`: distribution + list (paginado) + heatmap (7x24).
   - `visits`: list + landing-pages. `geo`: by-country. `devices`: breakdown (3 charts). `funnel`: conversion. `contacts`: list (PII) + by-status.
3. **9 rutas estaticas** bajo `(admin)/metrics/*`. La sesion-detalle usa `/metrics/sessions/detail?id=<id>` (query param) en vez de `[id]` dinamica, incompatible con `output: 'export'`.
4. **Sidebar**: agrega el item "Metricas" (raiz del area; las sub-secciones se navegan desde `/metrics`).
5. **staleTime por endpoint** matcheando el TTL de cache del backend (agregadas 60s, listados 30s, active-now 10s + refetch 15s).

## Como probar

```bash
# typecheck + lint + tests (532 verdes, coverage >=80% per-file en los archivos nuevos)
pnpm --filter @portfolio/admin typecheck
pnpm --filter @portfolio/admin lint
pnpm --filter @portfolio/admin test:coverage

# build estatico (genera las 9 rutas /metrics/* en out/). Requiere las
# NEXT_PUBLIC_* de docker/env/client/.local inyectadas (el CI usa las GH Vars):
pnpm --filter @portfolio/admin build
ls admin/out/metrics/index.html admin/out/metrics/sessions/detail/index.html
```

Tras deploy a dev: login en `https://admin.portfolio.dev.the-full-stack.com` -> sidebar "Metricas" -> `/metrics` (KPIs + active-now + charts) y las sub-secciones. Cada GET `/analytics` lleva `Authorization: Bearer <JWT>` (via el api-client). El Lambda `analytics` ya esta vivo en dev (verificado en PR #237).

## TODO

- Los tests `turnstile-widget` (50% branch) y `api-client` (74% branch) quedan bajo el threshold per-file, pero son PREEXISTENTES de dev (no introducidos por este PR; el CI no gatea coverage del admin, solo build).
- Spec E2E Playwright de las pages de metricas (login -> navegar /metrics/*) — diferido (requiere stack + Turnstile bypass).
- Cerrar el plan `docs/specs/b-analytics-api/` (eliminar la carpeta) ahora que backend + UI estan completos — en un commit de limpieza posterior.