### PR TITLE
chore(hooks): protect-branch evalua la rama del worktree, no del principal

### DIFF
--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -32,9 +32,26 @@ except Exception:
     pass" 2>/dev/null
 }
 
-# Retorna el nombre de la rama actual de git.
+# Retorna el nombre de la rama git de un directorio dado (default:
+# CLAUDE_PROJECT_DIR). Worktree-aware: si se pasa un dir, evalua la rama de
+# ESE checkout (el del worktree donde realmente ocurre el commit), no la del
+# checkout principal. Con git worktrees, CLAUDE_PROJECT_DIR apunta al checkout
+# principal (que puede estar en una rama protegida como dev) mientras el
+# comando corre en un worktree de feature/*; sin el dir explicito el hook
+# daria un falso positivo.
 current_branch() {
-  cd "$CLAUDE_PROJECT_DIR" && git symbolic-ref --short HEAD 2>/dev/null
+  local dir="${1:-$CLAUDE_PROJECT_DIR}"
+  git -C "$dir" symbolic-ref --short HEAD 2>/dev/null
+}
+
+# Extrae el directorio destino de un `cd <path>` al inicio de un comando shell
+# (el primer `cd` antes de `&&`/`;`). Vacio si no hay cd. Sirve para que el
+# hook evalue la rama del worktree donde el comando va a operar.
+cd_target_from_command() {
+  local cmd="$1"
+  printf '%s\n' "$cmd" | sed -n \
+    's/^[[:space:]]*cd[[:space:]]\{1,\}\([^&;|]*\).*/\1/p' \
+    | head -n1 | sed 's/[[:space:]]*$//'
 }
 
 # True si la rama actual es protegida (master/main/dev/release).

--- a/.claude/hooks/protect-branch.sh
+++ b/.claude/hooks/protect-branch.sh
@@ -20,7 +20,15 @@ case "$CMD" in
   *) exit 0 ;;
 esac
 
-BRANCH="$(current_branch)"
+# Worktree-aware: si el comando hace `cd <path>` (patron tipico al operar en
+# un git worktree), evaluamos la rama de ESE checkout — es donde el commit/push
+# realmente ocurre. Si no hay cd, usamos CLAUDE_PROJECT_DIR (checkout principal).
+CD_DIR="$(cd_target_from_command "$CMD")"
+if [ -n "$CD_DIR" ] && [ -d "$CD_DIR" ]; then
+  BRANCH="$(current_branch "$CD_DIR")"
+else
+  BRANCH="$(current_branch)"
+fi
 
 # Si no estamos en repo git o no podemos detectar rama, no bloquear (el comando fallara solo).
 [ -z "$BRANCH" ] && exit 0


### PR DESCRIPTION
## Problema

El hook `protect-branch.sh` (bloquea commits/push en ramas protegidas: `master`/`main`/`dev`/`stage`/`release`) da un **falso positivo con git worktrees**. `current_branch()` lee la rama de `CLAUDE_PROJECT_DIR`, que con worktrees apunta al **checkout principal** — ese puede estar en `dev` (protegida) mientras el comando opera en un worktree de `feature/*`. Resultado: el hook bloquea commits/push legitimos del worktree.

## Solucion

Worktree-aware: si el comando hace `cd <path>` al inicio, el hook evalua la rama de **ese** checkout (donde el commit/push realmente ocurre), no la del principal.

1. `_lib.sh` / `current_branch()` — ahora acepta un `dir` y usa `git -C "$dir"` en vez de `cd "$CLAUDE_PROJECT_DIR"`.
2. `_lib.sh` / `cd_target_from_command()` (nueva) — extrae el destino del `cd` inicial del comando (soporta `&&`, `;`, `|`, espacios extra; vacio si no hay `cd`).
3. `protect-branch.sh` — si hay `cd` a un dir existente, evalua la rama de ese dir; si no, cae a `CLAUDE_PROJECT_DIR` (comportamiento previo intacto).

## Como probar

```bash
# 1. Sintaxis
bash -n .claude/hooks/_lib.sh && bash -n .claude/hooks/protect-branch.sh

# 2. Unit de cd_target_from_command (bajo bash, como corre el hook)
bash --noprofile --norc -c '
source .claude/hooks/_lib.sh
[ "$(cd_target_from_command "cd /a/b && git status")" = "/a/b" ] && echo "&&  OK"
[ "$(cd_target_from_command "cd /a/b; git status")"  = "/a/b" ] && echo ";   OK"
[ -z "$(cd_target_from_command "git status")" ]               && echo "sin OK"
'

# 3. Escenario real: principal en dev, worktree en feature -> NO bloquea
git worktree add -b chore/wt-test ./tmp/wt feature 2>/dev/null || git worktree add -b chore/wt-test ./tmp/wt dev
bash --noprofile --norc -c '
source .claude/hooks/_lib.sh
CD="$(cd_target_from_command "cd $(pwd)/tmp/wt && git add -A")"
echo "rama evaluada: $(current_branch "$CD")  (esperado: chore/wt-test, NO dev)"
'
git worktree remove ./tmp/wt --force
git branch -D chore/wt-test
```

Verificado: el escenario 3 evalua `chore/wt-test` (rama del worktree), no `dev`. Antes del cambio leia `dev` y bloqueaba.

## TODO

Vacio.