### PR TITLE
fix(admin): la sesion sobrevive al reload aunque falte user en el storage

### DIFF
--- a/admin/src/features/auth/hooks/use-protected-route.ts
+++ b/admin/src/features/auth/hooks/use-protected-route.ts
@@ -20,8 +20,17 @@ import { useAuthStore } from "../store/use-auth-store";
 export function useProtectedRoute(): boolean {
 	const router = useRouter();
 	const pathname = usePathname();
+	// Suscribirse a accessToken (NO solo a la fn isAuthenticated): asi el
+	// componente re-renderiza cuando el bootstrap hidrata el access desde el
+	// refresh, y `authed` se recomputa con el token fresco. Sin esto, el
+	// re-render lo disparaba solo `bootstrapping` y `authed` podia quedar
+	// stale (false) -> redirect erroneo a /login pese a tener access valido.
+	const accessToken = useAuthStore((s) => s.accessToken);
 	const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 	const bootstrapping = useAuthStore((s) => s.bootstrapping);
+	// accessToken se referencia para que el linter no lo marque sin uso; el
+	// valor real lo lee isAuthenticated() del store.
+	void accessToken;
 	const authed = isAuthenticated();
 
 	useEffect(() => {

--- a/admin/src/features/auth/store/use-auth-store.ts
+++ b/admin/src/features/auth/store/use-auth-store.ts
@@ -98,9 +98,15 @@ export const useAuthStore = create<AuthState>()(
 			clearTokens: () => set({ ...EMPTY }),
 			reset: () => set({ ...EMPTY }),
 
+			// La sesion vive si hay un access JWT valido y no expirado. NO se
+			// exige `user`: es solo data de perfil para la UI, y el
+			// `/session/refresh` NO lo devuelve (solo access+refresh). Exigir
+			// `user` rompia la persistencia tras reload cuando el storage no lo
+			// tenia (entrada vieja/parcial) aunque el refresh hubiera hidratado
+			// un access valido -> redirect erroneo a /login.
 			isAuthenticated: () => {
-				const { accessToken, user } = get();
-				if (!accessToken || !user) return false;
+				const { accessToken } = get();
+				if (!accessToken) return false;
 				return !get().isAccessExpired();
 			},
 

--- a/admin/tests/unit/features/auth/components/auth-guard-reload-repro.test.tsx
+++ b/admin/tests/unit/features/auth/components/auth-guard-reload-repro.test.tsx
@@ -1,0 +1,107 @@
+import { makeJwt, nowSec } from "@tests/mocks/jwt";
+import { render, screen, waitFor } from "@tests/utils/render";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthGuard } from "@/features/auth/components/auth-guard";
+import { useAuthStore } from "@/features/auth/store/use-auth-store";
+import type { User } from "@/types/models";
+
+/**
+ * @module tests/unit/features/auth/components/auth-guard-reload-repro
+ * @description Reproduce el bug REAL "F5 -> /login": tras un reload el store se
+ *   rehidrata SOLO de localStorage, el access es null, y el `/session/refresh`
+ *   NO devuelve user (igual que prod). La sesion debe sostenerse en base al
+ *   access JWT, INDEPENDIENTE de si `user` esta presente.
+ */
+
+const { replaceMock } = vi.hoisted(() => ({ replaceMock: vi.fn() }));
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), replace: replaceMock }),
+	usePathname: () => "/",
+}));
+
+const USER: User = {
+	id: "019e8b33-6b48-7833-93d5-996d35d75fd5",
+	email: "u@t.com",
+	status: "active",
+	has_password: false,
+	mfa_methods: [],
+};
+
+function seedPersisted(state: Record<string, unknown>): void {
+	localStorage.setItem(
+		"portfolio-admin-auth",
+		JSON.stringify({ state, version: 0 }),
+	);
+}
+
+beforeEach(() => {
+	replaceMock.mockClear();
+	localStorage.clear();
+	useAuthStore.getState().reset();
+	// `reset()` NO toca `bootstrapping` (lo gobiernan los hooks de bootstrap).
+	// En un reload real el store nace con bootstrapping=true; lo restauramos
+	// aca para que cada caso parta del estado post-reload, no del residual del
+	// test anterior.
+	useAuthStore.getState().setBootstrapping(true);
+});
+
+describe("AuthGuard tras reload (rehidratacion real de localStorage)", () => {
+	it("Given una sesion persistida CON user y luego reload When monta Then NO redirige y muestra children", async () => {
+		// Arrange: el persist deja refreshToken + refreshExpiry + user.
+		const refreshToken = makeJwt({ sub: USER.id, exp: nowSec() + 2_592_000 });
+		seedPersisted({
+			refreshToken,
+			refreshExpiry: (nowSec() + 2_592_000) * 1000,
+			user: USER,
+		});
+		await useAuthStore.persist.rehydrate();
+		expect(useAuthStore.getState().accessToken).toBe(null);
+
+		// Act
+		render(
+			(
+				<AuthGuard>
+					<p>protegido</p>
+				</AuthGuard>
+			) as ReactElement,
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(screen.getByText("protegido")).toBeInTheDocument();
+		});
+		expect(replaceMock).not.toHaveBeenCalled();
+	});
+
+	it("Given una sesion persistida SIN user (storage viejo/parcial) y reload When el refresh OK (que NO trae user) Then sostiene la sesion por el access JWT, NO redirige", async () => {
+		// Arrange: localStorage SIN user (ej. entrada previa al user-in-partialize,
+		// o un refresh-only). El /session/refresh del backend NO devuelve user.
+		const refreshToken = makeJwt({ sub: USER.id, exp: nowSec() + 2_592_000 });
+		seedPersisted({
+			refreshToken,
+			refreshExpiry: (nowSec() + 2_592_000) * 1000,
+			// user ausente a proposito
+		});
+		await useAuthStore.persist.rehydrate();
+		expect(useAuthStore.getState().accessToken).toBe(null);
+		expect(useAuthStore.getState().user).toBe(null);
+
+		// Act
+		render(
+			(
+				<AuthGuard>
+					<p>protegido</p>
+				</AuthGuard>
+			) as ReactElement,
+		);
+
+		// Assert: con un access JWT valido tras el refresh, la sesion vive aunque
+		// user sea null. ANTES del fix esto redirigia a /login (isAuthenticated
+		// exigia user) -> ESTE es el bug reportado.
+		await waitFor(() => {
+			expect(screen.getByText("protegido")).toBeInTheDocument();
+		});
+		expect(replaceMock).not.toHaveBeenCalled();
+	});
+});

--- a/admin/tests/unit/features/auth/store/use-auth-store.test.ts
+++ b/admin/tests/unit/features/auth/store/use-auth-store.test.ts
@@ -83,6 +83,28 @@ describe("useAuthStore", () => {
 		expect(result).toBe(true);
 	});
 
+	it("Given un access vigente SIN user When isAuthenticated Then retorna true (auth = access JWT, no perfil)", () => {
+		// Arrange: regresion del bug "F5 -> /login". El /session/refresh NO
+		// devuelve user; tras un reload el user puede faltar en localStorage.
+		// La sesion debe vivir igual mientras el access JWT sea valido.
+		useAuthStore
+			.getState()
+			.setAccessToken(makeJwt({ sub: "usr_01", exp: nowSec() + 900 }));
+
+		// Act + Assert
+		expect(useAuthStore.getState().user).toBe(null);
+		expect(useAuthStore.getState().isAuthenticated()).toBe(true);
+	});
+
+	it("Given user presente pero SIN access When isAuthenticated Then retorna false", () => {
+		// Arrange: sin access JWT no hay sesion, aunque haya perfil.
+		useAuthStore.getState().setUser(USER);
+
+		// Act + Assert
+		expect(useAuthStore.getState().accessToken).toBe(null);
+		expect(useAuthStore.getState().isAuthenticated()).toBe(false);
+	});
+
 	it("Given estado seteado When clearTokens Then limpia todo", () => {
 		// Arrange
 		useAuthStore.getState().setTokens("a", "r", USER, nowSec() * 1000 + 1000);


### PR DESCRIPTION
## Problema

Al recargar (F5) `https://admin.portfolio.dev.the-full-stack.com`, el admin redirige a `/login?next=%2F` aunque haya una sesion valida. En la pestana Network se ve que `POST /auth {operation: session, action: refresh}` **se ejecuta y responde 200** con tokens nuevos (`access_token`, `refresh_token`, `expires_in`, `token_type`) — pero igual rebota al login.

**Causa raiz**: `isAuthenticated()` del store exigia `user` no-null:
```ts
if (!accessToken || !user) return false;
```
El `/session/refresh` del backend NO devuelve `user` (solo access+refresh). Tras un reload, si el `user` faltaba en localStorage (entrada vieja/parcial, o una sesion que solo paso por refresh), el access se hidrataba bien con el refresh exitoso, pero `isAuthenticated()` daba `false` -> redirect erroneo a `/login`.

Secundario: `useProtectedRoute` se suscribia solo a la fn `isAuthenticated` y a `bootstrapping`, NO a `accessToken`. Cuando el bootstrap hidrataba el access, el componente podia no re-renderizar a tiempo y evaluar un `authed` stale.

## Solucion

- `isAuthenticated()` se basa **solo en el access JWT valido y no expirado**. `user` es data de perfil para la UI (el app shell ya la lee con `user?.email`), NO un gate de autenticacion.
- `useProtectedRoute` se suscribe a `accessToken` para re-renderizar y recomputar `authed` cuando el bootstrap hidrata el token desde el refresh.

## Como probar

Local:
- `pnpm --filter @portfolio/admin test` (542 pass), `typecheck`, `lint`, `build` — todo verde.
- Test de regresion `tests/unit/features/auth/components/auth-guard-reload-repro.test.tsx`: reload rehidratando localStorage CON y SIN `user` -> sostiene la sesion (children), NO redirige. El caso SIN user fallaba (redirigia) antes del fix.
- `tests/unit/features/auth/store/use-auth-store.test.ts`: access valido sin user -> `isAuthenticated() === true`; user sin access -> `false`.

En dev (post-deploy):
- Login en el admin, **F5** en `/` -> NO debe rebotar a `/login`; el `/session/refresh` hidrata el access y la sesion persiste.

## TODO

- Opcional a futuro: backfillear un `user` minimo desde el `sub` del JWT tras un refresh-only, para que el saludo del shell no quede vacio si el storage no traia `user`. No bloquea: la UI degrada con `user?.email`.