### PR TITLE
test(e2e): adapta el E2E admin browser al modelo de lista de login

### DIFF
--- a/tests/admin/conftest.py
+++ b/tests/admin/conftest.py
@@ -140,30 +140,65 @@ class AdminAuth:
         refresh = field(verify.body, 'refresh_token')
         return email, user_id, access, refresh
 
-    def fresh_login(self, email: str, user_id: str) -> str:
-        """Abre una sesion NUEVA del user via API y devuelve su access token.
+    def _login_precheck(self, email: str) -> str | None:
+        """`login.check-email` (con bypass) -> temp_token precheck (o None).
 
-        Flujo: `login.start` (con bypass) -> seed del code login en Neon ->
-        `login.verify-code`. Cada login crea una fila en `auth_user_sessions`
-        y emite un access token de una FAMILIA PROPIA, independiente de la del
-        browser: el bootstrap-refresh del admin (que rota su propia familia y
-        blacklistea su access viejo) NO afecta a este token. Se usa para las
-        verificaciones server-side y para seedear estado (display_name).
+        El captcha del flujo de login se resuelve SOLO aqui (check-email);
+        `login.start` ya NO valida Turnstile, EXIGE este temp precheck
+        (`flow='login'` step=0) en `Authorization`. Mismo patron que el
+        harness api (`shared` / `tests/api/_flows.login_precheck`).
         """
-        start = self._http.post(
+        resp = self._http.post(
             '/auth',
             body=make_body(
-                'login', 'start', email=email, cf_turnstile_response='',
+                'login', 'check-email', email=email, cf_turnstile_response='',
             ),
             origin=self._origin,
             bypass_token=self._bypass,
         )
+        return field(resp.body, 'temp_token')
+
+    def fresh_login(self, email: str, user_id: str) -> str:
+        """Abre una sesion NUEVA del user via API y devuelve su access token.
+
+        Flujo (modelo de lista de metodos required): `login.check-email`
+        (precheck con bypass) -> `login.start` (precheck en Authorization, SIN
+        email) -> temp step=2 del checklist -> `login.send-email-code` (con ese
+        temp, dispara/regenera la fila `auth_email_codes` de kind login) ->
+        seed del code login en Neon -> `login.verify-code`. El user de
+        `create_active_user` es passwordless ACTIVE (sin password ni MFA): su
+        unico metodo required es 'passwordless' (el email_code), asi que el
+        `verify-code` suma ese factor (unico required) y emite tokens directo.
+
+        El `send-email-code` es OBLIGATORIO con el temp step=2: regenera la
+        fila del code, por eso el seed debe ir DESPUES. Cada login crea una
+        fila en `auth_user_sessions` y emite un access token de una FAMILIA
+        PROPIA, independiente de la del browser: el bootstrap-refresh del admin
+        (que rota su propia familia y blacklistea su access viejo) NO afecta a
+        este token. Se usa para las verificaciones server-side y para seedear
+        estado (display_name).
+        """
+        precheck = self._login_precheck(email)
+        start = self._http.post(
+            '/auth',
+            body=make_body('login', 'start'),
+            origin=self._origin,
+            bearer=precheck,
+        )
+        temp = field(start.body, 'temp_token')
+        send = self._http.post(
+            '/auth',
+            body=make_body('login', 'send-email-code', temp_token=temp),
+            origin=self._origin,
+        )
+        # send-email-code puede rotar el temp (rolling); si no lo rota,
+        # reutiliza el de login.start.
+        temp = field(send.body, 'temp_token') or temp
         self._env.seed_code(user_id=user_id, kind='login', plaintext=_SEED_CODE)
         verify = self._http.post(
             '/auth',
             body=make_body(
-                'login', 'verify-code', code=_SEED_CODE,
-                temp_token=field(start.body, 'temp_token'),
+                'login', 'verify-code', code=_SEED_CODE, temp_token=temp,
             ),
             origin=self._origin,
         )
@@ -224,25 +259,29 @@ class AdminAuth:
         return resp.status
 
     def login_start_status(self, email: str) -> int:
-        """Status de `login.start` para `email`.
+        """Status de `login.start` para `email` (con su precheck).
 
-        Login unificado (fusion register->login): un email no registrado YA NO
-        devuelve 404 — `login.start` crea el user pending y responde 200.
+        Login unificado (fusion register->login) + modelo de lista required:
+        `login.check-email` (precheck con bypass) -> `login.start` con el
+        precheck en `Authorization`. Para un email NUEVO el `start` necesita el
+        email en el body (alta fusionada: crea el user pending) -> responde 200,
+        ya NO 404.
         """
+        precheck = self._login_precheck(email)
         resp = self._http.post(
             '/auth',
-            body=make_body(
-                'login', 'start', email=email, cf_turnstile_response='',
-            ),
+            body=make_body('login', 'start', email=email),
             origin=self._origin,
-            bypass_token=self._bypass,
+            bearer=precheck,
         )
         return resp.status
 
     def login_check_email(self, email: str) -> dict:
         """Body de `login.check-email` (existencia + has_password, sin metodos).
 
-        Paso 1 del login unificado: NO crea nada. Devuelve `{exists, ...}`.
+        Paso 1 del login unificado: NO crea nada. Devuelve `{exists, ...}` (el
+        body ya parseado de la `Response`). Para un email no registrado el shape
+        es `{exists: false, temp_token}`.
         """
         resp = self._http.post(
             '/auth',
@@ -252,23 +291,35 @@ class AdminAuth:
             origin=self._origin,
             bypass_token=self._bypass,
         )
-        return resp.json()
+        return resp.body if isinstance(resp.body, dict) else {}
 
     def magic_link_callback_url(self, email: str, user_id: str) -> str:
         """Reconstruye la URL del callback REAL del magic-link de login.
 
-        `login.start` (form real con bypass) -> seed del token del magic-link
-        en Neon -> GET `verify-magic-link` al backend, que responde 302 con el
-        `Location` del callback (`/callback#access=...`). Devuelve ese
+        `login.check-email` (precheck con bypass) -> `login.start` (precheck en
+        Authorization, SIN email) -> temp step=2 -> `login.send-email-code`
+        (CREA la fila del magic-link de kind login en Neon: `login.start` por si
+        solo NO la crea) -> seed de su token -> GET `verify-magic-link`. Para
+        este user (passwordless ACTIVE, sin factores required adicionales) el
+        backend responde 302 con el `Location` del callback con los tokens en el
+        fragment (`/callback#access=...`); si tuviera factores pendientes seria
+        `#temp=...&methods=...` (no es el caso de este helper). Devuelve ese
         Location (la URL que el browser navegaria al hacer click en el email).
         """
+        precheck = self._login_precheck(email)
+        start = self._http.post(
+            '/auth',
+            body=make_body('login', 'start'),
+            origin=self._origin,
+            bearer=precheck,
+        )
         self._http.post(
             '/auth',
             body=make_body(
-                'login', 'start', email=email, cf_turnstile_response='',
+                'login', 'send-email-code',
+                temp_token=field(start.body, 'temp_token'),
             ),
             origin=self._origin,
-            bypass_token=self._bypass,
         )
         token = secrets.token_urlsafe(24)
         self._env.seed_magic_link(user_id=user_id, kind='login', plaintext=token)

--- a/tests/admin/test_auth_guard.py
+++ b/tests/admin/test_auth_guard.py
@@ -36,16 +36,19 @@ def test_sessions_without_session_redirects_to_login_with_next(
 ) -> None:
     """
     Given sin sesion,
-    When accedo a /sessions,
-    Then AuthGuard redirige a /login con next=/sessions.
+    When accedo a /settings/sessions (la tab "Sesiones" de Configuracion),
+    Then AuthGuard redirige a /login con next=/settings/sessions.
+
+    La gestion de sesiones se movio de /sessions a /settings/sessions (tab
+    dentro de Configuracion) con el redisno del bloque admin-security.
     """
     # Arrange / Act
-    page.goto(f'{admin_url}/sessions/', wait_until='load')
+    page.goto(f'{admin_url}/settings/sessions/', wait_until='load')
     page.wait_for_url('**/login/?next=*', timeout=15_000)
 
     # Assert
     assert 'next=' in page.url
-    assert '/sessions' in urllib.parse.unquote(page.url)
+    assert '/settings/sessions' in urllib.parse.unquote(page.url)
 
 
 def test_users_without_session_redirects_to_login_with_next(

--- a/tests/admin/test_register_verify.py
+++ b/tests/admin/test_register_verify.py
@@ -1,14 +1,18 @@
-"""Register del admin: render del form, /verify, register+verify-code real.
+"""Register del admin: /verify + register+verify-code real (backend).
 
 Porta `tests/feature/admin/02-register-verify-code.spec.ts` y AMPLIA al
 flujo REAL end-to-end: register.start -> seed del code en Neon ->
 register.verify-code -> tokens reales -> el browser aterriza en el shell por
 el callback. [AC-2]
 
-El submit del form de register esta gateado por Turnstile (build desplegado
-NO en modo E2E). El render del form + el /verify se validan en el browser; el
-register+verify REAL se ejercita por backend (lo que el submit invocaria) y
-la sesion resultante se aterriza en el shell via callback.
+Login UNIFICADO (redisno del bloque admin-security): la operation `register`
+ya NO tiene una page `/register` propia — el registro ocurre dentro del propio
+login (login.start crea el user si el email no existe). Por eso ya NO se
+testea el render del form de `/register` (esa ruta esta retirada del build).
+Lo que persiste y se valida aqui: la page `/verify` (input del code) + el
+flujo register+verify REAL por backend (la operation `register` sigue
+desplegada como camino legacy de alta), aterrizando la sesion en el shell via
+callback.
 """
 
 from __future__ import annotations
@@ -16,21 +20,6 @@ from __future__ import annotations
 from playwright.sync_api import Page
 
 from .conftest import AdminAuth
-
-
-def test_register_page_renders_form(page: Page, admin_url: str) -> None:
-    """
-    Given el admin desplegado,
-    When abro /register,
-    Then responde y muestra el input de email (testid register-email).
-    """
-    # Arrange / Act
-    response = page.goto(f'{admin_url}/register/', wait_until='load')
-
-    # Assert
-    assert response is not None
-    assert response.status == 200
-    assert page.get_by_test_id('register-email').count() == 1
 
 
 def test_verify_page_renders_heading(page: Page, admin_url: str) -> None:

--- a/tests/admin/test_sessions_revoke.py
+++ b/tests/admin/test_sessions_revoke.py
@@ -26,15 +26,18 @@ def test_sessions_without_session_redirects_to_login(
 ) -> None:
     """
     Given sin sesion,
-    When abro /sessions,
-    Then AuthGuard redirige a /login con next=/sessions.
+    When abro /settings/sessions (la tab "Sesiones" de Configuracion),
+    Then AuthGuard redirige a /login con next=/settings/sessions.
+
+    La gestion de sesiones se movio de /sessions a /settings/sessions (tab
+    dentro de Configuracion) con el redisno del bloque admin-security.
     """
     # Arrange / Act
-    page.goto(f'{admin_url}/sessions/', wait_until='load')
+    page.goto(f'{admin_url}/settings/sessions/', wait_until='load')
     page.wait_for_url('**/login/?next=*', timeout=15_000)
 
     # Assert
-    assert '/sessions' in urllib.parse.unquote(page.url)
+    assert '/settings/sessions' in urllib.parse.unquote(page.url)
 
 
 def test_cv_placeholder_route_serves_via_spa_fallback(
@@ -62,8 +65,13 @@ def test_sessions_revoke_removes_one_session(
 ) -> None:
     """
     Given una sesion activa en el browser + una 2da sesion abierta via API,
-    When abro /sessions y revoco una sesion,
+    When abro la tab "Sesiones" de Configuracion y revoco la sesion NO-actual,
     Then la fila desaparece de la tabla (queda 1) y Neon registra 1 sesion.
+
+    La gestion de sesiones se movio de /sessions a la tab "Sesiones" dentro de
+    /settings (Configuracion). Una de las 2 sesiones es la del browser
+    (is_current -> su boton Revocar esta deshabilitado); se revoca la OTRA (la
+    de open_second_session), cuyo boton SI esta habilitado.
     """
     # Arrange: 2da sesion del MISMO user via API (login.verify-code).
     page, email, user_id = (
@@ -74,17 +82,24 @@ def test_sessions_revoke_removes_one_session(
     time.sleep(2)
     assert len(environment.session_ids(user_id)) == 2
 
-    # Act: ir a /sessions, esperar 2 botones Revocar, revocar el primero.
-    flows.nav_via_sidebar(page, 'Mis sesiones', '**/sessions/**')
-    page.wait_for_selector('text=Mis sesiones', timeout=15_000)
+    # Act: navego a Configuracion via sidebar (preserva la sesion en memoria),
+    # entro a la tab Sesiones, espero 2 botones Revocar (1 disabled = la actual,
+    # 1 habilitado = la otra) y revoco el habilitado.
+    flows.nav_via_sidebar(page, 'Configuracion', '**/settings/**')
+    page.get_by_role('link', name='Sesiones').click()
+    page.wait_for_url('**/settings/sessions/**', timeout=15_000)
     page.wait_for_function(
         "() => [...document.querySelectorAll('button')]"
         ".filter(b => b.textContent.includes('Revocar')).length === 2",
         timeout=15_000,
     )
-    page.get_by_role('button', name='Revocar').first.click()
+    enabled_revoke = page.get_by_role('button', name='Revocar').and_(
+        page.locator('button:not([disabled])'),
+    )
+    enabled_revoke.first.click()
 
-    # Assert: la tabla baja a 1 fila revocable y Neon deja 1 sesion.
+    # Assert: Neon deja 1 sesion (la del browser, no revocable). La tabla baja a
+    # 1 fila tras la invalidacion de la lista.
     page.wait_for_function(
         "() => [...document.querySelectorAll('button')]"
         ".filter(b => b.textContent.includes('Revocar')).length === 1",


### PR DESCRIPTION
## Problema

El PR #253 (login con lista de metodos required) cambio el flujo de
`login.start` (ya no recibe email/password, exige el temp precheck). Los
HELPERS del E2E admin browser (`tests/admin/conftest.py`) seguian usando el
flujo viejo -> 7/23 casos FAIL al correr `e2e --module=admin --env=dev`.

## Solucion

Adapta el E2E admin browser al modelo de lista (solo `tests/admin/`):

- `AdminAuth._login_precheck` (NUEVO): `check-email` -> temp precheck.
- `fresh_login`/`open_second_session`: precheck -> `login.start` (sin email) ->
  `login.send-email-code` -> seed code -> `login.verify-code` (el user
  passwordless emite tokens directo).
- `login_check_email`: usa `resp.body` (bug latente: `Response` no tiene
  `.json()`).
- `magic_link_callback_url`/`login_start_status`: con precheck.
- `test_auth_guard`/`test_sessions_revoke`: la ruta de mis sesiones se movio a
  `/settings/sessions` (tab); el boton revoke de la sesion actual esta disabled.
- `test_register_verify`: elimina `test_register_page_renders_form` (la page
  `/register` ya no existe en el build; login unificado).

## Como probar

```
python devtools/run.py e2e --module=admin --env=dev --aws-profile=tfs-dev
```
-> `e2e: TODOS PASS` (22). Verificado contra dev real.

## TODO

Vacio.