### PR TITLE
fix(admin): WebAuthn registro/login de passkey rompia por wrapper publicKey en optionsJSON

### DIFF
--- a/admin/src/features/auth/components/webauthn-login-button.tsx
+++ b/admin/src/features/auth/components/webauthn-login-button.tsx
@@ -13,7 +13,9 @@ import { useWebauthnLoginVerify } from "../hooks/use-webauthn-login-verify";
 /**
  * @component WebAuthnLoginButton
  * @description Login con passkey: pide email -> login-options ->
- *   `startAuthentication(options)` -> login-verify (`{challenge_id, response}`).
+ *   `startAuthentication(options.publicKey)` -> login-verify
+ *   (`{challenge_id, response}`). El backend devuelve las options ENVUELTAS
+ *   en `publicKey`; @simplewebauthn espera el contenido plano en `optionsJSON`.
  *
  *   Dos modos:
  *   - Checklist (props `email` + `onResult`): el email ya es conocido (no se
@@ -43,7 +45,9 @@ export function WebAuthnLoginButton({
 
 	const runPasskey = async (targetEmail: string) => {
 		const { data } = await loginOptions.mutateAsync({ email: targetEmail });
-		const response = await startAuthentication({ optionsJSON: data.options });
+		const response = await startAuthentication({
+			optionsJSON: data.options.publicKey,
+		});
 		if (checklistMode) {
 			const result = await loginVerify.mutateAsync({
 				challenge_id: data.challenge_id,

--- a/admin/src/features/auth/components/webauthn-register-button.tsx
+++ b/admin/src/features/auth/components/webauthn-register-button.tsx
@@ -38,8 +38,10 @@ function describeRegisterError(error: unknown): string {
 /**
  * @component WebAuthnRegisterButton
  * @description Registra un passkey: register-options ->
- *   `startRegistration(options)` -> register-verify
- *   (`{challenge_id, response, nickname}`). Requiere sesion activa.
+ *   `startRegistration(options.publicKey)` -> register-verify
+ *   (`{challenge_id, response, nickname}`). Requiere sesion activa. El
+ *   backend devuelve las options ENVUELTAS en `publicKey`; @simplewebauthn
+ *   espera el contenido plano de ese `publicKey` en `optionsJSON`.
  *   El verify se espera con `mutateAsync` DENTRO del try para que un fallo
  *   del backend tambien se capture (no fire-and-forget silencioso).
  */
@@ -52,7 +54,9 @@ export function WebAuthnRegisterButton() {
 	const onRegister = async () => {
 		try {
 			const { data } = await registerOptions.mutateAsync();
-			const response = await startRegistration({ optionsJSON: data.options });
+			const response = await startRegistration({
+				optionsJSON: data.options.publicKey,
+			});
 			await registerVerify.mutateAsync({
 				challenge_id: data.challenge_id,
 				response,

--- a/admin/src/types/api.ts
+++ b/admin/src/types/api.ts
@@ -104,14 +104,26 @@ export interface RecoveryCodesResponse {
 	codes: string[];
 }
 
+/** El backend (fido2 `register_begin` -> `_to_json`) devuelve las options
+ *  ENVUELTAS en `publicKey` (la forma del dict que consume
+ *  `navigator.credentials.create({publicKey})`). `@simplewebauthn/browser`
+ *  `startRegistration` espera el contenido PLANO de ese `publicKey` en
+ *  `optionsJSON`, por eso el componente pasa `data.options.publicKey`. */
 export interface WebauthnRegisterOptionsResponse {
 	challenge_id: string;
-	options: import("@simplewebauthn/browser").PublicKeyCredentialCreationOptionsJSON;
+	options: {
+		publicKey: import("@simplewebauthn/browser").PublicKeyCredentialCreationOptionsJSON;
+	};
 }
 
+/** Idem register: el backend (fido2 `authenticate_begin` -> `_to_json`)
+ *  envuelve las options en `publicKey`; el componente pasa
+ *  `data.options.publicKey` a `startAuthentication`. */
 export interface WebauthnLoginOptionsResponse {
 	challenge_id: string;
-	options: import("@simplewebauthn/browser").PublicKeyCredentialRequestOptionsJSON;
+	options: {
+		publicKey: import("@simplewebauthn/browser").PublicKeyCredentialRequestOptionsJSON;
+	};
 }
 
 export interface WebauthnCredentialsResponse {

--- a/admin/tests/mocks/handlers/auth.ts
+++ b/admin/tests/mocks/handlers/auth.ts
@@ -467,20 +467,24 @@ export const authHandlers = [
 
 		// --- webauthn ---
 		if (operation === "webauthn" && action === "register-options") {
+			// El backend (fido2 register_begin -> _to_json) envuelve las options
+			// en `publicKey`, igual que el dict de navigator.credentials.create.
 			return HttpResponse.json({
 				is_valid: true,
 				code: 0,
 				data: {
 					challenge_id: "chal_01",
 					options: {
-						challenge: "fake",
-						rp: { id: "admin.test.the-full-stack.com", name: "admin" },
-						user: {
-							id: "dXNy",
-							name: "user@test.com",
-							displayName: "user@test.com",
+						publicKey: {
+							challenge: "fake",
+							rp: { id: "admin.test.the-full-stack.com", name: "admin" },
+							user: {
+								id: "dXNy",
+								name: "user@test.com",
+								displayName: "user@test.com",
+							},
+							pubKeyCredParams: [],
 						},
-						pubKeyCredParams: [],
 					},
 				},
 			});
@@ -493,15 +497,19 @@ export const authHandlers = [
 			});
 		}
 		if (operation === "webauthn" && action === "login-options") {
+			// El backend (fido2 authenticate_begin -> _to_json) envuelve las
+			// options en `publicKey`, igual que register-options.
 			return HttpResponse.json({
 				is_valid: true,
 				code: 0,
 				data: {
 					challenge_id: "chal_02",
 					options: {
-						challenge: "fake",
-						rpId: "admin.test.the-full-stack.com",
-						allowCredentials: [],
+						publicKey: {
+							challenge: "fake",
+							rpId: "admin.test.the-full-stack.com",
+							allowCredentials: [],
+						},
 					},
 				},
 			});

--- a/admin/tests/unit/features/auth/components/auth-components-branches.test.tsx
+++ b/admin/tests/unit/features/auth/components/auth-components-branches.test.tsx
@@ -248,7 +248,9 @@ describe("WebAuthnRegisterButton catch + nickname", () => {
 						code: 0,
 						data: {
 							challenge_id: "chal_01",
-							options: { challenge: "fake", pubKeyCredParams: [] },
+							options: {
+								publicKey: { challenge: "fake", pubKeyCredParams: [] },
+							},
 						},
 					});
 				}

--- a/admin/tests/unit/features/auth/components/webauthn-buttons.test.tsx
+++ b/admin/tests/unit/features/auth/components/webauthn-buttons.test.tsx
@@ -74,7 +74,7 @@ const REG_RESPONSE = { id: "reg" } as unknown as RegistrationResponseJSON;
 const AUTH_RESPONSE = { id: "auth" } as unknown as AuthenticationResponseJSON;
 
 describe("WebAuthnRegisterButton", () => {
-	it("Given options del backend When click Then startRegistration recibe optionsJSON", async () => {
+	it("Given options envueltas en publicKey When click Then startRegistration recibe el contenido PLANO (sin re-envolver)", async () => {
 		startRegistrationMock.mockReset();
 		startRegistrationMock.mockResolvedValue(REG_RESPONSE);
 		const user = userEvent.setup();
@@ -86,9 +86,13 @@ describe("WebAuthnRegisterButton", () => {
 			expect(startRegistrationMock).toHaveBeenCalledTimes(1);
 		});
 		const arg = startRegistrationMock.mock.calls[0]?.[0] as {
-			optionsJSON: { challenge: string };
+			optionsJSON: { challenge: string; publicKey?: unknown };
 		};
+		// El backend envuelve en `options.publicKey`; el componente debe pasar
+		// ESE contenido (plano) a optionsJSON, NO el wrapper. Si re-envolviera,
+		// `optionsJSON.challenge` seria undefined (la causa del bug ".replace").
 		expect(arg.optionsJSON.challenge).toBe("fake");
+		expect(arg.optionsJSON.publicKey).toBeUndefined();
 	});
 
 	it("Given el ceremony completo When click Then dispara toast.success y NO toast.error", async () => {
@@ -167,7 +171,9 @@ describe("WebAuthnRegisterButton", () => {
 						code: 0,
 						data: {
 							challenge_id: "chal_01",
-							options: { challenge: "fake", pubKeyCredParams: [] },
+							options: {
+								publicKey: { challenge: "fake", pubKeyCredParams: [] },
+							},
 						},
 					});
 				}


### PR DESCRIPTION
## Problema

Al hacer click en **Agregar passkey** (o **Usar passkey**) en el panel admin, el ceremony de WebAuthn fallaba con:

```
[webauthn-register] TypeError: Cannot read properties of undefined (reading 'replace')
```

El backend (Lambda `auth`, `webauthn.register-options`) devuelve las options ENVUELTAS en `publicKey`:

```json
{ "challenge_id": "...", "options": { "publicKey": { "challenge": "...", "rp": {...}, "user": {...} } } }
```

(El `_to_json` sobre el `CredentialCreationOptions` de fido2 produce ese wrapper, igual que el dict que consume `navigator.credentials.create({publicKey})`.)

Pero `@simplewebauthn/browser@13` espera que `optionsJSON` sea el contenido **plano** de ese `publicKey`. El componente pasaba `data.options` (el objeto con wrapper), así que la librería leía `optionsJSON.challenge` -> `undefined` -> `.replace()` sobre `undefined` -> el TypeError.

El **login con passkey** (`webauthn.login-options` -> `startAuthentication`) tenia el **mismo bug gemelo** (mismo patron de codigo, backend tambien con `_to_json`).

## Solucion

1. `webauthn-register-button.tsx`: `startRegistration({ optionsJSON: data.options.publicKey })` (antes `data.options`).
2. `webauthn-login-button.tsx`: `startAuthentication({ optionsJSON: data.options.publicKey })` (bug gemelo).
3. `types/api.ts`: `WebauthnRegisterOptionsResponse.options` y `WebauthnLoginOptionsResponse.options` se tipan como `{ publicKey: ... }`, reflejando el shape real del backend (antes estaban tipadas como el JSON plano, lo que ocultaba el bug en typecheck).
4. Mocks MSW (`tests/mocks/handlers/auth.ts`) + 2 mocks inline de tests: anidan las options bajo `publicKey`, alineados con el backend real. **Antes los mocks devolvian el formato plano** -> los tests pasaban validando el comportamiento BUGGY.
5. Test del register: nueva aserción de que `optionsJSON` recibe el contenido plano (`challenge` directo) y NO el wrapper `publicKey`, bloqueando la regresión.

El backend NO se toca: su comportamiento (el wrapper `publicKey`) es correcto.

## Como probar

Local (ya ejecutado, todo verde):

```bash
pnpm --filter @portfolio/admin lint        # Biome: 0 errores
pnpm --filter @portfolio/admin typecheck   # tsc --noEmit: limpio
cd admin && pnpm exec vitest run           # 143 archivos, 611 tests, todos verde
```

Manual en dev (tras deploy):
1. Login en `admin.portfolio.dev.the-full-stack.com`.
2. Ir a Settings > Seguridad > Agregar passkey -> el dialogo del sistema debe abrir (ya no el TypeError en consola).
3. Login con passkey desde el checklist -> `startAuthentication` recibe options validas.

## TODO

Ninguno. Cambio acotado al contrato WebAuthn del admin.