### PR TITLE
fix(auth+admin): un metodo MFA pendiente se puede eliminar (anti-lockout)

### DIFF
--- a/admin/src/features/settings/components/security-overview-panel.tsx
+++ b/admin/src/features/settings/components/security-overview-panel.tsx
@@ -76,13 +76,27 @@ function asString(detail: Record<string, unknown>, key: string): string | null {
 }
 
 /**
+ * @function isMfaPending
+ * @description True si el metodo MFA esta configurado pero NO confirmado (ej.
+ *   un setup-totp abandonado: detail.confirmed === false). Un pendiente no es
+ *   una via de entrada real: no se puede marcar requerido y se ofrece
+ *   confirmar o eliminar.
+ */
+function isMfaPending(method: SecurityMethod): boolean {
+	return method.configured && method.detail.confirmed === false;
+}
+
+/**
  * @function StatusBadge
- * @description Badge de estado de un metodo: 'No configurado' / 'Activo' /
- *   'Desactivado' segun configured + enabled.
+ * @description Badge de estado de un metodo: 'No configurado' / 'Pendiente' /
+ *   'Activo' / 'Desactivado' segun configured + confirmed + enabled.
  */
 function StatusBadge({ method }: { method: SecurityMethod }) {
 	if (!method.configured) {
 		return <Badge variant="outline">No configurado</Badge>;
+	}
+	if (isMfaPending(method)) {
+		return <Badge variant="outline">Pendiente de confirmacion</Badge>;
 	}
 	return method.enabled ? (
 		<Badge variant="secondary">Activo</Badge>
@@ -273,14 +287,19 @@ function WebauthnRow({
 
 /**
  * @function MfaRow
- * @description Fila de un metodo MFA (totp / email_code): estado + Switch on/off
- *   + Switch requerido. Si no esta configurado, muestra un boton 'Configurar'.
+ * @description Fila de un metodo MFA (totp / email_code) con 3 estados:
+ *   - no configurado: boton 'Configurar'.
+ *   - pendiente (configured && !confirmed, ej. setup-totp abandonado): SIN
+ *     switch requerido (no es marcable); botones 'Confirmar' (reabre el setup)
+ *     y 'Eliminar' (disable, anti-lockout).
+ *   - confirmado: Switch on/off + Switch 'Requerido al loguear'.
  */
 function MfaRow({
 	method,
 	onToggle,
 	onRequired,
 	onConfigure,
+	onDelete,
 	toggling,
 	settingRequired,
 }: {
@@ -296,19 +315,53 @@ function MfaRow({
 		required: boolean;
 	}) => void;
 	onConfigure: (type: SecurityMethodType) => void;
+	onDelete: (vars: { type: SecurityMethodType; kind: MfaKind }) => void;
 	toggling: boolean;
 	settingRequired: boolean;
 }) {
 	const kind = method.type as MfaKind;
+	const pending = isMfaPending(method);
 
 	return (
-		<div className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-4">
+		<div
+			data-testid={`security-row-${method.type}`}
+			className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-4"
+		>
 			<div className="flex items-center gap-2">
 				<span className="text-sm font-medium">{method.label}</span>
 				{method.preferred ? <Badge variant="secondary">Preferido</Badge> : null}
 				<StatusBadge method={method} />
 			</div>
-			{method.configured ? (
+			{!method.configured ? (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => onConfigure(method.type)}
+				>
+					Configurar
+				</Button>
+			) : pending ? (
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={() => onConfigure(method.type)}
+					>
+						Confirmar
+					</Button>
+					<Button
+						type="button"
+						variant="destructive"
+						size="sm"
+						disabled={toggling}
+						onClick={() => onDelete({ type: method.type, kind })}
+					>
+						Eliminar
+					</Button>
+				</div>
+			) : (
 				<div className="flex flex-wrap items-center gap-3">
 					<span className="flex items-center gap-2 text-xs text-muted-foreground">
 						<span>Activo</span>
@@ -329,15 +382,6 @@ function MfaRow({
 						}
 					/>
 				</div>
-			) : (
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					onClick={() => onConfigure(method.type)}
-				>
-					Configurar
-				</Button>
 			)}
 		</div>
 	);
@@ -517,6 +561,7 @@ export function SecurityOverviewPanel() {
 								onToggle={(vars) => toggle.mutate(vars)}
 								onRequired={(vars) => setRequired.mutate(vars)}
 								onConfigure={(type) => setSetupKind(type as MfaKind)}
+								onDelete={(vars) => toggle.mutate({ ...vars, enable: false })}
 							/>
 						)}
 					</div>

--- a/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
+++ b/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
@@ -267,6 +267,87 @@ describe("SecurityOverviewPanel", () => {
 		});
 	});
 
+	it("Given un TOTP pendiente (confirmed=false) When render Then muestra 'Pendiente' + Confirmar + Eliminar, sin switch requerido", async () => {
+		// Arrange: el TOTP esta configurado pero NO confirmado (setup-totp
+		// abandonado): detail.confirmed === false.
+		const methods = fiveMethods().map((m) =>
+			m.type === "totp"
+				? {
+						...m,
+						configured: true,
+						enabled: true,
+						detail: { confirmed: false },
+					}
+				: m,
+		);
+		mockOverview(methods);
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		await screen.findByText("Aplicacion de autenticacion (TOTP)");
+
+		// Assert: badge pendiente + botones Confirmar/Eliminar; sin el switch
+		// 'Requerido al loguear' (un pendiente no es marcable).
+		const totpRow = screen.getByTestId("security-row-totp");
+		expect(
+			within(totpRow).getByText(/pendiente de confirmacion/i),
+		).toBeInTheDocument();
+		expect(
+			within(totpRow).getByRole("button", { name: /confirmar/i }),
+		).toBeInTheDocument();
+		expect(
+			within(totpRow).getByRole("button", { name: /eliminar/i }),
+		).toBeInTheDocument();
+		expect(within(totpRow).queryByText(/requerido al loguear/i)).toBeNull();
+	});
+
+	it("Given un TOTP pendiente When clic Eliminar Then dispara mfa.disable {kind:totp}", async () => {
+		// Arrange: capturar el request de mfa.disable. apiFetch APLANA el body.
+		const methods = fiveMethods().map((m) =>
+			m.type === "totp"
+				? {
+						...m,
+						configured: true,
+						enabled: true,
+						detail: { confirmed: false },
+					}
+				: m,
+		);
+		let disabledKind: string | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					kind?: string;
+				};
+				if (body.operation === "mfa" && body.action === "disable") {
+					disabledKind = body.kind ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		await screen.findByText("Aplicacion de autenticacion (TOTP)");
+		const totpRow = screen.getByTestId("security-row-totp");
+		await user.click(
+			within(totpRow).getByRole("button", { name: /eliminar/i }),
+		);
+
+		// Assert: el backend recibe mfa.disable con kind=totp.
+		await waitFor(() => {
+			expect(disabledKind).toBe("totp");
+		});
+	});
+
 	it("Given security.overview falla When render Then muestra el ErrorAlert", async () => {
 		// Arrange
 		server.use(

--- a/serverless/lambda/services/auth/core/controllers/mfa/disable.py
+++ b/serverless/lambda/services/auth/core/controllers/mfa/disable.py
@@ -71,7 +71,13 @@ class Disable(BaseController):
                 'data': {'error': 'NOT_FOUND'},
             }
 
-        if mfa_svc.count_active(user_id=user.id) <= 1:
+        # El guard MUST_KEEP_ONE solo protege metodos CONFIRMADOS: un metodo
+        # no confirmado (ej. un setup-totp abandonado) no es una via de
+        # entrada real, asi que siempre se puede deshabilitar (anti-lockout:
+        # sin esto, un pendiente que no se puede confirmar ni marcar required
+        # deja al user atrapado).
+        confirmed = mfa_svc.is_confirmed(user_id=user.id, kind=kind)
+        if confirmed and mfa_svc.count_active(user_id=user.id) <= 1:
             return {
                 'is_valid': False,
                 'code': 4000,

--- a/serverless/lambda/services/auth/core/services/mfa_method_service.py
+++ b/serverless/lambda/services/auth/core/services/mfa_method_service.py
@@ -340,6 +340,30 @@ class MfaMethodService:
             )
             return method is not None and method.disabled_at is None
 
+    def is_confirmed(
+        self,
+        *,
+        user_id: UUID | str,
+        kind: AuthMfaKind,
+    ) -> bool:
+        """True si el metodo `kind` del user esta confirmado y activo.
+
+        Un metodo no confirmado (`confirmed_at IS NULL`, ej. un setup-totp
+        abandonado) NO es una via de entrada real: no cuenta para el guard
+        MUST_KEEP_ONE y por eso siempre se puede deshabilitar (anti-lockout).
+        """
+        with db_session() as session:
+            method = get_mfa_method(
+                session,
+                user_id=str(user_id),
+                kind=kind,
+            )
+            return (
+                method is not None
+                and method.disabled_at is None
+                and method.confirmed_at is not None
+            )
+
     def mark_used(self, *, user_id: UUID | str, kind: AuthMfaKind) -> None:
         """Setea last_used_at del metodo (login con TOTP exitoso)."""
         with db_session() as session:

--- a/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_disable_keeps_one.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_disable_keeps_one.py
@@ -18,6 +18,8 @@ def test_mfa_disable_keeps_one(monkeypatch):
 
     mfa_svc = MagicMock()
     mfa_svc.has_active_method.return_value = True
+    # Metodo CONFIRMADO: el guard MUST_KEEP_ONE aplica.
+    mfa_svc.is_confirmed.return_value = True
     mfa_svc.count_active.return_value = 1
 
     monkeypatch.setattr(

--- a/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_disable_unconfirmed_allowed.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_disable_unconfirmed_allowed.py
@@ -1,0 +1,43 @@
+"""Un metodo MFA NO confirmado siempre se puede deshabilitar (anti-lockout).
+
+Given un user con un TOTP en setup (confirmed=false, activo) y el guard
+  transversal count_active == 1 (el TOTP pendiente no es una via de entrada
+  real; el unico metodo confirmado es otro, ej. un passkey que SI cuenta),
+When se invoca mfa.disable sobre el TOTP pendiente,
+Then NO aplica el guard MUST_KEEP_ONE (un pendiente no protege el invariante)
+  y lo deshabilita -> 204. Asi el user no queda atrapado con un setup-totp
+  abandonado que no puede confirmar, marcar required, ni eliminar.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_authed_event, _make_user
+
+
+def test_mfa_disable_unconfirmed_method_bypasses_keep_one(monkeypatch):
+    """TOTP pendiente (no confirmado) -> disable permitido aunque count<=1."""
+    from controllers.mfa import disable
+
+    user = _make_user(status='active')
+
+    mfa_svc = MagicMock()
+    mfa_svc.has_active_method.return_value = True
+    # El metodo NO esta confirmado: el guard MUST_KEEP_ONE NO debe aplicar.
+    mfa_svc.is_confirmed.return_value = False
+    # count_active <= 1 NO debe bloquear cuando el metodo es no-confirmado.
+    mfa_svc.count_active.return_value = 1
+
+    monkeypatch.setattr(
+        disable, 'require_active_user', lambda *_a, **_k: user,
+    )
+    monkeypatch.setattr(disable, 'MfaMethodService', lambda _c: mfa_svc)
+    monkeypatch.setattr(disable, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(disable, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_authed_event(data={'kind': 'totp'})
+    result = disable.Disable(event=event).run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['status'] == 204
+    mfa_svc.disable.assert_called_once()

--- a/serverless/lambda/services/auth/tests/unit/services/test_mfa_method_service_more.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_mfa_method_service_more.py
@@ -198,6 +198,57 @@ def test_has_active_method_disabled_false(monkeypatch):
     )
 
 
+def test_is_confirmed_active_and_confirmed_true(monkeypatch):
+    from services import mfa_method_service
+    from shared.db.models.auth.enums import AuthMfaKind
+
+    method = MagicMock()
+    method.disabled_at = None
+    method.confirmed_at = datetime.now(tz=UTC)
+    monkeypatch.setattr(mfa_method_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        mfa_method_service,
+        'get_mfa_method',
+        lambda _s, *, user_id, kind: method,
+    )
+
+    svc = mfa_method_service.MfaMethodService(app_config=object())
+    assert svc.is_confirmed(user_id='u-1', kind=AuthMfaKind.TOTP) is True
+
+
+def test_is_confirmed_pending_false(monkeypatch):
+    from services import mfa_method_service
+    from shared.db.models.auth.enums import AuthMfaKind
+
+    method = MagicMock()
+    method.disabled_at = None
+    method.confirmed_at = None
+    monkeypatch.setattr(mfa_method_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        mfa_method_service,
+        'get_mfa_method',
+        lambda _s, *, user_id, kind: method,
+    )
+
+    svc = mfa_method_service.MfaMethodService(app_config=object())
+    assert svc.is_confirmed(user_id='u-1', kind=AuthMfaKind.TOTP) is False
+
+
+def test_is_confirmed_missing_false(monkeypatch):
+    from services import mfa_method_service
+    from shared.db.models.auth.enums import AuthMfaKind
+
+    monkeypatch.setattr(mfa_method_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        mfa_method_service,
+        'get_mfa_method',
+        lambda _s, *, user_id, kind: None,
+    )
+
+    svc = mfa_method_service.MfaMethodService(app_config=object())
+    assert svc.is_confirmed(user_id='u-1', kind=AuthMfaKind.TOTP) is False
+
+
 def test_mark_used_delegates(monkeypatch):
     from services import mfa_method_service
     from shared.db.models.auth.enums import AuthMfaKind

--- a/tests/api/test_auth_disable_unconfirmed_mfa.py
+++ b/tests/api/test_auth_disable_unconfirmed_mfa.py
@@ -1,0 +1,128 @@
+"""E2E: un metodo MFA no confirmado siempre se puede eliminar (anti-lockout).
+
+Regresion del lockout reportado: un user tenia un TOTP `configured` pero
+`confirmed:false` (setup-totp abandonado). No lo podia confirmar (no tenia el
+authenticator), no lo podia marcar required (404 por no confirmado), y
+`mfa.disable` daba 409 MUST_KEEP_ONE porque `count_active_mfa` solo cuenta
+confirmados -> el TOTP pendiente no sumaba, la cuenta caia a <=1 y el guard
+bloqueaba el disable. Resultado: atrapado con un metodo roto.
+
+El fix: el guard MUST_KEEP_ONE solo protege metodos CONFIRMADOS. Un pendiente
+no es una via de entrada real -> siempre se puede deshabilitar.
+
+Verifica DETERMINISTICAMENTE (API pura):
+- setup-totp crea el row PENDIENTE (confirmed=false), sin confirmar.
+- mfa.disable {kind:totp} del pendiente -> 204 (ya no 409), aunque sea el
+  unico metodo MFA "contado".
+- tras el disable, el TOTP ya no aparece en security.overview como activo.
+
+Requiere bypass (registra users active). Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+
+
+def _access_via_password(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login solo-password -> access token (la password es el unico required)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    return access
+
+
+def _overview(http: HttpClient, origin: str, access: str) -> dict:
+    """security.overview -> {type: entry} indexado por tipo de metodo."""
+    r = http.post(
+        '/auth', body=make_body('security', 'overview'), origin=origin,
+        bearer=access,
+    )
+    methods = r.body.get('methods') or []
+    return {m['type']: m for m in methods}
+
+
+@pytest.mark.api
+def test_disable_unconfirmed_totp_is_allowed(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user con un TOTP en setup (pendiente, confirmed=false),
+    When lo deshabilita con mfa.disable,
+    Then -> 204 (el guard MUST_KEEP_ONE no aplica a un pendiente) y el TOTP
+        deja de figurar configurado en el overview. El user no queda atrapado.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+disunc-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    access = _access_via_password(http, origin, email, bypass)
+
+    # setup-totp: crea el row TOTP PENDIENTE (confirmed=false), sin confirmar.
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-totp'), origin=origin,
+        bearer=access,
+    )
+    assert field(setup.body, 'secret_b32') is not None, (
+        f'setup-totp no dio secret: {setup.body}'
+    )
+    before = _overview(http, origin, access)
+    assert before['totp']['configured'] is True
+    assert before['totp']['detail'] == {'confirmed': False}
+
+    # disable del TOTP pendiente -> 204 (antes daba 409 MUST_KEEP_ONE).
+    disabled = http.post(
+        '/auth',
+        body=make_body('mfa', 'disable', kind='totp'),
+        origin=origin, bearer=access,
+    )
+    assert disabled.status == 204, (
+        f'disable de un TOTP pendiente deberia ser 204, '
+        f'fue {disabled.status}: {disabled.body}'
+    )
+
+    # el TOTP ya no figura activo/configurado en el overview.
+    after = _overview(http, origin, access)
+    assert after['totp']['enabled'] is False, (
+        f'el TOTP deberia quedar deshabilitado: {after["totp"]}'
+    )


### PR DESCRIPTION
## Problema

Un TOTP `configured:true` pero `confirmed:false` (setup-totp abandonado) dejaba al user **atrapado**:
- No se podia confirmar (no tenia el authenticator sincronizado).
- No se podia marcar `required` -> `NOT_FOUND` (fix previo PR #265: un no-confirmado no es marcable).
- **No se podia eliminar:** `mfa.disable` daba **409 MUST_KEEP_ONE_MFA_METHOD**. Causa: `count_active_mfa` solo cuenta metodos CONFIRMADOS, asi que el TOTP pendiente no sumaba, la cuenta caia a <=1 y el guard bloqueaba el disable creyendo que era el ultimo metodo.

Reportado con el `security.overview` (TOTP `required:false`, `detail.confirmed:false`) + el `set-required` -> `NOT_FOUND`.

## Solucion

**Backend (de raiz):** el guard `MUST_KEEP_ONE` solo protege metodos **confirmados**. Un metodo no confirmado no es una via de entrada real -> siempre se puede deshabilitar.
- `MfaMethodService.is_confirmed(user_id, kind)`: True solo si confirmado + activo.
- `mfa.disable` aplica el guard solo cuando `is_confirmed` es True.

**Frontend (UX):** el `MfaRow` detecta el estado pendiente (`configured && detail.confirmed===false`):
- badge 'Pendiente de confirmacion' + botones **'Confirmar'** (reabre el setup con QR nuevo) y **'Eliminar'** (`mfa.disable`), SIN el switch 'Requerido al loguear' (no es marcable).

## Como probar

```bash
python devtools/run.py serverless tests --type=unit --lambda=auth   # 227 pass
pnpm --filter @portfolio/admin test   # 614 pass

# E2E API contra dev (verde): disable de TOTP pendiente -> 204 (antes 409)
python devtools/run.py e2e --module=api --lambda=auth --env=dev --aws-profile=tfs-dev
#   test_auth_disable_unconfirmed_mfa: setup-totp (pendiente) -> mfa.disable -> 204.
```

En la UI `/settings/security`: un TOTP pendiente muestra 'Pendiente de confirmacion' con botones Confirmar y Eliminar; el Eliminar ahora funciona (desbloquea el lockout).

## TODO

Nada pendiente. `auth` ya desplegado en dev (deploy manual) para el E2E; el deploy formal lo hace `deploy-backend.yml` al mergear.