### PR TITLE
test(auth): confirma TOTP con el secret del QR en el lifecycle E2E

### DIFF
--- a/tests/api/test_auth_totp_full_lifecycle.py
+++ b/tests/api/test_auth_totp_full_lifecycle.py
@@ -26,6 +26,7 @@ en el teardown del conftest.
 from __future__ import annotations
 
 import secrets
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from shared.auth_support import (
@@ -45,6 +46,19 @@ from shared.totp import totp_now
 # secretos del repo. 32 chars base32 validos (A-Z2-7), pero NO el secret de la
 # DB -> el code que produce no matchea (caso 'app con entrada vieja').
 _OTHER_SECRET = ('JBSWY3DP' 'EHPK3PXP') * 2
+
+
+def _secret_from_otpauth(otpauth_url: str) -> str | None:
+    """Extrae el `secret` del `otpauth://` (lo que un autenticador escanea).
+
+    1Password / Google Authenticator / Authy leen el QR, que codifica el
+    `otpauth_url`, y derivan el code SOLO del query param `secret` — NO del
+    `secret_b32` del body. Replicar esa extraccion prueba que el QR lleva el
+    secret correcto (si difiriera del persistido, el code no matchearia y el
+    user veria INVALID_TOTP_CODE aunque copie bien de la app).
+    """
+    raw = parse_qs(urlparse(otpauth_url).query).get('secret')
+    return raw[0] if raw else None
 
 
 def _access_via_password(
@@ -116,18 +130,30 @@ def test_totp_full_lifecycle_setup_confirm_required_login(
     assert setup.status == 200, f'setup-totp fallo: {setup.body}'
     secret = field(setup.body, 'secret_b32')
     assert secret is not None, f'setup-totp no dio secret_b32: {setup.body}'
-    assert field(setup.body, 'otpauth_url') is not None, (
+    otpauth_url = field(setup.body, 'otpauth_url')
+    assert otpauth_url is not None, (
         f'setup-totp no dio otpauth_url: {setup.body}'
     )
+    # El valor embebido en el QR (lo que 1Password escanea) DEBE coincidir con
+    # el `secret_b32` y con el persistido en la DB. Si difiriera, la app
+    # generaria codes que el backend rechaza con INVALID_TOTP_CODE aunque el
+    # user copie bien -> el sintoma reportado. Confirmamos con el code derivado
+    # del valor del QR (no del body) para probar el camino real del user.
+    qr_value = _secret_from_otpauth(otpauth_url)
+    assert qr_value == secret, (
+        'el valor del otpauth_url (QR) debe coincidir con secret_b32: '
+        f'qr_len={len(qr_value or "")} body_len={len(secret)} equal=False'
+    )
 
-    # 2. confirm-totp con el code generado DEL secret recien creado -> 204.
+    # 2. confirm-totp con el code derivado del valor DEL QR -> 204 (camino que
+    #    recorre un autenticador real: lee el QR, deriva el code de su valor).
     confirm = http.post(
         '/auth',
-        body=make_body('mfa', 'confirm-totp', code=totp_now(secret)),
+        body=make_body('mfa', 'confirm-totp', code=totp_now(qr_value)),
         origin=origin, bearer=access,
     )
     assert confirm.status == 204, (
-        f'confirm-totp con el code correcto deberia ser 204, '
+        f'confirm-totp con el code del QR deberia ser 204, '
         f'fue {confirm.status}: {confirm.body}'
     )
 


### PR DESCRIPTION
## Problema

El usuario reporto que `mfa.confirm-totp` falla con `INVALID_TOTP_CODE` al
configurar TOTP con 1Password, copiando el codigo de la app. Pidio que el E2E
complete la config de TOTP para comprobar que el flujo funciona y diagnosticar
la causa.

## Solucion

**Diagnostico: el backend de TOTP es integro; el fallo es operacional.**

Se reviso la cadena completa `setup-totp` -> `confirm-totp`:
- `setup_totp.py` genera un secret nuevo, lo cifra (KMS) y construye el
  `otpauth_url` con **el mismo** `secret_b32`.
- `build_otpauth_url` (`shared/auth/totp.py`) usa `pyotp.TOTP(secret).provisioning_uri()`,
  que embebe el secret sin transformarlo.
- `upsert_totp_method` reescribe el ciphertext y resetea `confirmed_at`/`disabled_at`
  en cada re-setup; `confirm-totp` descifra ese mismo row.

No hay bug de servidor: el valor del QR == `secret_b32` == secret persistido ==
secret verificado.

El `INVALID_TOTP_CODE` con 1Password ocurre porque el codigo que se copia no
corresponde al secret actual del backend: el overview muestra un TOTP pendiente
del 2026-06-03, y la app tiene esa entrada vieja. Cada vez que se abre la
pantalla de setup el backend genera un secret nuevo; copiar de la entrada vieja
de la app da `INVALID_TOTP_CODE`.

**Refuerzo del E2E (este PR):** se cierra el hueco de cobertura agregando
`_secret_from_otpauth`, que extrae el query param `secret` del `otpauth_url`
(lo que un autenticador real escanea del QR). El lifecycle ahora:
1. Asegura que el valor del QR coincide con `secret_b32`.
2. Confirma con el code derivado **del valor del QR** (no del body), probando el
   camino real del usuario de punta a punta.

## Como probar

```bash
cd tests && ../devtools/.venv/bin/python -m pytest \
  api/test_auth_totp_full_lifecycle.py --env=dev --aws-profile=tfs-dev \
  --lambda=auth -v
```

2 tests verdes contra dev (lifecycle + caso negativo otro-secret -> 400),
`2 passed in 95.13s`.

## TODO

Nada pendiente. Para desbloquear el TOTP propio: borrar las entradas viejas de
`the-full-stack.com` en 1Password, eliminar el TOTP pendiente desde
`/settings/security` (boton 'Eliminar' del fix #266) y reconfigurar escaneando
el QR nuevo una sola vez.