### PR TITLE
fix(admin): no redirige a /login mientras la sesion sea recuperable por refresh

### DIFF
--- a/admin/src/features/auth/hooks/use-protected-route.ts
+++ b/admin/src/features/auth/hooks/use-protected-route.ts
@@ -28,16 +28,31 @@ export function useProtectedRoute(): boolean {
 	const accessToken = useAuthStore((s) => s.accessToken);
 	const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 	const bootstrapping = useAuthStore((s) => s.bootstrapping);
+	// Suscribirse tambien a refreshToken/refreshExpiry: si hay un refresh
+	// vigente, la sesion es RECUPERABLE (el bootstrap puede hidratar el access)
+	// y NO se debe redirigir todavia, aunque `authed` sea false en este render.
+	// Esto cierra la race de orden de los set() del bootstrap: en el browser
+	// real `setAccessToken` y `setBootstrapping(false)` caen en commits
+	// distintos, y el redirect podia dispararse leyendo un `authed` stale=false
+	// con el flag ya en false, PESE a un /session/refresh 200 reciente.
+	const refreshToken = useAuthStore((s) => s.refreshToken);
+	const refreshExpiry = useAuthStore((s) => s.refreshExpiry);
 	// accessToken se referencia para que el linter no lo marque sin uso; el
 	// valor real lo lee isAuthenticated() del store.
 	void accessToken;
 	const authed = isAuthenticated();
+	const recoverable =
+		!!refreshToken && !!refreshExpiry && refreshExpiry > Date.now();
 
 	useEffect(() => {
-		if (!bootstrapping && !authed) {
+		// Redirigir SOLO cuando: el bootstrap termino, NO hay sesion activa y la
+		// sesion NO es recuperable por un refresh vigente. Mientras haya refresh
+		// vivo, esperar al bootstrap (exito -> children; fallo -> el store hace
+		// reset, `recoverable` pasa a false -> recien ahi redirige).
+		if (!bootstrapping && !authed && !recoverable) {
 			router.replace(loginWithNext(pathname));
 		}
-	}, [authed, bootstrapping, router, pathname]);
+	}, [authed, bootstrapping, recoverable, router, pathname]);
 
 	return authed;
 }

--- a/admin/tests/unit/features/auth/components/auth-guard-reload-repro.test.tsx
+++ b/admin/tests/unit/features/auth/components/auth-guard-reload-repro.test.tsx
@@ -1,10 +1,14 @@
 import { makeJwt, nowSec } from "@tests/mocks/jwt";
+import { server } from "@tests/mocks/server";
 import { render, screen, waitFor } from "@tests/utils/render";
+import { delay, HttpResponse, http } from "msw";
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthGuard } from "@/features/auth/components/auth-guard";
 import { useAuthStore } from "@/features/auth/store/use-auth-store";
 import type { User } from "@/types/models";
+
+const API = "https://api.test.the-full-stack.com";
 
 /**
  * @module tests/unit/features/auth/components/auth-guard-reload-repro
@@ -99,6 +103,51 @@ describe("AuthGuard tras reload (rehidratacion real de localStorage)", () => {
 		// Assert: con un access JWT valido tras el refresh, la sesion vive aunque
 		// user sea null. ANTES del fix esto redirigia a /login (isAuthenticated
 		// exigia user) -> ESTE es el bug reportado.
+		await waitFor(() => {
+			expect(screen.getByText("protegido")).toBeInTheDocument();
+		});
+		expect(replaceMock).not.toHaveBeenCalled();
+	});
+
+	it("Given un reload con refresh LENTO (async real ~50ms) When monta Then NO redirige durante la ventana del refresh y termina en children", async () => {
+		// Arrange: refresh con latencia real (el bug en dev: el redirect fire
+		// DESPUES de que el refresh 200 resuelve, por una race de orden de los
+		// set() entre setAccessToken y setBootstrapping). Un MSW instantaneo NO
+		// reproducia esto; con delay se acerca al timing de produccion.
+		const refreshToken = makeJwt({ sub: USER.id, exp: nowSec() + 2_592_000 });
+		seedPersisted({
+			refreshToken,
+			refreshExpiry: (nowSec() + 2_592_000) * 1000,
+			user: USER,
+		});
+		await useAuthStore.persist.rehydrate();
+		server.use(
+			http.post(`${API}/auth`, async () => {
+				await delay(50);
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: {
+						access_token: makeJwt({ sub: USER.id, exp: nowSec() + 900 }),
+						refresh_token: makeJwt({ sub: USER.id, exp: nowSec() + 2_592_000 }),
+						expires_in: 900,
+					},
+				});
+			}),
+		);
+
+		// Act
+		render(
+			(
+				<AuthGuard>
+					<p>protegido</p>
+				</AuthGuard>
+			) as ReactElement,
+		);
+		// Durante la ventana del refresh: placeholder, NUNCA redirect.
+		expect(screen.getByText(/verificando sesion/i)).toBeInTheDocument();
+
+		// Assert: termina en children, sin haber redirigido en ningun momento.
 		await waitFor(() => {
 			expect(screen.getByText("protegido")).toBeInTheDocument();
 		});

--- a/admin/tests/unit/features/auth/hooks/use-protected-route.test.tsx
+++ b/admin/tests/unit/features/auth/hooks/use-protected-route.test.tsx
@@ -49,6 +49,43 @@ describe("useProtectedRoute", () => {
 		});
 	});
 
+	it("Given bootstrap resuelto, sin access pero CON refresh vigente When se monta Then NO redirige (sesion recuperable)", async () => {
+		// Arrange: la ventana de la race -> bootstrapping ya en false (commit
+		// distinto al de setAccessToken) pero hay un refresh vivo: el bootstrap
+		// aun puede hidratar el access. NO se debe redirigir.
+		useAuthStore.setState({
+			accessToken: null,
+			refreshToken: makeJwt({ sub: "usr_01", exp: nowSec() + 2_592_000 }),
+			refreshExpiry: (nowSec() + 2_592_000) * 1000,
+		});
+
+		// Act
+		const { result } = renderHook(() => useProtectedRoute());
+
+		// Assert
+		expect(result.current).toBe(false);
+		await waitFor(() => {
+			expect(replaceMock).not.toHaveBeenCalled();
+		});
+	});
+
+	it("Given bootstrap resuelto, sin access y con refresh EXPIRADO When se monta Then redirige (no recuperable)", async () => {
+		// Arrange: refresh vencido -> no recuperable -> redirige.
+		useAuthStore.setState({
+			accessToken: null,
+			refreshToken: "expirado",
+			refreshExpiry: Date.now() - 1000,
+		});
+
+		// Act
+		renderHook(() => useProtectedRoute());
+
+		// Assert
+		await waitFor(() => {
+			expect(replaceMock).toHaveBeenCalledWith("/login?next=%2Fusers");
+		});
+	});
+
 	it("Given sesion vigente When se monta Then devuelve true", () => {
 		// Arrange
 		useAuthStore.setState({


### PR DESCRIPTION
## Problema

Continuacion del PR #241. Tras ese fix, el F5 en el admin (`admin.portfolio.dev`) **seguia** rebotando a `/login` aunque el `POST /auth {session, refresh}` respondiera **200** y el store quedara con tokens validos.

Diagnostico con Playwright headless contra el admin desplegado (sembrando una sesion real en localStorage y recargando): la secuencia observada fue `Verificando sesion...` -> `[auth refresh] 200` -> `replaceState -> /login` con el `refreshToken` AUN presente en localStorage. Es decir, el redirect se disparaba **despues** de un refresh exitoso, sin que el store se hubiera reseteado.

**Causa raiz**: una race de orden de los `set()` del bootstrap en el browser real. `doRefresh()` hace `setAccessToken` (memoria) y luego `setBootstrapping(false)` en **microtasks distintos**. El efecto de redirect de `useProtectedRoute` podia correr en el commit donde `bootstrapping` ya era `false` pero `authed` se leia stale=`false`. Los unit tests con happy-dom batchean los `set()` distinto al browser y NO reproducian la ventana (por eso el PR #241 pasaba verde pero el bug seguia en dev).

## Solucion

`useProtectedRoute` ahora redirige **solo si la sesion NO es recuperable**:
- Se suscribe a `refreshToken`/`refreshExpiry`. Si hay un refresh **vigente**, la sesion es recuperable (el bootstrap puede hidratar el access) y NO se redirige todavia.
- Condicion de redirect: `!bootstrapping && !authed && !recoverable`.
- Flujo: refresh OK -> `authed` true -> children; refresh FALLA -> el store hace `reset()` -> `recoverable` pasa a false -> recien ahi redirige. Un refresh 200 nunca termina en `/login` por timing.

## Como probar

Local:
- `pnpm --filter @portfolio/admin test` (suite verde), `typecheck`, `lint`.
- `tests/unit/features/auth/hooks/use-protected-route.test.tsx`: "sin access pero CON refresh vigente -> NO redirige (recuperable)"; "refresh expirado -> redirige (no recuperable)".
- `auth-guard-reload-repro.test.tsx`: caso con refresh LENTO (delay 50ms) acercando el timing async real.

En dev (Parte C, post-deploy) — verificacion con Playwright headless contra el admin desplegado:
- Sembrar una sesion real en localStorage (`refreshToken` vigente), `goto /`, recargar -> NO debe redirigir a `/login`; la UI pasa de "Verificando sesion..." al panel.

## TODO

- (Heredado) opcional: backfillear un `user` minimo desde el `sub` del JWT tras un refresh-only para que el saludo del shell no quede vacio. No bloquea (UI degrada con `user?.email`).