### PR TITLE
fix(serverless): desactiva SnapStart en el backend para eliminar el costo de snapshots

### DIFF
--- a/devtools/serverless/provisioner.py
+++ b/devtools/serverless/provisioner.py
@@ -1565,6 +1565,12 @@ def _provision_create(
         region=region,
         resources=resources,
     )
+    # Si el manifest tiene snap_start=False pero la funcion YA existia en
+    # AWS con SnapStart activo (CREATE por state local perdido), hay que
+    # apagarlo + liberar sus snapshots. No-op barato en una funcion
+    # genuinamente nueva (sin SnapStart ni versiones). Corre tras el
+    # wiring (que ya apunto a $LATEST con qualifier vacio).
+    _disable_snap_start(rendered, profile=profile, region=region)
 
 
 def _wait_function_active(
@@ -1731,7 +1737,150 @@ def _publish_and_update_alias(
         )
         alias_arn = (created.json or {}).get('AliasArn', '')
     print(f'  OK  alias {_SNAP_START_ALIAS} -> version {version}')
+    _prune_old_versions(
+        rendered.function_name,
+        keep_version=version,
+        profile=profile,
+        region=region,
+    )
     return alias_arn
+
+
+def _prune_old_versions(
+    function_name: str,
+    *,
+    keep_version: str | None,
+    profile: str | None,
+    region: str,
+) -> None:
+    """Borra snapshots SnapStart facturables (versiones publicadas).
+
+    Cada version publicada con SnapStart retiene un snapshot que AWS
+    factura por hora (`Lambda-SnapStart-Cached-GB-S`) mientras exista.
+    Sin purga, cada `deploy` acumula una version mas y el costo crece de
+    forma ilimitada.
+
+    Si `keep_version` no es None (deploy con SnapStart activo): deja SOLO
+    esa version (la que apunta el alias `live`) + cualquier version
+    referenciada por OTRO alias, y borra el resto. Si `keep_version` es
+    None (desactivacion de SnapStart): borra TODAS las versiones
+    publicadas que NINGUN alias referencie. `$LATEST` nunca se toca (no
+    es una version publicada y no tiene snapshot).
+
+    Es best-effort: un fallo al borrar una version NO rompe el deploy
+    (se loguea un WARN y se continua).
+    """
+    aliased = aws(
+        [
+            'lambda',
+            'list-aliases',
+            '--function-name',
+            function_name,
+            '--query',
+            'Aliases[].FunctionVersion',
+        ],
+        profile=profile,
+        region=region,
+        parse_json=True,
+        check=False,
+    )
+    keep = {*(aliased.json or [])}
+    if keep_version is not None:
+        keep.add(keep_version)
+    listed = aws(
+        [
+            'lambda',
+            'list-versions-by-function',
+            '--function-name',
+            function_name,
+            '--query',
+            'Versions[].Version',
+        ],
+        profile=profile,
+        region=region,
+        parse_json=True,
+        check=False,
+    )
+    versions = [
+        v for v in (listed.json or []) if v != '$LATEST' and v not in keep
+    ]
+    if not versions:
+        return
+    deleted = 0
+    for version in versions:
+        result = aws(
+            [
+                'lambda',
+                'delete-function',
+                '--function-name',
+                function_name,
+                '--qualifier',
+                version,
+            ],
+            profile=profile,
+            region=region,
+            check=False,
+        )
+        if result.ok:
+            deleted += 1
+        else:
+            print(
+                f'  WARN  no se pudo borrar {function_name}:{version} '
+                '(snapshot SnapStart)',
+            )
+    if deleted:
+        print(
+            f'  OK  purgados {deleted} snapshots SnapStart de {function_name}',
+        )
+
+
+def _disable_snap_start(
+    rendered: RenderedLambda,
+    *,
+    profile: str | None,
+    region: str,
+) -> None:
+    """Desactiva SnapStart en una funcion y libera sus snapshots.
+
+    Solo se invoca cuando `rendered.snap_start=False`. Tres pasos:
+    1. `update-function-configuration --snap-start ApplyOn=None` (apaga
+       SnapStart; idempotente via `_ensure_snap_start_config`).
+    2. Borra el alias `live` (la integracion del trigger ya se re-apunto
+       a `$LATEST` en `_wire_http_trigger` porque el qualifier es vacio
+       con snap_start=False).
+    3. Purga TODAS las versiones publicadas restantes (sus snapshots
+       facturables `Lambda-SnapStart-Cached-GB-S`).
+
+    Best-effort en el borrado del alias y las versiones: un fallo NO
+    rompe el deploy.
+    """
+    if rendered.snap_start:
+        return
+    # 1. Apagar SnapStart (target 'None').
+    _ensure_snap_start_config(rendered, profile=profile, region=region)
+    # 2. Borrar el alias `live` (ya nadie lo referencia tras el rewire).
+    deleted_alias = aws(
+        [
+            'lambda',
+            'delete-alias',
+            '--function-name',
+            rendered.function_name,
+            '--name',
+            _SNAP_START_ALIAS,
+        ],
+        profile=profile,
+        region=region,
+        check=False,
+    )
+    if deleted_alias.ok:
+        print(f'  OK  alias {_SNAP_START_ALIAS} eliminado')
+    # 3. Purgar todas las versiones publicadas (snapshots facturables).
+    _prune_old_versions(
+        rendered.function_name,
+        keep_version=None,
+        profile=profile,
+        region=region,
+    )
 
 
 def _snap_start_qualifier(rendered: RenderedLambda) -> str:
@@ -1900,6 +2049,10 @@ def provision(
                 region=region,
                 resources=resources,
             )
+            # Tras re-apuntar el trigger a $LATEST, apaga SnapStart y
+            # libera los snapshots (orden critico: el rewire debe correr
+            # ANTES de borrar el alias `live`).
+            _disable_snap_start(rendered, profile=profile, region=region)
         elif action == _Action.UPDATE_BOTH:
             _provision_update_code(
                 rendered, zip_path, profile=profile, region=region
@@ -1912,6 +2065,7 @@ def provision(
                 region=region,
                 resources=resources,
             )
+            _disable_snap_start(rendered, profile=profile, region=region)
     except Exception as exc:
         # El estado parcial (con role_arn / log_group ya creados) se
         # adjunta a la excepcion para que el llamador lo persista y la

--- a/devtools/tests/unit/src/serverless/provisioner.py
+++ b/devtools/tests/unit/src/serverless/provisioner.py
@@ -425,6 +425,15 @@ class TestProvisionCreate:
             'lambda.get-policy',
             'lambda.remove-permission',
             'lambda.add-permission',
+            # Tras el wiring, `_disable_snap_start` corre tambien en CREATE
+            # (el manifest test tiene snap_start=False): cubre el caso de
+            # una funcion preexistente con SnapStart re-creada por state
+            # perdido. Aqui es no-op (get-function-configuration None +
+            # delete-alias + list-aliases + list-versions sin borrados).
+            'lambda.get-function-configuration',
+            'lambda.delete-alias',
+            'lambda.list-aliases',
+            'lambda.list-versions-by-function',
         ]
         assert state.resources['function_name'] == 'portfolio-contact-form-dev'
 
@@ -555,6 +564,98 @@ class TestProvisionCreate:
         )
         assert '--qualifier' in add_call
         assert add_call[add_call.index('--qualifier') + 1] == 'live'
+
+    def test_provision_update_config_disables_snap_start_and_purges(
+        self, monkeypatch
+    ):
+        """snap_start=False en UPDATE_CONFIG apaga SnapStart y libera snapshots.
+
+        Tras re-apuntar el trigger a $LATEST, `_disable_snap_start`:
+        1. update-function-configuration --snap-start ApplyOn=None (porque
+           la funcion AUN tiene PublishedVersions activo).
+        2. delete-alias del alias `live`.
+        3. delete-function --qualifier de cada version publicada que NINGUN
+           alias referencie (aqui: 1, 2 y 3; ninguna aliased tras el
+           delete-alias).
+        """
+        from serverless import provisioner
+        from serverless.aws_cli import AwsResult
+        from serverless.state import Action
+        from serverless.state import LambdaState
+
+        calls = []
+        responses = _default_responses()
+
+        def fake(args, **_kwargs):
+            calls.append(args)
+            key = '.'.join(args[:2])
+            if key == 'lambda.get-function-configuration':
+                # SnapStart sigue activo -> el update a None NO es no-op.
+                return AwsResult(
+                    returncode=0,
+                    stdout='',
+                    stderr='',
+                    json={'SnapStart': {'ApplyOn': 'PublishedVersions'}},
+                )
+            if key == 'lambda.list-aliases':
+                # Ningun alias queda (el live ya se borro).
+                return AwsResult(returncode=0, stdout='', stderr='', json=[])
+            if key == 'lambda.list-versions-by-function':
+                # $LATEST + 3 versiones publicadas con snapshot.
+                return AwsResult(
+                    returncode=0,
+                    stdout='',
+                    stderr='',
+                    json=['$LATEST', '1', '2', '3'],
+                )
+            return AwsResult(
+                returncode=0, stdout='', stderr='', json=responses.get(key)
+            )
+
+        monkeypatch.setattr(provisioner, 'aws', fake)
+        monkeypatch.setattr(provisioner.time, 'sleep', lambda _s: None)
+
+        # _manifest_http NO define snap_start -> render lo deja en False.
+        rendered = provisioner.render(_manifest_http(), stage='dev')
+        previous = LambdaState(
+            scope='contact-form',
+            stage='dev',
+            config_hash='sha256:OLD',
+            code_hash='sha256:k',
+            resources={'function_name': 'portfolio-contact-form-dev'},
+            updated_at='2026-05-21T10:00:00Z',
+        )
+        provisioner.provision(
+            rendered,
+            action=Action.UPDATE_CONFIG,
+            zip_path=_ZIP_PATH,
+            previous=previous,
+            profile=None,
+            region='us-east-1',
+        )
+
+        # 1. SnapStart apagado: update-function-configuration con ApplyOn=None.
+        snap_update = next(
+            c
+            for c in calls
+            if c[:2] == ['lambda', 'update-function-configuration']
+            and '--snap-start' in c
+        )
+        assert snap_update[snap_update.index('--snap-start') + 1] == (
+            'ApplyOn=None'
+        )
+        # 2. Alias `live` borrado.
+        delete_alias = next(
+            c for c in calls if c[:2] == ['lambda', 'delete-alias']
+        )
+        assert delete_alias[delete_alias.index('--name') + 1] == 'live'
+        # 3. Las 3 versiones publicadas se borran ($LATEST NO).
+        deleted_versions = sorted(
+            c[c.index('--qualifier') + 1]
+            for c in calls
+            if c[:2] == ['lambda', 'delete-function'] and '--qualifier' in c
+        )
+        assert deleted_versions == ['1', '2', '3']
 
     def test_provision_create_records_resources(self, monkeypatch):
         from serverless import provisioner
@@ -709,6 +810,12 @@ class TestProvisionUpdate:
         # para que cambios de `trigger.*` o `snap_start` en el manifest
         # se materialicen en API GW (URI :live, statement-id correcto).
         # La secuencia del wiring es la misma que en CREATE (post `_create_function`).
+        # Como el manifest test NO tiene snap_start (=False), tras el
+        # rewire `provision()` llama `_disable_snap_start`: verifica la
+        # config SnapStart (get-function-configuration; no-op porque ya
+        # esta en None), borra el alias `live` (delete-alias) y purga las
+        # versiones publicadas (list-aliases + list-versions-by-function;
+        # 0 a borrar en el fake).
         assert verbs == [
             'sts.get-caller-identity',
             'iam.create-role',
@@ -731,6 +838,10 @@ class TestProvisionUpdate:
             'lambda.get-policy',
             'lambda.remove-permission',
             'lambda.add-permission',
+            'lambda.get-function-configuration',
+            'lambda.delete-alias',
+            'lambda.list-aliases',
+            'lambda.list-versions-by-function',
         ]
         assert 'lambda.create-function' not in verbs
 
@@ -776,7 +887,10 @@ class TestProvisionUpdate:
 
         verbs = ['.'.join(c[:2]) for c in calls]
         # Post-fix: el wiring del trigger se re-aplica tambien en
-        # UPDATE_BOTH para alinear API GW con el manifest actual.
+        # UPDATE_BOTH para alinear API GW con el manifest actual. Como el
+        # manifest test NO tiene snap_start (=False), tras el rewire se
+        # llama `_disable_snap_start` (get-function-configuration no-op +
+        # delete-alias + list-aliases + list-versions-by-function).
         assert verbs == [
             'lambda.wait',
             'lambda.update-function-code',
@@ -801,6 +915,10 @@ class TestProvisionUpdate:
             'lambda.get-policy',
             'lambda.remove-permission',
             'lambda.add-permission',
+            'lambda.get-function-configuration',
+            'lambda.delete-alias',
+            'lambda.list-aliases',
+            'lambda.list-versions-by-function',
         ]
 
     def test_provision_update_config_cleans_sam_legacy_permission(

--- a/serverless/lambda/services/analytics/manifest.yaml
+++ b/serverless/lambda/services/analytics/manifest.yaml
@@ -22,11 +22,12 @@ memory: 512       # MB — footprint Neon (sqlalchemy + pydantic + clientes)
 timeout: 30       # segundos — el listado con filtros raros < 5s; 30s cubre
                   # el cold sin restore + la query mas pesada.
 
-# SnapStart: el handler precalienta engine (NullPool) + configure_mappers en
-# el INIT (warm_db); el snapshot los captura -> el restore evita el costo CPU
-# del primer query. El admin se usa esporadicamente (sin trafico constante
-# que mantenga el container warm), asi que SnapStart paga.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). El
+# admin se usa esporadicamente; el cold extra es aceptable. Re-evaluar
+# solo si lo exige. Ver .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Trigger HTTP ---
 trigger:

--- a/serverless/lambda/services/auth/manifest.yaml
+++ b/serverless/lambda/services/auth/manifest.yaml
@@ -24,10 +24,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
 timeout: 60       # segundos — colchon uniforme (red de seguridad cold sin
                   # restore + Turnstile siteverify HTTP). No afecta costo.
 
-# SnapStart: reduce cold start de ~3s a ~830ms (Restore Duration).
-# Critico en /auth: low traffic prod hace que cada request pague cold
-# start si no se mantiene warm.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). El
+# cold start lo mitiga la carga lazy de shared.auth. Re-evaluar solo si
+# la latencia de /auth lo exige. Ver .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Como se invoca este Lambda ---
 # GET + POST: el resto del flujo (register/login/verify/session) usa POST

--- a/serverless/lambda/services/contact_form/manifest.yaml
+++ b/serverless/lambda/services/contact_form/manifest.yaml
@@ -22,12 +22,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
                   # mejora no lo justifica. Ver .claude/rules/lambda-config.md.
 timeout: 60       # segundos — colchon uniforme (cold sin restore + Turnstile).
 
-# SnapStart: reduce cold start de 3.4s a ~830ms (Restore Duration).
-# Cuando true, cada deploy hace publish-version + update-alias `live`,
-# y el trigger HTTP apunta al alias `:live` (no $LATEST).
-# Critico para /contact: low traffic prod hace que cada submit pague
-# cold start (no se mantiene warm como /track).
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). El
+# cold start lo mitiga la carga lazy de shared. Re-evaluar solo si la
+# latencia de /contact lo exige. Ver .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Como se invoca este Lambda ---
 # http: expone un endpoint en la API del backend.

--- a/serverless/lambda/services/cv/manifest.yaml
+++ b/serverless/lambda/services/cv/manifest.yaml
@@ -18,10 +18,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
                   # Ver .claude/rules/lambda-config.md.
 timeout: 60       # segundos — colchon uniforme (cold sin restore + query).
 
-# SnapStart: el handler precalienta engine + configure_mappers en el INIT
-# (warm_db); el snapshot los captura y el restore evita el costo CPU del
-# primer query. Habilitado para bajar la memoria sin penalizar el cold.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). El
+# handler de cv es Neon-I/O-bound; la palanca real es la query, no el
+# restore. Re-evaluar solo si lo exige. Ver .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Trigger HTTP ---
 trigger:

--- a/serverless/lambda/services/db/manifest.yaml
+++ b/serverless/lambda/services/db/manifest.yaml
@@ -22,9 +22,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
 timeout: 60       # segundos — colchon uniforme. NOTA: si una migracion grande
                   # tardara >60s, subir SOLO este. Ver lambda-config.md.
 
-# SnapStart: snapshotea el INIT (imports + engine) para bajar el cold del
-# invoke directo de migraciones. Uniforme con el resto del backend.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). El
+# Lambda db corre migraciones esporadicas (no interactivo); el cold extra
+# es irrelevante. Ver .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Como se invoca este Lambda ---
 # direct  : se invoca directo (aws lambda invoke / deploy hook). Sin HTTP.

--- a/serverless/lambda/services/send_email/manifest.yaml
+++ b/serverless/lambda/services/send_email/manifest.yaml
@@ -17,8 +17,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
                   # (estimado). REVERTIR tras medir. Ver lambda-config.md.
 timeout: 60       # segundos — colchon uniforme (render Jinja2 + SES).
 
-# SnapStart: precalienta imports en el INIT -> snapshot. Habilitado.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). Es
+# async (latencia oculta), el cold extra no afecta UX. Ver
+# .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Trigger: invoke directo async (sin HTTP) ---
 trigger:

--- a/serverless/lambda/services/tracking_pixel/manifest.yaml
+++ b/serverless/lambda/services/tracking_pixel/manifest.yaml
@@ -23,10 +23,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
                   # Ver .claude/rules/lambda-config.md.
 timeout: 60       # segundos — colchon uniforme.
 
-# SnapStart: snapshotea el INIT (imports + clientes) para bajar el cold y
-# permitir reducir memoria. Aunque la latencia esta oculta (async), el
-# snapshot evita pagar el import completo en cada cold.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). Es
+# fire-and-forget (latencia oculta), el cold extra no afecta UX. Ver
+# .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Como se invoca este Lambda ---
 # http: expone un endpoint en la API del backend. devtools conecta la

--- a/serverless/lambda/services/tracking_writer/manifest.yaml
+++ b/serverless/lambda/services/tracking_writer/manifest.yaml
@@ -20,9 +20,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
                   # 256. REVERTIR tras medir. Ver .claude/rules/lambda-config.md.
 timeout: 60       # segundos — colchon uniforme (INSERT Neon + wake).
 
-# SnapStart: snapshotea el INIT (imports + engine NullPool + mappers del
-# dominio visitor) para bajar el cold del invoke async.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). Es
+# async (latencia oculta), el cold extra no afecta UX. Ver
+# .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Como se invoca este Lambda ---
 # direct: lo invoca otro Lambda (tracking_pixel) con InvocationType='Event'.

--- a/serverless/lambda/services/users/manifest.yaml
+++ b/serverless/lambda/services/users/manifest.yaml
@@ -23,9 +23,12 @@ memory: 1024      # MB — EXPERIMENTO de config 1024 (ver .claude/rules/lambda-
                   # Ver .claude/rules/lambda-config.md.
 timeout: 60       # segundos — colchon uniforme.
 
-# SnapStart: reduce cold start (~830ms Restore). Mismo criterio que auth:
-# low traffic prod hace que cada request pague cold start.
-snap_start: true
+# SnapStart DESACTIVADO (2026-06): el storage del snapshot
+# (Lambda-SnapStart-Cached-GB-S) se factura por hora por cada version
+# publicada y NO entra en el free tier (~$50/mes con 25 funciones). El
+# cold start lo mitiga la carga lazy de shared.auth. Re-evaluar solo si
+# lo exige. Ver .claude/rules/lambda-config.md.
+snap_start: false
 
 # --- Como se invoca este Lambda ---
 trigger:


### PR DESCRIPTION
## Problema

La factura de AWS de junio (cuenta `637423614564`) llego a ~\$104 MTD en 6 dias, cuando el backend deberia costar ~\$0/mes (free tier). El 99% del costo de Lambda era `Lambda-SnapStart-Cached-GB-S`: AWS factura por hora el storage del snapshot de **cada version publicada** con SnapStart, y ese cargo **NO entra en el free tier**.

El deployer publicaba una version nueva con SnapStart en cada `serverless deploy` pero **nunca borraba las viejas** -> 293 versiones acumuladas (contact-form-dev tenia 54, auth-dev 46, users-dev 39...), cada una reteniendo su snapshot facturable 24/7. Crecia ~\$18/dia (proyeccion >\$550/mes). No eran invocaciones (free tier de sobra).

## Solucion

Desactivar SnapStart en los 9 lambdas del backend. El cold start lo mitiga la carga lazy de `shared.*` ya existente.

1. **Deployer** (`devtools/serverless/provisioner.py`): nueva `_disable_snap_start` que, cuando el manifest tiene `snap_start: false`, apaga SnapStart (`ApplyOn=None`), borra el alias `live` y purga las versiones publicadas (sus snapshots). Se llama en los 3 paths (CREATE / UPDATE_CONFIG / UPDATE_BOTH) **despues** del rewire del trigger a `\$LATEST` (orden critico). Generaliza `_prune_old_versions` con `keep_version: str | None`.
2. **Manifests**: `snap_start: true -> false` en auth, contact_form, cv, db, analytics, tracking_writer, users, send_email, tracking_pixel.

## Como probar

```bash
python devtools/run.py serverless tests --type=unit  # o:
devtools/.venv/bin/python -m pytest devtools/tests/unit/src/serverless/provisioner.py -q
```

- 28/28 tests del provisioner verdes (incluye `test_provision_update_config_disables_snap_start_and_purges`).
- ruff + pre-push (lint+typecheck+unit+build+E2E app 72/72) en verde.

## Estado del deploy (fuera del PR)

- **dev + stage (17 funciones)**: ya deployadas localmente con devtools -> SnapStart off, 0 snapshots residuales. Verificado por AWS CLI + curl a endpoints (200).
- **prod (8 funciones)**: quedan para el pipeline `dev -> stage -> main`.
- Costo `Cached-GB-S` ya cayendo: \$18.75 (jun5) -> \$10.81 (jun6) -> ~\$0 cuando prod mergee.

## TODO

- Promover a prod via pipeline `dev -> stage -> main`.