### PR TITLE
fix(admin): el reload renderiza la sesion (authed reactivo, no fn estable)

### DIFF
--- a/admin/src/features/auth/hooks/use-protected-route.ts
+++ b/admin/src/features/auth/hooks/use-protected-route.ts
@@ -3,6 +3,7 @@
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { loginWithNext } from "@/lib/routes";
+import { isJwtExpired } from "../lib/token-expiry";
 import { useAuthStore } from "../store/use-auth-store";
 
 /**
@@ -25,22 +26,21 @@ export function useProtectedRoute(): boolean {
 	// refresh, y `authed` se recomputa con el token fresco. Sin esto, el
 	// re-render lo disparaba solo `bootstrapping` y `authed` podia quedar
 	// stale (false) -> redirect erroneo a /login pese a tener access valido.
+	// `authed` se DERIVA del accessToken reactivo (NO de la fn estable
+	// isAuthenticated()). Esto es clave con el React Compiler: si solo se
+	// llamara isAuthenticated() (referencia estable) y se subscribiera
+	// accessToken con un `void` descartable, el Compiler trataba accessToken
+	// como dead-code y NO re-renderizaba al hidratarse el access -> el store
+	// quedaba authed=true pero la UI atascada en "Verificando sesion". Derivar
+	// authed de accessToken lo vuelve un input reactivo real del render.
 	const accessToken = useAuthStore((s) => s.accessToken);
-	const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 	const bootstrapping = useAuthStore((s) => s.bootstrapping);
 	// Suscribirse tambien a refreshToken/refreshExpiry: si hay un refresh
 	// vigente, la sesion es RECUPERABLE (el bootstrap puede hidratar el access)
 	// y NO se debe redirigir todavia, aunque `authed` sea false en este render.
-	// Esto cierra la race de orden de los set() del bootstrap: en el browser
-	// real `setAccessToken` y `setBootstrapping(false)` caen en commits
-	// distintos, y el redirect podia dispararse leyendo un `authed` stale=false
-	// con el flag ya en false, PESE a un /session/refresh 200 reciente.
 	const refreshToken = useAuthStore((s) => s.refreshToken);
 	const refreshExpiry = useAuthStore((s) => s.refreshExpiry);
-	// accessToken se referencia para que el linter no lo marque sin uso; el
-	// valor real lo lee isAuthenticated() del store.
-	void accessToken;
-	const authed = isAuthenticated();
+	const authed = !!accessToken && !isJwtExpired(accessToken);
 	const recoverable =
 		!!refreshToken && !!refreshExpiry && refreshExpiry > Date.now();
 

--- a/admin/tests/unit/features/auth/components/auth-guard-reload-repro.test.tsx
+++ b/admin/tests/unit/features/auth/components/auth-guard-reload-repro.test.tsx
@@ -153,4 +153,47 @@ describe("AuthGuard tras reload (rehidratacion real de localStorage)", () => {
 		});
 		expect(replaceMock).not.toHaveBeenCalled();
 	});
+
+	it("Given un reload y el backend responde el refresh FLAT (sin envelope, como prod) When monta Then hidrata el access y muestra children", async () => {
+		// Arrange: el backend REAL responde FLAT — {access_token, refresh_token,
+		// expires_in, token_type} al nivel raiz, SIN el wrapper {is_valid,code,
+		// data}. apiFetch lo re-envuelve. El bug en dev (guard atascado en
+		// "Verificando sesion") aparece si doRefresh no extrae bien el access de
+		// esa respuesta. Los otros tests devolvian el shape YA enveloped (MSW),
+		// enmascarando el path real.
+		const refreshToken = makeJwt({ sub: USER.id, exp: nowSec() + 2_592_000 });
+		seedPersisted({
+			refreshToken,
+			refreshExpiry: (nowSec() + 2_592_000) * 1000,
+			user: USER,
+		});
+		await useAuthStore.persist.rehydrate();
+		server.use(
+			http.post(`${API}/auth`, () =>
+				// FLAT, sin {is_valid, code, data}.
+				HttpResponse.json({
+					access_token: makeJwt({ sub: USER.id, exp: nowSec() + 900 }),
+					refresh_token: makeJwt({ sub: USER.id, exp: nowSec() + 2_592_000 }),
+					expires_in: 900,
+					token_type: "Bearer",
+				}),
+			),
+		);
+
+		// Act
+		render(
+			(
+				<AuthGuard>
+					<p>protegido</p>
+				</AuthGuard>
+			) as ReactElement,
+		);
+
+		// Assert: hidrata el access y muestra children (NO se queda en el
+		// placeholder ni redirige).
+		await waitFor(() => {
+			expect(screen.getByText("protegido")).toBeInTheDocument();
+		});
+		expect(replaceMock).not.toHaveBeenCalled();
+	});
 });

--- a/admin/tests/unit/features/auth/hooks/use-protected-route.test.tsx
+++ b/admin/tests/unit/features/auth/hooks/use-protected-route.test.tsx
@@ -105,4 +105,32 @@ describe("useProtectedRoute", () => {
 		// Assert
 		expect(result.current).toBe(true);
 	});
+
+	it("Given monta sin access y luego se hidrata el access When cambia el store Then authed pasa a true reactivamente (sin user)", async () => {
+		// Arrange: estado post-reload (bootstrap aun true, sin access). authed se
+		// DERIVA del accessToken reactivo, no de la fn estable isAuthenticated:
+		// asi el hook re-renderiza cuando el bootstrap hidrata el access. (En
+		// prod, con React Compiler, leer la fn estable + `void accessToken`
+		// dejaba authed congelado en false aunque el store tuviera access.)
+		useAuthStore.setState({
+			accessToken: null,
+			refreshToken: makeJwt({ sub: "usr_01", exp: nowSec() + 2_592_000 }),
+			refreshExpiry: (nowSec() + 2_592_000) * 1000,
+		});
+		useAuthStore.getState().setBootstrapping(true);
+		const { result } = renderHook(() => useProtectedRoute());
+		expect(result.current).toBe(false);
+
+		// Act: el bootstrap hidrata el access (refresh OK).
+		useAuthStore
+			.getState()
+			.setAccessToken(makeJwt({ sub: "usr_01", exp: nowSec() + 900 }));
+		useAuthStore.getState().setBootstrapping(false);
+
+		// Assert: authed reactivo pasa a true; no redirige.
+		await waitFor(() => {
+			expect(result.current).toBe(true);
+		});
+		expect(replaceMock).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Problema

Cierre del bug del F5. Tras el PR #242 (que mato el rebote a `/login`), el `AuthGuard` quedaba **atascado en "Verificando sesion..."** pese a que el `POST /auth {session,refresh}` respondia **200** y el store quedaba con sesion valida.

Diagnostico definitivo leyendo el store en un browser real (chromium, build local contra la API dev con `--disable-web-security` para esquivar CORS): a los ~2.6s el store estaba `accessToken` seteado, `bootstrapping=false`, **`authed=true`** — pero la UI seguia mostrando el placeholder. El componente NO re-renderizaba.

**Causa raiz**: el React Compiler (`reactCompiler: true`) eliminaba como dead-code el `void accessToken`. `useProtectedRoute` computaba `authed = isAuthenticated()` llamando una **referencia estable** (la fn del store), sin ningun input reactivo que ligara `authed` al `accessToken`. Con `accessToken` descartado por el Compiler, el componente no se re-renderizaba al hidratarse el access -> `authed` congelado en `false` -> guard atascado. `happy-dom` no corre el React Compiler, por eso los unit tests pasaban en verde mientras el bug seguia en dev.

## Solucion

`useProtectedRoute` deriva `authed` **directo del `accessToken` reactivo**:
```ts
const authed = !!accessToken && !isJwtExpired(accessToken);
```
Asi `accessToken` es un input real del render: cuando el bootstrap lo hidrata, el hook re-renderiza y `authed` pasa a `true` -> el guard muestra los children.

## Como probar

Local:
- `pnpm --filter @portfolio/admin test` (suite verde, 162 auth tests), `typecheck`, `lint`.
- `tests/unit/features/auth/hooks/use-protected-route.test.tsx`: "monta sin access y luego se hidrata -> authed pasa a true reactivamente".
- `auth-guard-reload-repro.test.tsx`: caso del refresh FLAT (shape real del backend).

Browser real (verificado): build local contra la API dev, sembrando una sesion en localStorage + reload -> la UI pasa de "Verificando sesion..." al panel (`ADMIN / Metricas / Configuracion / ...`); el probe `/users` (useIsAdmin) dispara -> children renderizaron, sin redirect ni atasco.

En dev (Parte C, post-deploy): mismo flujo via Playwright headless contra el admin desplegado.

## TODO

- (Heredado) opcional: backfillear un `user` minimo desde el `sub` del JWT tras un refresh-only. No bloquea.