### PR TITLE
fix(auth+admin): login exige todos los metodos required + toggle required de la password

### DIFF
--- a/admin/src/features/auth/api/auth-client.ts
+++ b/admin/src/features/auth/api/auth-client.ts
@@ -292,6 +292,22 @@ export const authClient = {
 			body: { operation: "security", action: "overview", data: {} },
 		}),
 
+	/**
+	 * security.password-set-required: marca/desmarca la password como requerida
+	 * al loguear (factor de la lista). 204; 404 si el user no tiene password.
+	 * Desmarcarla siempre es seguro: el fallback passwordless garantiza >=1
+	 * required (no hay 409).
+	 */
+	passwordSetRequired: (data: { required: boolean }) =>
+		apiFetch<Envelope<unknown>>("/auth", {
+			method: "POST",
+			body: {
+				operation: "security",
+				action: "password-set-required",
+				data,
+			},
+		}),
+
 	/** mfa.enable: activa (soft-enable) un metodo MFA por kind. 204. */
 	mfaEnable: (data: { kind: MfaKind }) =>
 		apiFetch<Envelope<unknown>>("/auth", {

--- a/admin/src/features/settings/components/security-overview-panel.tsx
+++ b/admin/src/features/settings/components/security-overview-panel.tsx
@@ -366,10 +366,20 @@ function RecoveryCodesRow({ method }: { method: SecurityMethod }) {
 
 /**
  * @function PasswordRow
- * @description Fila de password: SIN switches. Muestra ultimo cambio + boton
- *   'Cambiar contrasena' que abre el ChangePasswordForm en un Dialog.
+ * @description Fila de password: muestra ultimo cambio + Switch 'Requerido al
+ *   loguear' (security.password-set-required) + boton 'Cambiar contrasena' que
+ *   abre el ChangePasswordForm en un Dialog. El Switch solo aparece si el user
+ *   ya tiene contrasena configurada (no hay flag required sin password).
  */
-function PasswordRow({ method }: { method: SecurityMethod }) {
+function PasswordRow({
+	method,
+	onRequired,
+	settingRequired,
+}: {
+	method: SecurityMethod;
+	onRequired: (vars: { type: SecurityMethodType; required: boolean }) => void;
+	settingRequired: boolean;
+}) {
 	const [open, setOpen] = useState(false);
 	const lastChange = asString(method.detail, "last_change_at");
 	// configured=true => el user ya tiene contrasena seteada.
@@ -377,7 +387,10 @@ function PasswordRow({ method }: { method: SecurityMethod }) {
 	const cta = hasPassword ? "Cambiar contrasena" : "Establecer contrasena";
 
 	return (
-		<div className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-4">
+		<div
+			data-testid="security-row-password"
+			className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-4"
+		>
 			<div className="space-y-0.5">
 				<div className="flex items-center gap-2">
 					<span className="text-sm font-medium">{method.label}</span>
@@ -389,14 +402,25 @@ function PasswordRow({ method }: { method: SecurityMethod }) {
 					</p>
 				) : null}
 			</div>
-			<Button
-				type="button"
-				variant="outline"
-				size="sm"
-				onClick={() => setOpen(true)}
-			>
-				{cta}
-			</Button>
+			<div className="flex flex-wrap items-center gap-3">
+				{hasPassword ? (
+					<RequiredSwitch
+						required={method.required}
+						disabled={settingRequired}
+						onConfirm={(required) =>
+							onRequired({ type: method.type, required })
+						}
+					/>
+				) : null}
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => setOpen(true)}
+				>
+					{cta}
+				</Button>
+			</div>
 			<Dialog open={open} onOpenChange={setOpen}>
 				<DialogContent>
 					<DialogHeader>
@@ -480,7 +504,11 @@ export function SecurityOverviewPanel() {
 						) : method.type === "recovery_codes" ? (
 							<RecoveryCodesRow method={method} />
 						) : method.type === "password" ? (
-							<PasswordRow method={method} />
+							<PasswordRow
+								method={method}
+								settingRequired={setRequired.isPending}
+								onRequired={(vars) => setRequired.mutate(vars)}
+							/>
 						) : (
 							<MfaRow
 								method={method}

--- a/admin/src/features/settings/hooks/use-set-required.ts
+++ b/admin/src/features/settings/hooks/use-set-required.ts
@@ -23,7 +23,8 @@ export interface SetRequiredVars {
 /**
  * @function dispatchSetRequired
  * @description Enruta la mutation segun `type`: webauthn via credential_id,
- *   MFA via kind. No aplica a recovery_codes ni password.
+ *   MFA via kind, password via security.password-set-required. No aplica a
+ *   recovery_codes (es el escape anti-lockout, nunca requerido).
  */
 async function dispatchSetRequired(vars: SetRequiredVars): Promise<unknown> {
 	const { type, kind, recordId, required } = vars;
@@ -41,6 +42,10 @@ async function dispatchSetRequired(vars: SetRequiredVars): Promise<unknown> {
 	if (type === "totp" || type === "email_code") {
 		const resolvedKind: MfaKind = kind ?? type;
 		return authClient.mfaSetRequired({ kind: resolvedKind, required });
+	}
+
+	if (type === "password") {
+		return authClient.passwordSetRequired({ required });
 	}
 
 	throw new Error(`No se puede marcar como requerido el metodo: ${type}`);

--- a/admin/tests/mocks/handlers/auth.ts
+++ b/admin/tests/mocks/handlers/auth.ts
@@ -555,6 +555,12 @@ export const authHandlers = [
 			return new HttpResponse(null, { status: 204 });
 		}
 
+		// security.password-set-required: marca/desmarca la password como
+		// requerida al loguear -> 204 (sin payload).
+		if (operation === "security" && action === "password-set-required") {
+			return new HttpResponse(null, { status: 204 });
+		}
+
 		return HttpResponse.json(
 			{ error: "NOT_IMPLEMENTED", code: 5010 },
 			{ status: 501 },

--- a/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
+++ b/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
@@ -1,5 +1,11 @@
 import { server } from "@tests/mocks/server";
-import { render, screen, waitFor } from "@tests/utils/render";
+import {
+	render,
+	screen,
+	userEvent,
+	waitFor,
+	within,
+} from "@tests/utils/render";
 import { HttpResponse, http } from "msw";
 import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -197,17 +203,68 @@ describe("SecurityOverviewPanel", () => {
 		).toBeInTheDocument();
 	});
 
-	it("Given password When render Then muestra el boton Cambiar contrasena sin switches", async () => {
+	it("Given password configured When render Then muestra Cambiar contrasena Y el switch Requerido al loguear", async () => {
 		// Arrange
 		mockOverview(fiveMethods());
 
 		// Act
 		render((<SecurityOverviewPanel />) as ReactElement);
 
-		// Assert
+		// Assert: la password ahora ofrece el control de required (igual que
+		// TOTP/webauthn), no solo el boton de cambio.
+		const passwordRow = await screen.findByTestId("security-row-password");
 		expect(
-			await screen.findByRole("button", { name: /cambiar contrasena/i }),
+			within(passwordRow).getByRole("button", { name: /cambiar contrasena/i }),
 		).toBeInTheDocument();
+		expect(
+			within(passwordRow).getByText(/requerido al loguear/i),
+		).toBeInTheDocument();
+	});
+
+	it("Given password required=false When activo el switch Then dispara security.password-set-required {required:true}", async () => {
+		// Arrange: overview con SOLO la password (aisla el switch bajo prueba;
+		// otras filas tienen sus propios RequiredSwitch que ensucian el assert).
+		// UN solo handler sirve el overview y captura el password-set-required.
+		// apiFetch APLANA el body ({operation, action, ...data}), asi que
+		// `required` viaja al nivel raiz del request, NO en `data`.
+		const onlyPassword = fiveMethods().filter((m) => m.type === "password");
+		let capturedRequired: boolean | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					required?: boolean;
+				};
+				if (
+					body.operation === "security" &&
+					body.action === "password-set-required"
+				) {
+					capturedRequired = body.required ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods: onlyPassword },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: activar el switch de la password -> AlertDialog -> Confirmar.
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const passwordRow = await screen.findByTestId("security-row-password");
+		await user.click(within(passwordRow).getByRole("switch"));
+		// El AlertDialog de advertencia se monta en un portal; esperar su
+		// titulo antes de confirmar.
+		await screen.findByText(/hacer obligatorio este metodo/i);
+		await user.click(screen.getByRole("button", { name: /confirmar/i }));
+
+		// Assert: el backend recibe password-set-required con required=true.
+		await waitFor(() => {
+			expect(capturedRequired).toBe(true);
+		});
 	});
 
 	it("Given security.overview falla When render Then muestra el ErrorAlert", async () => {

--- a/serverless/lambda/services/auth/core/controllers/security/overview.py
+++ b/serverless/lambda/services/auth/core/controllers/security/overview.py
@@ -54,16 +54,22 @@ def _mfa_entry(method_type: str, method: dict[str, Any] | None) -> dict[str, Any
             'last_used_at': None,
             'detail': {},
         }
+    confirmed = bool(method['confirmed'])
     return {
         'type': method_type,
         'label': _LABELS[method_type],
         'configured': True,
         'enabled': bool(method['enabled']),
-        'required': bool(method['required']),
+        # Un metodo NO confirmado nunca se reporta `required`: aunque la
+        # columna tenga el flag (estado heredado), el login lo ignora
+        # (list_required_methods exige confirmado). Cruzar required AND
+        # confirmed evita que settings muestre un required que el login no
+        # respeta. `set_required` ya impide crear este estado a futuro.
+        'required': bool(method['required']) and confirmed,
         'preferred': bool(method['preferred']),
         'created_at': method['created_at'],
         'last_used_at': method['last_used_at'],
-        'detail': {'confirmed': bool(method['confirmed'])},
+        'detail': {'confirmed': confirmed},
     }
 
 

--- a/serverless/lambda/services/auth/tests/unit/controllers/security/test_overview_unconfirmed_method_not_required.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/security/test_overview_unconfirmed_method_not_required.py
@@ -1,0 +1,72 @@
+"""security.overview no reporta `required` un metodo NO confirmado.
+
+Given un user con un TOTP en estado heredado inconsistente (required=True en
+  la columna pero confirmed=False, sin secret confirmado para validar el code),
+When se invoca security.overview,
+Then la entry totp se reporta `required: False` (el login lo ignora, no debe
+  mostrarse requerido). El flag real de la columna se cruza con `confirmed`.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_authed_event, _make_user
+
+
+def test_overview_unconfirmed_totp_reports_not_required(monkeypatch):
+    """TOTP required=True pero confirmed=False -> entry required=False."""
+    from controllers.security import overview as security_overview
+
+    user = _make_user(status='active')
+
+    mfa_svc = MagicMock()
+    mfa_svc.list_all.return_value = [
+        {
+            'kind': 'totp',
+            'preferred': False,
+            'required': True,
+            'confirmed': False,
+            'enabled': True,
+            'created_at': '2026-01-01T00:00:00+00:00',
+            'last_used_at': None,
+        },
+    ]
+    webauthn_svc = MagicMock()
+    webauthn_svc.list_all.return_value = []
+    recovery_svc = MagicMock()
+    recovery_svc.counts.return_value = {'total': 0, 'remaining': 0}
+    password_svc = MagicMock()
+    password_svc.status.return_value = {
+        'has_password': True,
+        'required': True,
+        'last_change_at': None,
+    }
+
+    monkeypatch.setattr(
+        security_overview, 'require_active_user', lambda *_a, **_k: user,
+    )
+    monkeypatch.setattr(
+        security_overview, 'MfaMethodService', lambda _c: mfa_svc,
+    )
+    monkeypatch.setattr(
+        security_overview, 'WebauthnService', lambda _c: webauthn_svc,
+    )
+    monkeypatch.setattr(
+        security_overview, 'RecoveryCodesService', lambda _c: recovery_svc,
+    )
+    monkeypatch.setattr(
+        security_overview, 'PasswordService', lambda _c: password_svc,
+    )
+    monkeypatch.setattr(
+        security_overview, 'RateLimitService', lambda _c: MagicMock(),
+    )
+
+    event = _make_authed_event()
+    result = security_overview.Overview(event=event).run()
+
+    totp = result['data']['methods'][0]
+    assert totp['type'] == 'totp'
+    assert totp['configured'] is True
+    assert totp['enabled'] is True
+    # required=True en la columna pero confirmed=False -> NO required.
+    assert totp['required'] is False
+    assert totp['detail'] == {'confirmed': False}

--- a/serverless/lambda/shared/db/repositories/auth_mfa.py
+++ b/serverless/lambda/shared/db/repositories/auth_mfa.py
@@ -201,14 +201,27 @@ def set_required(
     kind: AuthMfaKind,
     required: bool,
 ) -> bool:
-    """Setea `required` en el row `(user_id, kind)` activo. False si no existe.
+    """Setea `required` en el row `(user_id, kind)` activo y confirmado. False si no.
 
-    Un metodo desactivado (`disabled_at IS NOT NULL`) NO se puede marcar
-    requerido (el login lo ignoraria) -> se trata como inexistente (False
-    -> 404 en el controller).
+    Un metodo no usable en el login NO puede quedar `required` (seria un
+    estado inconsistente: settings lo muestra requerido pero `login.start`
+    lo ignora -> el user nunca cumple ese factor). Se rechaza (False -> 404
+    en el controller) si el metodo:
+
+    - no existe,
+    - esta desactivado (`disabled_at IS NOT NULL`), o
+    - NO esta confirmado (`confirmed_at IS NULL`): un TOTP pendiente no tiene
+      secret confirmado para validar el code; exigirlo bloquearia el login.
+
+    Invariante: solo un metodo confirmado + activo puede ser `required`, que
+    es exactamente lo que `list_required_methods` exige para `login.start`.
     """
     method = get_mfa_method(session, user_id=user_id, kind=kind)
-    if method is None or method.disabled_at is not None:
+    if (
+        method is None
+        or method.disabled_at is not None
+        or method.confirmed_at is None
+    ):
         return False
     method.required = required
     session.flush()

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mfa_set_required_unconfirmed_false.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mfa_set_required_unconfirmed_false.py
@@ -1,0 +1,37 @@
+"""
+Given un row MFA activo pero NO confirmado (confirmed_at IS NULL),
+When se llama set_required con required=True,
+Then NO marca required (un metodo no confirmado no es usable en el login) y
+    retorna False (el controller lo traduce a 404).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from shared.db.models.auth.enums import AuthMfaKind
+from shared.db.models.auth.mfa_method import AuthMfaMethod
+from shared.db.repositories.auth_mfa import set_required
+
+pytestmark = pytest.mark.unit
+
+
+def test_set_required_unconfirmed_returns_false_and_keeps_flag():
+    # Arrange
+    session = MagicMock()
+    method = AuthMfaMethod(
+        user_id='u1',
+        kind=AuthMfaKind.TOTP,
+        confirmed_at=None,
+        required=False,
+    )
+    session.execute.return_value.scalar_one_or_none.return_value = method
+
+    # Act
+    ok = set_required(
+        session, user_id='u1', kind=AuthMfaKind.TOTP, required=True,
+    )
+
+    # Assert
+    assert ok is False
+    assert method.required is False
+    session.flush.assert_not_called()

--- a/tests/api/test_auth_set_required_requires_confirmed.py
+++ b/tests/api/test_auth_set_required_requires_confirmed.py
@@ -1,0 +1,147 @@
+"""E2E del invariante: un metodo MFA no confirmado NO puede ser `required`.
+
+Regresion del bug reportado: un user tenia un TOTP con `required=true` en la
+columna pero `confirmed=false` (nunca se valido el code del authenticator).
+`login.start` lo IGNORABA (list_required_methods exige confirmado), asi que
+settings mostraba "required: true" pero el login no lo pedia -> contradiccion.
+
+El fix cierra el invariante en el origen: `mfa.set-required` rechaza (404) un
+TOTP no confirmado. Asi nunca se llega al estado inconsistente y `login.start`
+solo lista factores realmente exigibles.
+
+Verifica DETERMINISTICAMENTE (API pura):
+- setup-totp crea el row PENDIENTE (confirmed=false), sin confirmar.
+- mfa.set-required {kind:totp, required:true} -> 404 NOT_FOUND.
+- login.start NO lista `totp` en `methods` (solo `password`).
+- tras confirm-totp + set-required, login.start SI lista `totp`.
+
+Requiere bypass (registra users active). Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+from shared.totp import totp_now
+
+
+def _access_via_password(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login solo-password -> access token (la password es el unico required)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    return access
+
+
+def _login_methods(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> list[str]:
+    """`login.start` -> la lista de factores `methods` que el login exige."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    return list(start.body.get('methods') or [])
+
+
+@pytest.mark.api
+def test_set_required_unconfirmed_totp_is_rejected_and_not_in_login(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user con un TOTP en setup (pendiente, confirmed=false),
+    When intenta marcarlo `required` antes de confirmarlo,
+    Then mfa.set-required -> 404 NOT_FOUND y login.start NO lista totp; tras
+        confirmar y marcarlo required, login.start SI lo lista.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+reqconf-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    access = _access_via_password(http, origin, email, bypass)
+
+    # setup-totp: crea el row TOTP PENDIENTE (confirmed=false), sin confirmar.
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-totp'), origin=origin,
+        bearer=access,
+    )
+    secret = field(setup.body, 'secret_b32')
+    assert secret is not None, f'setup-totp no dio secret: {setup.body}'
+
+    # set-required sobre el TOTP NO confirmado -> 404 NOT_FOUND (el invariante).
+    req_unconfirmed = http.post(
+        '/auth',
+        body=make_body('mfa', 'set-required', kind='totp', required=True),
+        origin=origin, bearer=access,
+    )
+    assert req_unconfirmed.status == 404, (
+        f'set-required de un TOTP no confirmado deberia ser 404, '
+        f'fue {req_unconfirmed.status}: {req_unconfirmed.body}'
+    )
+
+    # login.start NO lista el TOTP pendiente (solo password).
+    methods_before = _login_methods(http, origin, email, bypass)
+    assert methods_before == ['password'], (
+        f'un TOTP pendiente no deberia exigirse en el login: {methods_before}'
+    )
+
+    # confirm-totp + set-required -> ahora SI es required y login.start lo lista.
+    confirm = http.post(
+        '/auth',
+        body=make_body('mfa', 'confirm-totp', code=totp_now(secret)),
+        origin=origin, bearer=access,
+    )
+    assert confirm.status == 204, f'confirm-totp fallo: {confirm.body}'
+    req_confirmed = http.post(
+        '/auth',
+        body=make_body('mfa', 'set-required', kind='totp', required=True),
+        origin=origin, bearer=access,
+    )
+    assert req_confirmed.status == 204, (
+        f'set-required de un TOTP confirmado deberia ser 204, '
+        f'fue {req_confirmed.status}: {req_confirmed.body}'
+    )
+    methods_after = _login_methods(http, origin, email, bypass)
+    assert set(methods_after) == {'password', 'totp'}, (
+        f'tras confirmar+required, el login deberia exigir totp: {methods_after}'
+    )


### PR DESCRIPTION
## Problema

Dos bugs reportados sobre el modelo de factores `required` del login:

1. **`login.start` no exige el TOTP aunque settings lo muestra `required:true`.** Un user tenia el TOTP con `required:true` en la columna pero `confirmed:false` (nunca valido el code del authenticator). `login.start` (`list_required_methods`) exige `confirmed_at IS NOT NULL`, asi que ignoraba ese TOTP -> `methods` devolvia solo `[password, webauthn]`. Pero `security.overview` mostraba `required:true` directo de la columna. Resultado: settings dice requerido, login no lo pide -> contradiccion. El estado inconsistente lo permitia `set_required`, que solo filtraba `disabled_at`, no `confirmed_at`.

2. **`/settings/security` no permite togglear el `required` de la password.** El `PasswordRow` solo mostraba 'Cambiar contrasena', sin el switch 'Requerido al loguear' que TOTP/webauthn ya tienen. El backend `security.password-set-required` ya existia, pero el frontend nunca lo cableaba (`dispatchSetRequired` lanzaba error para `type='password'` y `authClient` no tenia el metodo).

## Solucion

**1. Invariante backend (cierre de raiz):** un metodo MFA NO confirmado no puede ser `required`.
- `set_required` rechaza (404) marcar required un TOTP/email_code con `confirmed_at IS NULL`: un metodo no usable en el login no debe quedar requerido.
- `security.overview` cruza `required AND confirmed`: un metodo pendiente con el flag heredado se reporta `required:false` (no muestra un required que el login no respeta).

**2. Toggle required de la password (frontend):**
- `PasswordRow` agrega el `RequiredSwitch` (igual que TOTP/webauthn).
- `authClient.passwordSetRequired` + `dispatchSetRequired` enruta `type='password'` -> `security.password-set-required`.

## Como probar

```bash
# Backend unit
python devtools/run.py serverless tests --type=unit --shared   # 559 pass (repo set_required)
python devtools/run.py serverless tests --type=unit --lambda=auth   # 223 pass (overview)

# Frontend unit
pnpm --filter @portfolio/admin test   # 612 pass

# E2E API contra dev (verde): el invariante real
python devtools/run.py e2e --module=api --lambda=auth --env=dev --aws-profile=tfs-dev
#   test_auth_set_required_requires_confirmed: set-required de TOTP pendiente -> 404;
#   login.start no lista el TOTP pendiente; tras confirm-totp+required, login.start lo exige.
```

En la UI: `/settings/security` ahora muestra el switch 'Requerido al loguear' en la fila de la contrasena; activarlo/desactivarlo persiste via `security.password-set-required`.

## TODO

Nada pendiente del scope. El `auth` ya esta desplegado en dev (deploy manual con devtools) para correr el E2E; el deploy formal lo hara `deploy-backend.yml` al mergear.