### PR TITLE
fix(auth): login multi-factor con passkey no convergia (checklist no acumulaba el factor previo)

### DIFF
--- a/admin/src/features/auth/api/auth-client.ts
+++ b/admin/src/features/auth/api/auth-client.ts
@@ -261,6 +261,7 @@ export const authClient = {
 	webauthnLoginVerify: (data: {
 		challenge_id: string;
 		response: AuthenticationResponseJSON;
+		temp_token?: string;
 	}) =>
 		apiFetch<Envelope<VerifyResult>>("/auth", {
 			method: "POST",

--- a/admin/src/features/auth/components/login-checklist.tsx
+++ b/admin/src/features/auth/components/login-checklist.tsx
@@ -196,6 +196,7 @@ export function LoginChecklist({
 						email={email}
 						onResult={onResult("webauthn")}
 						testid="checklist-webauthn"
+						tempToken={tempToken}
 					/>
 				);
 			default:

--- a/admin/src/features/auth/components/webauthn-login-button.tsx
+++ b/admin/src/features/auth/components/webauthn-login-button.tsx
@@ -27,15 +27,20 @@ import { useWebauthnLoginVerify } from "../hooks/use-webauthn-login-verify";
  * @props {string} [email] - email conocido (modo checklist)
  * @props {(data: VerifyResult) => void} [onResult] - resultado del verify
  * @props {string} [testid] - data-testid del boton (modo checklist)
+ * @props {string} [tempToken] - temp_token rolling del checklist multi-factor;
+ *   se manda al login-verify para que el backend acumule los factores ya
+ *   satisfechos (ej. password). Sin el, el login multi-factor no converge.
  */
 export function WebAuthnLoginButton({
 	email: emailProp,
 	onResult,
 	testid,
+	tempToken,
 }: {
 	email?: string;
 	onResult?: (data: VerifyResult) => void;
 	testid?: string;
+	tempToken?: string;
 } = {}) {
 	const checklistMode = emailProp !== undefined && onResult !== undefined;
 	const [email, setEmail] = useState("");
@@ -49,9 +54,13 @@ export function WebAuthnLoginButton({
 			optionsJSON: data.options.publicKey,
 		});
 		if (checklistMode) {
+			// tempToken: en el checklist multi-factor el backend lo necesita para
+			// acumular los factores ya satisfechos (ej. password). Sin el, el
+			// passkey se verifica aislado y el login nunca converge.
 			const result = await loginVerify.mutateAsync({
 				challenge_id: data.challenge_id,
 				response,
+				temp_token: tempToken,
 			});
 			onResult?.(result.data);
 			return;

--- a/devtools/pyproject.toml
+++ b/devtools/pyproject.toml
@@ -40,6 +40,11 @@ dependencies = [
     # (tests/shared/secrets.py) to mint the signed Turnstile bypass token;
     # mirrors shared.crypto on the backend.
     "cryptography>=44,<46",
+    # WebAuthn software authenticator: firma ceremonies (register/login) en los
+    # E2E de API del checklist multi-factor (tests/), para verificar el flujo
+    # passkey de forma DETERMINISTA sin el Virtual Authenticator del browser
+    # (CDP es flaky). Solo en tests, mismo authenticator que usa el backend.
+    "soft-webauthn>=0.1.4,<0.2.0",
 ]
 
 [tool.uv]

--- a/devtools/uv.lock
+++ b/devtools/uv.lock
@@ -108,37 +108,49 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "45.0.7"
+version = "44.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980, upload-time = "2025-09-01T11:15:03.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/d6/1411ab4d6108ab167d06254c5be517681f1e331f90edf1379895bcb87020/cryptography-44.0.3.tar.gz", hash = "sha256:fe19d8bc5536a91a24a8133328880a41831b6c5df54599a8417b62fe015d3053", size = 711096, upload-time = "2025-05-02T19:36:04.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/91/925c0ac74362172ae4516000fe877912e33b5983df735ff290c653de4913/cryptography-45.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3be4f21c6245930688bd9e162829480de027f8bf962ede33d4f8ba7d67a00cee", size = 7041105, upload-time = "2025-09-01T11:13:59.684Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/63/43641c5acce3a6105cf8bd5baeceeb1846bb63067d26dae3e5db59f1513a/cryptography-45.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:67285f8a611b0ebc0857ced2081e30302909f571a46bfa7a3cc0ad303fe015c6", size = 4205799, upload-time = "2025-09-01T11:14:02.517Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/29/c238dd9107f10bfde09a4d1c52fd38828b1aa353ced11f358b5dd2507d24/cryptography-45.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:577470e39e60a6cd7780793202e63536026d9b8641de011ed9d8174da9ca5339", size = 4430504, upload-time = "2025-09-01T11:14:04.522Z" },
-    { url = "https://files.pythonhosted.org/packages/62/62/24203e7cbcc9bd7c94739428cd30680b18ae6b18377ae66075c8e4771b1b/cryptography-45.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4bd3e5c4b9682bc112d634f2c6ccc6736ed3635fc3319ac2bb11d768cc5a00d8", size = 4209542, upload-time = "2025-09-01T11:14:06.309Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/e3/e7de4771a08620eef2389b86cd87a2c50326827dea5528feb70595439ce4/cryptography-45.0.7-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:465ccac9d70115cd4de7186e60cfe989de73f7bb23e8a7aa45af18f7412e75bf", size = 3889244, upload-time = "2025-09-01T11:14:08.152Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b8/bca71059e79a0bb2f8e4ec61d9c205fbe97876318566cde3b5092529faa9/cryptography-45.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16ede8a4f7929b4b7ff3642eba2bf79aa1d71f24ab6ee443935c0d269b6bc513", size = 4461975, upload-time = "2025-09-01T11:14:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/58/67/3f5b26937fe1218c40e95ef4ff8d23c8dc05aa950d54200cc7ea5fb58d28/cryptography-45.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8978132287a9d3ad6b54fcd1e08548033cc09dc6aacacb6c004c73c3eb5d3ac3", size = 4209082, upload-time = "2025-09-01T11:14:11.229Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e4/b3e68a4ac363406a56cf7b741eeb80d05284d8c60ee1a55cdc7587e2a553/cryptography-45.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b6a0e535baec27b528cb07a119f321ac024592388c5681a5ced167ae98e9fff3", size = 4460397, upload-time = "2025-09-01T11:14:12.924Z" },
-    { url = "https://files.pythonhosted.org/packages/22/49/2c93f3cd4e3efc8cb22b02678c1fad691cff9dd71bb889e030d100acbfe0/cryptography-45.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a24ee598d10befaec178efdff6054bc4d7e883f615bfbcd08126a0f4931c83a6", size = 4337244, upload-time = "2025-09-01T11:14:14.431Z" },
-    { url = "https://files.pythonhosted.org/packages/04/19/030f400de0bccccc09aa262706d90f2ec23d56bc4eb4f4e8268d0ddf3fb8/cryptography-45.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa26fa54c0a9384c27fcdc905a2fb7d60ac6e47d14bc2692145f2b3b1e2cfdbd", size = 4568862, upload-time = "2025-09-01T11:14:16.185Z" },
-    { url = "https://files.pythonhosted.org/packages/29/56/3034a3a353efa65116fa20eb3c990a8c9f0d3db4085429040a7eef9ada5f/cryptography-45.0.7-cp311-abi3-win32.whl", hash = "sha256:bef32a5e327bd8e5af915d3416ffefdbe65ed975b646b3805be81b23580b57b8", size = 2936578, upload-time = "2025-09-01T11:14:17.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:3808e6b2e5f0b46d981c24d79648e5c25c35e59902ea4391a0dcb3e667bf7443", size = 3405400, upload-time = "2025-09-01T11:14:18.958Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e8/c436233ddf19c5f15b25ace33979a9dd2e7aa1a59209a0ee8554179f1cc0/cryptography-45.0.7-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bfb4c801f65dd61cedfc61a83732327fafbac55a47282e6f26f073ca7a41c3b2", size = 7021824, upload-time = "2025-09-01T11:14:20.954Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/4c/8f57f2500d0ccd2675c5d0cc462095adf3faa8c52294ba085c036befb901/cryptography-45.0.7-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81823935e2f8d476707e85a78a405953a03ef7b7b4f55f93f7c2d9680e5e0691", size = 4202233, upload-time = "2025-09-01T11:14:22.454Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/ac/59b7790b4ccaed739fc44775ce4645c9b8ce54cbec53edf16c74fd80cb2b/cryptography-45.0.7-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3994c809c17fc570c2af12c9b840d7cea85a9fd3e5c0e0491f4fa3c029216d59", size = 4423075, upload-time = "2025-09-01T11:14:24.287Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/d4f07ea21434bf891faa088a6ac15d6d98093a66e75e30ad08e88aa2b9ba/cryptography-45.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dad43797959a74103cb59c5dac71409f9c27d34c8a05921341fb64ea8ccb1dd4", size = 4204517, upload-time = "2025-09-01T11:14:25.679Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ac/924a723299848b4c741c1059752c7cfe09473b6fd77d2920398fc26bfb53/cryptography-45.0.7-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ce7a453385e4c4693985b4a4a3533e041558851eae061a58a5405363b098fcd3", size = 3882893, upload-time = "2025-09-01T11:14:27.1Z" },
-    { url = "https://files.pythonhosted.org/packages/83/dc/4dab2ff0a871cc2d81d3ae6d780991c0192b259c35e4d83fe1de18b20c70/cryptography-45.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b04f85ac3a90c227b6e5890acb0edbaf3140938dbecf07bff618bf3638578cf1", size = 4450132, upload-time = "2025-09-01T11:14:28.58Z" },
-    { url = "https://files.pythonhosted.org/packages/12/dd/b2882b65db8fc944585d7fb00d67cf84a9cef4e77d9ba8f69082e911d0de/cryptography-45.0.7-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:48c41a44ef8b8c2e80ca4527ee81daa4c527df3ecbc9423c41a420a9559d0e27", size = 4204086, upload-time = "2025-09-01T11:14:30.572Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/fa/1d5745d878048699b8eb87c984d4ccc5da4f5008dfd3ad7a94040caca23a/cryptography-45.0.7-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f3df7b3d0f91b88b2106031fd995802a2e9ae13e02c36c1fc075b43f420f3a17", size = 4449383, upload-time = "2025-09-01T11:14:32.046Z" },
-    { url = "https://files.pythonhosted.org/packages/36/8b/fc61f87931bc030598e1876c45b936867bb72777eac693e905ab89832670/cryptography-45.0.7-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd342f085542f6eb894ca00ef70236ea46070c8a13824c6bde0dfdcd36065b9b", size = 4332186, upload-time = "2025-09-01T11:14:33.95Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/11/09700ddad7443ccb11d674efdbe9a832b4455dc1f16566d9bd3834922ce5/cryptography-45.0.7-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1993a1bb7e4eccfb922b6cd414f072e08ff5816702a0bdb8941c247a6b1b287c", size = 4561639, upload-time = "2025-09-01T11:14:35.343Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ed/8f4c1337e9d3b94d8e50ae0b08ad0304a5709d483bfcadfcc77a23dbcb52/cryptography-45.0.7-cp37-abi3-win32.whl", hash = "sha256:18fcf70f243fe07252dcb1b268a687f2358025ce32f9f88028ca5c364b123ef5", size = 2926552, upload-time = "2025-09-01T11:14:36.929Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/ff/026513ecad58dacd45d1d24ebe52b852165a26e287177de1d545325c0c25/cryptography-45.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:7285a89df4900ed3bfaad5679b1e668cb4b38a8de1ccbfc84b05f34512da0a90", size = 3392742, upload-time = "2025-09-01T11:14:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/08/53/c776d80e9d26441bb3868457909b4e74dd9ccabd182e10b2b0ae7a07e265/cryptography-44.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:962bc30480a08d133e631e8dfd4783ab71cc9e33d5d7c1e192f0b7c06397bb88", size = 6670281, upload-time = "2025-05-02T19:34:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/06/af2cf8d56ef87c77319e9086601bef621bedf40f6f59069e1b6d1ec498c5/cryptography-44.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffc61e8f3bf5b60346d89cd3d37231019c17a081208dfbbd6e1605ba03fa137", size = 3959305, upload-time = "2025-05-02T19:34:53.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/01/80de3bec64627207d030f47bf3536889efee8913cd363e78ca9a09b13c8e/cryptography-44.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58968d331425a6f9eedcee087f77fd3c927c88f55368f43ff7e0a19891f2642c", size = 4171040, upload-time = "2025-05-02T19:34:54.675Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/48/bb16b7541d207a19d9ae8b541c70037a05e473ddc72ccb1386524d4f023c/cryptography-44.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e28d62e59a4dbd1d22e747f57d4f00c459af22181f0b2f787ea83f5a876d7c76", size = 3963411, upload-time = "2025-05-02T19:34:56.61Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b2/7d31f2af5591d217d71d37d044ef5412945a8a8e98d5a2a8ae4fd9cd4489/cryptography-44.0.3-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af653022a0c25ef2e3ffb2c673a50e5a0d02fecc41608f4954176f1933b12359", size = 3689263, upload-time = "2025-05-02T19:34:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/25/50/c0dfb9d87ae88ccc01aad8eb93e23cfbcea6a6a106a9b63a7b14c1f93c75/cryptography-44.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:157f1f3b8d941c2bd8f3ffee0af9b049c9665c39d3da9db2dc338feca5e98a43", size = 4196198, upload-time = "2025-05-02T19:35:00.988Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c9/55c6b8794a74da652690c898cb43906310a3e4e4f6ee0b5f8b3b3e70c441/cryptography-44.0.3-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:c6cd67722619e4d55fdb42ead64ed8843d64638e9c07f4011163e46bc512cf01", size = 3966502, upload-time = "2025-05-02T19:35:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f7/7cb5488c682ca59a02a32ec5f975074084db4c983f849d47b7b67cc8697a/cryptography-44.0.3-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b424563394c369a804ecbee9b06dfb34997f19d00b3518e39f83a5642618397d", size = 4196173, upload-time = "2025-05-02T19:35:05.018Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0b/2f789a8403ae089b0b121f8f54f4a3e5228df756e2146efdf4a09a3d5083/cryptography-44.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c91fc8e8fd78af553f98bc7f2a1d8db977334e4eea302a4bfd75b9461c2d8904", size = 4087713, upload-time = "2025-05-02T19:35:07.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/330c13655f1af398fc154089295cf259252f0ba5df93b4bc9d9c7d7f843e/cryptography-44.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:25cd194c39fa5a0aa4169125ee27d1172097857b27109a45fadc59653ec06f44", size = 4299064, upload-time = "2025-05-02T19:35:08.879Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a8/8c540a421b44fd267a7d58a1fd5f072a552d72204a3f08194f98889de76d/cryptography-44.0.3-cp37-abi3-win32.whl", hash = "sha256:3be3f649d91cb182c3a6bd336de8b61a0a71965bd13d1a04a0e15b39c3d5809d", size = 2773887, upload-time = "2025-05-02T19:35:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0d/c4b1657c39ead18d76bbd122da86bd95bdc4095413460d09544000a17d56/cryptography-44.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:3883076d5c4cc56dbef0b898a74eb6992fdac29a7b9013870b34efe4ddb39a0d", size = 3209737, upload-time = "2025-05-02T19:35:12.12Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a3/ad08e0bcc34ad436013458d7528e83ac29910943cea42ad7dd4141a27bbb/cryptography-44.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:5639c2b16764c6f76eedf722dbad9a0914960d3489c0cc38694ddf9464f1bb2f", size = 6673501, upload-time = "2025-05-02T19:35:13.775Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f0/7491d44bba8d28b464a5bc8cc709f25a51e3eac54c0a4444cf2473a57c37/cryptography-44.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3ffef566ac88f75967d7abd852ed5f182da252d23fac11b4766da3957766759", size = 3960307, upload-time = "2025-05-02T19:35:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/e5c5d0e1364d3346a5747cdcd7ecbb23ca87e6dea4f942a44e88be349f06/cryptography-44.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:192ed30fac1728f7587c6f4613c29c584abdc565d7417c13904708db10206645", size = 4170876, upload-time = "2025-05-02T19:35:18.138Z" },
+    { url = "https://files.pythonhosted.org/packages/73/96/025cb26fc351d8c7d3a1c44e20cf9a01e9f7cf740353c9c7a17072e4b264/cryptography-44.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7d5fe7195c27c32a64955740b949070f21cba664604291c298518d2e255931d2", size = 3964127, upload-time = "2025-05-02T19:35:19.864Z" },
+    { url = "https://files.pythonhosted.org/packages/01/44/eb6522db7d9f84e8833ba3bf63313f8e257729cf3a8917379473fcfd6601/cryptography-44.0.3-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3f07943aa4d7dad689e3bb1638ddc4944cc5e0921e3c227486daae0e31a05e54", size = 3689164, upload-time = "2025-05-02T19:35:21.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fb/d61a4defd0d6cee20b1b8a1ea8f5e25007e26aeb413ca53835f0cae2bcd1/cryptography-44.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cb90f60e03d563ca2445099edf605c16ed1d5b15182d21831f58460c48bffb93", size = 4198081, upload-time = "2025-05-02T19:35:23.187Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/50/457f6911d36432a8811c3ab8bd5a6090e8d18ce655c22820994913dd06ea/cryptography-44.0.3-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ab0b005721cc0039e885ac3503825661bd9810b15d4f374e473f8c89b7d5460c", size = 3967716, upload-time = "2025-05-02T19:35:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6e/dca39d553075980ccb631955c47b93d87d27f3596da8d48b1ae81463d915/cryptography-44.0.3-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3bb0847e6363c037df8f6ede57d88eaf3410ca2267fb12275370a76f85786a6f", size = 4197398, upload-time = "2025-05-02T19:35:27.678Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/9d/d1f2fe681eabc682067c66a74addd46c887ebacf39038ba01f8860338d3d/cryptography-44.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0cc66c74c797e1db750aaa842ad5b8b78e14805a9b5d1348dc603612d3e3ff5", size = 4087900, upload-time = "2025-05-02T19:35:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f5/3599e48c5464580b73b236aafb20973b953cd2e7b44c7c2533de1d888446/cryptography-44.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6866df152b581f9429020320e5eb9794c8780e90f7ccb021940d7f50ee00ae0b", size = 4301067, upload-time = "2025-05-02T19:35:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/d2c48c8137eb39d0c193274db5c04a75dab20d2f7c3f81a7dcc3a8897701/cryptography-44.0.3-cp39-abi3-win32.whl", hash = "sha256:c138abae3a12a94c75c10499f1cbae81294a6f983b3af066390adee73f433028", size = 2775467, upload-time = "2025-05-02T19:35:33.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/51f212198681ea7b0deaaf8846ee10af99fba4e894f67b353524eab2bbe5/cryptography-44.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:5d186f32e52e66994dce4f766884bcb9c68b8da62d61d9d215bfe5fb56d21334", size = 3210375, upload-time = "2025-05-02T19:35:35.369Z" },
+]
+
+[[package]]
+name = "fido2"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/cc/4529123364d41f342145f2fd775307eaed817cd22810895dea10e15a4d06/fido2-1.2.0.tar.gz", hash = "sha256:e39f95920122d64283fda5e5581d95a206e704fa42846bfa4662f86aa0d3333b", size = 266369, upload-time = "2024-11-27T09:08:21.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/48/e9b99d66f27d3416a619324568739fd6603e093b2f79138d6f47ccf727b6/fido2-1.2.0-py3-none-any.whl", hash = "sha256:f7c8ee62e359aa980a45773f9493965bb29ede1b237a9218169dbfe60c80e130", size = 219418, upload-time = "2024-11-27T09:08:18.932Z" },
 ]
 
 [[package]]
@@ -309,6 +321,7 @@ dependencies = [
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "soft-webauthn" },
 ]
 
 [package.metadata]
@@ -324,6 +337,7 @@ requires-dist = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", specifier = ">=0.15.12" },
+    { name = "soft-webauthn", specifier = ">=0.1.4,<0.2.0" },
 ]
 
 [[package]]
@@ -510,6 +524,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "soft-webauthn"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "fido2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/31/65cf69054dced6c143ca8631ce3075cdbb9d096739b8a5254467baa38ec8/soft-webauthn-0.1.4.tar.gz", hash = "sha256:e96513342e69bbfde5a60adcb03ab0d562d70d5d2e20ee7203fcfbdf4f1b06d0", size = 3467, upload-time = "2022-07-08T12:48:29.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5b/cd4b1738509cdb9382d632c503be0b242d589e4dfe39dcc75d74fcf1618c/soft_webauthn-0.1.4-py3-none-any.whl", hash = "sha256:eacb98e406b0bc170455f9fd00977400d6129e7c557f872cf118e9431d1cb9e1", size = 4389, upload-time = "2022-07-08T12:48:27.817Z" },
 ]
 
 [[package]]

--- a/serverless/lambda/services/auth/core/controllers/webauthn/login_verify.py
+++ b/serverless/lambda/services/auth/core/controllers/webauthn/login_verify.py
@@ -21,12 +21,14 @@ from services.mfa_method_service import MfaMethodService
 from services.rate_limit_service import RateLimitService
 from services.webauthn_service import WebauthnService
 from settings.config import app_config
+from shared.auth.jwt import JwtError
 from shared.auth.webauthn import WebauthnCloneError, WebauthnVerifyError
 from shared.lambda_kit.base_controller import BaseController
 
-from ..login._mfa_login import decide_mfa_step
+from ..login._mfa_login import decide_mfa_step, parse_satisfied
 
 _ENDPOINT = '/auth#webauthn.login-verify'
+_MFA_FLOW = 'login-mfa'
 
 
 class LoginVerify(BaseController):
@@ -118,15 +120,28 @@ class LoginVerify(BaseController):
                 'data': {'error': 'WEBAUTHN_VERIFY_FAILED'},
             }
 
-        # Multi-factor: la passkey cuenta como factor 'webauthn' satisfecho.
-        # Si el user tiene OTROS metodos requeridos (ej. tambien TOTP),
-        # `decide_mfa_step` devuelve un temp step=2 pidiendo el faltante; si
-        # webauthn cubre los requeridos (o no hay), emite access+refresh.
+        # Multi-factor: la passkey cuenta como factor 'webauthn' satisfecho,
+        # ACUMULANDO los factores previos del checklist. Cuando webauthn es un
+        # factor del checklist, el front manda el temp step=2 rolling (flow
+        # 'login-mfa[:...]'); de su `flow` se extraen los factores ya hechos
+        # (ej. password) y se le suma 'webauthn'. Sin temp (login passwordless
+        # directo) el unico satisfecho es 'webauthn'. El temp se valida (typ +
+        # flow + step + que su `sub` sea el user del challenge: anti
+        # cross-account) y se blacklistea (rolling); un temp invalido degrada a
+        # solo 'webauthn' (el challenge ya autentica al user, no se rompe el
+        # passwordless).
+        satisfied = ['webauthn']
+        if data.temp_token:
+            satisfied = self._satisfied_from_temp(
+                jwt_svc=jwt_svc,
+                temp_token=data.temp_token,
+                user_id=user_id,
+            )
         data_out = decide_mfa_step(
             jwt_svc=jwt_svc,
             app_config=app_config,
             user_id=user_id,
-            satisfied=['webauthn'],
+            satisfied=satisfied,
             required=MfaMethodService(app_config).required_methods(
                 user_id=user_id,
             ),
@@ -144,3 +159,37 @@ class LoginVerify(BaseController):
         )
 
         return {'is_valid': True, 'code': 0, 'data': data_out}
+
+    def _satisfied_from_temp(
+        self,
+        *,
+        jwt_svc: JwtService,
+        temp_token: str,
+        user_id: str,
+    ) -> list[str]:
+        """`[*factores previos del temp, 'webauthn']` validando + rotando el temp.
+
+        El temp debe ser un step=2 del checklist (`typ='temp'`, flow
+        `login-mfa[:...]`) cuyo `sub` sea el user del challenge (anti
+        cross-account). Si valida, blacklistea su `jti` (rolling) y devuelve los
+        factores previos + 'webauthn'. Si NO valida (token invalido, flow/step
+        equivocado, o sub de otro user), degrada a `['webauthn']`: el challenge
+        ya autentico al user, no se rompe el passwordless directo.
+        """
+        try:
+            claims = jwt_svc.verify(temp_token, expected_typ='temp')
+        except JwtError:
+            return ['webauthn']
+        flow_ok = (
+            claims.flow is not None
+            and claims.flow.split(':', 1)[0] == _MFA_FLOW
+        )
+        if not flow_ok or claims.step != 2 or str(claims.sub) != str(user_id):
+            return ['webauthn']
+        jwt_svc.blacklist(
+            jti=claims.jti,
+            exp=claims.exp,
+            user_id=user_id,
+            reason='rotation',
+        )
+        return [*parse_satisfied(claims.flow), 'webauthn']

--- a/serverless/lambda/services/auth/core/models/webauthn.py
+++ b/serverless/lambda/services/auth/core/models/webauthn.py
@@ -44,10 +44,17 @@ class WebauthnLoginOptionsIn(BaseModel):
 
 
 class WebauthnLoginVerifyIn(BaseModel):
-    """POST /auth operation=webauthn action=login-verify."""
+    """POST /auth operation=webauthn action=login-verify.
+
+    `temp_token` es OPCIONAL: cuando webauthn es un factor del checklist
+    multi-factor del login, el front manda el temp step=2 rolling para que el
+    backend acumule los factores ya satisfechos (ej. password). Ausente en el
+    login passwordless directo (solo passkey).
+    """
 
     challenge_id: UUID
     response: dict[str, Any]
+    temp_token: str | None = None
     meta: _Meta = Field(default_factory=_Meta, alias='_meta')
     model_config = ConfigDict(populate_by_name=True, extra='ignore')
 

--- a/serverless/lambda/services/auth/tests/unit/controllers/webauthn/test_webauthn_login_verify_multifactor_accumulates.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/webauthn/test_webauthn_login_verify_multifactor_accumulates.py
@@ -1,0 +1,144 @@
+"""login-verify acumula los factores previos del checklist via el temp_token.
+
+Given un user con `required=[password, webauthn]` y un challenge de login
+    valido, mas un temp_token step=2 cuyo flow ya lleva `password` satisfecho
+    (`login-mfa:password`),
+When se invoca webauthn.login-verify con ese temp_token,
+Then acumula `satisfied=[password, webauthn]`, cubre los required y emite
+    access+refresh (mfa_complete) + blacklistea el temp recibido (rolling).
+
+Regresion guard del bug del checklist multi-factor: antes login-verify
+hardcodeaba `satisfied=['webauthn']` y descartaba la password ya hecha, asi que
+`decide_mfa_step` veia un required pendiente y nunca emitia tokens.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from .._helpers import _make_temp_event
+
+
+def test_webauthn_login_verify_accumulates_password_from_temp(monkeypatch):
+    """temp con password satisfecho + webauthn -> emite tokens (mfa_complete)."""
+    from controllers.webauthn import login_verify
+
+    uid = uuid4()
+    jwt_svc = MagicMock()
+    jwt_svc.issue_access.return_value = ('ACCESS-JWT', MagicMock())
+    jwt_svc.issue_refresh.return_value = ('REFRESH-JWT', MagicMock())
+    # El temp del checklist: step=2, flow con 'password' ya satisfecho, sub=uid.
+    claims = MagicMock()
+    claims.flow = 'login-mfa:password'
+    claims.step = 2
+    claims.sub = str(uid)
+    claims.jti = 'TEMP-JTI'
+    claims.exp = 9_999_999_999
+    jwt_svc.verify.return_value = claims
+
+    webauthn_svc = MagicMock()
+    webauthn_svc.verify_login.return_value = b'\x10' * 16
+    mfa_svc = MagicMock()
+    mfa_svc.required_methods.return_value = ['password', 'webauthn']
+    challenge_svc = MagicMock()
+    challenge_svc.get_and_consume.return_value = {
+        'user_id': str(uid),
+        'kind': 'login',
+        'state': {'s': 1},
+    }
+
+    monkeypatch.setattr(login_verify, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(login_verify, 'WebauthnService', lambda _c: webauthn_svc)
+    monkeypatch.setattr(login_verify, 'MfaMethodService', lambda _c: mfa_svc)
+    monkeypatch.setattr(
+        login_verify, 'ChallengeService', lambda _c: challenge_svc,
+    )
+    monkeypatch.setattr(login_verify, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(login_verify, 'RateLimitService', lambda _c: MagicMock())
+    from controllers.login import _mfa_login
+
+    monkeypatch.setattr(
+        _mfa_login, 'SessionTrackingService', lambda _c: MagicMock(),
+    )
+
+    event = _make_temp_event(
+        data={
+            'challenge_id': '01900000-0000-7000-8000-000000000001',
+            'response': {'id': 'x'},
+            'temp_token': 'TEMP-FROM-CHECKLIST',
+        },
+    )
+    result = login_verify.LoginVerify(event=event).run()
+
+    # Emite tokens (los 2 required cubiertos) — mfa_complete.
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['data']['access_token'] == 'ACCESS-JWT'
+    assert result['data']['refresh_token'] == 'REFRESH-JWT'
+    assert result['data']['mfa_complete'] is True
+    # El temp recibido se blacklistea (rolling).
+    jwt_svc.blacklist.assert_called_once()
+    assert jwt_svc.blacklist.call_args.kwargs['jti'] == 'TEMP-JTI'
+
+
+def test_webauthn_login_verify_temp_other_user_degrades_to_webauthn_only(
+    monkeypatch,
+):
+    """temp con sub de OTRO user -> NO acumula (anti cross-account): solo webauthn.
+
+    El user del challenge tiene `required=[webauthn]` (passkey unico factor): con
+    `satisfied=['webauthn']` cubre el required y emite tokens; el factor del temp
+    ajeno se ignora y el temp NO se blacklistea.
+    """
+    from controllers.webauthn import login_verify
+
+    uid = uuid4()
+    other = uuid4()
+    jwt_svc = MagicMock()
+    jwt_svc.issue_access.return_value = ('ACCESS-JWT', MagicMock())
+    jwt_svc.issue_refresh.return_value = ('REFRESH-JWT', MagicMock())
+    claims = MagicMock()
+    claims.flow = 'login-mfa:password'
+    claims.step = 2
+    claims.sub = str(other)  # sub de otro user
+    claims.jti = 'TEMP-JTI'
+    claims.exp = 9_999_999_999
+    jwt_svc.verify.return_value = claims
+
+    webauthn_svc = MagicMock()
+    webauthn_svc.verify_login.return_value = b'\x10' * 16
+    mfa_svc = MagicMock()
+    mfa_svc.required_methods.return_value = ['webauthn']
+    challenge_svc = MagicMock()
+    challenge_svc.get_and_consume.return_value = {
+        'user_id': str(uid),
+        'kind': 'login',
+        'state': {'s': 1},
+    }
+
+    monkeypatch.setattr(login_verify, 'JwtService', lambda _c: jwt_svc)
+    monkeypatch.setattr(login_verify, 'WebauthnService', lambda _c: webauthn_svc)
+    monkeypatch.setattr(login_verify, 'MfaMethodService', lambda _c: mfa_svc)
+    monkeypatch.setattr(
+        login_verify, 'ChallengeService', lambda _c: challenge_svc,
+    )
+    monkeypatch.setattr(login_verify, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(login_verify, 'RateLimitService', lambda _c: MagicMock())
+    from controllers.login import _mfa_login
+
+    monkeypatch.setattr(
+        _mfa_login, 'SessionTrackingService', lambda _c: MagicMock(),
+    )
+
+    event = _make_temp_event(
+        data={
+            'challenge_id': '01900000-0000-7000-8000-000000000001',
+            'response': {'id': 'x'},
+            'temp_token': 'TEMP-FROM-OTHER-USER',
+        },
+    )
+    result = login_verify.LoginVerify(event=event).run()
+
+    # Emite tokens (webauthn cubre el unico required); el temp ajeno NO rota.
+    assert result['is_valid'] is True
+    assert result['data']['access_token'] == 'ACCESS-JWT'
+    jwt_svc.blacklist.assert_not_called()

--- a/tests/admin/test_login_multifactor.py
+++ b/tests/admin/test_login_multifactor.py
@@ -126,7 +126,7 @@ def mf_setup(
             origin=origin,
             bearer=access,
         )
-        cred_id = creds.body['data']['credentials'][0]['credential_id']
+        cred_id = creds.body['credentials'][0]['credential_id']
         wa_req = http.post(
             '/auth',
             body=make_body(

--- a/tests/admin/test_login_multifactor.py
+++ b/tests/admin/test_login_multifactor.py
@@ -154,8 +154,10 @@ def test_login_with_password_and_webauthn_required_lands_in_shell(
         + passkey via Virtual Authenticator, en ese orden),
     Then el login converge (mfa_complete) y aterriza en el shell autenticado.
 
-    Hoy FALLA: webauthn.login-verify no acumula los factores previos del
-    checklist -> mfa_complete nunca true -> no hay redirect al shell.
+    Regresion guard: antes del fix, webauthn.login-verify hardcodeaba
+    satisfied=['webauthn'] y no recibia el temp_token del checklist, asi que
+    mfa_complete nunca era true y no habia redirect. El fix (backend acumula
+    los factores del temp + front pasa el tempToken) lo cierra.
     """
     page, email, admin = mf_setup
 
@@ -171,10 +173,17 @@ def test_login_with_password_and_webauthn_required_lands_in_shell(
     page.get_by_role('button', name='Continuar').click()
     page.wait_for_selector('text=1 de 2 completados', timeout=15_000)
 
-    # Factor 2: webauthn (el Virtual Authenticator responde el ceremony).
+    # Factor 2: webauthn. El picker monta el boton de forma async tras
+    # setView('webauthn'); esperar a que sea visible ANTES de clickear (sin
+    # esto el click puede caer antes de que el handler este montado y el
+    # ceremony no arranca).
     page.get_by_test_id('picker-method-webauthn').click()
-    page.get_by_test_id('checklist-webauthn').click()
+    webauthn_btn = page.get_by_test_id('checklist-webauthn')
+    webauthn_btn.wait_for(state='visible', timeout=10_000)
+    webauthn_btn.click()
+    # El ceremony del Virtual Authenticator tarda ~1-2s ("Validando..."); el
+    # wait del shell le da margen amplio.
 
-    # Assert: el login converge y aterriza en el shell.
+    # Assert: el login converge (mfa_complete) y aterriza en el shell.
     page.wait_for_selector(_SHELL_MARKER, timeout=30_000)
     assert page.url.rstrip('/') == admin

--- a/tests/api/test_auth_multifactor_checklist.py
+++ b/tests/api/test_auth_multifactor_checklist.py
@@ -1,0 +1,346 @@
+"""E2E del login multi-factor (checklist) del Lambda auth — combinaciones.
+
+Verifica DETERMINISTICAMENTE (API pura, sin browser) el contrato del checklist
+de login cuando el user tiene >1 factor `required`:
+
+- Cada verify intermedio devuelve `mfa_complete: false` + `methods` con los
+  factores que faltan (key explicita de progreso).
+- El verify que satisface el ULTIMO factor devuelve `mfa_complete: true` +
+  `access_token` + `refresh_token` (el token final que se usara).
+- Los factores se completan EN CUALQUIER ORDEN; el backend acumula via el
+  `temp_token` rolling (cada verify emite uno nuevo con el factor sumado).
+
+Cubre el bug del passkey en el checklist (webauthn.login-verify ahora acumula
+los factores previos del temp en vez de hardcodear ['webauthn']).
+
+Combinaciones probadas:
+- password + totp
+- password + webauthn          (el caso reportado)
+- password + totp + webauthn   (3 factores, orden arbitrario)
+
+Requiere bypass (registra users active): sin el, se omite. El passkey se firma
+con `SoftPasskey` (authenticator de software, UV) — sin browser ni Virtual
+Authenticator CDP. Emails sinteticos limpiados en el teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+from shared.totp import totp_now
+from shared.webauthn_device import SoftPasskey
+
+
+def _enroll_totp(http: HttpClient, origin: str, access: str) -> str:
+    """Enrola + confirma TOTP y lo marca required. Devuelve el secret_b32."""
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-totp'), origin=origin,
+        bearer=access,
+    )
+    secret = field(setup.body, 'secret_b32')
+    assert secret is not None
+    http.post(
+        '/auth',
+        body=make_body('mfa', 'confirm-totp', code=totp_now(secret)),
+        origin=origin, bearer=access,
+    )
+    http.post(
+        '/auth',
+        body=make_body('mfa', 'set-required', kind='totp', required=True),
+        origin=origin, bearer=access,
+    )
+    return secret
+
+
+def _enroll_passkey(
+    http: HttpClient, origin: str, admin: str, access: str,
+) -> SoftPasskey:
+    """Registra un passkey (SoftPasskey) y lo marca required. Devuelve el device."""
+    pk = SoftPasskey(admin)
+    ro = http.post(
+        '/auth', body=make_body('webauthn', 'register-options'),
+        origin=origin, bearer=access,
+    )
+    rv = http.post(
+        '/auth',
+        body=make_body(
+            'webauthn', 'register-verify',
+            challenge_id=ro.body['challenge_id'],
+            response=pk.register_response(ro.body['options']),
+        ),
+        origin=origin, bearer=access,
+    )
+    assert rv.status == 201, f'register-verify fallo: {rv.status} {rv.body}'
+    cs = http.post(
+        '/auth', body=make_body('webauthn', 'list-credentials'),
+        origin=origin, bearer=access,
+    )
+    cred_id = cs.body['credentials'][0]['credential_id']
+    http.post(
+        '/auth',
+        body=make_body(
+            'webauthn', 'set-required', credential_id=cred_id, required=True,
+        ),
+        origin=origin, bearer=access,
+    )
+    return pk
+
+
+def _verify_factor(
+    http: HttpClient,
+    origin: str,
+    factor: str,
+    *,
+    temp: str,
+    email: str,
+    secret: str | None,
+    passkey: SoftPasskey | None,
+    env_obj: Environment,
+    user_id: str,
+) -> dict:
+    """Completa UN factor del checklist con el `temp` actual. Devuelve el body.
+
+    `password`/`totp` van directo con el temp. `webauthn` hace
+    login-options -> firma -> login-verify CON el temp. `email_code` envia el
+    code, lo seedea en Neon y lo verifica.
+    """
+    if factor == 'password':
+        r = http.post(
+            '/auth',
+            body=make_body(
+                'login', 'verify-password',
+                password=STRONG_PASSWORD, temp_token=temp,
+            ),
+            origin=origin,
+        )
+        return r.body
+    if factor == 'totp':
+        assert secret is not None
+        r = http.post(
+            '/auth',
+            body=make_body(
+                'login', 'verify-totp', code=totp_now(secret), temp_token=temp,
+            ),
+            origin=origin,
+        )
+        return r.body
+    if factor == 'webauthn':
+        assert passkey is not None
+        lo = http.post(
+            '/auth',
+            body=make_body('webauthn', 'login-options', email=email),
+            origin=origin,
+        )
+        r = http.post(
+            '/auth',
+            body=make_body(
+                'webauthn', 'login-verify',
+                challenge_id=lo.body['challenge_id'],
+                response=passkey.login_response(lo.body['options']),
+                temp_token=temp,
+            ),
+            origin=origin,
+        )
+        return r.body
+    raise AssertionError(f'factor no soportado en el helper: {factor}')
+
+
+def _run_checklist(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str,
+    *,
+    factors_order: list[str],
+    enroll: dict,
+) -> dict:
+    """Crea el user, completa los factores en `factors_order` y verifica contrato.
+
+    `enroll` trae los artefactos del setup (`secret`, `passkey`, `email`,
+    `user_id`). Asercion del contrato en cada paso: los intermedios devuelven
+    `mfa_complete: false` + `methods` no vacio; el ultimo `mfa_complete: true` +
+    tokens. Devuelve el body final (con los tokens).
+    """
+    origin = admin_origin(env)
+    email = enroll['email']
+    user_id = enroll['user_id']
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    # check del set de required: el backend lista TODOS los factores.
+    assert set(start.body.get('methods') or []) == set(factors_order)
+    assert start.body.get('mfa_complete') is False
+    temp = field(start.body, 'temp_token')
+
+    last = len(factors_order) - 1
+    final_body: dict = {}
+    for i, factor in enumerate(factors_order):
+        body = _verify_factor(
+            http, origin, factor, temp=temp, email=email,
+            secret=enroll.get('secret'), passkey=enroll.get('passkey'),
+            env_obj=environment, user_id=user_id,
+        )
+        if i < last:
+            # Contrato intermedio: NO completo, faltan factores, temp rolling.
+            assert body.get('mfa_complete') is False, (
+                f'factor {factor}: esperaba mfa_complete=false, body={body}'
+            )
+            pending = body.get('methods') or []
+            assert factor not in pending, (
+                f'{factor} no deberia seguir pendiente: {pending}'
+            )
+            assert pending, f'tras {factor} deberian faltar factores: {body}'
+            temp = field(body, 'temp_token')
+            assert temp, f'falta temp_token rolling tras {factor}: {body}'
+        else:
+            # Contrato final: completo + token final.
+            assert body.get('mfa_complete') is True, (
+                f'ultimo factor {factor}: esperaba mfa_complete=true, body={body}'
+            )
+            assert field(body, 'access_token'), f'falta access_token: {body}'
+            assert field(body, 'refresh_token'), f'falta refresh_token: {body}'
+            final_body = body
+    return final_body
+
+
+def _setup_user(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str,
+    created_emails: list[str],
+    *,
+    with_totp: bool,
+    with_webauthn: bool,
+) -> dict:
+    """Crea un user active con password + (opcional) totp/webauthn required."""
+    origin = admin_origin(env)
+    admin = admin_origin(env)
+    email = f'success+mfck-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    # access fresco para el enroll (password unico required aun).
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    enroll: dict = {'email': email, 'user_id': user_id}
+    if with_totp:
+        enroll['secret'] = _enroll_totp(http, origin, access)
+    if with_webauthn:
+        enroll['passkey'] = _enroll_passkey(http, origin, admin, access)
+    return enroll
+
+
+@pytest.mark.api
+def test_login_checklist_password_and_totp(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user con password + totp `required`,
+    When completa ambos factores del checklist (password -> totp),
+    Then los intermedios dan mfa_complete=false + methods, y el ultimo da
+        mfa_complete=true + access/refresh.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+    enroll = _setup_user(
+        http, environment, env, bypass, created_emails,
+        with_totp=True, with_webauthn=False,
+    )
+    _run_checklist(
+        http, environment, env, bypass,
+        factors_order=['password', 'totp'], enroll=enroll,
+    )
+
+
+@pytest.mark.api
+def test_login_checklist_password_and_webauthn(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user con password + webauthn (passkey) `required`,
+    When completa password y luego el passkey (con el temp del checklist),
+    Then el login converge (mfa_complete=true + tokens) — el passkey acumula el
+        password ya hecho (regresion del bug del checklist multi-factor).
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+    enroll = _setup_user(
+        http, environment, env, bypass, created_emails,
+        with_totp=False, with_webauthn=True,
+    )
+    _run_checklist(
+        http, environment, env, bypass,
+        factors_order=['password', 'webauthn'], enroll=enroll,
+    )
+
+
+@pytest.mark.api
+def test_login_checklist_three_factors_arbitrary_order(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user con password + totp + webauthn `required`,
+    When completa los 3 en orden arbitrario (webauthn -> password -> totp),
+    Then solo el ULTIMO factor cierra el login (mfa_complete=true + tokens);
+        los 2 intermedios dan mfa_complete=false con los pendientes correctos.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+    enroll = _setup_user(
+        http, environment, env, bypass, created_emails,
+        with_totp=True, with_webauthn=True,
+    )
+    _run_checklist(
+        http, environment, env, bypass,
+        factors_order=['webauthn', 'password', 'totp'], enroll=enroll,
+    )

--- a/tests/shared/webauthn_device.py
+++ b/tests/shared/webauthn_device.py
@@ -1,0 +1,164 @@
+"""Authenticator WebAuthn de software para los E2E de API (sin browser).
+
+Encapsula `soft_webauthn.SoftWebauthnDevice` para firmar los ceremonies de
+register y login de un passkey contra el backend REAL (Lambda `auth`), de
+forma DETERMINISTA — sin el Virtual Authenticator del browser (CDP es flaky)
+ni la propagacion de Cloudflare.
+
+Por que la subclase `_UvDevice`: el backend pide `user_verification=REQUIRED`
+en el login; el `SoftWebauthnDevice.get()` de soft-webauthn 0.1.4 hardcodea
+`flags=0x01` (solo User-Present), asi que fido2 rechaza con "User verification
+required, but user verified flag not set". La subclase firma con `flags=0x05`
+(UP|UV) para que la assertion incluya el flag UV (y la firma cubra ese flag).
+
+Conversion: el backend emite/espera los campos binarios como base64url JSON
+(spec WebAuthn); `SoftWebauthnDevice` trabaja con bytes (formato navegador).
+Estos helpers convierten en ambos sentidos.
+"""
+
+from __future__ import annotations
+
+import base64
+from struct import pack
+from typing import Any
+
+from soft_webauthn import SoftWebauthnDevice
+
+
+def b64url_to_bytes(value: str) -> bytes:
+    """base64url string -> bytes (tolera padding ausente)."""
+    return base64.urlsafe_b64decode(value + '=' * (-len(value) % 4))
+
+
+def bytes_to_b64url(value: bytes) -> str:
+    """bytes -> base64url string sin padding (formato del spec WebAuthn)."""
+    return base64.urlsafe_b64encode(value).decode('ascii').rstrip('=')
+
+
+# Flags del authenticatorData: bit0 UP (User Present) + bit2 UV (User
+# Verified). El backend exige UV en el login (userVerification=REQUIRED).
+_FLAGS_UP_UV = b'\x05'
+
+
+class _UvDevice(SoftWebauthnDevice):
+    """`SoftWebauthnDevice` que firma el login con el flag UV (User Verified).
+
+    Sobreescribe `get` para usar `flags=0x05` (UP|UV) en vez del `0x01` que
+    hardcodea soft-webauthn 0.1.4 — sin esto el backend (fido2,
+    userVerification=REQUIRED) rechaza la assertion.
+    """
+
+    def get(self, options: dict[str, Any], origin: str) -> dict[str, Any]:
+        from hashlib import sha256
+        import json
+
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        pub = options['publicKey']
+        if self.rp_id != pub['rpId']:
+            raise ValueError('Requested rpID does not match current credential')
+
+        self.sign_count += 1
+        client_data = json.dumps(
+            {
+                'type': 'webauthn.get',
+                'challenge': bytes_to_b64url(pub['challenge']),
+                'origin': origin,
+            },
+        ).encode('utf-8')
+        client_data_hash = sha256(client_data).digest()
+        rp_id_hash = sha256(self.rp_id.encode('ascii')).digest()
+        authenticator_data = (
+            rp_id_hash + _FLAGS_UP_UV + pack('>I', self.sign_count)
+        )
+        signature = self.private_key.sign(
+            authenticator_data + client_data_hash,
+            ec.ECDSA(hashes.SHA256()),
+        )
+        return {
+            'id': base64.urlsafe_b64encode(self.credential_id),
+            'rawId': self.credential_id,
+            'response': {
+                'authenticatorData': authenticator_data,
+                'clientDataJSON': client_data,
+                'signature': signature,
+                'userHandle': self.user_handle,
+            },
+            'type': 'public-key',
+        }
+
+
+class SoftPasskey:
+    """Un passkey de software: registra y autentica contra el backend `auth`.
+
+    `origin` es el origin del RP (el admin desplegado), que debe estar en
+    `WEBAUTHN_ALLOWED_ORIGINS` del Lambda. El mismo objeto conserva la
+    credential entre `register` y `login` (resident key).
+    """
+
+    def __init__(self, origin: str) -> None:
+        self._origin = origin
+        self._device = _UvDevice()
+
+    def register_response(self, options: dict[str, Any]) -> dict[str, Any]:
+        """Firma la attestation de `register-options`. Devuelve el response JSON.
+
+        `options` es el `{publicKey: {...b64url...}}` que devuelve el backend.
+        """
+        pub = options['publicKey']
+        create_opts = {
+            'publicKey': {
+                **pub,
+                'challenge': b64url_to_bytes(pub['challenge']),
+                'user': {
+                    **pub['user'],
+                    'id': b64url_to_bytes(pub['user']['id']),
+                },
+            },
+        }
+        att = self._device.create(create_opts, self._origin)
+        return {
+            'id': bytes_to_b64url(att['rawId']),
+            'rawId': bytes_to_b64url(att['rawId']),
+            'type': att['type'],
+            'response': {
+                'attestationObject': bytes_to_b64url(
+                    att['response']['attestationObject'],
+                ),
+                'clientDataJSON': bytes_to_b64url(
+                    att['response']['clientDataJSON'],
+                ),
+            },
+        }
+
+    def login_response(self, options: dict[str, Any]) -> dict[str, Any]:
+        """Firma la assertion de `login-options` (con flag UV). Response JSON."""
+        pub = options['publicKey']
+        get_opts = {
+            'publicKey': {
+                **pub,
+                'challenge': b64url_to_bytes(pub['challenge']),
+                'allowCredentials': [
+                    {**c, 'id': b64url_to_bytes(c['id'])}
+                    for c in pub.get('allowCredentials', [])
+                ],
+            },
+        }
+        asrt = self._device.get(get_opts, self._origin)
+        uh = asrt['response'].get('userHandle')
+        return {
+            'id': bytes_to_b64url(asrt['rawId']),
+            'rawId': bytes_to_b64url(asrt['rawId']),
+            'type': asrt['type'],
+            'response': {
+                'authenticatorData': bytes_to_b64url(
+                    asrt['response']['authenticatorData'],
+                ),
+                'clientDataJSON': bytes_to_b64url(
+                    asrt['response']['clientDataJSON'],
+                ),
+                'signature': bytes_to_b64url(asrt['response']['signature']),
+                'userHandle': bytes_to_b64url(uh) if uh else None,
+            },
+        }


### PR DESCRIPTION
## Problema

En el login del admin con DOS factores `required` (ej. password + passkey), al completar ambos el checklist NO redirigia al shell: se quedaba con los metodos marcados como hechos pero sin iniciar sesion.

Causa: `webauthn.login-verify` hardcodeaba `satisfied=['webauthn']` y NO recibia el `temp_token` rolling del checklist. Cuando el passkey era un factor de un checklist multi-factor, descartaba que la password ya estaba hecha -> `decide_mfa_step` veia un required pendiente -> `mfa_complete` nunca `true` -> sin tokens, sin redirect. Los demas factores (password/totp/email_code) SI encadenaban el temp; solo webauthn quedaba aislado.

## Solucion

**Backend** (`auth`):
- `WebauthnLoginVerifyIn` acepta `temp_token` opcional.
- `login-verify`, si viene el temp del checklist, lo verifica (typ=temp, flow `login-mfa`, step=2, `sub` == user del challenge: anti cross-account), lo blacklistea (rolling) y acumula `satisfied=[*parse_satisfied(flow), 'webauthn']`. Sin temp (passwordless directo) o temp invalido -> degrada a `['webauthn']` sin romper.

**Frontend** (`admin`):
- `WebAuthnLoginButton` acepta `tempToken` y lo manda en `login-verify`; el `LoginChecklist` se lo pasa con el temp rolling actual. `auth-client` tipa `temp_token?`.

## Como probar (verificado)

E2E de API DETERMINISTA contra dev (sin browser), 3 combinaciones — **verde**:
```bash
cd tests && ../devtools/.venv/bin/python -m pytest api/test_auth_multifactor_checklist.py --env=dev --aws-profile=tfs-dev
# 3 passed: password+totp, password+webauthn, password+totp+webauthn (orden arbitrario)
```
Contrato verificado en cada paso: verify intermedios -> `mfa_complete:false` + `methods` pendientes; ultimo -> `mfa_complete:true` + `access_token`/`refresh_token` (token final).

El passkey se firma con `SoftPasskey` (authenticator de software, flag UV) — sin el Virtual Authenticator del browser (CDP flaky). El backend auth ya esta deployado en dev con el fix.

Verificacion adicional: 222 tests unit del auth (incl. login-verify acumula con temp / degrada sin temp) + lint-deps OK + front biome/typecheck/611 unit verde.

## TODO

- El E2E browser del checklist (`tests/admin/test_login_multifactor.py`) queda como smoke best-effort: el harness CDP+WebAuthn+Cloudflare edge es flaky. La cobertura determinista del path la da el E2E de API.
- `NEXT_PUBLIC_E2E_BYPASS=true` quedo en el environment dev (GH Variable) para automatizar el form de login en E2E; stage/prod en false, backend prod rechaza el bypass siempre.