### PR TITLE
fix(auth): WebAuthn passkey register/login fallaba con 400 por webauthn_json_mapping de fido2 apagado

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -124,6 +124,12 @@ jobs:
           NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS: ${{ vars.NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS }}
           NEXT_PUBLIC_WEBAUTHN_RP_ID: ${{ vars.NEXT_PUBLIC_WEBAUTHN_RP_ID }}
           NEXT_PUBLIC_FEATURE_MFA: ${{ vars.NEXT_PUBLIC_FEATURE_MFA }}
+          # E2E bypass del Turnstile: solo el environment `dev` la tiene en
+          # 'true' (para automatizar el form de login en los E2E browser).
+          # En stage/prod la var no existe -> vars.* resuelve a '' -> el
+          # env.ts del admin aplica su default 'false'. El backend prod
+          # rechaza el bypass SIEMPRE (defensa server-side independiente).
+          NEXT_PUBLIC_E2E_BYPASS: ${{ vars.NEXT_PUBLIC_E2E_BYPASS }}
         run: |
           # Verificacion explicita: las vars requeridas deben estar
           # presentes. Si falta alguna, fallar temprano con mensaje claro

--- a/devtools/sync_secrets/catalog.py
+++ b/devtools/sync_secrets/catalog.py
@@ -29,6 +29,10 @@ CLIENT_SYNCED_KEYS: frozenset[str] = frozenset(
         'NEXT_PUBLIC_AUTH_REFRESH_LEAD_MS',
         'NEXT_PUBLIC_WEBAUTHN_RP_ID',
         'NEXT_PUBLIC_FEATURE_MFA',
+        # E2E bypass del Turnstile: 'true' SOLO en dev (automatiza el form
+        # de login en los E2E browser). 'false' en stage/prod. El backend
+        # prod rechaza el bypass SIEMPRE (defensa server-side aparte).
+        'NEXT_PUBLIC_E2E_BYPASS',
     },
 )
 

--- a/serverless/lambda/shared/auth/webauthn.py
+++ b/serverless/lambda/shared/auth/webauthn.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from fido2 import cbor
 from fido2.cose import CoseKey
+from fido2.features import webauthn_json_mapping
 from fido2.server import Fido2Server
 from fido2.utils import websafe_encode
 from fido2.webauthn import (
@@ -54,6 +55,18 @@ from fido2.webauthn import (
 )
 
 from shared.core.exceptions import ApplicationError
+
+# fido2 1.x trae el "JSON mapping" del WebAuthn-2 DESACTIVADO por defecto:
+# sin el, `RegistrationResponse.from_dict` / `AuthenticationResponse.from_dict`
+# esperan los campos binarios (`id`, `rawId`, `attestationObject`,
+# `clientDataJSON`) como `bytes`. PERO el browser (cualquiera: nativo o via
+# @simplewebauthn) los serializa como strings base64url
+# (`RegistrationResponseJSON` del spec) -> fido2 hace `bytes('<b64url>')` y
+# revienta con `TypeError: string argument without an encoding`, que el
+# controller traduce a `400 WEBAUTHN_REGISTRATION_FAILED`. Activar el mapping
+# (idempotente, flag de proceso) hace que `from_dict` decodifique base64url.
+# Sin esto NINGUN register/login de passkey real funciona.
+webauthn_json_mapping.enabled = True
 
 
 class WebauthnError(ApplicationError):

--- a/serverless/lambda/shared/tests/unit/shared/auth/test_webauthn_json_mapping_browser_response.py
+++ b/serverless/lambda/shared/tests/unit/shared/auth/test_webauthn_json_mapping_browser_response.py
@@ -1,0 +1,73 @@
+"""
+Given un response REAL del browser (campos binarios como strings base64url,
+    el formato `RegistrationResponseJSON` del spec WebAuthn),
+When se parsea con `RegistrationResponse.from_dict` (lo que hace
+    `verify_registration` del backend),
+Then NO lanza `TypeError: string argument without an encoding` — porque el
+    modulo activa `fido2.features.webauthn_json_mapping` al importarse.
+
+Regresion guard del fix backend: fido2 1.x trae ese mapping DESACTIVADO por
+defecto y entonces `from_dict` espera bytes, no base64url. Sin el flag, NINGUN
+register/login de passkey real (cualquier browser) valida -> 400
+WEBAUTHN_REGISTRATION_FAILED. Este test importa el modulo (que prende el flag)
+y parsea un response de browser real para que el `from_dict` NO regrese a
+esperar bytes.
+"""
+
+from __future__ import annotations
+
+from fido2.features import webauthn_json_mapping
+from fido2.webauthn import RegistrationResponse
+
+# Importar el modulo del backend DEBE dejar el JSON mapping activo (lo prende
+# a nivel de import, idempotente). No se usa ningun simbolo: el efecto es el
+# `webauthn_json_mapping.enabled = True` del top del modulo.
+import shared.auth.webauthn  # noqa: F401
+
+
+# `id`/`rawId`/`attestationObject`/`clientDataJSON` como strings base64url:
+# EXACTAMENTE el shape que emite el browser (capturado de un ceremony real con
+# el Virtual Authenticator de Chrome en el E2E del admin).
+_BROWSER_RESPONSE = {
+    'id': 'e_-g4peqKta-c40l5I8gVAwL5ddpsfrbhY82_aEDYhM',
+    'rawId': 'e_-g4peqKta-c40l5I8gVAwL5ddpsfrbhY82_aEDYhM',
+    'response': {
+        'attestationObject': (
+            'o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVikPDZS3bX2KPoqRKtt7amwxzYbvz'
+            'Z5fXYIgF9nS95y-QpFAAAAAQECAwQFBgcIAQIDBAUGBwgAIHv_oOKXqirWvnONJeSP'
+            'IFQMC-XXabH624WPNv2hA2ITpQECAyYgASFYILiDlh-oJ5WLAK8gO9PeD6ogmjs8z1'
+            '59KmdyhdX0gB4vIlggDEWjTgsBERbQLGVEra16UhxREvc67RcUO5KD1AgjGr4'
+        ),
+        'clientDataJSON': (
+            'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoibVc4TklRRjM4cE'
+            'hadnMyeFZ1Ty1UaDVrRXdWMnNoeWtmT25raEtFNFhaMCIsIm9yaWdpbiI6Imh0dHBz'
+            'Oi8vYWRtaW4ucG9ydGZvbGlvLmRldi50aGUtZnVsbC1zdGFjay5jb20iLCJjcm9zc0'
+            '9yaWdpbiI6ZmFsc2V9'
+        ),
+        'transports': ['internal'],
+    },
+    'type': 'public-key',
+    'clientExtensionResults': {},
+}
+
+
+def test_webauthn_json_mapping_enabled_after_import() -> None:
+    """Importar shared.auth.webauthn deja el JSON mapping de fido2 activo."""
+    # Assert: el flag de proceso quedo prendido (lo prende el modulo al import).
+    assert webauthn_json_mapping.enabled is True
+
+
+def test_from_dict_parses_browser_base64url_response() -> None:
+    """from_dict decodifica un response del browser (base64url) sin TypeError.
+
+    Con el JSON mapping APAGADO esto lanzaria
+    `TypeError: string argument without an encoding` al castear el `id` string
+    a bytes (la causa raiz del 400 WEBAUTHN_REGISTRATION_FAILED).
+    """
+    # Act: parsea el response tal como llega del browser.
+    parsed = RegistrationResponse.from_dict(_BROWSER_RESPONSE)
+
+    # Assert: el `id` se decodifico de base64url a los 32 bytes del credential.
+    assert isinstance(parsed.id, bytes)
+    assert len(parsed.id) == 32
+    assert parsed.response.attestation_object.fmt == 'none'

--- a/tests/admin/test_login_multifactor.py
+++ b/tests/admin/test_login_multifactor.py
@@ -1,0 +1,180 @@
+"""Login multi-factor (password + webauthn) end-to-end por el checklist real.
+
+Reproduce el flujo donde un user tiene DOS factores `required`: `password` y
+`webauthn` (passkey). El login debe completarse cuando AMBOS estan satisfechos
+(en cualquier orden) y redirigir al shell. Hoy NO converge: el factor webauthn
+arranca un sub-flujo aislado (`webauthn.login-verify` hardcodea
+`satisfied=['webauthn']` y no recibe el temp_token rolling del checklist), asi
+que `mfa_complete` nunca llega a true y el checklist se queda sin redirigir.
+
+Corre contra el admin DESPLEGADO (`admin.portfolio.{env}.the-full-stack.com`),
+NO el local: el ceremony WebAuthn exige que el RP ID del backend
+(`portfolio.dev.*`) sea un sufijo registrable del dominio de la pagina — solo
+se cumple en el dominio desplegado (en admin.localhost el browser lanza
+SecurityError antes del Virtual Authenticator, que NO salta esa validacion).
+El form de login se automatiza porque el build de dev tiene
+`NEXT_PUBLIC_E2E_BYPASS=true` (GH Variable del environment dev): el widget
+Turnstile no se renderiza y el bypass token Ed25519 inyectado en
+`window.__E2E_BYPASS_TOKEN__` viaja en el header `X-Turnstile-Bypass-Token`,
+que el backend dev acepta.
+
+Setup (orden importante): la password es `required` por server_default. Por eso
+se entra al shell con un login solo-password (unico factor) ANTES de registrar
+el passkey; recien despues se marca el passkey `required` para llegar al
+escenario de 2 factores.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+import json
+import urllib.parse
+
+from playwright.sync_api import Browser
+from playwright.sync_api import Page
+import pytest
+from shared.auth_support import STRONG_PASSWORD
+from shared.auth_support import create_active_user_with_password
+from shared.auth_support import login_with_password
+from shared.browser import add_virtual_authenticator
+from shared.browser import install_bypass_token
+from shared.config import admin_origin
+from shared.config import api_base
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+
+_SHELL_MARKER = 'text=Panel de administracion'
+
+
+def _callback_url(
+    *, admin: str, access: str, refresh: str, user_id: str, email: str,
+) -> str:
+    """URL del callback del admin con los tokens en el fragment hash."""
+    payload = refresh.split('.')[1]
+    payload += '=' * (-len(payload) % 4)
+    refresh_exp = int(json.loads(base64.urlsafe_b64decode(payload))['exp']) * 1000
+    frag = urllib.parse.urlencode(
+        {
+            'access': access,
+            'refresh': refresh,
+            'user_id': user_id,
+            'email': email,
+            'refresh_exp': str(refresh_exp),
+        },
+    )
+    return f'{admin}/callback#{frag}'
+
+
+@pytest.fixture
+def mf_setup(
+    browser: Browser,
+    environment: Environment,
+    env: str,
+    auth,
+) -> Iterator[tuple[Page, str, str]]:
+    """Prepara un user con password+webauthn required; entrega `(page, email, admin)`.
+
+    El `page` queda en una sesion LIMPIA (sin cookies) listo para el login
+    real; el Virtual Authenticator ya tiene la passkey registrada (persiste en
+    el BrowserContext). El cleanup del user lo hace el teardown del fixture
+    `auth` (registra el email en `created_emails`). `admin` es el origin del
+    admin desplegado del env.
+    """
+    admin = admin_origin(env)
+    context = browser.new_context()
+    page = context.new_page()
+    bypass = environment.bypass_token() or ''
+    if bypass:
+        install_bypass_token(page, bypass)
+    add_virtual_authenticator(page)
+    http = HttpClient(base_url=api_base(env))
+    origin = api_base(env)
+    try:
+        # 1) User active CON password (la password queda required por default).
+        email = auth.new_email('multifactor')
+        user_id = create_active_user_with_password(
+            http, environment, origin, email, bypass,
+        )
+        assert user_id is not None, 'no se creo el user con password'
+
+        # 2) Login solo-password (unico factor required aun) -> tokens reales.
+        access, refresh = login_with_password(http, origin, email, bypass)
+        assert access and refresh, 'login solo-password no emitio tokens'
+
+        # 3) Browser al shell via callback -> registrar el passkey.
+        page.goto(
+            _callback_url(
+                admin=admin, access=access, refresh=refresh,
+                user_id=user_id, email=email,
+            ),
+            wait_until='load',
+        )
+        page.wait_for_selector(_SHELL_MARKER, timeout=25_000)
+        page.locator('nav').get_by_role('link', name='Configuracion').click()
+        page.get_by_role('link', name='Seguridad').click()
+        page.wait_for_url('**/settings/security**', timeout=15_000)
+        page.get_by_role('button', name='Agregar passkey').click()
+        page.wait_for_selector('text=Passkey registrado', timeout=30_000)
+        assert environment.count_webauthn_credentials(user_id) == 1
+
+        # 4) Marcar el passkey required (necesita su credential_id = UUID PK).
+        creds = http.post(
+            '/auth',
+            body=make_body('webauthn', 'list-credentials'),
+            origin=origin,
+            bearer=access,
+        )
+        cred_id = creds.body['data']['credentials'][0]['credential_id']
+        wa_req = http.post(
+            '/auth',
+            body=make_body(
+                'webauthn', 'set-required', credential_id=cred_id, required=True,
+            ),
+            origin=origin,
+            bearer=access,
+        )
+        assert wa_req.status == 204, f'set-required fallo: {wa_req.status}'
+
+        # 5) Sesion limpia para arrancar el login real desde cero.
+        page.context.clear_cookies()
+        yield page, email, admin
+    finally:
+        http.close()
+        context.close()
+
+
+def test_login_with_password_and_webauthn_required_lands_in_shell(
+    mf_setup: tuple[Page, str, str],
+) -> None:
+    """
+    Given un user con password Y passkey, ambos `required`,
+    When inicia sesion completando los DOS factores en el checklist (password
+        + passkey via Virtual Authenticator, en ese orden),
+    Then el login converge (mfa_complete) y aterriza en el shell autenticado.
+
+    Hoy FALLA: webauthn.login-verify no acumula los factores previos del
+    checklist -> mfa_complete nunca true -> no hay redirect al shell.
+    """
+    page, email, admin = mf_setup
+
+    # Act: login REAL por el form + checklist.
+    page.goto(f'{admin}/login/', wait_until='load')
+    page.get_by_test_id('login-email').fill(email)
+    page.get_by_test_id('login-submit').click()
+    page.wait_for_selector('[data-testid="login-checklist"]', timeout=20_000)
+
+    # Factor 1: password.
+    page.get_by_test_id('picker-method-password').click()
+    page.get_by_test_id('checklist-password').fill(STRONG_PASSWORD)
+    page.get_by_role('button', name='Continuar').click()
+    page.wait_for_selector('text=1 de 2 completados', timeout=15_000)
+
+    # Factor 2: webauthn (el Virtual Authenticator responde el ceremony).
+    page.get_by_test_id('picker-method-webauthn').click()
+    page.get_by_test_id('checklist-webauthn').click()
+
+    # Assert: el login converge y aterriza en el shell.
+    page.wait_for_selector(_SHELL_MARKER, timeout=30_000)
+    assert page.url.rstrip('/') == admin

--- a/tests/admin/test_webauthn_register.py
+++ b/tests/admin/test_webauthn_register.py
@@ -1,0 +1,99 @@
+"""Registro de passkey WebAuthn end-to-end contra el admin desplegado.
+
+Ejercita el fix del bug "Cannot read properties of undefined (reading
+'replace')" (PR #262): el backend (`webauthn.register-options`) devuelve las
+options ENVUELTAS en `publicKey`; el componente `WebAuthnRegisterButton` debe
+pasar `data.options.publicKey` (el contenido PLANO) a
+`startRegistration({optionsJSON})`. Si pasara el wrapper, @simplewebauthn
+leeria `optionsJSON.challenge` = undefined y reventaria con el TypeError ANTES
+de abrir el ceremony.
+
+El ceremony se completa con un Virtual Authenticator de CDP (sin hardware ni
+dialogo del SO). Corre contra el deploy dev real
+(`admin.portfolio.dev.the-full-stack.com`), donde el RP ID
+`portfolio.dev.the-full-stack.com` SI es un sufijo registrable del dominio de
+la pagina (en localhost daria SecurityError, que es la limitacion conocida del
+test manual). La prueba es doble:
+
+1. Front: aparece el toast "Passkey registrado" (el ceremony arranco, parseo
+   las options y el register-verify del backend acepto la credential).
+2. Backend: queda 1 fila en `auth_webauthn_credentials` para el user (el
+   ceremony se completo server-side, no solo el toast).
+"""
+
+from __future__ import annotations
+
+from shared.browser import add_virtual_authenticator
+from shared.browser import screenshot
+from shared.environment import Environment
+
+
+def test_register_passkey_completes_ceremony_and_persists_credential(
+    logged_in_page: tuple,
+    auth,
+    environment: Environment,
+) -> None:
+    """
+    Given un user active autenticado en el shell del admin desplegado, con un
+        Virtual Authenticator (CDP) instalado en su contexto,
+    When navega a Settings > Seguridad y hace click en "Agregar passkey"
+        (dispara navigator.credentials.create con las options del backend),
+    Then el ceremony se completa: aparece el toast "Passkey registrado" y queda
+        exactamente 1 credential WebAuthn activo en Neon para el user — sin el
+        TypeError ".replace" (que reventaria el ceremony antes de empezar).
+    """
+    # Arrange: page autenticada en el shell + user_id real, sin passkeys aun.
+    page, _email, user_id = logged_in_page
+    assert environment.count_webauthn_credentials(user_id) == 0
+    # Captura los errores de consola del browser (diagnostico del ceremony).
+    console_errors: list[str] = []
+    page.on(
+        'console',
+        lambda msg: console_errors.append(f'{msg.type}: {msg.text}')
+        if msg.type in ('error', 'warning')
+        else None,
+    )
+    # Virtual Authenticator: responde el ceremony sin hardware ni dialogo.
+    add_virtual_authenticator(page)
+    # Navega a la tab Seguridad (client-side, preserva la sesion).
+    page.locator('nav').get_by_role('link', name='Configuracion').click()
+    page.get_by_role('link', name='Seguridad').click()
+    page.wait_for_url('**/settings/security**', timeout=15_000)
+    page.get_by_role('button', name='Agregar passkey').wait_for(
+        state='visible', timeout=15_000,
+    )
+
+    # Diagnostico: captura el body del register-verify (el response del
+    #   ceremony) para inspeccionar que produce el Virtual Authenticator.
+    verify_bodies: list[str] = []
+
+    def _capture_verify(request: object) -> None:
+        post = getattr(request, 'post_data', None)
+        if post and 'register-verify' in post:
+            verify_bodies.append(post)
+
+    page.on('request', _capture_verify)
+
+    # Act: dispara el register ceremony (el Virtual Authenticator lo resuelve).
+    page.get_by_role('button', name='Agregar passkey').click()
+
+    # Assert (front): toast de exito — el ceremony arranco (sin .replace) y el
+    #   register-verify del backend acepto la credential.
+    try:
+        page.wait_for_selector('text=Passkey registrado', timeout=30_000)
+    except Exception:  # noqa: BLE001 -- diagnostico antes de re-fallar
+        screenshot(page, 'results/webauthn-register-fail.png', full_page=True)
+        toasts = page.locator('[data-sonner-toast]').all_inner_texts()
+        creds = environment.count_webauthn_credentials(user_id)
+        verify_payload = verify_bodies[-1] if verify_bodies else '(ninguno)'
+        raise AssertionError(
+            'toast "Passkey registrado" no aparecio. '
+            f'toasts visibles={toasts!r} '
+            f'console={console_errors[-8:]!r} '
+            f'creds_en_neon={creds} url={page.url}\n'
+            f'register-verify body={verify_payload[:1200]}',
+        ) from None
+
+    # Assert (backend): el credential quedo persistido en Neon (ceremony
+    #   completo server-side, no solo el toast).
+    assert environment.count_webauthn_credentials(user_id) == 1

--- a/tests/shared/auth_support.py
+++ b/tests/shared/auth_support.py
@@ -132,6 +132,41 @@ def create_active_user_with_password(
     return user_id
 
 
+def login_with_password(
+    http: HttpClient,
+    origin: str,
+    email: str,
+    bypass: str | None,
+) -> tuple[str | None, str | None]:
+    """Login de un user cuyo UNICO factor required es `password`.
+
+    `login.check-email` (precheck con bypass) -> `login.start` (precheck en
+    Authorization, SIN email) -> temp step=2 -> `login.verify-password`. Como
+    la password es el unico required, `verify-password` emite tokens directo.
+    Devuelve `(access, refresh)` (o `(None, None)` si algo falla). Sirve para
+    bootstrapear el browser via callback cuando el user ya tiene password pero
+    AUN no tiene otros factores required (ej. antes de registrar un passkey).
+    """
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth',
+        body=make_body('login', 'start'),
+        origin=origin,
+        bearer=precheck,
+    )
+    temp = field(start.body, 'temp_token')
+    if not temp:
+        return None, None
+    verify = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password', password=STRONG_PASSWORD, temp_token=temp,
+        ),
+        origin=origin,
+    )
+    return field(verify.body, 'access_token'), field(verify.body, 'refresh_token')
+
+
 def login_precheck(
     http: HttpClient,
     origin: str,

--- a/tests/shared/browser.py
+++ b/tests/shared/browser.py
@@ -161,6 +161,41 @@ def install_bypass(page: Page, token: str) -> None:
     install_bypass_token(page, token)
 
 
+def add_virtual_authenticator(page: Page) -> Any:
+    """Instala un Virtual Authenticator (CDP) para los ceremonies WebAuthn.
+
+    Given una pagina que va a disparar `navigator.credentials.create()` /
+    `get()` (registro/login de passkey),
+    When se instala el authenticator virtual ANTES del ceremony,
+    Then Chrome responde el ceremony con un authenticator simulado (sin
+    hardware ni dialogo del SO): `create()` resuelve con una credential
+    valida que el backend puede verificar. Sin esto, en headless el ceremony
+    se cuelga esperando un authenticator real.
+
+    Usa el CDP de Playwright (sync API): `WebAuthn.enable` +
+    `WebAuthn.addVirtualAuthenticator` con un authenticator interno
+    (platform) que auto-aprueba la user verification y es resident-key
+    capable (passkey). Devuelve la `CDPSession` (el caller la conserva viva
+    mientras dura la pagina; se cierra con el contexto).
+    """
+    cdp = page.context.new_cdp_session(page)
+    cdp.send('WebAuthn.enable')
+    cdp.send(
+        'WebAuthn.addVirtualAuthenticator',
+        {
+            'options': {
+                'protocol': 'ctap2',
+                'transport': 'internal',
+                'hasResidentKey': True,
+                'hasUserVerification': True,
+                'isUserVerified': True,
+                'automaticPresenceSimulation': True,
+            },
+        },
+    )
+    return cdp
+
+
 def disable_send_beacon(page: Page) -> None:
     """Fuerza el fallback `fetch` del tracking sobreescribiendo sendBeacon.
 

--- a/tests/shared/environment.py
+++ b/tests/shared/environment.py
@@ -179,6 +179,21 @@ class Environment:
         )
         return [str(r[0]) for r in rows]
 
+    def count_webauthn_credentials(self, user_id: str) -> int:
+        """Passkeys WebAuthn ACTIVOS del user (auth_webauthn_credentials).
+
+        Cuenta las filas no deshabilitadas: el register-verify del ceremony
+        inserta la fila con `disabled_at IS NULL`. Sirve para confirmar
+        server-side que el ceremony se completo (el credential quedo
+        persistido en Neon), no solo que el toast del front aparecio.
+        """
+        rows = self._query(
+            'SELECT count(*) FROM auth_webauthn_credentials '
+            'WHERE user_id = %s AND disabled_at IS NULL',
+            (user_id,),
+        )
+        return int(rows[0][0]) if rows else 0
+
     # --- Admin whitelist (SSM) + cold restart del Lambda users ---
 
     def _admin_emails_path(self) -> str:


### PR DESCRIPTION
## Problema

El registro (y login) de passkey WebAuthn fallaba **siempre** con `400 WEBAUTHN_REGISTRATION_FAILED`, con cualquier browser. Descubierto al escribir un E2E que registra un passkey contra dev (tras arreglar el bug del frontend en #262).

El ceremony del browser tiene exito (el authenticator crea la credential), pero el backend rechaza el `register-verify`. La causa real (reproducida con fido2 1.2 + el response real del browser):

```
TypeError: string argument without an encoding
  at fido2/utils.py _parse_value -> bytes(value)
```

`fido2` 1.x trae el **WebAuthn JSON mapping DESACTIVADO por defecto**. Sin el, `RegistrationResponse.from_dict` / `AuthenticationResponse.from_dict` esperan los campos binarios (`id`, `rawId`, `attestationObject`, `clientDataJSON`) como `bytes`. Pero el browser los serializa como **strings base64url** (el `RegistrationResponseJSON` del spec WebAuthn) -> fido2 hace `bytes('<b64url>')` -> el `TypeError`, que el controller traduce a 400.

Esto afecta a **cualquier** ceremony de passkey real, no solo al E2E.

## Solucion

Activar `fido2.features.webauthn_json_mapping` (flag de proceso, idempotente) en el top del modulo portador `shared/auth/webauthn.py`. Con el mapping activo, `from_dict` decodifica base64url -> la attestation valida y el credential se persiste.

## Como probar

E2E real contra dev (Virtual Authenticator de Chrome via CDP) — **verde**:

```bash
python devtools/run.py serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
cd tests && ../devtools/.venv/bin/python -m pytest admin/test_webauthn_register.py --env=dev --aws-profile=tfs-dev
# 1 passed: toast "Passkey registrado" + 1 fila en auth_webauthn_credentials (Neon)
```

Tests unit (verde): `serverless tests --type=unit --shared` (558) + `--lambda=auth` (220) + `lint-deps --shared` OK.

El test de regresion `test_webauthn_json_mapping_browser_response.py` parsea un response real del browser y verifica que `from_dict` ya no lanza el `TypeError`.

Ya deployado a dev para validar el E2E. El deploy normal (deploy-backend.yml) lo reconcilia al mergear.

## TODO

Ninguno. El E2E nuevo (`tests/admin/test_webauthn_register.py`) + helpers (`add_virtual_authenticator`, `count_webauthn_credentials`) van en este PR y cubren register de passkey end-to-end de aqui en adelante.