### PR TITLE
feat(analytics): /metrics en 1 request (action dashboard) en vez de 7

### DIFF
--- a/admin/src/app/(admin)/metrics/page.tsx
+++ b/admin/src/app/(admin)/metrics/page.tsx
@@ -11,28 +11,20 @@ import { TimeseriesChart } from "@/features/analytics/components/TimeseriesChart
 import { TopNichesChart } from "@/features/analytics/components/TopNichesChart";
 import { TopPagesTable } from "@/features/analytics/components/TopPagesTable";
 import { TopReferrersTable } from "@/features/analytics/components/TopReferrersTable";
+import { useDashboard } from "@/features/analytics/hooks/use-dashboard";
 import { useMetricsRange } from "@/features/analytics/hooks/use-metrics-range";
-import { useOverview } from "@/features/analytics/hooks/use-overview";
-import { useRetention } from "@/features/analytics/hooks/use-retention";
-import { useTimeseries } from "@/features/analytics/hooks/use-timeseries";
-import { useTopNiches } from "@/features/analytics/hooks/use-top-niches";
-import { useTopPages } from "@/features/analytics/hooks/use-top-pages";
-import { useTopReferrers } from "@/features/analytics/hooks/use-top-referrers";
 
 /**
  * @page MetricsOverviewPage
  * @description Raiz del area de metricas (`/metrics`): KPIs (overview),
- *   contador live (active-now), serie temporal (timeseries) y ranking de
- *   paginas (top-pages). El rango from/to es compartido por la page.
+ *   contador live (active-now), serie temporal (timeseries), rankings y
+ *   retencion. Una SOLA request (`analytics/dashboard`) trae las 7 vistas en
+ *   vez de 7 requests separadas; el rango from/to es compartido por la page.
  */
 export default function MetricsOverviewPage() {
 	const { range, setRange } = useMetricsRange();
-	const overview = useOverview(range);
-	const timeseries = useTimeseries({ ...range, bucket: "day" });
-	const topPages = useTopPages(range);
-	const topReferrers = useTopReferrers(range);
-	const topNiches = useTopNiches(range);
-	const retention = useRetention(range);
+	const dashboard = useDashboard({ ...range, bucket: "day" });
+	const data = dashboard.data;
 
 	return (
 		<section className="space-y-6">
@@ -40,14 +32,17 @@ export default function MetricsOverviewPage() {
 				<div className="flex items-center gap-3">
 					<BarChart3 className="h-5 w-5 text-muted-foreground" />
 					<h1 className="text-2xl font-semibold">Metricas</h1>
-					<ActiveNowBadge />
+					<ActiveNowBadge
+						count={data?.active_now.active_sessions}
+						standalone={false}
+					/>
 				</div>
 				<MetricsDateRange range={range} onChange={setRange} />
 			</header>
 
-			{overview.error ? <ErrorAlert error={overview.error} /> : null}
+			{dashboard.error ? <ErrorAlert error={dashboard.error} /> : null}
 
-			<OverviewKpis data={overview.data} isLoading={overview.isLoading} />
+			<OverviewKpis data={data?.overview} isLoading={dashboard.isLoading} />
 
 			<Card>
 				<CardHeader>
@@ -55,8 +50,8 @@ export default function MetricsOverviewPage() {
 				</CardHeader>
 				<CardContent>
 					<TimeseriesChart
-						data={timeseries.data}
-						isLoading={timeseries.isLoading}
+						data={data?.timeseries}
+						isLoading={dashboard.isLoading}
 					/>
 				</CardContent>
 			</Card>
@@ -67,11 +62,7 @@ export default function MetricsOverviewPage() {
 						<CardTitle>Paginas mas vistas</CardTitle>
 					</CardHeader>
 					<CardContent>
-						{topPages.error ? (
-							<ErrorAlert error={topPages.error} />
-						) : (
-							<TopPagesTable items={topPages.data?.items ?? []} />
-						)}
+						<TopPagesTable items={data?.top_pages.items ?? []} />
 					</CardContent>
 				</Card>
 
@@ -80,14 +71,10 @@ export default function MetricsOverviewPage() {
 						<CardTitle>Top referrers</CardTitle>
 					</CardHeader>
 					<CardContent>
-						{topReferrers.error ? (
-							<ErrorAlert error={topReferrers.error} />
-						) : (
-							<TopReferrersTable
-								label="Referrer"
-								items={topReferrers.data?.referrers ?? []}
-							/>
-						)}
+						<TopReferrersTable
+							label="Referrer"
+							items={data?.top_referrers.referrers ?? []}
+						/>
 					</CardContent>
 				</Card>
 
@@ -96,14 +83,10 @@ export default function MetricsOverviewPage() {
 						<CardTitle>Top niches</CardTitle>
 					</CardHeader>
 					<CardContent>
-						{topNiches.error ? (
-							<ErrorAlert error={topNiches.error} />
-						) : (
-							<TopNichesChart
-								data={topNiches.data}
-								isLoading={topNiches.isLoading}
-							/>
-						)}
+						<TopNichesChart
+							data={data?.top_niches}
+							isLoading={dashboard.isLoading}
+						/>
 					</CardContent>
 				</Card>
 
@@ -112,14 +95,10 @@ export default function MetricsOverviewPage() {
 						<CardTitle>Retencion</CardTitle>
 					</CardHeader>
 					<CardContent>
-						{retention.error ? (
-							<ErrorAlert error={retention.error} />
-						) : (
-							<RetentionChart
-								data={retention.data}
-								isLoading={retention.isLoading}
-							/>
-						)}
+						<RetentionChart
+							data={data?.retention}
+							isLoading={dashboard.isLoading}
+						/>
 					</CardContent>
 				</Card>
 			</div>

--- a/admin/src/features/analytics/api/analytics-client.ts
+++ b/admin/src/features/analytics/api/analytics-client.ts
@@ -1,6 +1,8 @@
 import { fetchMetric } from "@/lib/metrics-client";
 import type {
 	ActiveNowResponse,
+	DashboardParams,
+	DashboardResponse,
 	DateRangeParams,
 	OverviewResponse,
 	RetentionResponse,
@@ -40,4 +42,7 @@ export const analyticsClient = {
 
 	retention: (params: DateRangeParams) =>
 		fetchMetric<RetentionResponse>("analytics", "retention", { ...params }),
+
+	dashboard: (params: DashboardParams) =>
+		fetchMetric<DashboardResponse>("analytics", "dashboard", { ...params }),
 };

--- a/admin/src/features/analytics/api/query-keys.ts
+++ b/admin/src/features/analytics/api/query-keys.ts
@@ -1,5 +1,6 @@
 import { metricsKey } from "@/lib/metrics-query-keys";
 import type {
+	DashboardParams,
 	DateRangeParams,
 	TimeseriesParams,
 	TopPagesParams,
@@ -24,4 +25,6 @@ export const analyticsKeys = {
 	activeNow: () => metricsKey("analytics", "active-now"),
 	retention: (params: DateRangeParams) =>
 		metricsKey("analytics", "retention", params),
+	dashboard: (params: DashboardParams) =>
+		metricsKey("analytics", "dashboard", params),
 };

--- a/admin/src/features/analytics/components/ActiveNowBadge.tsx
+++ b/admin/src/features/analytics/components/ActiveNowBadge.tsx
@@ -6,13 +6,31 @@ import { useActiveNow } from "../hooks/use-active-now";
 
 /**
  * @component ActiveNowBadge
- * @description Contador live de sesiones activas (analytics/active-now), con
- *   refetch cada 15s. Punto verde pulsante + conteo. Si falla o carga, muestra
- *   un guion sin romper el layout.
+ * @description Contador live de sesiones activas (analytics/active-now). Punto
+ *   verde pulsante + conteo. Mientras carga o si falla, muestra un guion sin
+ *   romper el layout.
+ *
+ *   Dos modos:
+ *   - `standalone` (default): dispara su propia query `useActiveNow` (refetch
+ *     15s). Uso suelto del badge fuera de /metrics.
+ *   - `standalone={false}`: NO consulta — la page /metrics ya recibe active-now
+ *     en el payload de `analytics/dashboard` y lo pasa via `count`. Asi el
+ *     badge no agrega una request extra al fan-out unificado.
+ *
+ * @props {number} [count] - sesiones activas (del dashboard). Si es undefined
+ *   muestra el guion.
+ * @props {boolean} [standalone] - si dispara su propia query (default true).
  */
-export function ActiveNowBadge() {
-	const { data, isLoading, isError } = useActiveNow();
-	const count = isLoading || isError || !data ? "–" : data.active_sessions;
+export function ActiveNowBadge({
+	count: countProp,
+	standalone = true,
+}: {
+	count?: number;
+	standalone?: boolean;
+} = {}) {
+	const { data, isLoading, isError } = useActiveNow({ enabled: standalone });
+	const liveCount = isLoading || isError || !data ? "–" : data.active_sessions;
+	const count = standalone ? liveCount : (countProp ?? "–");
 
 	return (
 		<Badge variant="secondary" className="gap-2">

--- a/admin/src/features/analytics/hooks/use-active-now.ts
+++ b/admin/src/features/analytics/hooks/use-active-now.ts
@@ -9,12 +9,16 @@ import { analyticsKeys } from "../api/query-keys";
  * @description Contador live de sesiones activas (analytics/active-now).
  *   staleTime 10s + refetchInterval 15s (live; TTL backend 10s). NO depende
  *   del rango de fechas.
+ *
+ * @param options - `enabled` desactiva la query (default true). La page
+ *   /metrics lo apaga porque ya recibe active-now en el payload del dashboard.
  */
-export function useActiveNow() {
+export function useActiveNow({ enabled = true }: { enabled?: boolean } = {}) {
 	return useQuery({
 		queryKey: analyticsKeys.activeNow(),
 		queryFn: () => analyticsClient.activeNow(),
 		staleTime: 10_000,
 		refetchInterval: 15_000,
+		enabled,
 	});
 }

--- a/admin/src/features/analytics/hooks/use-dashboard.ts
+++ b/admin/src/features/analytics/hooks/use-dashboard.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { analyticsClient } from "../api/analytics-client";
+import { analyticsKeys } from "../api/query-keys";
+import type { DashboardParams } from "../types";
+
+/**
+ * @function useDashboard
+ * @description Una sola query que trae las 7 vistas del overview de /metrics
+ *   (analytics/dashboard): overview, timeseries, top-pages, top-referrers,
+ *   top-niches, active-now y retention. Reemplaza las 7 requests previas.
+ *
+ *   staleTime 10s + refetchInterval 15s para mantener vivo el contador
+ *   active-now incluido en el payload. Las 7 sub-vistas estan cacheadas en
+ *   el backend (60s las agregadas, 10s active-now), asi que el refetch cada
+ *   15s solo dispara una query real a Neon para active-now; el resto sale del
+ *   cache DDB del Lambda.
+ *
+ * @param params - rango (from/to) + bucket de la serie + limit de rankings
+ */
+export function useDashboard(params: DashboardParams) {
+	return useQuery({
+		queryKey: analyticsKeys.dashboard(params),
+		queryFn: () => analyticsClient.dashboard(params),
+		staleTime: 10_000,
+		refetchInterval: 15_000,
+	});
+}

--- a/admin/src/features/analytics/types.ts
+++ b/admin/src/features/analytics/types.ts
@@ -104,3 +104,23 @@ export interface RetentionResponse {
 	total: number;
 	returning_rate: number;
 }
+
+/** Params del dashboard: rango + bucket de la serie + limit de los rankings. */
+export interface DashboardParams extends DateRangeParams {
+	bucket?: "day" | "hour" | "week";
+	limit?: number;
+}
+
+/**
+ * analytics/dashboard — las 7 vistas del overview de /metrics en una sola
+ * respuesta. Cada clave espeja el `data` de la action homonima.
+ */
+export interface DashboardResponse {
+	overview: OverviewResponse;
+	timeseries: TimeseriesResponse;
+	top_pages: TopPagesResponse;
+	top_referrers: TopReferrersResponse;
+	top_niches: TopNichesResponse;
+	active_now: ActiveNowResponse;
+	retention: RetentionResponse;
+}

--- a/admin/tests/mocks/handlers/metrics.ts
+++ b/admin/tests/mocks/handlers/metrics.ts
@@ -4,8 +4,9 @@ import { HttpResponse, http } from "msw";
  * @module tests/mocks/handlers/metrics
  * @description MSW handler del Lambda `analytics` (`GET /analytics?operation=
  *   ...&action=...`). Responde un payload FLAT por (operation, action) — el
- *   api-client lo re-envuelve en `{is_valid, code, data}`. Cubre las 19 actions
- *   de las 8 features de metricas con data sintetica determinista.
+ *   api-client lo re-envuelve en `{is_valid, code, data}`. Cubre las 20 actions
+ *   de las 8 features de metricas con data sintetica determinista (incluye
+ *   `analytics:dashboard`, que combina las 7 vistas del overview).
  */
 
 const API = "https://api.test.the-full-stack.com";
@@ -208,6 +209,19 @@ const FIXTURES: Record<string, Record<string, unknown>> = {
 			{ status: "converted", count: 2, pct: 20.0 },
 		],
 	},
+};
+
+// La action `dashboard` combina las 7 vistas del overview en un solo payload
+// (cada clave reusa el fixture homonimo, para que dashboard y las granulares
+// no diverjan).
+FIXTURES["analytics:dashboard"] = {
+	overview: FIXTURES["analytics:overview"],
+	timeseries: FIXTURES["analytics:timeseries"],
+	top_pages: FIXTURES["analytics:top-pages"],
+	top_referrers: FIXTURES["analytics:top-referrers"],
+	top_niches: FIXTURES["analytics:top-niches"],
+	active_now: FIXTURES["analytics:active-now"],
+	retention: FIXTURES["analytics:retention"],
 };
 
 export const metricsHandlers = [

--- a/admin/tests/unit/app/metrics/page.test.tsx
+++ b/admin/tests/unit/app/metrics/page.test.tsx
@@ -1,0 +1,71 @@
+import { makeJwt } from "@tests/mocks/jwt";
+import { server } from "@tests/mocks/server";
+import { render, screen, waitFor } from "@tests/utils/render";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MetricsOverviewPage from "@/app/(admin)/metrics/page";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/app/metrics/page
+ * @description Regresion del fan-out de /metrics: la page debe disparar UNA
+ *   sola request a `/analytics` (action=dashboard) en vez de 7 (overview +
+ *   timeseries + top-pages + top-referrers + top-niches + active-now +
+ *   retention). Cuenta las requests GET interceptadas por MSW y asserta que
+ *   todas son `action=dashboard`.
+ */
+
+vi.mock("next/navigation", () => ({
+	useSearchParams: () => new URLSearchParams(),
+	useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+	usePathname: () => "/metrics",
+}));
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("MetricsOverviewPage", () => {
+	it("Given la page When monta Then dispara UNA sola request action=dashboard (no 7)", async () => {
+		// Arrange: cuento las acciones de cada GET a /analytics.
+		const actions: string[] = [];
+		server.events.on("request:start", ({ request }) => {
+			const url = new URL(request.url);
+			if (request.method === "GET" && url.pathname.endsWith("/analytics")) {
+				actions.push(url.searchParams.get("action") ?? "");
+			}
+		});
+
+		// Act
+		render(<MetricsOverviewPage />);
+
+		// Assert: espera a que resuelva (los KPIs del fixture aparecen).
+		await waitFor(() => {
+			expect(screen.getByText("Metricas")).toBeInTheDocument();
+		});
+		await waitFor(() => {
+			// El conteo del badge live viene del dashboard (3 activos del fixture).
+			expect(screen.getByText(/3 activos/)).toBeInTheDocument();
+		});
+
+		// Toda request a /analytics fue action=dashboard, y ninguna granular.
+		expect(actions.length).toBeGreaterThanOrEqual(1);
+		expect([...new Set(actions)]).toEqual(["dashboard"]);
+		expect(actions).not.toContain("overview");
+		expect(actions).not.toContain("active-now");
+
+		server.events.removeAllListeners("request:start");
+	});
+
+	it("Given el dashboard resuelto When render Then muestra los KPIs del overview", async () => {
+		// Arrange + Act
+		render(<MetricsOverviewPage />);
+
+		// Assert: el KPI Sesiones del fixture (100) se renderiza.
+		await waitFor(() => {
+			expect(screen.getByText("Sesiones")).toBeInTheDocument();
+		});
+		await waitFor(() => {
+			expect(screen.getByText("100")).toBeInTheDocument();
+		});
+	});
+});

--- a/admin/tests/unit/features/analytics/ActiveNowBadge.test.tsx
+++ b/admin/tests/unit/features/analytics/ActiveNowBadge.test.tsx
@@ -94,4 +94,41 @@ describe("ActiveNowBadge", () => {
 			);
 		});
 	});
+
+	it("Given standalone=false + count por prop (del dashboard) When render Then lo usa directo", () => {
+		// Arrange: el backend devolveria 3, pero standalone=false NO consulta y
+		// la prop manda (la page /metrics ya trae active-now en el dashboard).
+		// Act
+		const { container } = render(
+			<ActiveNowBadge count={7} standalone={false} />,
+			{ wrapper: Wrapper },
+		);
+
+		// Assert
+		expect(container.textContent?.replace(/\s+/g, " ")).toContain("7 activos");
+	});
+
+	it("Given standalone=false + count=1 When render Then usa el singular", () => {
+		// Arrange + Act
+		const { container } = render(
+			<ActiveNowBadge count={1} standalone={false} />,
+			{ wrapper: Wrapper },
+		);
+
+		// Assert
+		expect(container.textContent?.replace(/\s+/g, " ")).toContain("1 activo");
+		expect(container.textContent?.replace(/\s+/g, " ")).not.toContain(
+			"1 activos",
+		);
+	});
+
+	it("Given standalone=false sin count When render Then muestra el guion (sin consultar)", () => {
+		// Arrange + Act: estado mientras el dashboard aun no resolvio.
+		const { container } = render(<ActiveNowBadge standalone={false} />, {
+			wrapper: Wrapper,
+		});
+
+		// Assert
+		expect(container.textContent?.replace(/\s+/g, " ")).toContain("– activos");
+	});
 });

--- a/admin/tests/unit/features/analytics/use-dashboard.test.tsx
+++ b/admin/tests/unit/features/analytics/use-dashboard.test.tsx
@@ -1,0 +1,56 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { makeJwt } from "@tests/mocks/jwt";
+import { renderHook, waitFor } from "@tests/utils/render";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useDashboard } from "@/features/analytics/hooks/use-dashboard";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+
+/**
+ * @module tests/unit/features/analytics/use-dashboard
+ * @description useDashboard: una sola query resuelve analytics/dashboard y
+ *   devuelve las 7 vistas (overview/timeseries/top_pages/top_referrers/
+ *   top_niches/active_now/retention) desempaquetadas del Envelope. La data
+ *   sintetica del MSW handler de metrics combina los fixtures granulares.
+ */
+
+const PARAMS = { from: "2026-04-27", to: "2026-05-28", bucket: "day" } as const;
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, refetchInterval: false },
+		},
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+beforeEach(() => {
+	useAuthStore.setState({ accessToken: makeJwt({ sub: "usr_01" }) });
+});
+
+describe("useDashboard", () => {
+	it("Given un rango When la query resuelve Then devuelve las 7 vistas en un solo payload", async () => {
+		// Arrange + Act
+		const { result } = renderHook(() => useDashboard(PARAMS), {
+			wrapper: makeWrapper(),
+		});
+
+		// Assert
+		await waitFor(() => {
+			expect(result.current.isSuccess).toBe(true);
+		});
+		const data = result.current.data;
+		expect(data?.overview.sessions).toBe(100);
+		expect(data?.timeseries.points).toHaveLength(2);
+		expect(data?.top_pages.items[0]?.page_path).toBe("/");
+		expect(data?.top_referrers.referrers[0]?.referrer).toBe("(direct)");
+		expect(data?.top_niches.items[0]?.niche).toBe("fintech");
+		expect(data?.active_now.active_sessions).toBe(3);
+		expect(data?.retention.returning_rate).toBe(0.2);
+	});
+});

--- a/serverless/lambda/services/analytics/README.md
+++ b/serverless/lambda/services/analytics/README.md
@@ -10,9 +10,9 @@ habilitado (`snap_start: true` + `warm_db()` en el INIT).
 
 Patron: `lambda-controller` (operation + action -> controller + service).
 
-## Operations (8) / actions (19)
+## Operations (8) / actions (20)
 
-- `analytics`: overview, timeseries, top-pages, top-referrers, top-niches, active-now, retention
+- `analytics`: overview, timeseries, top-pages, top-referrers, top-niches, active-now, retention, dashboard
 - `events`: distribution, list, heatmap
 - `sessions`: list, detail
 - `visits`: list, landing-pages

--- a/serverless/lambda/services/analytics/core/controllers/analytics/dashboard.py
+++ b/serverless/lambda/services/analytics/core/controllers/analytics/dashboard.py
@@ -1,0 +1,26 @@
+"""Controller analytics/dashboard — las 7 vistas del overview en 1 request."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from controllers._base import AnalyticsControllerBase
+from models.analytics import DashboardInput
+
+
+class Dashboard(AnalyticsControllerBase):
+    """Agrega overview/timeseries/top-pages/top-referrers/top-niches/
+    active-now/retention del rango en una sola respuesta.
+    """
+
+    event_model = DashboardInput
+    service_module = 'services.analytics_service'
+    service_name = 'dashboard'
+
+    def service_kwargs(self, data: DashboardInput) -> dict[str, Any]:
+        return {
+            'date_from': data.date_from,
+            'date_to': data.date_to_exclusive(),
+            'bucket': data.bucket,
+            'limit': data.limit,
+        }

--- a/serverless/lambda/services/analytics/core/models/analytics.py
+++ b/serverless/lambda/services/analytics/core/models/analytics.py
@@ -1,10 +1,12 @@
-"""Modelos Pydantic de la operacion `analytics` (7 actions).
+"""Modelos Pydantic de la operacion `analytics` (8 actions).
 
 - overview / retention: solo rango (heredan DateRange).
 - timeseries: rango + bucket (day|hour|week) + niche/event_type opcionales.
 - top-pages / top-niches: rango + limit (+ niche en top-pages).
 - top-referrers: rango + limit.
 - active-now: SIN rango (solo _meta) — modelo aparte que NO hereda DateRange.
+- dashboard: union de los params de las 7 actions del overview de /metrics
+  (rango + bucket + limit). Una sola request que agrega las 7 vistas.
 """
 
 from __future__ import annotations
@@ -74,6 +76,22 @@ class ActiveNowInput(BaseModel):
 class RetentionInput(DateRange):
     """GET ?operation=analytics&action=retention&from=&to="""
 
+    meta: RequestMeta = Field(default_factory=RequestMeta, alias='_meta')
+
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
+class DashboardInput(DateRange):
+    """GET ?operation=analytics&action=dashboard&from=&to=&bucket=&limit=
+
+    Union de los params de las 7 vistas del overview de /metrics:
+    rango (from/to), bucket de la serie temporal (day|hour|week) y limit
+    de los rankings (top-pages/referrers/niches). Una sola request que
+    devuelve las 7 vistas agregadas + el contador live (active-now).
+    """
+
+    bucket: str = Field(default='day', pattern='^(day|hour|week)$')
+    limit: int = Field(default=_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX)
     meta: RequestMeta = Field(default_factory=RequestMeta, alias='_meta')
 
     model_config = ConfigDict(populate_by_name=True, extra='ignore')

--- a/serverless/lambda/services/analytics/core/services/analytics_service.py
+++ b/serverless/lambda/services/analytics/core/services/analytics_service.py
@@ -1,10 +1,11 @@
 """Service de la operacion `analytics`: KPIs y agregaciones del visitante.
 
-7 funciones publicas (una por action). Todas las agregadas van cacheadas
-60s (active-now solo 10s con tag 'analytics-live'). Cada funcion envuelve
-su query en try/except -> ServiceError. La convencion de rango es half-open:
-el caller pasa `date_to` ya EXCLUSIVO (date_to_exclusive del DateRange), el
-SQL usa `< date_to` directo (NUNCA suma 1 dia aca).
+8 funciones publicas (una por action). Las 7 agregadas van cacheadas 60s
+(active-now solo 10s con tag 'analytics-live'); `dashboard` NO se cachea —
+es un orquestador delgado sobre las otras 7 (que ya cachean cada una). Cada
+funcion envuelve su query en try/except -> ServiceError. La convencion de
+rango es half-open: el caller pasa `date_to` ya EXCLUSIVO (date_to_exclusive
+del DateRange), el SQL usa `< date_to` directo (NUNCA suma 1 dia aca).
 """
 
 from __future__ import annotations
@@ -436,4 +437,41 @@ def retention(*, date_from: date, date_to: date) -> dict[str, Any]:
         'returning_visitors': returning_visitors,
         'total': total,
         'returning_rate': _rate(returning_visitors, total),
+    }
+
+
+def dashboard(
+    *,
+    date_from: date,
+    date_to: date,
+    bucket: str = 'day',
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Agrega las 7 vistas del overview de /metrics en UN solo resultado.
+
+    Reemplaza las 7 requests del admin por una sola: orquesta las funciones
+    ya cacheadas (overview/timeseries/top_pages/top_referrers/top_niches/
+    active_now/retention) y devuelve cada `data` bajo su clave. NO se cachea
+    aca: cada sub-funcion mantiene su propio cache (60s las agregadas, 10s
+    active-now), asi una sub-vista expira sin invalidar las demas.
+
+    `date_to` es EXCLUSIVO (el caller pasa date_to_exclusive). Cualquier
+    ServiceError de una sub-funcion se propaga (la maneja el controller).
+    """
+    return {
+        'overview': overview(date_from=date_from, date_to=date_to),
+        'timeseries': timeseries(
+            date_from=date_from, date_to=date_to, bucket=bucket
+        ),
+        'top_pages': top_pages(
+            date_from=date_from, date_to=date_to, limit=limit
+        ),
+        'top_referrers': top_referrers(
+            date_from=date_from, date_to=date_to, limit=limit
+        ),
+        'top_niches': top_niches(
+            date_from=date_from, date_to=date_to, limit=limit
+        ),
+        'active_now': active_now(),
+        'retention': retention(date_from=date_from, date_to=date_to),
     }

--- a/serverless/lambda/services/analytics/core/settings/operations.py
+++ b/serverless/lambda/services/analytics/core/settings/operations.py
@@ -1,6 +1,6 @@
 """Mapeo de operaciones del Lambda `analytics`.
 
-8 operations (un dominio de metricas cada una), 19 actions en total. Cada
+8 operations (un dominio de metricas cada una), 20 actions en total. Cada
 operation declara su carpeta de controllers (`controller`); el
 `import_controller` resuelve la action del query string del GET por
 convencion en `controllers/<controller>/<action>.py` (clase en PascalCase:

--- a/serverless/lambda/services/analytics/events/dashboard.json
+++ b/serverless/lambda/services/analytics/events/dashboard.json
@@ -1,0 +1,24 @@
+{
+  "httpMethod": "GET",
+  "path": "/analytics",
+  "queryStringParameters": {
+    "operation": "analytics",
+    "action": "dashboard",
+    "from": "2026-04-27",
+    "to": "2026-05-27",
+    "bucket": "day",
+    "limit": "10"
+  },
+  "headers": {
+    "x-forwarded-for": "203.0.113.42",
+    "cloudfront-viewer-country": "AR",
+    "user-agent": "curl/8.0",
+    "authorization": "Bearer REPLACE_WITH_VALID_ACCESS_JWT"
+  },
+  "requestContext": {
+    "requestId": "test-analytics-dashboard-001",
+    "identity": { "sourceIp": "203.0.113.42" }
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/serverless/lambda/services/analytics/tests/unit/controllers/test_dashboard_controller_when_valid_then_calls_service.py
+++ b/serverless/lambda/services/analytics/tests/unit/controllers/test_dashboard_controller_when_valid_then_calls_service.py
@@ -1,0 +1,50 @@
+"""
+Given un evento valido de analytics/dashboard con JWT y service mockeado,
+When el controller ejecuta (auth no-op + rate-limit no-op),
+Then llama al service con date_from/date_to_exclusive/bucket/limit y
+normaliza el shape.
+"""
+
+from datetime import date
+
+import services.analytics_service as analytics_service
+from controllers.analytics.dashboard import Dashboard
+
+
+def test_dashboard_controller_when_valid_then_calls_service(
+    mocker, mock_require_auth, mock_check_or_raise
+):
+    # Arrange
+    expected = {
+        'overview': {'sessions': 10},
+        'timeseries': {'points': []},
+        'top_pages': {'items': []},
+        'top_referrers': {'referrers': []},
+        'top_niches': {'items': []},
+        'active_now': {'active_sessions': 2},
+        'retention': {'total': 0},
+    }
+    spy = mocker.patch.object(
+        analytics_service, 'dashboard', return_value=expected
+    )
+    event = {
+        'from': '2026-04-27',
+        'to': '2026-05-27',
+        'bucket': 'day',
+        'limit': '10',
+        '_meta': {'ip': '1.2.3.4', 'authorization': 'Bearer x'},
+    }
+    controller = Dashboard({**event})
+
+    # Act
+    controller.validate()
+    result = controller.execute()
+
+    # Assert
+    assert result == {'is_valid': True, 'data': expected, 'code': 0}
+    spy.assert_called_once_with(
+        date_from=date(2026, 4, 27),
+        date_to=date(2026, 5, 28),
+        bucket='day',
+        limit=10,
+    )

--- a/serverless/lambda/services/analytics/tests/unit/models/test_dashboard_input_defaults_and_kwargs.py
+++ b/serverless/lambda/services/analytics/tests/unit/models/test_dashboard_input_defaults_and_kwargs.py
@@ -1,0 +1,29 @@
+"""
+Given una request de dashboard sin bucket/limit explicitos,
+When se valida DashboardInput,
+Then bucket='day', limit=10 y date_to_exclusive = date_to + 1 dia.
+"""
+
+from datetime import date
+
+from models.analytics import DashboardInput
+
+
+def test_dashboard_input_defaults_and_date_to_exclusive():
+    # Arrange
+    raw = {
+        'from': '2026-04-27',
+        'to': '2026-05-27',
+        '_meta': {'ip': '1.2.3.4', 'authorization': 'Bearer x'},
+    }
+
+    # Act
+    parsed = DashboardInput.model_validate(raw)
+
+    # Assert: defaults de bucket/limit
+    assert parsed.bucket == 'day'
+    assert parsed.limit == 10
+    # Assert: rango half-open (date_to EXCLUSIVO = to + 1)
+    assert parsed.date_from == date(2026, 4, 27)
+    assert parsed.date_to == date(2026, 5, 27)
+    assert parsed.date_to_exclusive() == date(2026, 5, 28)

--- a/serverless/lambda/services/analytics/tests/unit/services/test_analytics_dashboard_when_called_then_aggregates_seven_views.py
+++ b/serverless/lambda/services/analytics/tests/unit/services/test_analytics_dashboard_when_called_then_aggregates_seven_views.py
@@ -1,0 +1,70 @@
+"""
+Given las 7 funciones agregadas del service mockeadas,
+When se invoca analytics_service.dashboard con rango/bucket/limit,
+Then las llama una vez cada una (con los kwargs correctos) y devuelve un
+solo dict con las 7 vistas bajo su clave.
+"""
+
+from datetime import date
+
+import services.analytics_service as analytics_service
+
+
+def test_analytics_dashboard_when_called_then_aggregates_seven_views(mocker):
+    # Arrange: cada sub-funcion devuelve un marcador identificable.
+    overview = mocker.patch.object(
+        analytics_service, 'overview', return_value={'k': 'overview'}
+    )
+    timeseries = mocker.patch.object(
+        analytics_service, 'timeseries', return_value={'k': 'timeseries'}
+    )
+    top_pages = mocker.patch.object(
+        analytics_service, 'top_pages', return_value={'k': 'top_pages'}
+    )
+    top_referrers = mocker.patch.object(
+        analytics_service, 'top_referrers', return_value={'k': 'top_referrers'}
+    )
+    top_niches = mocker.patch.object(
+        analytics_service, 'top_niches', return_value={'k': 'top_niches'}
+    )
+    active_now = mocker.patch.object(
+        analytics_service, 'active_now', return_value={'k': 'active_now'}
+    )
+    retention = mocker.patch.object(
+        analytics_service, 'retention', return_value={'k': 'retention'}
+    )
+    date_from = date(2026, 4, 27)
+    date_to = date(2026, 5, 28)
+
+    # Act
+    result = analytics_service.dashboard(
+        date_from=date_from, date_to=date_to, bucket='week', limit=5
+    )
+
+    # Assert: shape combinado
+    assert result == {
+        'overview': {'k': 'overview'},
+        'timeseries': {'k': 'timeseries'},
+        'top_pages': {'k': 'top_pages'},
+        'top_referrers': {'k': 'top_referrers'},
+        'top_niches': {'k': 'top_niches'},
+        'active_now': {'k': 'active_now'},
+        'retention': {'k': 'retention'},
+    }
+
+    # Assert: cada sub-funcion llamada una vez con los kwargs correctos
+    overview.assert_called_once_with(date_from=date_from, date_to=date_to)
+    timeseries.assert_called_once_with(
+        date_from=date_from, date_to=date_to, bucket='week'
+    )
+    top_pages.assert_called_once_with(
+        date_from=date_from, date_to=date_to, limit=5
+    )
+    top_referrers.assert_called_once_with(
+        date_from=date_from, date_to=date_to, limit=5
+    )
+    top_niches.assert_called_once_with(
+        date_from=date_from, date_to=date_to, limit=5
+    )
+    active_now.assert_called_once_with()
+    retention.assert_called_once_with(date_from=date_from, date_to=date_to)


### PR DESCRIPTION
## Problema

La page `/metrics` del admin disparaba 7 requests en paralelo al Lambda `analytics` para pintar el overview: `overview`, `timeseries`, `top-pages`, `top-referrers`, `top-niches`, `active-now` y `retention` (mas el refetch cada 15s de `active-now`). Cada carga del dashboard = fan-out de ~7-8 fetches, visible en la pestana Network.

## Solucion

Una nueva action `analytics.dashboard` que agrega las 7 vistas en una sola respuesta, y el admin la consume con un solo hook.

**Backend** (`d80e5346`):
- `DashboardInput` (union de rango + `bucket` + `limit` de las 7 actions del overview).
- `analytics_service.dashboard()` orquesta las 7 funciones ya cacheadas (overview/timeseries/top_pages/top_referrers/top_niches/active_now/retention) y devuelve cada `data` bajo su clave. NO cachea aca: cada sub-funcion mantiene su propio cache (60s agregadas, 10s active-now), asi una sub-vista expira sin invalidar las demas.
- Controller `analytics/dashboard.py` (clase `Dashboard`), descubierto por convencion (sin tocar `OPERATIONS`).
- Event fixture `events/dashboard.json` + tests (modelo, service, controller). 59 unit pass, 100% coverage en los archivos nuevos, lint-deps OK.

**Frontend** (`664caa52`):
- La page `/metrics` pasa de 7 hooks a un solo `useDashboard` (refetch 15s para mantener vivo el contador `active-now` incluido en el payload). Las 7 sub-vistas estan cacheadas en backend, asi que el refetch solo dispara una query real a Neon para `active-now`; el resto sale del cache DDB del Lambda.
- `ActiveNowBadge` acepta `count` + `standalone`: en `/metrics` (`standalone={false}`) NO dispara su propia query (evita una 8a request); suelto sigue consultando con `useActiveNow`.
- `useActiveNow` acepta `enabled` para apagarse cuando el badge no es standalone.
- Tipos `DashboardResponse`/`DashboardParams`, client `analyticsClient.dashboard`, query-key.
- Conserva los hooks granulares (`use-overview`, etc.) para uso futuro.
- MSW: fixture `analytics:dashboard` que combina los 7 granulares.

## Como probar

Local:
- Backend: `python devtools/run.py serverless tests --type=unit --lambda=analytics` (59 pass) + `serverless lint-deps --lambda=analytics`.
- Frontend: `pnpm --filter @portfolio/admin test` (538 pass) + `typecheck` + `lint` + `build`.
- Test de regresion clave: `tests/unit/app/metrics/page.test.tsx` asserta que la page dispara UNA sola request `action=dashboard` y cero granulares.

Tras el deploy a dev (Parte C, post-merge):
- `curl 'https://api.portfolio.dev.the-full-stack.com/analytics?operation=analytics&action=dashboard&from=...&to=...'` con `Authorization: Bearer <access JWT>` -> devuelve `{overview, timeseries, top_pages, top_referrers, top_niches, active_now, retention}` en un solo body.
- Abrir `https://admin.portfolio.dev.the-full-stack.com/metrics`, mirar Network: una sola fila `analytics?...action=dashboard` (mas el refetch cada 15s del mismo dashboard), en vez de las ~7-8 previas.

## TODO

- Las otras sub-rutas de `/metrics/*` (events, sessions, geo, etc.) siguen con sus queries propias por dominio; si en el futuro alguna pantalla concentra varias vistas, replicar el patron de agregacion.