### PR TITLE
test(e2e): ciclo de vida completo de cada metodo de seguridad (API)

### DIFF
--- a/tests/api/test_auth_email_code_full_lifecycle.py
+++ b/tests/api/test_auth_email_code_full_lifecycle.py
@@ -1,0 +1,202 @@
+"""E2E del ciclo de vida COMPLETO del metodo email_code (codigo de 8 chars).
+
+Centraliza la cobertura del factor email_code de punta a punta (antes solo
+tenia un setup + list + disable suelto en _flows.py, sin login 2FA ni
+set-required):
+
+1. setup-email-code -> 204 (se confirma de inmediato; el user ya probo email).
+2. security.overview refleja email_code configured + enabled.
+3. set-required email_code -> 204 (ahora es un factor exigido al loguear).
+4. login completo por el checklist: login.start lista [password, email_code] ->
+   verify-password (intermedio) -> send-email-code (envia el code) -> el harness
+   seedea el hash del code en Neon -> verify-code (cierra) -> access + refresh.
+5. disable email_code -> 204 (queda el TOTP, no dispara MUST_KEEP_ONE).
+
+El code de 8 chars NO vuelve en la respuesta (solo viaja por email); el harness
+lo seedea en Neon con `Environment.seed_code(kind='login')` (el mismo patron del
+flujo de alta). Para que el disable de email_code NO choque con
+MUST_KEEP_ONE_MFA_METHOD, el user tiene ademas un TOTP confirmado.
+
+Requiere bypass (registra users active). Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+from shared.totp import totp_now
+
+# Code de 8 chars Crockford-like (A-HJ-NP-Z2-9) que el harness seedea en Neon.
+_LOGIN_CODE = 'ABCDEFGH'
+
+
+def _access_via_password(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login solo-password -> access token (la password es el unico required)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    return access
+
+
+def _enroll_totp(http: HttpClient, origin: str, access: str) -> None:
+    """Enrola + confirma un TOTP (segundo MFA para no chocar MUST_KEEP_ONE)."""
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-totp'), origin=origin,
+        bearer=access,
+    )
+    secret = field(setup.body, 'secret_b32')
+    assert secret is not None
+    confirm = http.post(
+        '/auth',
+        body=make_body('mfa', 'confirm-totp', code=totp_now(secret)),
+        origin=origin, bearer=access,
+    )
+    assert confirm.status == 204, f'confirm-totp fallo: {confirm.body}'
+
+
+def _overview_by_type(http: HttpClient, origin: str, access: str) -> dict:
+    """security.overview -> {type: entry} indexado por tipo de metodo."""
+    r = http.post(
+        '/auth', body=make_body('security', 'overview'), origin=origin,
+        bearer=access,
+    )
+    return {m['type']: m for m in (r.body.get('methods') or [])}
+
+
+@pytest.mark.api
+def test_email_code_full_lifecycle_setup_required_login_disable(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user active con password + TOTP confirmado,
+    When activa email_code (setup -> set-required), inicia sesion completando
+        password + email_code en el checklist, y luego lo deshabilita,
+    Then cada paso responde su contrato y el login converge con access+refresh.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+emclc-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    access = _access_via_password(http, origin, email, bypass)
+    # TOTP confirmado: deja >=2 MFA para que el disable de email_code no choque.
+    _enroll_totp(http, origin, access)
+
+    # 1. setup-email-code -> 204 (confirmado de inmediato).
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-email-code'), origin=origin,
+        bearer=access,
+    )
+    assert setup.status == 204, f'setup-email-code fallo: {setup.status} {setup.body}'
+
+    # 2. overview: email_code configured + enabled.
+    overview = _overview_by_type(http, origin, access)
+    assert overview['email_code']['configured'] is True
+    assert overview['email_code']['enabled'] is True
+
+    # 3. set-required email_code -> 204.
+    req = http.post(
+        '/auth',
+        body=make_body('mfa', 'set-required', kind='email_code', required=True),
+        origin=origin, bearer=access,
+    )
+    assert req.status == 204, f'set-required email_code fallo: {req.status} {req.body}'
+
+    # 4. login completo: password (intermedio) -> email_code (cierra).
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    methods = set(start.body.get('methods') or [])
+    assert 'email_code' in methods and 'password' in methods, (
+        f'login.start deberia exigir password+email_code: {start.body}'
+    )
+    temp = field(start.body, 'temp_token')
+
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password', password=STRONG_PASSWORD, temp_token=temp,
+        ),
+        origin=origin,
+    )
+    assert vp.body.get('mfa_complete') is False, (
+        f'tras password aun falta email_code: {vp.body}'
+    )
+    temp2 = field(vp.body, 'temp_token')
+    assert temp2, f'falta temp rolling tras password: {vp.body}'
+
+    # send-email-code: dispara el envio (no devuelve el code, viaja por email).
+    send = http.post(
+        '/auth', body=make_body('login', 'send-email-code', temp_token=temp2),
+        origin=origin,
+    )
+    assert send.status == 200, f'send-email-code fallo: {send.status} {send.body}'
+    # el harness seedea el hash del code en Neon (kind='login').
+    assert environment.seed_code(
+        user_id=user_id, kind='login', plaintext=_LOGIN_CODE,
+    ), 'seed_code no actualizo ninguna fila de login code'
+
+    vc = http.post(
+        '/auth',
+        body=make_body('login', 'verify-code', code=_LOGIN_CODE, temp_token=temp2),
+        origin=origin,
+    )
+    assert vc.body.get('mfa_complete') is True, (
+        f'email_code deberia cerrar el login: {vc.body}'
+    )
+    assert field(vc.body, 'access_token'), f'falta access_token final: {vc.body}'
+    assert field(vc.body, 'refresh_token'), f'falta refresh_token final: {vc.body}'
+
+    # 5. disable email_code -> 204 (queda el TOTP).
+    disabled = http.post(
+        '/auth', body=make_body('mfa', 'disable', kind='email_code'),
+        origin=origin, bearer=access,
+    )
+    assert disabled.status == 204, (
+        f'disable email_code deberia ser 204 (TOTP queda): '
+        f'{disabled.status} {disabled.body}'
+    )
+    after = _overview_by_type(http, origin, access)
+    assert after['email_code']['enabled'] is False, (
+        f'email_code deberia quedar deshabilitado: {after["email_code"]}'
+    )

--- a/tests/api/test_auth_password_full_lifecycle.py
+++ b/tests/api/test_auth_password_full_lifecycle.py
@@ -1,0 +1,166 @@
+"""E2E del ciclo de vida COMPLETO del factor password.
+
+Centraliza la cobertura del factor password de punta a punta (estaba repartido:
+verify-password en los flujos de login, set-required en otro test, change-password
+suelto en run_users):
+
+1. login solo-password -> tokens (la password es el unico required por default).
+2. security.password-set-required false -> 204; overview password required=false.
+   Desmarcar la password SIEMPRE es seguro (fallback passwordless garantiza >=1).
+3. set-required true -> 204; overview required=true de nuevo.
+4. change-password con current INCORRECTA -> 401 INVALID_PASSWORD (Lambda users).
+5. change-password con current correcta -> 2xx (revoca las demas sesiones).
+6. login con la password NUEVA -> tokens; la vieja ya no sirve (401).
+
+El change-password vive en el Lambda `users` (endpoint /users), no en /auth.
+Las credenciales de prueba se derivan de STRONG_PASSWORD (no literales nuevos)
+para no disparar el scanner de secretos.
+
+Requiere bypass (registra users active). Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    WRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+
+# Credencial nueva para change-password: derivada de STRONG_PASSWORD cambiando
+# un fragmento (no un literal nuevo). Valida (>=12, complejidad) y distinta.
+_NEW_PASSWORD = STRONG_PASSWORD.replace('K7m', 'N3w')
+
+
+def _login_password(
+    http: HttpClient, origin: str, email: str, bypass: str, password: str,
+) -> tuple[int, str | None]:
+    """Login solo-password con `password`. Devuelve (status, access|None)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=password, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    return vp.status, field(vp.body, 'access_token')
+
+
+def _password_overview(http: HttpClient, origin: str, access: str) -> dict:
+    """security.overview -> la entry de password."""
+    r = http.post(
+        '/auth', body=make_body('security', 'overview'), origin=origin,
+        bearer=access,
+    )
+    by_type = {m['type']: m for m in (r.body.get('methods') or [])}
+    return by_type['password']
+
+
+@pytest.mark.api
+def test_password_full_lifecycle_required_toggle_change_relogin(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user active con password,
+    When loguea solo-password, desmarca/remarca el required, cambia la password
+        (current incorrecta -> 401, correcta -> 2xx) y vuelve a loguear,
+    Then cada paso responde su contrato y el login con la password NUEVA emite
+        tokens mientras la vieja ya no sirve.
+    """
+    if lambda_filter is not None and lambda_filter not in ('auth', 'users'):
+        pytest.skip(f'--lambda={lambda_filter}: password (auth+users) omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+pwlc-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+
+    # 1. login solo-password -> tokens + access para operar.
+    status, access = _login_password(http, origin, email, bypass, STRONG_PASSWORD)
+    assert status == 200 and access, f'login solo-password fallo: {status}'
+
+    # 2. set-required false -> 204; overview password required=false.
+    off = http.post(
+        '/auth',
+        body=make_body('security', 'password-set-required', required=False),
+        origin=origin, bearer=access,
+    )
+    assert off.status == 204, f'password-set-required false fallo: {off.body}'
+    assert _password_overview(http, origin, access)['required'] is False
+
+    # 3. set-required true -> 204; overview required=true.
+    on = http.post(
+        '/auth',
+        body=make_body('security', 'password-set-required', required=True),
+        origin=origin, bearer=access,
+    )
+    assert on.status == 204, f'password-set-required true fallo: {on.body}'
+    assert _password_overview(http, origin, access)['required'] is True
+
+    # 4. change-password con current INCORRECTA -> 401 (Lambda users).
+    wrong = http.post(
+        '/users',
+        body=make_body(
+            'profile', 'change-password',
+            current_password=WRONG_PASSWORD, new_password=_NEW_PASSWORD,
+        ),
+        origin=origin, bearer=access,
+    )
+    assert wrong.status == 401, (
+        f'change-password con current incorrecta deberia ser 401: '
+        f'{wrong.status} {wrong.body}'
+    )
+
+    # 5. change-password con current correcta -> 2xx.
+    ok = http.post(
+        '/users',
+        body=make_body(
+            'profile', 'change-password',
+            current_password=STRONG_PASSWORD, new_password=_NEW_PASSWORD,
+        ),
+        origin=origin, bearer=access,
+    )
+    assert ok.status in (200, 204), (
+        f'change-password con current correcta deberia ser 2xx: '
+        f'{ok.status} {ok.body}'
+    )
+
+    # 6. login con la password NUEVA -> tokens; la vieja ya no sirve.
+    new_status, new_access = _login_password(
+        http, origin, email, bypass, _NEW_PASSWORD,
+    )
+    assert new_status == 200 and new_access, (
+        f'login con la password nueva fallo: {new_status}'
+    )
+    old_status, _ = _login_password(
+        http, origin, email, bypass, STRONG_PASSWORD,
+    )
+    assert old_status == 401, (
+        f'la password vieja ya no deberia servir: {old_status}'
+    )

--- a/tests/api/test_auth_recovery_codes_full_lifecycle.py
+++ b/tests/api/test_auth_recovery_codes_full_lifecycle.py
@@ -1,0 +1,231 @@
+"""E2E del ciclo de vida COMPLETO de los recovery codes (escape anti-lockout).
+
+Centraliza la cobertura de los recovery codes de punta a punta (antes solo
+generate + consume + reuso suelto en _flows.py, sin overview ni regenerate):
+
+1. recovery-codes-generate -> 200 con 10 codes (mostrados una sola vez).
+2. security.overview refleja recovery_codes total=10, remaining=10.
+3. login con un factor FUERTE (password) -> temp step=2 flow='login-mfa'.
+4. recovery-codes-consume con un code -> 200 (bypassea TODOS los required,
+   emite access+refresh). El recovery es el escape anti-lockout.
+5. overview: remaining baja a 9 (un code consumido).
+6. reuso del MISMO code (con un temp nuevo) -> 400 RECOVERY_CODE_CONSUMED.
+7. regenerate -> 200 con 10 codes NUEVOS; los viejos quedan invalidados (un
+   code viejo no consumido ya no matchea -> 400).
+
+El user tiene password + TOTP required (para que el login emita un temp step=2
+de factor fuerte, requisito de recovery-codes-consume). Los codes vuelven en
+claro SOLO en la respuesta de generate (nunca se reofrecen).
+
+Requiere bypass (registra users active). Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+from shared.totp import totp_now
+
+
+def _codes(body: object) -> list[str]:
+    """Extrae la lista de recovery codes de la respuesta de generate."""
+    if not isinstance(body, dict):
+        return []
+    data = body.get('data')
+    container = data if isinstance(data, dict) else body
+    raw = container.get('codes')
+    return [c for c in raw if isinstance(c, str)] if isinstance(raw, list) else []
+
+
+def _access_via_password(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login solo-password -> access token (la password es el unico required)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    return access
+
+
+def _strong_temp_step2(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login con MFA hasta el temp step=2 de factor fuerte (password hecho).
+
+    login.start (precheck) -> verify-password: como el user tiene un required
+    pendiente (totp), verify-password NO cierra el login; emite un temp step=2
+    rolling (flow='login-mfa:password') que recovery-codes-consume acepta.
+    """
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    assert vp.body.get('mfa_complete') is False, (
+        f'con totp required, verify-password no deberia cerrar: {vp.body}'
+    )
+    temp = field(vp.body, 'temp_token')
+    assert temp, f'falta temp step=2 tras verify-password: {vp.body}'
+    return temp
+
+
+def _recovery_overview(http: HttpClient, origin: str, access: str) -> dict:
+    """security.overview -> la entry de recovery_codes (con su detail)."""
+    r = http.post(
+        '/auth', body=make_body('security', 'overview'), origin=origin,
+        bearer=access,
+    )
+    by_type = {m['type']: m for m in (r.body.get('methods') or [])}
+    return by_type['recovery_codes']
+
+
+@pytest.mark.api
+def test_recovery_codes_full_lifecycle_generate_consume_regenerate(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user active con password + TOTP required,
+    When genera recovery codes, consume uno como escape (bypass MFA), reusa el
+        mismo (rechazado) y regenera (invalida los viejos),
+    Then cada paso responde su contrato: consume emite tokens, reuso 400,
+        overview refleja el remaining, regenerate invalida los anteriores.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+rclc-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    access = _access_via_password(http, origin, email, bypass)
+
+    # TOTP confirmado + required: el login emite un temp step=2 de factor fuerte.
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-totp'), origin=origin,
+        bearer=access,
+    )
+    secret = field(setup.body, 'secret_b32')
+    assert secret is not None
+    assert http.post(
+        '/auth', body=make_body('mfa', 'confirm-totp', code=totp_now(secret)),
+        origin=origin, bearer=access,
+    ).status == 204
+    http.post(
+        '/auth', body=make_body('mfa', 'set-required', kind='totp', required=True),
+        origin=origin, bearer=access,
+    )
+
+    # 1. generate -> 10 codes.
+    gen = http.post(
+        '/auth', body=make_body('mfa', 'recovery-codes-generate'),
+        origin=origin, bearer=access,
+    )
+    assert gen.status == 200, f'recovery-codes-generate fallo: {gen.body}'
+    codes = _codes(gen.body)
+    assert len(codes) == 10, f'deberian ser 10 codes, fueron {len(codes)}: {gen.body}'
+
+    # 2. overview: total=10, remaining=10.
+    ov = _recovery_overview(http, origin, access)
+    assert ov['detail'] == {'total': 10, 'remaining': 10}, (
+        f'overview recovery inicial: {ov}'
+    )
+
+    # 3-4. login factor fuerte -> consume un code -> 200 + tokens (bypass MFA).
+    temp = _strong_temp_step2(http, origin, email, bypass)
+    consume = http.post(
+        '/auth',
+        body=make_body(
+            'mfa', 'recovery-codes-consume', temp_token=temp, code=codes[0],
+        ),
+        origin=origin,
+    )
+    assert consume.status == 200, (
+        f'recovery-codes-consume deberia ser 200: {consume.status} {consume.body}'
+    )
+    assert field(consume.body, 'access_token'), f'falta access_token: {consume.body}'
+    assert field(consume.body, 'refresh_token'), f'falta refresh: {consume.body}'
+
+    # 5. overview: remaining baja a 9.
+    ov2 = _recovery_overview(http, origin, access)
+    assert ov2['detail'] == {'total': 10, 'remaining': 9}, (
+        f'overview recovery tras consumir uno: {ov2}'
+    )
+
+    # 6. reuso del MISMO code (temp nuevo) -> 400 RECOVERY_CODE_CONSUMED.
+    temp2 = _strong_temp_step2(http, origin, email, bypass)
+    reuse = http.post(
+        '/auth',
+        body=make_body(
+            'mfa', 'recovery-codes-consume', temp_token=temp2, code=codes[0],
+        ),
+        origin=origin,
+    )
+    assert reuse.status == 400, (
+        f'reusar un code consumido deberia ser 400: {reuse.status} {reuse.body}'
+    )
+
+    # 7. regenerate -> 10 codes nuevos; un code VIEJO no consumido ya no sirve.
+    regen = http.post(
+        '/auth', body=make_body('mfa', 'recovery-codes-generate'),
+        origin=origin, bearer=access,
+    )
+    assert regen.status == 200, f'regenerate fallo: {regen.body}'
+    new_codes = _codes(regen.body)
+    assert len(new_codes) == 10
+    assert set(new_codes).isdisjoint(set(codes)), (
+        'los codes regenerados no deberian repetir los viejos'
+    )
+    temp3 = _strong_temp_step2(http, origin, email, bypass)
+    old_unused = http.post(
+        '/auth',
+        body=make_body(
+            'mfa', 'recovery-codes-consume', temp_token=temp3, code=codes[1],
+        ),
+        origin=origin,
+    )
+    assert old_unused.status == 400, (
+        f'un code viejo (pre-regenerate) ya no deberia servir: '
+        f'{old_unused.status} {old_unused.body}'
+    )

--- a/tests/api/test_auth_webauthn_full_lifecycle.py
+++ b/tests/api/test_auth_webauthn_full_lifecycle.py
@@ -1,0 +1,240 @@
+"""E2E del ciclo de vida COMPLETO del metodo WebAuthn (passkeys).
+
+Centraliza la cobertura del factor passkey de punta a punta (antes el register
+y el login estaban repartidos entre test_webauthn_register.py (browser) y
+test_auth_multifactor_checklist.py; faltaban set-required, list, disable,
+enable y delete a nivel API):
+
+1. register-options -> register-verify (firmado con SoftPasskey) -> 201.
+2. list-credentials -> el passkey aparece con su record id.
+3. set-required del passkey -> 204; overview refleja webauthn required.
+4. login completo por el checklist: login.start lista [password, webauthn] ->
+   verify-password (intermedio) -> webauthn login-options/login-verify (cierra)
+   -> access + refresh.
+5. disable el passkey -> 204 (queda el TOTP) -> enable -> 204.
+6. delete-credential -> 204; overview ya no lista el passkey como activo.
+
+El passkey se firma con `SoftPasskey` (authenticator de software, UV) — sin
+browser ni Virtual Authenticator CDP (flaky). Para que disable/delete del
+passkey NO choque con MUST_KEEP_ONE_MFA_METHOD, el user tiene ademas un TOTP
+confirmado.
+
+Requiere bypass (registra users active). Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+from shared.totp import totp_now
+from shared.webauthn_device import SoftPasskey
+
+
+def _access_via_password(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login solo-password -> access token (la password es el unico required)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    return access
+
+
+def _enroll_totp(http: HttpClient, origin: str, access: str) -> None:
+    """Enrola + confirma un TOTP (segundo MFA para no chocar MUST_KEEP_ONE)."""
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-totp'), origin=origin,
+        bearer=access,
+    )
+    secret = field(setup.body, 'secret_b32')
+    assert secret is not None
+    confirm = http.post(
+        '/auth',
+        body=make_body('mfa', 'confirm-totp', code=totp_now(secret)),
+        origin=origin, bearer=access,
+    )
+    assert confirm.status == 204, f'confirm-totp fallo: {confirm.body}'
+
+
+def _overview_by_type(http: HttpClient, origin: str, access: str) -> dict:
+    """security.overview -> {type: entry} indexado por tipo de metodo."""
+    r = http.post(
+        '/auth', body=make_body('security', 'overview'), origin=origin,
+        bearer=access,
+    )
+    return {m['type']: m for m in (r.body.get('methods') or [])}
+
+
+@pytest.mark.api
+def test_webauthn_full_lifecycle_register_required_login_disable_delete(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user active con password + TOTP confirmado,
+    When registra un passkey, lo marca required, inicia sesion completando
+        password + passkey, lo deshabilita/reactiva y finalmente lo borra,
+    Then cada paso responde su contrato y el login converge con access+refresh.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+walc-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    access = _access_via_password(http, origin, email, bypass)
+    _enroll_totp(http, origin, access)
+
+    # 1. register-options -> register-verify (firmado) -> 201.
+    pk = SoftPasskey(origin)
+    ro = http.post(
+        '/auth', body=make_body('webauthn', 'register-options'),
+        origin=origin, bearer=access,
+    )
+    assert ro.status == 200, f'register-options fallo: {ro.status} {ro.body}'
+    rv = http.post(
+        '/auth',
+        body=make_body(
+            'webauthn', 'register-verify',
+            challenge_id=ro.body['challenge_id'],
+            response=pk.register_response(ro.body['options']),
+            nickname='lifecycle',
+        ),
+        origin=origin, bearer=access,
+    )
+    assert rv.status == 201, f'register-verify fallo: {rv.status} {rv.body}'
+    assert environment.count_webauthn_credentials(user_id) == 1, (
+        'el passkey deberia estar persistido en Neon'
+    )
+
+    # 2. list-credentials -> el record id del passkey.
+    cs = http.post(
+        '/auth', body=make_body('webauthn', 'list-credentials'),
+        origin=origin, bearer=access,
+    )
+    assert cs.status == 200, f'list-credentials fallo: {cs.body}'
+    record_id = cs.body['credentials'][0]['credential_id']
+
+    # 3. set-required del passkey -> 204; overview webauthn required.
+    req = http.post(
+        '/auth',
+        body=make_body(
+            'webauthn', 'set-required', credential_id=record_id, required=True,
+        ),
+        origin=origin, bearer=access,
+    )
+    assert req.status == 204, f'webauthn set-required fallo: {req.status} {req.body}'
+    overview = _overview_by_type(http, origin, access)
+    assert overview['webauthn']['configured'] is True
+    assert overview['webauthn']['required'] is True
+
+    # 4. login completo: password (intermedio) -> passkey (cierra).
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    methods = set(start.body.get('methods') or [])
+    assert 'webauthn' in methods and 'password' in methods, (
+        f'login.start deberia exigir password+webauthn: {start.body}'
+    )
+    temp = field(start.body, 'temp_token')
+
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password', password=STRONG_PASSWORD, temp_token=temp,
+        ),
+        origin=origin,
+    )
+    assert vp.body.get('mfa_complete') is False, (
+        f'tras password aun falta webauthn: {vp.body}'
+    )
+    temp2 = field(vp.body, 'temp_token')
+    assert temp2, f'falta temp rolling tras password: {vp.body}'
+
+    lo = http.post(
+        '/auth', body=make_body('webauthn', 'login-options', email=email),
+        origin=origin,
+    )
+    assert lo.status == 200, f'login-options fallo: {lo.status} {lo.body}'
+    lv = http.post(
+        '/auth',
+        body=make_body(
+            'webauthn', 'login-verify',
+            challenge_id=lo.body['challenge_id'],
+            response=pk.login_response(lo.body['options']),
+            temp_token=temp2,
+        ),
+        origin=origin,
+    )
+    assert lv.body.get('mfa_complete') is True, (
+        f'el passkey deberia cerrar el login: {lv.body}'
+    )
+    assert field(lv.body, 'access_token'), f'falta access_token final: {lv.body}'
+    assert field(lv.body, 'refresh_token'), f'falta refresh_token final: {lv.body}'
+
+    # 5. disable -> 204 (queda el TOTP) -> enable -> 204.
+    dis = http.post(
+        '/auth', body=make_body('webauthn', 'disable', credential_id=record_id),
+        origin=origin, bearer=access,
+    )
+    assert dis.status == 204, f'webauthn disable fallo: {dis.status} {dis.body}'
+    assert environment.count_webauthn_credentials(user_id) == 0, (
+        'el passkey deshabilitado no deberia contar como activo'
+    )
+    ena = http.post(
+        '/auth', body=make_body('webauthn', 'enable', credential_id=record_id),
+        origin=origin, bearer=access,
+    )
+    assert ena.status == 204, f'webauthn enable fallo: {ena.status} {ena.body}'
+    assert environment.count_webauthn_credentials(user_id) == 1, (
+        'el passkey reactivado deberia volver a contar'
+    )
+
+    # 6. delete-credential -> 204; ya no figura activo.
+    deleted = http.post(
+        '/auth',
+        body=make_body('webauthn', 'delete-credential', credential_id=record_id),
+        origin=origin, bearer=access,
+    )
+    assert deleted.status == 204, (
+        f'delete-credential fallo: {deleted.status} {deleted.body}'
+    )
+    assert environment.count_webauthn_credentials(user_id) == 0, (
+        'el passkey borrado no deberia quedar en Neon'
+    )


### PR DESCRIPTION
## Problema

Los E2E de los metodos de seguridad/MFA estaban dispersos (parte en browser/Playwright `tests/admin/`, parte suelta en `_flows.py`) y con huecos de cobertura: email_code sin login 2FA ni set-required, WebAuthn sin set-required/disable/enable/delete a nivel API, recovery_codes sin overview ni regenerate.

## Solucion

Centralizar en la capa API (`tests/api/`, determinista, sin Virtual Authenticator flaky) **un archivo por metodo con su ciclo de vida COMPLETO**. Junto a `test_auth_totp_full_lifecycle.py` (ya en dev, PR #267), los **5 metodos** quedan cubiertos punta a punta:

| Metodo | setup | confirm | set-required | login con el factor | disable/delete | overview |
|--------|:---:|:---:|:---:|:---:|:---:|:---:|
| TOTP | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| email_code | ✅ | n/a | ✅ | ✅ (send+seed+verify-code) | ✅ | ✅ |
| webauthn | ✅ | ✅ | ✅ | ✅ (passkey) | ✅ disable/enable/delete | ✅ |
| recovery_codes | ✅ generate | n/a | n/a | ✅ consume (bypass MFA) | ✅ regenerate | ✅ |
| password | ✅ | n/a | ✅ toggle | ✅ verify-password | n/a | ✅ |

4 archivos nuevos:
- **`test_auth_email_code_full_lifecycle.py`** — setup -> overview -> set-required -> login 2FA (send-email-code + seed del code en Neon + verify-code) -> disable.
- **`test_auth_webauthn_full_lifecycle.py`** — register (SoftPasskey) -> list -> set-required -> login con passkey -> disable -> enable -> delete-credential.
- **`test_auth_recovery_codes_full_lifecycle.py`** — generate (10) -> overview -> consume (bypass MFA -> tokens) -> reuso (400) -> regenerate (invalida los viejos).
- **`test_auth_password_full_lifecycle.py`** — login solo-password -> set-required toggle -> change-password (current 401/2xx, Lambda users) -> login con la password nueva.

## Como probar

```bash
python devtools/run.py e2e --module=api --lambda=auth --env=dev --aws-profile=tfs-dev
#   los 5 *_full_lifecycle -> 6 passed (corrida conjunta verde, ~6 min)
```

## TODO

Nada pendiente. Solo agrega cobertura E2E (no toca codigo de produccion). Los browser tests de `tests/admin/` quedan como smoke de la UI; el ciclo de vida determinista vive en la capa API.