### PR TITLE
fix(auth): turnstile solo en login.check-email + temp JWT precheck

### DIFF
--- a/.claude/rules/auth-system.md
+++ b/.claude/rules/auth-system.md
@@ -107,17 +107,22 @@ Aplica SIEMPRE que se trabaje con:
 
 ### Login UX (anti enumeration)
 
-- **SIEMPRE** `login.start` con email inexistente devuelve `404
-  {error: 'EMAIL_NOT_FOUND', suggest_register: true}`.
+- **SIEMPRE** `login.start` exige el temp JWT precheck (`flow='login'`
+  step=0) en `Authorization`. Sin el -> `401 MISSING_PRECHECK` (forzar a
+  pasar por `login.check-email` con Turnstile primero). El `sub` del
+  precheck debe matchear el user del email si ya existe (anti-cross-
+  account); si no matchea -> `401 MISSING_PRECHECK`.
+- **SIEMPRE** con un precheck valido, `login.start` con email inexistente
+  CREA el user `pending` (fusion register->login) y envia el email
+  unificado (`created: true`). Ya NO devuelve `404 EMAIL_NOT_FOUND`.
 - **SIEMPRE** `login.start` con email cuyo status es `disabled` o
-  `locked` devuelve EL MISMO `404 {error: 'EMAIL_NOT_FOUND',
+  `locked` devuelve `404 {error: 'EMAIL_NOT_FOUND',
   suggest_register: false}` (anti-enumeration). Audit log registra el
   intento con `error_code='ACCOUNT_DISABLED'` o `'ACCOUNT_LOCKED'`.
-- **SIEMPRE** `login.start` con email cuyo status es `pending` devuelve
-  `409 PENDING_VERIFICATION` para forzar que termine el flujo de register.
-- **NUNCA** devolver 404 con body distinto entre "no existe" y
-  "existe + disabled/locked". La diferencia visible al cliente es solo
-  `suggest_register`.
+- **SIEMPRE** `login.start` con email `pending` re-emite el email unificado
+  (`created: false`); ya NO devuelve `409 PENDING_VERIFICATION`.
+- **NUNCA** revelar la existencia del email en `login.start` mas alla de lo
+  que ya expone `login.check-email` (existencia + `has_password`).
 
 #### `login.check-email` (precheck del login)
 
@@ -135,6 +140,15 @@ Aplica SIEMPRE que se trabaje con:
   estado real (`ACCOUNT_DISABLED`/`ACCOUNT_LOCKED`).
 - **NUNCA** devolver `has_password` ni la existencia para un user
   disabled/locked: ahi solo `unavailable`.
+- **SIEMPRE** `login.check-email` es el UNICO punto del flujo de login con
+  Turnstile, y emite un **temp JWT precheck** (`flow='login'` step=0) en la
+  respuesta (`temp_token`) para los casos que pueden continuar a
+  `login.start` (active, pending, y email nuevo/`exists:false` con un `sub`
+  placeholder, para el alta fusionada). `login.start` lo EXIGE en
+  `Authorization`. Es el reemplazo del Turnstile de `login.start`.
+- **NUNCA** emitir el `temp_token` precheck en el caso `unavailable`
+  (disabled/locked/deleted): ese user no puede entrar, no hay flujo que
+  continuar.
 
 #### Flujo de entrada unico: `register` fusionado en `login`
 
@@ -175,9 +189,21 @@ Aplica SIEMPRE que se trabaje con:
 
 ### Turnstile y rate-limit
 
-- **SIEMPRE** Turnstile obligatorio en `register.start` y `login.start`
-  (AC-12). El resto del flujo NO valida Turnstile — confia en el JWT
-  temp + rate-limit.
+- **SIEMPRE** Turnstile SOLO en los DOS endpoints **iniciales** (step 0)
+  del flujo de auth: `login.check-email` y `register.start` (AC-12). El
+  token de Turnstile es single-use: validarlo dos veces en el mismo flujo
+  da `timeout-or-duplicate`. Ningun otro endpoint lo valida.
+- **NUNCA** un endpoint **no-inicial** (step != 0) valida Turnstile. La
+  autorizacion de esos endpoints es un JWT (access) o un JWT temporal
+  (rolling temp del flujo). En particular `login.start` ya NO valida
+  Turnstile: EXIGE el temp JWT precheck (`flow='login'` step=0) emitido por
+  `login.check-email` en el header `Authorization`; sin el -> `401
+  MISSING_PRECHECK`. El `sub` del precheck debe matchear el user del email
+  (anti-cross-account); para un email nuevo (alta fusionada) el precheck
+  lleva un `sub` placeholder y `login.start` crea el pending sin comparar.
+- **SIEMPRE** la auto-blacklist anti-solver se alimenta solo por los
+  endpoints con Turnstile (`login.check-email` + `register.start`): el
+  `brought_turnstile_token=True` se cuenta por `(ip, endpoint, window)`.
 - **SIEMPRE** rate-limit per-IP via `shared.rate_limit.check_or_raise`
   con las reglas seedeadas (ver
   [.claude/docs/auth-system/03-rate-limit-rules.md](../docs/auth-system/03-rate-limit-rules.md)).

--- a/admin/src/features/auth/api/auth-client.ts
+++ b/admin/src/features/auth/api/auth-client.ts
@@ -40,8 +40,9 @@ export const authClient = {
 
 	/**
 	 * login.check-email: pre-chequeo del email antes de iniciar el flujo.
-	 * Devuelve banderas (exists, has_password, pending, unavailable), NO la lista
-	 * de metodos. Sin sesion (skipAuth) + exige Turnstile.
+	 * Devuelve banderas (exists, has_password, pending, unavailable) + el
+	 * `temp_token` precheck, NO la lista de metodos. Sin sesion (skipAuth) +
+	 * exige Turnstile (UNICO punto del flujo de login con captcha).
 	 */
 	loginCheckEmail: (data: { email: string; cf_turnstile_response: string }) =>
 		apiFetch<Envelope<CheckEmailResponse>>("/auth", {
@@ -51,19 +52,23 @@ export const authClient = {
 		}),
 
 	/**
-	 * login.start: 200 TempTokenResponse (con methods). Ahora `data.created`
-	 * indica si el email no existia y fue CREADO (registro fusionado); el 404
-	 * EMAIL_NOT_FOUND ya NO ocurre.
+	 * login.start: 200 TempTokenResponse (con methods). `data.created` indica
+	 * si el email no existia y fue CREADO (registro fusionado).
+	 *
+	 * Ya NO valida Turnstile: el captcha se resuelve una sola vez en
+	 * login.check-email, que emite el `precheckToken` (temp JWT flow='login'
+	 * step=0). login.start lo EXIGE en `Authorization: Bearer`; sin el -> 401
+	 * MISSING_PRECHECK. `skipAuth: true` evita que apiFetch inyecte el access
+	 * token del store; el header lo seteamos a mano con el precheck.
 	 */
-	loginStart: (data: {
-		email: string;
-		cf_turnstile_response: string;
-		password?: string;
-		niche?: string;
-	}) =>
+	loginStart: (
+		data: { email: string; password?: string; niche?: string },
+		precheckToken: string,
+	) =>
 		apiFetch<Envelope<TempTokenResponse & { created?: boolean }>>("/auth", {
 			method: "POST",
 			skipAuth: true,
+			headers: { Authorization: `Bearer ${precheckToken}` },
 			body: { operation: "login", action: "start", data },
 		}),
 

--- a/admin/src/features/auth/components/login-form.tsx
+++ b/admin/src/features/auth/components/login-form.tsx
@@ -53,6 +53,11 @@ type Stage =
 export function LoginForm() {
 	const router = useRouter();
 	const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+	// Temp JWT precheck (flow='login' step=0) que devuelve login.check-email
+	// tras validar Turnstile. login.start lo manda en Authorization en vez del
+	// captcha (el token de Turnstile es single-use: reusarlo daba
+	// `timeout-or-duplicate`).
+	const [precheckToken, setPrecheckToken] = useState<string | null>(null);
 	const [stage, setStage] = useState<Stage>({ kind: "email" });
 	const checkEmail = useCheckEmail();
 	const loginStart = useLoginStart();
@@ -80,6 +85,9 @@ export function LoginForm() {
 			},
 			{
 				onSuccess: ({ data }) => {
+					// El precheck autoriza login.start. unavailable no trae temp
+					// (no hay flujo que continuar) y ese stage no llama login.start.
+					setPrecheckToken(data.temp_token ?? null);
 					if (data.unavailable) {
 						setStage({ kind: "unavailable" });
 						return;
@@ -99,19 +107,20 @@ export function LoginForm() {
 	});
 
 	const startPasswordless = (email: string) => {
+		if (precheckToken === null) return;
 		loginStart.mutate(
-			{ email, cf_turnstile_response: turnstileToken ?? "" },
+			{ data: { email }, precheckToken },
 			{ onSuccess: goToVerify },
 		);
 	};
 
 	const onPasswordSubmit = (email: string) =>
 		passwordForm.handleSubmit((values) => {
+			if (precheckToken === null) return;
 			loginStart.mutate(
 				{
-					email,
-					password: values.password,
-					cf_turnstile_response: turnstileToken ?? "",
+					data: { email, password: values.password },
+					precheckToken,
 				},
 				{
 					onSuccess: ({ data }) => {

--- a/admin/src/features/auth/hooks/use-login-start.ts
+++ b/admin/src/features/auth/hooks/use-login-start.ts
@@ -6,15 +6,23 @@ import { useAuthStore } from "../store/use-auth-store";
 
 /**
  * @function useLoginStart
- * @description Dispara login.start. En exito guarda el temp_token (el caller
- *   decide el siguiente paso segun `methods`). El 404 EMAIL_NOT_FOUND con
- *   `suggest_register` lo maneja el componente (`error.data`).
+ * @description Dispara login.start. Recibe `{data, precheckToken}`: el
+ *   `precheckToken` es el temp JWT que devolvio login.check-email; se manda
+ *   en `Authorization: Bearer` (login.start ya NO usa Turnstile). En exito
+ *   guarda el temp_token de la respuesta (el caller decide el siguiente paso
+ *   segun `methods`).
  */
 export function useLoginStart() {
 	const setTempToken = useAuthStore((s) => s.setTempToken);
 
 	return useMutation({
-		mutationFn: authClient.loginStart,
+		mutationFn: ({
+			data,
+			precheckToken,
+		}: {
+			data: { email: string; password?: string; niche?: string };
+			precheckToken: string;
+		}) => authClient.loginStart(data, precheckToken),
 		onSuccess: ({ data }) => {
 			setTempToken(data.temp_token);
 		},

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -114,4 +114,10 @@ export interface CheckEmailResponse {
 	has_password?: boolean;
 	pending?: boolean;
 	unavailable?: boolean;
+	/**
+	 * Temp JWT precheck (flow='login' step=0) que autoriza login.start.
+	 * Presente salvo en el caso `unavailable` (no hay flujo que continuar).
+	 * login.start lo manda en `Authorization: Bearer` en vez de Turnstile.
+	 */
+	temp_token?: string;
 }

--- a/admin/tests/mocks/handlers/auth.ts
+++ b/admin/tests/mocks/handlers/auth.ts
@@ -157,6 +157,13 @@ export const authHandlers = [
 					},
 				});
 			}
+			// Login con password directo: password incorrecta -> 401.
+			if (data.password === "wrong-password-99") {
+				return HttpResponse.json(
+					{ is_valid: false, code: 4000, data: { error: "INVALID_PASSWORD" } },
+					{ status: 401 },
+				);
+			}
 			return HttpResponse.json({
 				is_valid: true,
 				code: 0,
@@ -382,6 +389,20 @@ export const authHandlers = [
 				code: 0,
 				data: { credentials: [] },
 			});
+		}
+
+		// Soft-enable / set-required: el backend responde 204 (sin payload). El
+		// cliente re-envuelve el body vacio en {is_valid:true, code:0, data:null}.
+		const enableRequiredActions = new Set([
+			"enable",
+			"set-required",
+			"disable",
+		]);
+		if (
+			(operation === "mfa" || operation === "webauthn") &&
+			enableRequiredActions.has(action)
+		) {
+			return new HttpResponse(null, { status: 204 });
 		}
 
 		return HttpResponse.json(

--- a/admin/tests/mocks/handlers/auth.ts
+++ b/admin/tests/mocks/handlers/auth.ts
@@ -78,15 +78,17 @@ export const authHandlers = [
 
 		// --- login ---
 		if (operation === "login" && action === "check-email") {
-			// Banderas FLAT (sin lista de metodos). El caller decide el paso 2.
+			// Banderas FLAT (sin lista de metodos) + temp_token precheck. El
+			// caller decide el paso 2 y manda el temp en Authorization a start.
 			if (data.email === "unknown@test.com") {
 				return HttpResponse.json({
 					is_valid: true,
 					code: 0,
-					data: { exists: false },
+					data: { exists: false, temp_token: "mock-precheck-token" },
 				});
 			}
 			if (data.email === "blocked@test.com") {
+				// unavailable: SIN temp (no hay flujo que continuar).
 				return HttpResponse.json({
 					is_valid: true,
 					code: 0,
@@ -97,19 +99,39 @@ export const authHandlers = [
 				return HttpResponse.json({
 					is_valid: true,
 					code: 0,
-					data: { exists: true, has_password: false },
+					data: {
+						exists: true,
+						has_password: false,
+						temp_token: "mock-precheck-token",
+					},
 				});
 			}
 			// Default: cuenta existente con password.
 			return HttpResponse.json({
 				is_valid: true,
 				code: 0,
-				data: { exists: true, has_password: true },
+				data: {
+					exists: true,
+					has_password: true,
+					temp_token: "mock-precheck-token",
+				},
 			});
 		}
 		if (operation === "login" && action === "start") {
+			// login.start ya NO usa Turnstile: exige el temp precheck en
+			// Authorization (lo emitio check-email). Sin el -> 401.
+			const auth = request.headers.get("Authorization") ?? "";
+			const precheck = auth.startsWith("Bearer ")
+				? auth.slice("Bearer ".length).trim()
+				: "";
+			if (precheck === "") {
+				return HttpResponse.json(
+					{ is_valid: false, code: 4003, data: { error: "MISSING_PRECHECK" } },
+					{ status: 401 },
+				);
+			}
 			if (data.email === "unknown@test.com") {
-				// login.start ahora CREA el user (registro fusionado): devuelve
+				// login.start CREA el user (registro fusionado): devuelve
 				// temp_token + created. El 404 EMAIL_NOT_FOUND ya NO ocurre.
 				return HttpResponse.json({
 					is_valid: true,

--- a/admin/tests/unit/features/auth/api/auth-client-enable-required.test.tsx
+++ b/admin/tests/unit/features/auth/api/auth-client-enable-required.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { authClient } from "@/features/auth/api/auth-client";
+
+/**
+ * @module tests/unit/features/auth/api/auth-client-enable-required
+ * @description Cubre las 5 actions soft-enable / set-required del cliente auth
+ *   (mfa.enable, mfa.set-required, webauthn.enable, webauthn.disable,
+ *   webauthn.set-required) contra el MSW handler. Cada una hace POST /auth con
+ *   su `{operation, action}` y devuelve el envelope. No tenian cobertura.
+ */
+
+describe("authClient enable / set-required actions", () => {
+	it("Given mfaEnable When llamado Then resuelve el envelope (is_valid)", async () => {
+		// Act
+		const res = await authClient.mfaEnable({ kind: "totp" });
+
+		// Assert
+		expect(res.is_valid).toBe(true);
+	});
+
+	it("Given mfaSetRequired When llamado Then resuelve el envelope", async () => {
+		// Act
+		const res = await authClient.mfaSetRequired({
+			kind: "totp",
+			required: true,
+		});
+
+		// Assert
+		expect(res.is_valid).toBe(true);
+	});
+
+	it("Given webauthnEnable When llamado Then resuelve el envelope", async () => {
+		// Act
+		const res = await authClient.webauthnEnable({ credential_id: "cred-1" });
+
+		// Assert
+		expect(res.is_valid).toBe(true);
+	});
+
+	it("Given webauthnDisable When llamado Then resuelve el envelope", async () => {
+		// Act
+		const res = await authClient.webauthnDisable({ credential_id: "cred-1" });
+
+		// Assert
+		expect(res.is_valid).toBe(true);
+	});
+
+	it("Given webauthnSetRequired When llamado Then resuelve el envelope", async () => {
+		// Act
+		const res = await authClient.webauthnSetRequired({
+			credential_id: "cred-1",
+			required: false,
+		});
+
+		// Assert
+		expect(res.is_valid).toBe(true);
+	});
+});

--- a/admin/tests/unit/features/auth/components/login-form.test.tsx
+++ b/admin/tests/unit/features/auth/components/login-form.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, userEvent, waitFor } from "@tests/utils/render";
 import type { ReactElement } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LoginForm } from "@/features/auth/components/login-form";
 import { useAuthStore } from "@/features/auth/store/use-auth-store";
 
@@ -38,6 +38,11 @@ async function solveTurnstile(): Promise<void> {
 }
 
 describe("LoginForm", () => {
+	beforeEach(() => {
+		pushMock.mockClear();
+		useAuthStore.getState().reset();
+	});
+
 	it("Given email invalido When submit Then NO llama a la API (Zod bloquea)", async () => {
 		// Arrange
 		const user = userEvent.setup();
@@ -107,5 +112,49 @@ describe("LoginForm", () => {
 			expect(pushMock).toHaveBeenCalledWith("/verify?flow=login");
 		});
 		expect(useAuthStore.getState().tempToken).toBe("mock-temp-created");
+	});
+
+	it("Given password correcta When submit Then login.start con el precheck navega a /verify", async () => {
+		// Arrange: cuenta con password (default) -> input de password.
+		const user = userEvent.setup();
+		render((<LoginForm />) as ReactElement);
+		await user.type(screen.getByLabelText(/email/i), "user@test.com");
+		await solveTurnstile();
+		await user.click(screen.getByRole("button", { name: /^continuar$/i }));
+		await screen.findByTestId("login-password");
+
+		// Act: el precheck (mock-precheck-token) viaja en Authorization, NO el
+		// captcha. login.start con password OK -> temp + navega.
+		await user.type(
+			screen.getByTestId("login-password"),
+			"a-strong-passphrase-12",
+		);
+		await user.click(screen.getByTestId("login-password-submit"));
+
+		// Assert
+		await waitFor(() => {
+			expect(pushMock).toHaveBeenCalledWith("/verify?flow=login");
+		});
+		expect(useAuthStore.getState().tempToken).toBe("mock-temp-login");
+	});
+
+	it("Given password incorrecta When submit Then muestra el error inline (401)", async () => {
+		// Arrange
+		const user = userEvent.setup();
+		render((<LoginForm />) as ReactElement);
+		await user.type(screen.getByLabelText(/email/i), "user@test.com");
+		await solveTurnstile();
+		await user.click(screen.getByRole("button", { name: /^continuar$/i }));
+		await screen.findByTestId("login-password");
+
+		// Act: password que el mock rechaza con 401 INVALID_PASSWORD.
+		await user.type(screen.getByTestId("login-password"), "wrong-password-99");
+		await user.click(screen.getByTestId("login-password-submit"));
+
+		// Assert: error inline, NO navega.
+		await waitFor(() => {
+			expect(screen.getByText(/contrasena incorrecta/i)).toBeInTheDocument();
+		});
+		expect(pushMock).not.toHaveBeenCalled();
 	});
 });

--- a/admin/tests/unit/features/auth/hooks/use-login-start.test.tsx
+++ b/admin/tests/unit/features/auth/hooks/use-login-start.test.tsx
@@ -24,15 +24,15 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 describe("useLoginStart", () => {
-	it("Given email inexistente When mutate Then crea el user (created) y setea tempToken", async () => {
+	it("Given email inexistente + precheck When mutate Then crea el user (created) y setea tempToken", async () => {
 		// Arrange
 		const { result } = renderHook(() => useLoginStart(), { wrapper });
 
-		// Act
+		// Act: el precheckToken viaja en Authorization (no Turnstile).
 		const response = await act(async () =>
 			result.current.mutateAsync({
-				email: "unknown@test.com",
-				cf_turnstile_response: "tok",
+				data: { email: "unknown@test.com" },
+				precheckToken: "mock-precheck-token",
 			}),
 		);
 
@@ -41,20 +41,35 @@ describe("useLoginStart", () => {
 		expect(useAuthStore.getState().tempToken).toBe("mock-temp-created");
 	});
 
-	it("Given email con MFA When mutate Then setea tempToken y devuelve methods", async () => {
+	it("Given email con MFA + precheck When mutate Then setea tempToken y devuelve methods", async () => {
 		// Arrange
 		const { result } = renderHook(() => useLoginStart(), { wrapper });
 
 		// Act
 		const response = await act(async () =>
 			result.current.mutateAsync({
-				email: "mfa@test.com",
-				cf_turnstile_response: "tok",
+				data: { email: "mfa@test.com" },
+				precheckToken: "mock-precheck-token",
 			}),
 		);
 
 		// Assert
 		expect(response.data.methods).toEqual(["totp"]);
 		expect(useAuthStore.getState().tempToken).toBe("mock-temp-mfa");
+	});
+
+	it("Given login.start SIN precheck When el header falta Then 401 MISSING_PRECHECK", async () => {
+		// Arrange
+		const { result } = renderHook(() => useLoginStart(), { wrapper });
+
+		// Act / Assert: un precheck vacio -> Authorization sin Bearer -> 401.
+		await expect(
+			act(async () =>
+				result.current.mutateAsync({
+					data: { email: "mfa@test.com" },
+					precheckToken: "",
+				}),
+			),
+		).rejects.toMatchObject({ status: 401 });
 	});
 });

--- a/docs/specs/login-turnstile-precheck/README.md
+++ b/docs/specs/login-turnstile-precheck/README.md
@@ -1,0 +1,288 @@
+# Plan: Turnstile solo en login.check-email + temp JWT precheck
+
+> Mueve la validacion de Turnstile del flujo de login a UN solo punto
+> (`login.check-email`, el primer boton "iniciar sesion"). `check-email`
+> emite un temp JWT `flow='login'` step=0 que autoriza `login.start`; este
+> ya NO valida Turnstile sino que EXIGE ese temp en `Authorization`.
+
+## Cuando leer
+
+| Tema | Archivo |
+|------|---------|
+| Contexto + solucion + AC | Este README (secciones 1-7) |
+| Commits + paralelizacion + verificacion | Este README (secciones 9-11) |
+
+Plan **Medium** (8-10 archivos): carpeta + README unico (condensado).
+
+## 1. Contexto / Problema
+
+El usuario reporto que el login del admin desplegado contra dev falla con:
+
+```json
+{"error": "Turnstile verify failed: ['timeout-or-duplicate']",
+ "code": "CAPTCHA_INVALID"}
+```
+
+**Causa raiz (doble):**
+
+1. **Backend**: el flujo de login valida Turnstile en DOS controllers
+   independientes — `login.check-email` (`check_email.py:54-58`) Y
+   `login.start` (`start.py:70-74`). Ambos llaman
+   `verify_captcha_or_bypass`.
+2. **Frontend**: el `LoginForm` del admin mantiene UN solo
+   `turnstileToken` (`admin/src/features/auth/components/login-form.tsx:55`),
+   lo adjunta a `check-email` (`:79`) donde Cloudflare lo QUEMA (single-use),
+   y luego reusa el MISMO token en `login.start` (`:103` passwordless y
+   `:114` con password) -> Cloudflare responde `timeout-or-duplicate`.
+
+### Hallazgos de exploracion (cerrados, no reabrir)
+
+- `cf_turnstile_response` ya es OPCIONAL en `LoginStartIn` y
+  `LoginCheckEmailIn` (`models/login.py:28,45`, `Field(default='')`). La
+  obligatoriedad la impone solo el `verify_captcha_or_bypass` del controller.
+- La AUTO-BLACKLIST anti-solver (`shared/rate_limit/`) cuenta tokens por
+  `(ip, endpoint, window)` SEPARADO. `login.check-email` ya alimenta su
+  propio counter nativamente — al quitar Turnstile de `login.start`, la
+  proteccion anti-solver se mantiene via `check-email`. Threshold real = 10
+  tokens/60s, bloqueo 1h.
+- Ningun test ASSERTea Turnstile en `login.start`: los 7 solo lo
+  monkeypatchean a no-op. Hay que limpiar esos monkeypatch.
+- `register.start` sigue vivo como endpoint publico de alta y CONSERVA
+  Turnstile. NO se toca.
+- El patron temp JWT (`issue_temp(flow, step)` + `verify(expected_flow)` +
+  blacklist rolling) ya existe en `jwt_service.py`. `_Meta.authorization`
+  (`models/_common.py:44`) ya expone el header `Authorization` (lo consume
+  `require_active_user`).
+
+## 2. Solucion Propuesta
+
+Modelo de seguridad basado en **temp JWT** (decision del usuario): el
+Turnstile se resuelve UNA vez al inicio; el resto del flujo se autoriza con
+un temp JWT de vida corta + rate-limit per-IP.
+
+### Decisiones clave
+
+- **D-1**: `login.check-email` es el UNICO punto con Turnstile en el flujo
+  de login. Emite un **temp JWT `flow='login'` step=0** en su respuesta
+  (`temp_token`) SOLO en los casos que pueden continuar a `login.start`
+  (email `exists+active` o `pending`). Para `exists:false` y `unavailable`
+  NO emite temp (no hay flujo que continuar).
+- **D-2**: `login.start` QUITA `verify_captcha_or_bypass`. En su lugar EXIGE
+  el temp JWT `flow='login'` en el header `Authorization: Bearer <temp>`
+  (via `_Meta.authorization`). Lo verifica, valida que el `sub` matchee el
+  email del body, y lo blacklistea (rolling). Sin temp valido -> **401
+  MISSING_PRECHECK**.
+- **D-3**: el paso de password (login.start con password) y el passwordless
+  (login.start que crea pending / re-emite email) van SIN Turnstile,
+  protegidos por el temp JWT + rate-limit per-IP. El email se envia en
+  `login.start` (no en check-email) cuando el user presiona "continuar".
+- **D-4**: la auto-blacklist anti-solver pasa a alimentarse SOLO por
+  `login.check-email` (que ya lo hace). `register.start` conserva su
+  Turnstile + su propia auto-blacklist.
+
+## 3. Criterios de Aceptacion (AC)
+
+- **AC-1**: Given `login.check-email` de un email active, When ejecuta con
+  Turnstile OK, Then la respuesta incluye `temp_token` (temp JWT
+  `flow='login'` step=0) ademas de `{exists, has_password}`.
+- **AC-2**: Given `login.check-email` de un email pending, When ejecuta,
+  Then la respuesta incluye `temp_token` + `{exists, pending, has_password}`.
+- **AC-3**: Given `login.check-email` de un email inexistente
+  (`exists:false`) o unavailable, When ejecuta, Then la respuesta NO incluye
+  `temp_token`.
+- **AC-4**: Given `login.start` SIN header `Authorization` (o con un JWT no
+  `flow='login'`/expirado/revocado), When ejecuta, Then responde **401
+  MISSING_PRECHECK** y NO toca Neon ni envia email.
+- **AC-5**: Given `login.start` con un temp JWT `flow='login'` valido cuyo
+  `sub` NO matchea el email del body, When ejecuta, Then responde **401
+  MISSING_PRECHECK** (anti-cross-account).
+- **AC-6**: Given `login.start` con el temp JWT valido del email correcto,
+  When ejecuta, Then NO valida Turnstile, blacklistea el temp (rolling) y
+  procede (passwordless: envia email; con password: valida argon2).
+- **AC-7**: Given `login.start`, Then el controller ya NO llama
+  `verify_captcha_or_bypass` (ni en validate ni en execute).
+- **AC-8**: Given el frontend del admin, When `check-email` devuelve OK,
+  Then guarda el `temp_token` y lo manda en `Authorization: Bearer` en
+  `login.start`, SIN `cf_turnstile_response`.
+- **AC-9** (E2E post-deploy): el login real en dev (curl) funciona:
+  `check-email` con Turnstile -> `temp_token`; `login.start` con ese temp en
+  `Authorization` -> 200, sin `timeout-or-duplicate`.
+
+## 4. Diagrama de Flujo (Antes y Despues)
+
+### Antes
+```
+[boton iniciar sesion] -> login.check-email {email, cf_turnstile_response}
+                            verify_captcha (QUEMA el token single-use)
+                            -> {exists, has_password}
+[boton continuar / password] -> login.start {email, [password], cf_turnstile_response=<MISMO token>}
+                            verify_captcha -> timeout-or-duplicate -> 403  ❌
+```
+
+### Despues
+```
+[boton iniciar sesion] -> login.check-email {email, cf_turnstile_response}
+                            verify_captcha (OK)
+                            -> {exists, has_password, temp_token}  (si continua)
+[boton continuar / password] -> login.start {email, [password]}
+                            Authorization: Bearer <temp_token>
+                            verify_jwt(flow='login') + sub==email -> blacklist rolling
+                            sin temp valido -> 401 MISSING_PRECHECK
+                            -> procede (email / password)  ✅
+```
+
+## 5. Diagrama ER
+
+N/A — no hay cambios en base de datos. El temp JWT es stateless (HS256); su
+blacklist usa la tabla DDB `jwt-blacklist` existente (sin cambio de schema).
+
+## 6. Tests Requeridos
+
+### 6.B. Unit (Lambda auth, mirror en `tests/unit/controllers/login/`)
+
+- `test_check_email_active_with_password.py` (MODIF): assertea
+  `temp_token` en la respuesta [AC-1].
+- `test_check_email_pending.py` (NUEVO): pending -> `temp_token` +
+  `{exists, pending, has_password:false}` [AC-2].
+- `test_check_email_not_found.py` (MODIF): `exists:false` -> SIN
+  `temp_token` [AC-3].
+- `test_check_email_unavailable.py` (NUEVO): disabled/locked -> SIN
+  `temp_token` [AC-3].
+- `test_login_start_missing_precheck_401.py` (NUEVO): sin Authorization ->
+  401 MISSING_PRECHECK; no toca services [AC-4].
+- `test_login_start_precheck_sub_mismatch_401.py` (NUEVO): temp valido,
+  sub != email -> 401 [AC-5].
+- Los 7 `test_login_start_*` existentes (MODIF): inyectar el temp JWT valido
+  en `_meta.authorization` (via `_make_authed_event`) + mockear
+  `jwt_svc.verify` para devolver claims con `sub` matcheando; quitar el
+  monkeypatch de `verify_captcha_or_bypass` [AC-6/7].
+
+### 6.C. Typecheck / lint
+- `serverless lint-deps --lambda=auth` + `tests --type=coverage --lambda=auth`
+  (>=80%).
+- `pnpm --filter @portfolio/admin lint` + `typecheck` + `test` + `build`.
+
+### 6.D. E2E (manual post-deploy)
+- `WHEN check-email en dev con Turnstile THEN devuelve temp_token; WHEN
+  login.start con ese temp en Authorization THEN 200 (sin timeout-or-
+  duplicate) [AC-9]`.
+
+## 7. Archivos Afectados
+
+### Modificar — Backend (Lambda auth)
+- `serverless/lambda/services/auth/core/controllers/login/check_email.py`
+  — emite temp JWT `flow='login'` step=0 en los casos active/pending;
+  agrega `temp_token` a la respuesta.
+  - Verificar: `serverless tests --type=unit --lambda=auth`
+- `serverless/lambda/services/auth/core/controllers/login/start.py`
+  — quita `verify_captcha_or_bypass` (import + validate); agrega
+  `_require_precheck()` que lee `meta.authorization`, verifica el temp
+  `flow='login'`, valida `sub==email`, blacklistea rolling; 401
+  MISSING_PRECHECK si falla.
+  - Verificar: idem
+- `serverless/lambda/services/auth/tests/unit/controllers/login/*` — ver 6.B.
+
+### Crear — Backend (tests)
+- `test_check_email_pending.py`, `test_check_email_unavailable.py`,
+  `test_login_start_missing_precheck_401.py`,
+  `test_login_start_precheck_sub_mismatch_401.py`.
+
+### Modificar — Frontend (admin)
+- `admin/src/features/auth/components/login-form.tsx` — guarda el
+  `temp_token` de `check-email`; lo manda en `Authorization` a `login.start`;
+  NO manda `cf_turnstile_response` en `login.start`.
+- `admin/src/features/auth/api/auth-client.ts` (o donde viva el cliente) —
+  el shape de `loginStart` acepta `temp_token` (Authorization) en vez de
+  `cf_turnstile_response`.
+  - Verificar: `pnpm --filter @portfolio/admin test` + `build`
+- tests admin del LoginForm/auth-client (MODIF): el segundo paso manda el
+  temp en Authorization, no el captcha.
+
+### Modificar — Docs
+- `.claude/rules/auth-system.md` — AC-12: "login.start" -> "login.check-email";
+  la seccion de check-email documenta el temp JWT step=0.
+
+### NO se tocan
+- `register.start` (conserva Turnstile).
+- El schema DDB / Neon.
+- El resto del flujo (`verify-*`, `session.*`).
+
+## 8. Descomposicion para Paralelizacion
+
+N/A — secuencial inline. Backend (commits 2-3) y frontend (commit 4) tocan
+arboles disjuntos pero el plan es Medium y se ejecuta en orden. Los tests
+corren en Bash/devtools (NO fan-out de 1 agente por suite).
+
+## 9. Commits (rama `fix/login-turnstile-precheck` desde `dev`)
+
+1. `docs(specs): plan turnstile solo en login.check-email`
+2. `feat(auth): check-email emite temp JWT precheck del login` — check_email.py
+   + tests check-email. [AC-1/2/3]
+3. `fix(auth): login.start exige el temp precheck en vez de turnstile` —
+   start.py + tests login.start (limpia monkeypatch turnstile). [AC-4/5/6/7]
+4. `fix(admin): login.start usa el temp de check-email, no el captcha` —
+   login-form + auth-client + tests admin. [AC-8]
+5. `docs(rules): turnstile del login pasa a check-email (AC-12)` —
+   auth-system.md.
+6. `test(specs): verificacion E2E + limpieza del plan` — seccion 11 +
+   `git rm -r docs/specs/login-turnstile-precheck/`.
+
+Un solo PR `fix/login-turnstile-precheck -> dev`.
+
+## 10. Paralelizacion con git worktrees
+
+N/A — secuencial.
+
+## 11. Verificacion E2E iterativa (fase final)
+
+**Parte A — refactor de tests**: `rg -n verify_captcha_or_bypass
+serverless/lambda/services/auth/core/controllers/login/start.py` -> 0
+resultados; ningun test de login.start monkeypatchea turnstile;
+`rg -n cf_turnstile_response admin/src/features/auth` -> solo el paso
+check-email.
+
+**Parte B — bateria local (repo verde)**:
+```
+python devtools/run.py serverless lint-deps --lambda=auth
+python devtools/run.py serverless tests --type=unit --lambda=auth
+python devtools/run.py serverless tests --type=coverage --lambda=auth  # >=80%
+pnpm --filter @portfolio/admin lint
+pnpm --filter @portfolio/admin typecheck
+pnpm --filter @portfolio/admin test
+pnpm --filter @portfolio/admin build
+```
+Bucle: si algo falla -> corregir -> re-ejecutar. No declarar listo con rojo o
+coverage <80%.
+
+**Gate de cierre**: solo con Parte A+B verde. push + PR -> dev, 3 checks CI
+verdes, merge `--merge`.
+
+**Parte C — despliegue REAL (post-merge, OBLIGATORIA — toca el Lambda auth)**:
+El merge dispara `deploy-backend.yml` (redeploya `auth`) + `deploy-apps.yml`
+(admin). Tras esperar ambos runs:
+1. **Backend**: curl real contra dev:
+   - `login.check-email` con un Turnstile real (o el flujo del admin) ->
+     confirmar `temp_token` en la respuesta.
+   - `login.start` con ese temp en `Authorization: Bearer` -> 200 (NO
+     `timeout-or-duplicate`) [AC-9].
+   - `login.start` SIN Authorization -> 401 MISSING_PRECHECK.
+   - E2E api module (`e2e --module=api --env=dev`) verde (el bypass token
+     E2E sigue funcionando: si el E2E pega directo a login.start, ajustar el
+     flow para que pase por check-email primero o mande un temp).
+2. **Frontend**: abrir `admin.portfolio.dev.the-full-stack.com`, login con
+   password real -> NO debe dar `timeout-or-duplicate`; el captcha se
+   resuelve una sola vez.
+
+Bucle de correccion identico a Parte B. No declarar listo sin Parte C verde.
+
+## 12. Definition of Done
+
+- [ ] AC-1..AC-9 cubiertos por test (unit) + Parte C (E2E).
+- [ ] Coverage per-file >= 80% (auth + admin modificados).
+- [ ] lint + typecheck + lint-deps limpios.
+- [ ] Build admin OK.
+- [ ] CI verde; PR mergeado con `--merge`.
+- [ ] Parte C: check-email -> temp_token; login.start con temp -> 200;
+      sin temp -> 401; login real del admin sin `timeout-or-duplicate`.
+- [ ] Carpeta `docs/specs/login-turnstile-precheck/` eliminada en el ultimo
+      commit.

--- a/serverless/lambda/services/auth/core/controllers/login/check_email.py
+++ b/serverless/lambda/services/auth/core/controllers/login/check_email.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from models.login import LoginCheckEmailIn
 from services.audit_service import AuditService
+from services.jwt_service import JwtService
 from services.password_service import PasswordService
 from services.rate_limit_service import RateLimitService
 from services.user_service import UserService
@@ -29,6 +30,10 @@ from shared.db.models.auth.enums import AuthUserStatus
 from shared.lambda_kit.base_controller import BaseController
 
 _ENDPOINT = '/auth#login.check-email'
+# El temp JWT precheck (paso 0 del login) autoriza `login.start`: este
+# es el UNICO punto del flujo de login con Turnstile (decision D-1/D-2).
+_PRECHECK_FLOW = 'login'
+_PRECHECK_STEP = 0
 
 
 class CheckEmail(BaseController):
@@ -61,13 +66,21 @@ class CheckEmail(BaseController):
     def execute(self) -> dict[str, Any]:
         """Reporta existencia + has_password (sin la lista de metodos MFA).
 
+        Tras validar Turnstile (en `validate`), emite un temp JWT precheck
+        (`flow='login'` step=0) en los casos que pueden continuar a
+        `login.start` (active o pending). `login.start` lo exige en
+        `Authorization` y ya NO valida Turnstile (decision D-1/D-2). Para
+        un email inexistente o unavailable NO se emite temp (no hay flujo
+        que continuar).
+
         Returns:
-            200 `{exists:false}` si el email no existe (AC-C2).
-            200 `{exists:true, pending:true, has_password:false}` si pending
-            (AC-C3).
+            200 `{exists:false}` si el email no existe (AC-C2/AC-3).
+            200 `{exists:true, pending:true, has_password:false, temp_token}`
+            si pending (AC-C3/AC-2).
             200 `{exists:true, unavailable:true}` si disabled/locked/deleted
-            (AC-C4).
-            200 `{exists:true, has_password:<bool>}` si active (AC-C1).
+            (AC-C4/AC-3, sin temp_token).
+            200 `{exists:true, has_password:<bool>, temp_token}` si active
+            (AC-C1/AC-1).
         """
         data: LoginCheckEmailIn = self.validated_data  # type: ignore[assignment]
         meta = data.meta
@@ -99,6 +112,7 @@ class CheckEmail(BaseController):
                     'exists': True,
                     'pending': True,
                     'has_password': False,
+                    'temp_token': self._issue_precheck(user_id=user.id),
                 },
             }
 
@@ -113,7 +127,8 @@ class CheckEmail(BaseController):
                 'data': {'exists': True, 'unavailable': True},
             }
 
-        # active: expone has_password (NO la lista de metodos MFA).
+        # active: expone has_password (NO la lista de metodos MFA) + el temp
+        # precheck que autoriza login.start.
         status = PasswordService(app_config).status(user_id=user.id)
         return {
             'is_valid': True,
@@ -121,5 +136,19 @@ class CheckEmail(BaseController):
             'data': {
                 'exists': True,
                 'has_password': bool(status['has_password']),
+                'temp_token': self._issue_precheck(user_id=user.id),
             },
         }
+
+    def _issue_precheck(self, *, user_id: Any) -> str:
+        """Emite el temp JWT precheck (`flow='login'` step=0) para el user.
+
+        Solo se llama tras pasar Turnstile (en `validate`). `login.start`
+        lo verifica (flow + sub) y lo blacklistea rolling.
+        """
+        token, _ = JwtService(app_config).issue_temp(
+            user_id=user_id,
+            flow=_PRECHECK_FLOW,
+            step=_PRECHECK_STEP,
+        )
+        return token

--- a/serverless/lambda/services/auth/core/controllers/login/check_email.py
+++ b/serverless/lambda/services/auth/core/controllers/login/check_email.py
@@ -25,6 +25,7 @@ from services.password_service import PasswordService
 from services.rate_limit_service import RateLimitService
 from services.user_service import UserService
 from settings.config import app_config
+from shared.core.ulid import new_uuidv7
 from shared.crypto.captcha import verify_captcha_or_bypass
 from shared.db.models.auth.enums import AuthUserStatus
 from shared.lambda_kit.base_controller import BaseController
@@ -98,10 +99,19 @@ class CheckEmail(BaseController):
 
         user = user_svc.get_by_email(email)
         if user is None:
+            # Email nuevo: emite el precheck igual (la fusion register->login
+            # permite que login.start CREE el pending). El temp lleva un sub
+            # placeholder (aun no hay user); login.start no compara el sub
+            # cuando el email no existe (solo cuando ya existe, anti-cross-
+            # account). El abuso queda acotado: crear un pending ya costo un
+            # Turnstile, igual que register.start (decision usuario).
             return {
                 'is_valid': True,
                 'code': 0,
-                'data': {'exists': False},
+                'data': {
+                    'exists': False,
+                    'temp_token': self._issue_precheck(user_id=new_uuidv7()),
+                },
             }
 
         if user.status == AuthUserStatus.PENDING:

--- a/serverless/lambda/services/auth/core/controllers/login/start.py
+++ b/serverless/lambda/services/auth/core/controllers/login/start.py
@@ -1,12 +1,17 @@
 """Controller `login.start` — inicia el flujo de login passwordless.
 
 Espejo de `register.start`. El visitante existente pide login: el
-controller verifica Turnstile + rate-limit, valida que el email exista
-y este activo, genera code + magic-link nuevos, publica los 2 mensajes
-SQS al worker, y devuelve un temp_token (rolling JWT, 5 min) con
+controller EXIGE el temp JWT precheck (`flow='login'` step=0, emitido por
+`login.check-email` tras validar Turnstile), valida que su `sub` matchee el
+email del body, lo blacklistea (rolling), genera code + magic-link nuevos,
+envia el email unificado, y devuelve un temp_token (rolling JWT, 5 min) con
 flow='login'.
 
-AC cubiertos: AC-5, AC-6, AC-20.
+`login.start` ya NO valida Turnstile: el captcha se resuelve UNA sola vez en
+`login.check-email` (decision D-1/D-2). Sin un temp precheck valido ->
+401 MISSING_PRECHECK.
+
+AC cubiertos: AC-4, AC-5, AC-6, AC-7, AC-20.
 """
 
 from __future__ import annotations
@@ -23,7 +28,7 @@ from services.mfa_method_service import MfaMethodService
 from services.rate_limit_service import RateLimitService
 from services.user_service import UserService
 from settings.config import app_config
-from shared.crypto.captcha import verify_captcha_or_bypass
+from shared.auth.jwt import JwtError
 from shared.db.models.auth.enums import (
     AuthCodeKind,
     AuthLinkKind,
@@ -40,6 +45,8 @@ _TEMP_TTL_SECONDS = 300
 # flow (decision 10). Solo metodos fuertes post-password.
 _MFA_FLOW = 'login-mfa'
 _MFA_METHODS = ['totp', 'webauthn']
+# El precheck (flow='login' step=0) lo emite login.check-email tras Turnstile.
+_PRECHECK_FLOW = 'login'
 
 
 class Start(BaseController):
@@ -48,7 +55,11 @@ class Start(BaseController):
     event_model = LoginStartIn
 
     def validate(self) -> dict[str, Any]:
-        """Pydantic + rate-limit + Turnstile."""
+        """Pydantic + rate-limit per-IP. SIN Turnstile (decision D-2).
+
+        El captcha se resuelve en `login.check-email`; aqui la autorizacion
+        es el temp JWT precheck (verificado en `execute`).
+        """
         base = super().validate()
         if not base.get('is_valid'):
             return base
@@ -56,23 +67,62 @@ class Start(BaseController):
         data: LoginStartIn = self.validated_data  # type: ignore[assignment]
         meta = data.meta
 
-        # brought_turnstile_token: True solo si el usuario adjunto un CAPTCHA
-        # real (no el bypass dev/E2E vacio). Es el unico endpoint del flujo
-        # auth donde el usuario resuelve un Turnstile -> el unico que alimenta
-        # la auto-blacklist (un solver hace muchos start con CAPTCHA en 60s).
         RateLimitService(app_config).check_or_raise(
             ip=meta.ip or '',
             endpoint=_ENDPOINT,
             country=meta.country,
-            turnstile_validated=False,
-            brought_turnstile_token=bool(data.cf_turnstile_response),
-        )
-        verify_captcha_or_bypass(
-            data.cf_turnstile_response,
-            remote_ip=meta.ip,
-            bypass_token=meta.bypass_token,
+            turnstile_validated=True,
         )
         return base
+
+    @staticmethod
+    def _extract_bearer(authorization: str | None) -> str | None:
+        """Extrae el JWT de un header `Authorization: Bearer <token>`."""
+        if not authorization:
+            return None
+        parts = authorization.split(' ', 1)
+        if len(parts) != 2 or parts[0].lower() != 'bearer':
+            return None
+        token = parts[1].strip()
+        return token or None
+
+    def _verify_precheck(
+        self, *, jwt_svc: Any, meta: Any,
+    ) -> Any | None:
+        """Verifica el temp precheck del header `Authorization`.
+
+        Returns:
+            Los claims del temp (`flow='login'`) si es valido, o None si
+            falta / no verifica / no es del flow correcto. NO compara el
+            `sub` con el email (eso lo hace `execute` con el user resuelto).
+        """
+        token = self._extract_bearer(meta.authorization)
+        if token is None:
+            return None
+        try:
+            return jwt_svc.verify(
+                token,
+                expected_typ='temp',
+                expected_flow=_PRECHECK_FLOW,
+            )
+        except JwtError:
+            return None
+
+    @staticmethod
+    def _missing_precheck(*, audit_svc: Any, meta: Any) -> dict[str, Any]:
+        """Respuesta 401 MISSING_PRECHECK (sin precheck valido)."""
+        audit_svc.log(
+            event='login.start',
+            success=False,
+            error_code='MISSING_PRECHECK',
+            ip=meta.ip,
+        )
+        return {
+            'is_valid': False,
+            'code': 4003,
+            'status': 401,
+            'data': {'error': 'MISSING_PRECHECK'},
+        }
 
     def execute(self) -> dict[str, Any]:
         """Verifica que el email exista/active, publica code + magic-link.
@@ -98,7 +148,30 @@ class Start(BaseController):
         email_svc = EmailDispatchService(app_config)
         audit_svc = AuditService(app_config)
 
+        # Precheck obligatorio: el temp JWT flow='login' step=0 emitido por
+        # login.check-email (tras Turnstile). Sin el -> 401 MISSING_PRECHECK
+        # (decision D-2). Reemplaza al Turnstile de este endpoint (AC-4/7).
+        claims = self._verify_precheck(jwt_svc=jwt_svc, meta=meta)
+        if claims is None:
+            return self._missing_precheck(audit_svc=audit_svc, meta=meta)
+
         existing = user_svc.get_by_email(email)
+
+        # Anti-cross-account (AC-5): si el email YA existe, el `sub` del
+        # precheck DEBE matchear su id (el precheck se emitio para ESE user).
+        # Si el email NO existe, es un alta (fusion register->login): el
+        # precheck se emitio con un sub placeholder, login.start crea el
+        # pending; no hay sub que comparar.
+        if existing is not None and str(claims.sub) != str(existing.id):
+            return self._missing_precheck(audit_svc=audit_svc, meta=meta)
+
+        # Precheck OK: lo blacklistea (rolling, single-use).
+        jwt_svc.blacklist(
+            jti=claims.jti,
+            exp=claims.exp,
+            user_id=existing.id if existing is not None else claims.sub,
+            reason='rotation',
+        )
 
         # Fusion register -> login (plan admin-security-overview, bloque D):
         # si el email NO existe, se CREA el user pending (lo que antes hacia

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_check_email_not_found.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_check_email_not_found.py
@@ -1,9 +1,10 @@
-"""AC-C2/AC-3: check-email de un email inexistente -> {exists:false}.
+"""AC-2/AC-3: check-email de un email inexistente -> {exists:false, temp_token}.
 
 Given un email que no esta en auth_users,
 When se invoca login.check-email,
-Then devuelve {exists:false} SIN temp_token (no hay flujo que continuar; la
-UI ofrece crear cuenta).
+Then devuelve {exists:false} CON temp_token: la fusion register->login deja
+que login.start CREE el pending, asi que el alta tambien necesita el precheck.
+El temp se emite con un sub placeholder (aun no hay user).
 """
 
 from unittest.mock import MagicMock
@@ -12,12 +13,13 @@ from .._helpers import _make_event_register_start
 
 
 def test_check_email_not_found(monkeypatch):
-    """AC-C2/AC-3: email inexistente -> exists:false, sin temp_token."""
+    """AC-2/AC-3: email inexistente -> exists:false + temp_token (alta)."""
     from controllers.login import check_email
 
     user_svc = MagicMock()
     user_svc.get_by_email.return_value = None
     jwt_svc = MagicMock()
+    jwt_svc.issue_temp.return_value = ('PRECHECK-NEW-EMAIL-JWT', MagicMock())
 
     monkeypatch.setattr(check_email, 'UserService', lambda _c: user_svc)
     monkeypatch.setattr(
@@ -35,7 +37,10 @@ def test_check_email_not_found(monkeypatch):
 
     assert result['is_valid'] is True
     assert result['code'] == 0
-    assert result['data'] == {'exists': False}
-    assert 'temp_token' not in result['data']
-    # Email inexistente: NO se emite precheck (no hay flujo que continuar).
-    jwt_svc.issue_temp.assert_not_called()
+    assert result['data'] == {
+        'exists': False,
+        'temp_token': 'PRECHECK-NEW-EMAIL-JWT',
+    }
+    # Email inexistente: SI emite precheck (login.start crea el pending).
+    assert jwt_svc.issue_temp.call_args.kwargs['flow'] == 'login'
+    assert jwt_svc.issue_temp.call_args.kwargs['step'] == 0

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_check_email_pending.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_check_email_pending.py
@@ -1,10 +1,10 @@
-"""AC-C1/AC-1: check-email de un user active con password.
+"""AC-2: check-email de un user pending -> {exists, pending, temp_token}.
 
-Given un email que existe active y tiene password,
+Given un email que existe en status pending,
 When se invoca login.check-email,
-Then devuelve {exists:true, has_password:true, temp_token} SIN la lista de
-metodos MFA. El temp_token es el precheck (flow='login' step=0) que autoriza
-login.start.
+Then devuelve {exists:true, pending:true, has_password:false, temp_token}.
+El temp_token es el precheck (flow='login' step=0) que autoriza login.start
+para terminar el alta (pending -> active).
 """
 
 from unittest.mock import MagicMock
@@ -12,27 +12,22 @@ from unittest.mock import MagicMock
 from .._helpers import _make_event_register_start
 
 
-def test_check_email_active_with_password(monkeypatch):
-    """AC-C1/AC-1: active con password -> exists+has_password+temp_token."""
+def test_check_email_pending(monkeypatch):
+    """AC-2: pending -> exists+pending+has_password=false+temp_token."""
     from controllers.login import check_email
     from shared.db.models.auth.enums import AuthUserStatus
 
     user = MagicMock()
-    user.id = 'usr-1'
-    user.status = AuthUserStatus.ACTIVE
+    user.id = 'usr-pending-1'
+    user.status = AuthUserStatus.PENDING
     user_svc = MagicMock()
     user_svc.get_by_email.return_value = user
-    password_svc = MagicMock()
-    password_svc.status.return_value = {
-        'has_password': True,
-        'last_change_at': '2026-01-01T00:00:00+00:00',
-    }
     jwt_svc = MagicMock()
-    jwt_svc.issue_temp.return_value = ('PRECHECK-TEMP-JWT', MagicMock())
+    jwt_svc.issue_temp.return_value = ('PRECHECK-PENDING-JWT', MagicMock())
 
     monkeypatch.setattr(check_email, 'UserService', lambda _c: user_svc)
     monkeypatch.setattr(
-        check_email, 'PasswordService', lambda _c: password_svc,
+        check_email, 'PasswordService', lambda _c: MagicMock(),
     )
     monkeypatch.setattr(check_email, 'JwtService', lambda _c: jwt_svc)
     monkeypatch.setattr(check_email, 'AuditService', lambda _c: MagicMock())
@@ -41,17 +36,16 @@ def test_check_email_active_with_password(monkeypatch):
         check_email, 'verify_captcha_or_bypass', lambda *_a, **_k: {},
     )
 
-    event = _make_event_register_start(email='u@example.com')
+    event = _make_event_register_start(email='pending@example.com')
     result = check_email.CheckEmail(event=event).run()
 
     assert result['is_valid'] is True
     assert result['code'] == 0
     assert result['data'] == {
         'exists': True,
-        'has_password': True,
-        'temp_token': 'PRECHECK-TEMP-JWT',
+        'pending': True,
+        'has_password': False,
+        'temp_token': 'PRECHECK-PENDING-JWT',
     }
-    assert 'methods' not in result['data']
-    # El precheck se emite con flow='login' step=0.
     assert jwt_svc.issue_temp.call_args.kwargs['flow'] == 'login'
     assert jwt_svc.issue_temp.call_args.kwargs['step'] == 0

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_check_email_unavailable.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_check_email_unavailable.py
@@ -1,22 +1,29 @@
-"""AC-C2/AC-3: check-email de un email inexistente -> {exists:false}.
+"""AC-3: check-email de un user disabled/locked -> {exists, unavailable}.
 
-Given un email que no esta en auth_users,
+Given un email que existe pero esta disabled o locked,
 When se invoca login.check-email,
-Then devuelve {exists:false} SIN temp_token (no hay flujo que continuar; la
-UI ofrece crear cuenta).
+Then devuelve {exists:true, unavailable:true} SIN temp_token (no hay flujo
+que continuar; anti-enumeration: mismo body para disabled/locked/deleted).
 """
+
+import pytest
 
 from unittest.mock import MagicMock
 
 from .._helpers import _make_event_register_start
 
 
-def test_check_email_not_found(monkeypatch):
-    """AC-C2/AC-3: email inexistente -> exists:false, sin temp_token."""
+@pytest.mark.parametrize('status', ['disabled', 'locked', 'deleted'])
+def test_check_email_unavailable(monkeypatch, status):
+    """AC-3: disabled/locked/deleted -> unavailable, sin temp_token."""
     from controllers.login import check_email
+    from shared.db.models.auth.enums import AuthUserStatus
 
+    user = MagicMock()
+    user.id = 'usr-unavail-1'
+    user.status = AuthUserStatus(status)
     user_svc = MagicMock()
-    user_svc.get_by_email.return_value = None
+    user_svc.get_by_email.return_value = user
     jwt_svc = MagicMock()
 
     monkeypatch.setattr(check_email, 'UserService', lambda _c: user_svc)
@@ -30,12 +37,12 @@ def test_check_email_not_found(monkeypatch):
         check_email, 'verify_captcha_or_bypass', lambda *_a, **_k: {},
     )
 
-    event = _make_event_register_start(email='nobody@example.com')
+    event = _make_event_register_start(email='blocked@example.com')
     result = check_email.CheckEmail(event=event).run()
 
     assert result['is_valid'] is True
     assert result['code'] == 0
-    assert result['data'] == {'exists': False}
+    assert result['data'] == {'exists': True, 'unavailable': True}
     assert 'temp_token' not in result['data']
-    # Email inexistente: NO se emite precheck (no hay flujo que continuar).
+    # disabled/locked/deleted: NO se emite precheck.
     jwt_svc.issue_temp.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_active_no_password.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_active_no_password.py
@@ -5,6 +5,7 @@ When se invoca login.start,
 Then publica code + magic-link + devuelve temp_token con methods.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from .._helpers import _make_event_register_start, _make_user
@@ -24,6 +25,10 @@ def test_login_start_email_active_no_password(monkeypatch):
     link_svc.generate_and_persist.return_value = ('T' + 'X' * 31, b'\x01' * 32)
     jwt_svc = MagicMock()
     jwt_svc.issue_temp.return_value = ('TEMP-LOGIN-JWT', MagicMock())
+    jwt_svc.verify.return_value = SimpleNamespace(
+        sub=user.id, jti='precheck-jti', exp=9999999999, flow='login',
+        typ='temp',
+    )
     email_svc = MagicMock()
 
     monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
@@ -33,13 +38,9 @@ def test_login_start_email_active_no_password(monkeypatch):
     monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
     monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
-    monkeypatch.setattr(
-        start,
-        'verify_captcha_or_bypass',
-        lambda *_a, **_k: {'success': True},
-    )
 
     event = _make_event_register_start(email='visitor@example.com')
+    event['_meta']['authorization'] = 'Bearer PRECHECK-TEMP'
     controller = start.Start(event=event)
     result = controller.run()
 

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_not_found_404.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_not_found_404.py
@@ -6,6 +6,7 @@ Then crea el user pending, publica UN email unificado y devuelve un
   temp_token (flow login, step 1) + created=True. (Ya NO devuelve 404.)
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from .._helpers import _make_event_register_start
@@ -28,6 +29,11 @@ def test_login_start_email_not_found_creates_pending(monkeypatch):
     link_svc.generate_and_persist.return_value = ('TOKEN-XYZ', MagicMock())
     jwt_svc = MagicMock()
     jwt_svc.issue_temp.return_value = ('TEMP-JWT', MagicMock())
+    # Email nuevo: existing is None -> el sub del precheck no se compara.
+    jwt_svc.verify.return_value = SimpleNamespace(
+        sub='placeholder-uuid', jti='precheck-jti', exp=9999999999,
+        flow='login', typ='temp',
+    )
     email_svc = MagicMock()
 
     monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
@@ -37,13 +43,9 @@ def test_login_start_email_not_found_creates_pending(monkeypatch):
     monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
     monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
-    monkeypatch.setattr(
-        start,
-        'verify_captcha_or_bypass',
-        lambda *_a, **_k: {'success': True},
-    )
 
     event = _make_event_register_start(email='unknown@example.com')
+    event['_meta']['authorization'] = 'Bearer PRECHECK-TEMP'
     result = start.Start(event=event).run()
 
     assert result['is_valid'] is True

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_pending_409.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_email_pending_409.py
@@ -6,6 +6,7 @@ Then re-emite code + magic-link, publica el email y devuelve un temp_token
   (flow login, step 1) + created=False. (Ya NO devuelve 409.)
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from .._helpers import _make_event_register_start
@@ -29,6 +30,10 @@ def test_login_start_email_pending_reemits(monkeypatch):
     link_svc.generate_and_persist.return_value = ('TOKEN-ABC', MagicMock())
     jwt_svc = MagicMock()
     jwt_svc.issue_temp.return_value = ('TEMP-JWT', MagicMock())
+    jwt_svc.verify.return_value = SimpleNamespace(
+        sub='usr-pending', jti='precheck-jti', exp=9999999999, flow='login',
+        typ='temp',
+    )
     email_svc = MagicMock()
 
     monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
@@ -38,13 +43,9 @@ def test_login_start_email_pending_reemits(monkeypatch):
     monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
     monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
-    monkeypatch.setattr(
-        start,
-        'verify_captcha_or_bypass',
-        lambda *_a, **_k: {'success': True},
-    )
 
     event = _make_event_register_start(email='pending@example.com')
+    event['_meta']['authorization'] = 'Bearer PRECHECK-TEMP'
     result = start.Start(event=event).run()
 
     assert result['is_valid'] is True

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_missing_precheck_401.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_missing_precheck_401.py
@@ -1,0 +1,71 @@
+"""AC-4: login.start sin precheck valido -> 401 MISSING_PRECHECK.
+
+Given un evento de login.start sin un temp JWT precheck valido (sin header
+  Authorization, o con uno que jwt_svc.verify rechaza),
+When se invoca login.start,
+Then devuelve 401 MISSING_PRECHECK y NO toca user_svc / email_svc.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_event_register_start
+
+
+def test_login_start_no_authorization_header_401(monkeypatch):
+    """AC-4: sin header Authorization -> 401 MISSING_PRECHECK."""
+    from controllers.login import start
+
+    user_svc = MagicMock()
+    jwt_svc = MagicMock()
+    email_svc = MagicMock()
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
+
+    # Sin authorization en _meta: el precheck falta -> 401.
+    event = _make_event_register_start(email='visitor@example.com')
+    result = start.Start(event=event).run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4003
+    assert result['status'] == 401
+    assert result['data']['error'] == 'MISSING_PRECHECK'
+    user_svc.get_by_email.assert_not_called()
+    user_svc.create_pending.assert_not_called()
+    email_svc.publish_unified.assert_not_called()
+
+
+def test_login_start_invalid_precheck_token_401(monkeypatch):
+    """AC-4: header con un temp que verify rechaza -> 401 MISSING_PRECHECK."""
+    from controllers.login import start
+    from shared.auth.jwt import JwtInvalidError
+
+    user_svc = MagicMock()
+    jwt_svc = MagicMock()
+    jwt_svc.verify.side_effect = JwtInvalidError('bad')
+    email_svc = MagicMock()
+
+    monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
+    monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(start, 'EmailDispatchService', lambda _c: email_svc)
+    monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_event_register_start(email='visitor@example.com')
+    event['_meta']['authorization'] = 'Bearer BAD'
+    result = start.Start(event=event).run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4003
+    assert result['status'] == 401
+    assert result['data']['error'] == 'MISSING_PRECHECK'
+    user_svc.get_by_email.assert_not_called()
+    user_svc.create_pending.assert_not_called()
+    email_svc.publish_unified.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_precheck_sub_mismatch_401.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_precheck_sub_mismatch_401.py
@@ -1,9 +1,10 @@
-"""AC-20: email locked/disabled -> 404 EMAIL_NOT_FOUND, suggest_register=False.
+"""AC-5: precheck sub que no matchea el user existente -> 401 (anti cross-account).
 
-Given un email con status='locked' (mismo flujo para 'disabled'),
+Given un email que existe active PERO el `sub` del precheck NO matchea su
+  user.id,
 When se invoca login.start,
-Then anti-enumeration: 404 EMAIL_NOT_FOUND con suggest_register=False
-(NO revela que el user existe).
+Then devuelve 401 MISSING_PRECHECK (el precheck se emitio para otro user) y
+  NO envia email.
 """
 
 from types import SimpleNamespace
@@ -12,21 +13,21 @@ from unittest.mock import MagicMock
 from .._helpers import _make_event_register_start, _make_user
 
 
-def test_login_start_email_locked_404(monkeypatch):
-    """AC-20: locked -> 404 anti-enumeration (tras precheck OK)."""
+def test_login_start_precheck_sub_mismatch_401(monkeypatch):
+    """AC-5: sub del precheck != user.id -> 401 anti cross-account."""
     from controllers.login import start
 
-    user = _make_user(email='visitor@example.com', status='locked')
+    user = _make_user(email='visitor@example.com', status='active')
 
     user_svc = MagicMock()
     user_svc.get_by_email.return_value = user
     jwt_svc = MagicMock()
     jwt_svc.verify.return_value = SimpleNamespace(
-        sub=user.id, jti='precheck-jti', exp=9999999999, flow='login',
+        sub='DIFFERENT-USER-ID', jti='x', exp=9999999999, flow='login',
         typ='temp',
     )
-
     email_svc = MagicMock()
+
     monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
     monkeypatch.setattr(start, 'CodeService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'MagicLinkService', lambda _c: MagicMock())
@@ -37,13 +38,10 @@ def test_login_start_email_locked_404(monkeypatch):
 
     event = _make_event_register_start(email='visitor@example.com')
     event['_meta']['authorization'] = 'Bearer PRECHECK-TEMP'
-    controller = start.Start(event=event)
-    result = controller.run()
+    result = start.Start(event=event).run()
 
     assert result['is_valid'] is False
-    assert result['code'] == 4001
-    assert result['status'] == 404
-    assert result['data']['error'] == 'EMAIL_NOT_FOUND'
-    assert result['data']['suggest_register'] is False
+    assert result['code'] == 4003
+    assert result['status'] == 401
+    assert result['data']['error'] == 'MISSING_PRECHECK'
     email_svc.publish_unified.assert_not_called()
-    email_svc.publish_magic_link.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_with_password_mfa.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_with_password_mfa.py
@@ -5,6 +5,7 @@ When se invoca login.start con {email, password},
 Then emite temp JWT step=2 flow='login-mfa' + methods=['totp','webauthn'].
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from .._helpers import _make_user
@@ -22,6 +23,7 @@ def _event_with_password(password: str) -> dict:
             'user_agent': 'pytest',
             'bypass_token': None,
             'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'authorization': 'Bearer PRECHECK-TEMP',
             'cloudfront_meta': {},
         },
     }
@@ -37,6 +39,10 @@ def test_login_start_with_password_mfa(monkeypatch):
     user_svc.get_by_email.return_value = user
     jwt_svc = MagicMock()
     jwt_svc.issue_temp.return_value = ('TEMP-STEP2-JWT', MagicMock())
+    jwt_svc.verify.return_value = SimpleNamespace(
+        sub=user.id, jti='precheck-jti', exp=9999999999, flow='login',
+        typ='temp',
+    )
     mfa_svc = MagicMock()
     mfa_svc.count_active.return_value = 1
 
@@ -48,11 +54,6 @@ def test_login_start_with_password_mfa(monkeypatch):
     monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'MfaMethodService', lambda _c: mfa_svc)
-    monkeypatch.setattr(
-        start,
-        'verify_captcha_or_bypass',
-        lambda *_a, **_k: {'success': True},
-    )
     monkeypatch.setattr(start, 'check_password', lambda **_k: True)
 
     event = _event_with_password('a-strong-passphrase-12')

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_with_password_no_mfa.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_with_password_no_mfa.py
@@ -5,6 +5,7 @@ When se invoca login.start con {email, password},
 Then emite access+refresh directo (skip step 2).
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from .._helpers import _make_user
@@ -22,6 +23,7 @@ def _event_with_password(password: str) -> dict:
             'user_agent': 'pytest',
             'bypass_token': None,
             'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'authorization': 'Bearer PRECHECK-TEMP',
             'cloudfront_meta': {},
         },
     }
@@ -38,6 +40,10 @@ def test_login_start_with_password_no_mfa(monkeypatch):
     jwt_svc = MagicMock()
     jwt_svc.issue_access.return_value = ('ACCESS-JWT', MagicMock())
     jwt_svc.issue_refresh.return_value = ('REFRESH-JWT', MagicMock())
+    jwt_svc.verify.return_value = SimpleNamespace(
+        sub=user.id, jti='precheck-jti', exp=9999999999, flow='login',
+        typ='temp',
+    )
     mfa_svc = MagicMock()
     mfa_svc.count_active.return_value = 0
 
@@ -49,11 +55,6 @@ def test_login_start_with_password_no_mfa(monkeypatch):
     monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'MfaMethodService', lambda _c: mfa_svc)
-    monkeypatch.setattr(
-        start,
-        'verify_captcha_or_bypass',
-        lambda *_a, **_k: {'success': True},
-    )
     monkeypatch.setattr(start, 'check_password', lambda **_k: True)
 
     event = _event_with_password('a-strong-passphrase-12')

--- a/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_with_password_wrong.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/login/test_login_start_with_password_wrong.py
@@ -5,6 +5,7 @@ When se invoca login.start con {email, password},
 Then incrementa failed_attempts y devuelve 401 INVALID_PASSWORD.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from .._helpers import _make_user
@@ -22,6 +23,7 @@ def _event_with_password(password: str) -> dict:
             'user_agent': 'pytest',
             'bypass_token': None,
             'origin': 'https://admin.portfolio.dev.the-full-stack.com',
+            'authorization': 'Bearer PRECHECK-TEMP',
             'cloudfront_meta': {},
         },
     }
@@ -36,6 +38,10 @@ def test_login_start_with_password_wrong(monkeypatch):
     user_svc = MagicMock()
     user_svc.get_by_email.return_value = user
     jwt_svc = MagicMock()
+    jwt_svc.verify.return_value = SimpleNamespace(
+        sub=user.id, jti='precheck-jti', exp=9999999999, flow='login',
+        typ='temp',
+    )
     mfa_svc = MagicMock()
 
     monkeypatch.setattr(start, 'UserService', lambda _c: user_svc)
@@ -46,11 +52,6 @@ def test_login_start_with_password_wrong(monkeypatch):
     monkeypatch.setattr(start, 'AuditService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'RateLimitService', lambda _c: MagicMock())
     monkeypatch.setattr(start, 'MfaMethodService', lambda _c: mfa_svc)
-    monkeypatch.setattr(
-        start,
-        'verify_captcha_or_bypass',
-        lambda *_a, **_k: {'success': True},
-    )
     monkeypatch.setattr(start, 'check_password', lambda **_k: False)
 
     event = _event_with_password('wrong-passphrase-1234')


### PR DESCRIPTION
## Problema

El login del admin desplegado contra dev fallaba con `CAPTCHA_INVALID` / `timeout-or-duplicate`:

```json
{"error": "Turnstile verify failed: ['timeout-or-duplicate']", "code": "CAPTCHA_INVALID"}
```

Causa raiz (doble):
1. **Backend**: el flujo de login validaba Turnstile en DOS controllers (`login.check-email` Y `login.start`). El token de Turnstile es single-use.
2. **Frontend**: el `LoginForm` reusaba el mismo token (ya quemado por `check-email`) en `login.start` -> Cloudflare lo rechazaba.

## Solucion

Regla pedida por el usuario: **el Turnstile va solo en el primer boton (`login.check-email`). Ninguna peticion no-inicial (step != 0) lleva Turnstile — se autorizan por JWT o JWT temporal.**

- `login.check-email` (UNICO punto con Turnstile en el login) ahora emite un **temp JWT precheck** (`flow='login'` step=0) en la respuesta, para los casos que pueden continuar (active, pending, y email nuevo con `sub` placeholder para el alta fusionada). En `unavailable` NO emite temp.
- `login.start` **quita** la validacion de Turnstile y **exige** el temp precheck en `Authorization: Bearer`. Sin el -> **401 MISSING_PRECHECK**. Si el email ya existe, el `sub` del precheck debe matchear su id (anti-cross-account).
- Frontend: `check-email` guarda el `temp_token`; `login.start` lo manda en `Authorization`, sin `cf_turnstile_response`.
- Turnstile queda SOLO en los 2 endpoints iniciales del flujo de auth: `login.check-email` + `register.start`.

## Como probar

**Local (ya verde):**
- `python devtools/run.py serverless tests --type=coverage --lambda=auth` -> 227 passed, 91.66%
- `python devtools/run.py serverless lint-deps --lambda=auth` -> OK
- `pnpm --filter @portfolio/admin test` -> 574 passed; `typecheck` + `lint` limpios
- archivos modificados >=80% per-file (login-form 95%, auth-client 96%)

**Post-deploy dev (Parte C):**
```bash
# 1. check-email con Turnstile -> debe devolver temp_token
# 2. login.start con ese temp en Authorization -> 200 (sin timeout-or-duplicate)
# 3. login.start SIN Authorization -> 401 MISSING_PRECHECK
```
+ login real en `admin.portfolio.dev.the-full-stack.com` con password -> NO mas `timeout-or-duplicate`.

## TODO

- Migrar los `/metrics/*` sub-pages al picker CloudWatch (deuda separada, fuera de scope).