### PR TITLE
fix(auth): surface el error real al registrar un passkey WebAuthn

### DIFF
--- a/admin/src/features/auth/components/webauthn-register-button.tsx
+++ b/admin/src/features/auth/components/webauthn-register-button.tsx
@@ -1,19 +1,47 @@
 "use client";
 
-import { startRegistration } from "@simplewebauthn/browser";
+import { startRegistration, WebAuthnError } from "@simplewebauthn/browser";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ApiError } from "@/lib/api-client";
 import { useWebauthnRegisterOptions } from "../hooks/use-webauthn-register-options";
 import { useWebauthnRegisterVerify } from "../hooks/use-webauthn-register-verify";
+
+/**
+ * @function describeRegisterError
+ * @description Traduce el error del flujo a un mensaje accionable. El
+ *   `navigator.credentials.create()` (via @simplewebauthn) lanza
+ *   `WebAuthnError` con un `code` semantico cuando el ceremony falla ANTES
+ *   o DURANTE el dialogo del sistema (ej. el authenticator ya tenia el
+ *   passkey -> `InvalidStateError`); el backend lanza `ApiError`. Un toast
+ *   generico oculta la causa y hace el bug indiagnosticable.
+ *
+ * @param {unknown} error - El error capturado en onRegister.
+ * @returns {string} Mensaje para el usuario con la causa real.
+ */
+function describeRegisterError(error: unknown): string {
+	if (error instanceof WebAuthnError) {
+		if (error.name === "InvalidStateError") {
+			return "Este dispositivo ya tiene un passkey registrado para tu cuenta.";
+		}
+		return `No pudimos crear el passkey: ${error.message}`;
+	}
+	if (error instanceof ApiError) {
+		return `El servidor rechazo el passkey (${error.code}): ${error.message}`;
+	}
+	return "No pudimos registrar el passkey";
+}
 
 /**
  * @component WebAuthnRegisterButton
  * @description Registra un passkey: register-options ->
  *   `startRegistration(options)` -> register-verify
  *   (`{challenge_id, response, nickname}`). Requiere sesion activa.
+ *   El verify se espera con `mutateAsync` DENTRO del try para que un fallo
+ *   del backend tambien se capture (no fire-and-forget silencioso).
  */
 export function WebAuthnRegisterButton() {
 	const [nickname, setNickname] = useState("");
@@ -25,13 +53,16 @@ export function WebAuthnRegisterButton() {
 		try {
 			const { data } = await registerOptions.mutateAsync();
 			const response = await startRegistration({ optionsJSON: data.options });
-			registerVerify.mutate({
+			await registerVerify.mutateAsync({
 				challenge_id: data.challenge_id,
 				response,
 				nickname: nickname || undefined,
 			});
-		} catch {
-			toast.error("No pudimos registrar el passkey");
+			toast.success("Passkey registrado");
+			setNickname("");
+		} catch (error) {
+			console.error("[webauthn-register]", error);
+			toast.error(describeRegisterError(error));
 		}
 	};
 

--- a/admin/tests/unit/features/auth/components/auth-components-branches.test.tsx
+++ b/admin/tests/unit/features/auth/components/auth-components-branches.test.tsx
@@ -35,13 +35,38 @@ vi.mock("@marsidev/react-turnstile", () => ({
 	),
 }));
 
-const { startRegistrationMock, startAuthenticationMock } = vi.hoisted(() => ({
-	startRegistrationMock: vi.fn(),
-	startAuthenticationMock: vi.fn(),
-}));
+const { startRegistrationMock, startAuthenticationMock, MockWebAuthnError } =
+	vi.hoisted(() => {
+		// Replica minima de @simplewebauthn/browser.WebAuthnError: el componente
+		// WebAuthnRegisterButton hace `instanceof WebAuthnError` en su manejo de
+		// error, asi que el mock DEBE exportarla (si falta -> `instanceof undefined`
+		// lanza TypeError no capturado -> crashea el worker pool de vitest).
+		class MockWebAuthnError extends Error {
+			code: string;
+			constructor({
+				message,
+				code,
+				cause,
+			}: {
+				message: string;
+				code: string;
+				cause: Error;
+			}) {
+				super(message, { cause });
+				this.name = cause.name;
+				this.code = code;
+			}
+		}
+		return {
+			startRegistrationMock: vi.fn(),
+			startAuthenticationMock: vi.fn(),
+			MockWebAuthnError,
+		};
+	});
 vi.mock("@simplewebauthn/browser", () => ({
 	startRegistration: startRegistrationMock,
 	startAuthentication: startAuthenticationMock,
+	WebAuthnError: MockWebAuthnError,
 }));
 
 const API = "https://api.test.the-full-stack.com";

--- a/admin/tests/unit/features/auth/components/webauthn-buttons.test.tsx
+++ b/admin/tests/unit/features/auth/components/webauthn-buttons.test.tsx
@@ -2,7 +2,9 @@ import type {
 	AuthenticationResponseJSON,
 	RegistrationResponseJSON,
 } from "@simplewebauthn/browser";
+import { server } from "@tests/mocks/server";
 import { render, screen, userEvent, waitFor } from "@tests/utils/render";
+import { HttpResponse, http } from "msw";
 import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { WebAuthnLoginButton } from "@/features/auth/components/webauthn-login-button";
@@ -12,27 +14,68 @@ import { useAuthStore } from "@/features/auth/store/use-auth-store";
 /**
  * @module tests/unit/features/auth/components/webauthn-buttons
  * @description Verifica que los botones WebAuthn pasen las options del backend
- *   a startRegistration/startAuthentication y reenvien el response.
+ *   a startRegistration/startAuthentication, reenvien el response, y que el
+ *   register surface el error real (WebAuthnError) en vez de un toast
+ *   generico que oculta la causa.
  */
 
 vi.mock("next/navigation", () => ({
 	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 
-const { startRegistrationMock, startAuthenticationMock } = vi.hoisted(() => ({
-	startRegistrationMock: vi.fn(),
-	startAuthenticationMock: vi.fn(),
-}));
+const { startRegistrationMock, startAuthenticationMock, MockWebAuthnError } =
+	vi.hoisted(() => {
+		// Replica minima de @simplewebauthn/browser.WebAuthnError. El mock
+		// reemplaza el modulo ENTERO, asi que el componente importa ESTA clase
+		// y su `instanceof` la reconoce. Evita `importActual` del barrel real
+		// (arrastra el AbortService singleton + helpers DOM -> agota el worker
+		// pool al correr toda la suite -> "Worker exited unexpectedly").
+		class MockWebAuthnError extends Error {
+			code: string;
+			constructor({
+				message,
+				code,
+				cause,
+			}: {
+				message: string;
+				code: string;
+				cause: Error;
+			}) {
+				super(message, { cause });
+				this.name = cause.name;
+				this.code = code;
+			}
+		}
+		return {
+			startRegistrationMock: vi.fn(),
+			startAuthenticationMock: vi.fn(),
+			MockWebAuthnError,
+		};
+	});
 vi.mock("@simplewebauthn/browser", () => ({
 	startRegistration: startRegistrationMock,
 	startAuthentication: startAuthenticationMock,
+	WebAuthnError: MockWebAuthnError,
 }));
 
+const { toastSuccessMock, toastErrorMock } = vi.hoisted(() => ({
+	toastSuccessMock: vi.fn(),
+	toastErrorMock: vi.fn(),
+}));
+// Toaster es un componente null en estos tests (no se renderiza el real).
+// Evita `importActual("sonner")` (carga el Toaster real en el worker).
+vi.mock("sonner", () => ({
+	toast: { success: toastSuccessMock, error: toastErrorMock },
+	Toaster: () => null,
+}));
+
+const API = "https://api.test.the-full-stack.com";
 const REG_RESPONSE = { id: "reg" } as unknown as RegistrationResponseJSON;
 const AUTH_RESPONSE = { id: "auth" } as unknown as AuthenticationResponseJSON;
 
 describe("WebAuthnRegisterButton", () => {
 	it("Given options del backend When click Then startRegistration recibe optionsJSON", async () => {
+		startRegistrationMock.mockReset();
 		startRegistrationMock.mockResolvedValue(REG_RESPONSE);
 		const user = userEvent.setup();
 		render((<WebAuthnRegisterButton />) as ReactElement);
@@ -46,6 +89,120 @@ describe("WebAuthnRegisterButton", () => {
 			optionsJSON: { challenge: string };
 		};
 		expect(arg.optionsJSON.challenge).toBe("fake");
+	});
+
+	it("Given el ceremony completo When click Then dispara toast.success y NO toast.error", async () => {
+		startRegistrationMock.mockReset();
+		toastSuccessMock.mockReset();
+		toastErrorMock.mockReset();
+		startRegistrationMock.mockResolvedValue(REG_RESPONSE);
+		const user = userEvent.setup();
+		render((<WebAuthnRegisterButton />) as ReactElement);
+
+		await user.click(screen.getByRole("button", { name: /agregar passkey/i }));
+
+		await waitFor(() => {
+			expect(toastSuccessMock).toHaveBeenCalledTimes(1);
+		});
+		expect(toastErrorMock).not.toHaveBeenCalled();
+	});
+
+	it("Given el authenticator ya registrado (InvalidStateError) When click Then toast.error con mensaje especifico", async () => {
+		startRegistrationMock.mockReset();
+		toastErrorMock.mockReset();
+		startRegistrationMock.mockRejectedValue(
+			new MockWebAuthnError({
+				message: "The authenticator was previously registered",
+				code: "ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED",
+				cause: Object.assign(new Error("ya existe"), {
+					name: "InvalidStateError",
+				}),
+			}),
+		);
+		const user = userEvent.setup();
+		render((<WebAuthnRegisterButton />) as ReactElement);
+
+		await user.click(screen.getByRole("button", { name: /agregar passkey/i }));
+
+		await waitFor(() => {
+			expect(toastErrorMock).toHaveBeenCalledWith(
+				"Este dispositivo ya tiene un passkey registrado para tu cuenta.",
+			);
+		});
+	});
+
+	it("Given otro WebAuthnError (no InvalidStateError) When click Then toast.error con el message del browser", async () => {
+		startRegistrationMock.mockReset();
+		toastErrorMock.mockReset();
+		startRegistrationMock.mockRejectedValue(
+			new MockWebAuthnError({
+				message: "The RP ID is invalid for this domain",
+				code: "ERROR_INVALID_RP_ID",
+				cause: Object.assign(new Error("rp id"), { name: "SecurityError" }),
+			}),
+		);
+		const user = userEvent.setup();
+		render((<WebAuthnRegisterButton />) as ReactElement);
+
+		await user.click(screen.getByRole("button", { name: /agregar passkey/i }));
+
+		await waitFor(() => {
+			expect(toastErrorMock).toHaveBeenCalledWith(
+				"No pudimos crear el passkey: The RP ID is invalid for this domain",
+			);
+		});
+	});
+
+	it("Given register-verify falla en el backend When click Then toast.error con el codigo del servidor", async () => {
+		startRegistrationMock.mockReset();
+		toastErrorMock.mockReset();
+		startRegistrationMock.mockResolvedValue(REG_RESPONSE);
+		// El ceremony del browser tiene exito, pero el backend rechaza el verify.
+		server.use(
+			http.post(`${API}/auth`, async ({ request }) => {
+				const body = (await request.json()) as { action: string };
+				if (body.action === "register-options") {
+					return HttpResponse.json({
+						is_valid: true,
+						code: 0,
+						data: {
+							challenge_id: "chal_01",
+							options: { challenge: "fake", pubKeyCredParams: [] },
+						},
+					});
+				}
+				return HttpResponse.json(
+					{ error: "WEBAUTHN_REGISTRATION_FAILED", code: 1002 },
+					{ status: 400 },
+				);
+			}),
+		);
+		const user = userEvent.setup();
+		render((<WebAuthnRegisterButton />) as ReactElement);
+
+		await user.click(screen.getByRole("button", { name: /agregar passkey/i }));
+
+		await waitFor(() => {
+			expect(toastErrorMock).toHaveBeenCalledWith(
+				"El servidor rechazo el passkey (1002): WEBAUTHN_REGISTRATION_FAILED",
+			);
+		});
+	});
+
+	it("Given un error generico When click Then toast.error con el mensaje por defecto", async () => {
+		startRegistrationMock.mockReset();
+		toastErrorMock.mockReset();
+		startRegistrationMock.mockRejectedValue(new Error("boom"));
+		const user = userEvent.setup();
+		render((<WebAuthnRegisterButton />) as ReactElement);
+
+		await user.click(screen.getByRole("button", { name: /agregar passkey/i }));
+
+		await waitFor(() => {
+			expect(toastErrorMock).toHaveBeenCalledWith(
+				"No pudimos registrar el passkey",
+			);
+		});
 	});
 });
 


### PR DESCRIPTION
## Problema

En `/settings/security/`, al hacer clic en "Agregar passkey", el admin mostraba "error" y no actualizaba la UI, sin que el usuario supiera por que. El passkey tampoco aparecia como configurado.

Causa raiz: el componente `WebAuthnRegisterButton` ocultaba el error real:
1. El `catch {}` era generico — para `register-options`, para `navigator.credentials.create()` (via `startRegistration`) y para cualquier fallo, mostraba siempre "No pudimos registrar el passkey" sin la causa.
2. El paso `register-verify` era *fire-and-forget* (`.mutate()` sin `onError`): un fallo del backend (400/401) quedaba invisible — ni toast, ni log, ni refresh de la UI.

La respuesta de la API (`webauthn.register-options`) es **correcta**; el `rp.id` (`portfolio.dev.the-full-stack.com`) es un sufijo registrable valido para `admin.portfolio.dev.the-full-stack.com`. El fallo ocurre en el navegador y estaba tragado.

## Solucion

1. `describeRegisterError(error)` traduce el `WebAuthnError` (con su `code`/`name` del browser) y el `ApiError` del backend a un mensaje accionable. Mensaje especifico para `InvalidStateError` ("este dispositivo ya tiene un passkey registrado para tu cuenta") — la causa mas probable del sintoma reportado (el ceremony previo creo el passkey en el authenticator pero el verify fallo silenciosamente, asi que reintentar choca con `InvalidStateError` y el dialogo del sistema nunca aparece).
2. `register-verify` pasa de `.mutate()` (fire-and-forget) a `await mutateAsync()` DENTRO del `try`: un fallo del backend ahora se captura y se muestra.
3. `console.error(error)` para diagnostico + `toast.success` al completar + limpia el nickname.
4. El componente hace `error instanceof WebAuthnError`: los tests que mockean `@simplewebauthn/browser` exportan una clase `MockWebAuthnError` propia (sin `importActual` del barrel real, que arrastraba el AbortService + helpers DOM y agotaba el worker pool de vitest -> "Worker exited unexpectedly").

## Como probar

1. `pnpm --filter @portfolio/admin exec vitest run tests/unit/features/auth/components/webauthn-buttons.test.tsx` -> 7/7 pasan.
2. Suite completa del admin: 611/611 tests, 143/143 archivos.
3. Coverage del componente: 100% statements, 91.66% branches (umbral 80%).
4. Build del admin verde con las env vars del entorno.
5. Manualmente en `https://admin.portfolio.dev.the-full-stack.com/settings/security/` tras el deploy: al fallar el registro, el toast ahora muestra la causa real (ej. `InvalidStateError` -> mensaje de passkey ya registrado). Para registrar de nuevo tras un `InvalidStateError`: borrar la passkey huerfana del gestor del navegador (chrome://settings/passkeys) para `portfolio.dev.the-full-stack.com` y reintentar.

## TODO

Ninguno.