### PR TITLE
feat(auth+admin): eliminar MFA pendiente (mfa.delete) + mejoras del panel de seguridad

### DIFF
--- a/admin/src/features/auth/api/auth-client.ts
+++ b/admin/src/features/auth/api/auth-client.ts
@@ -198,6 +198,18 @@ export const authClient = {
 			body: { operation: "mfa", action: "disable", data },
 		}),
 
+	/**
+	 * mfa.delete: hard-delete del metodo (vuelve a configured:false en el
+	 * overview). 204; 404 si no existe; 409 MUST_KEEP_ONE solo si el metodo es
+	 * el ultimo CONFIRMADO. Un metodo pendiente (no confirmado) siempre se
+	 * puede borrar -> deja la pantalla limpia para reconfigurar de cero.
+	 */
+	mfaDelete: (data: { kind: MfaKind }) =>
+		apiFetch<Envelope<unknown>>("/auth", {
+			method: "POST",
+			body: { operation: "mfa", action: "delete", data },
+		}),
+
 	/** mfa.list: estado actual de los metodos MFA. */
 	mfaList: () =>
 		apiFetch<Envelope<MfaListResponse>>("/auth", {

--- a/admin/src/features/auth/components/email-code-setup.tsx
+++ b/admin/src/features/auth/components/email-code-setup.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import { useSetupEmailCode } from "../hooks/use-setup-email-code";
+
+/**
+ * @component EmailCodeSetup
+ * @description Setup de email-code (codigo de 8 chars por email). A diferencia
+ *   de TOTP NO hay QR ni confirmacion de codigo: el backend lo inserta
+ *   confirmado de inmediato (el user ya probo su email al registrarse). Un solo
+ *   boton dispara mfa.setup-email-code y queda activo.
+ *
+ * @props {() => void} [onDone] - callback al activarse (cierra el Dialog padre).
+ */
+export function EmailCodeSetup({
+	onDone,
+}: {
+	onDone?: () => void;
+}): ReactElement {
+	const setupEmailCode = useSetupEmailCode();
+
+	const onSubmit = (event: React.FormEvent) => {
+		event.preventDefault();
+		setupEmailCode.mutate(undefined, {
+			onSuccess: () => onDone?.(),
+		});
+	};
+
+	return (
+		<form onSubmit={onSubmit} className="space-y-4">
+			<p className="text-sm text-muted-foreground">
+				Recibiras un codigo de 8 caracteres en tu email al iniciar sesion. Se
+				activa de inmediato, sin escanear nada.
+			</p>
+			<Button
+				type="submit"
+				className="w-full"
+				disabled={setupEmailCode.isPending}
+			>
+				{setupEmailCode.isPending ? "Activando..." : "Activar codigo por email"}
+			</Button>
+		</form>
+	);
+}

--- a/admin/src/features/auth/hooks/use-delete-credential.ts
+++ b/admin/src/features/auth/hooks/use-delete-credential.ts
@@ -9,7 +9,9 @@ import { authKeys } from "../api/query-keys";
 /**
  * @function useDeleteCredential
  * @description Borra un passkey. El 409 (MUST_KEEP_ONE_MFA_METHOD) NO invalida
- *   la query: muestra el error y propaga. En exito invalida `authKeys.webauthn()`.
+ *   la query: muestra el error y propaga. En exito invalida `authKeys.webauthn()`
+ *   Y `authKeys.securityOverview()` para que el panel de seguridad refresque la
+ *   fila del passkey borrado.
  */
 export function useDeleteCredential() {
 	const queryClient = useQueryClient();
@@ -18,6 +20,9 @@ export function useDeleteCredential() {
 		mutationFn: authClient.webauthnDeleteCredential,
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: authKeys.webauthn() });
+			void queryClient.invalidateQueries({
+				queryKey: authKeys.securityOverview(),
+			});
 		},
 		onError: (error) => {
 			if (error instanceof ApiError && error.status === 409) {

--- a/admin/src/features/auth/hooks/use-generate-recovery-codes.ts
+++ b/admin/src/features/auth/hooks/use-generate-recovery-codes.ts
@@ -1,15 +1,25 @@
 "use client";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { authClient } from "../api/auth-client";
+import { authKeys } from "../api/query-keys";
 
 /**
  * @function useGenerateRecoveryCodes
  * @description Genera 10 recovery codes (mostrados UNA sola vez). El caller
- *   debe forzar al usuario a guardarlos antes de cerrar el modal.
+ *   debe forzar al usuario a guardarlos antes de cerrar el modal. En exito
+ *   invalida `authKeys.securityOverview()` para que el panel refresque el
+ *   conteo total/remaining (de 0 a 10, o el reset tras regenerar).
  */
 export function useGenerateRecoveryCodes() {
+	const queryClient = useQueryClient();
+
 	return useMutation({
 		mutationFn: authClient.mfaRecoveryCodesGenerate,
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: authKeys.securityOverview(),
+			});
+		},
 	});
 }

--- a/admin/src/features/auth/hooks/use-setup-email-code.ts
+++ b/admin/src/features/auth/hooks/use-setup-email-code.ts
@@ -6,7 +6,9 @@ import { authKeys } from "../api/query-keys";
 
 /**
  * @function useSetupEmailCode
- * @description Activa MFA via email-code. En exito invalida `authKeys.mfa()`.
+ * @description Activa MFA via email-code. En exito invalida `authKeys.mfa()` y
+ *   `authKeys.securityOverview()` para que el panel de seguridad refresque la
+ *   fila de email_code (pasa a configured + enabled).
  */
 export function useSetupEmailCode() {
 	const queryClient = useQueryClient();
@@ -15,6 +17,9 @@ export function useSetupEmailCode() {
 		mutationFn: authClient.mfaSetupEmailCode,
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: authKeys.mfa() });
+			void queryClient.invalidateQueries({
+				queryKey: authKeys.securityOverview(),
+			});
 		},
 	});
 }

--- a/admin/src/features/auth/index.ts
+++ b/admin/src/features/auth/index.ts
@@ -20,6 +20,7 @@ export type {
 } from "@/types/api";
 // Componentes
 export { AuthGuard } from "./components/auth-guard";
+export { EmailCodeSetup } from "./components/email-code-setup";
 export { LoginChecklist } from "./components/login-checklist";
 export { LoginForm } from "./components/login-form";
 export { LoginMethodPicker } from "./components/login-method-picker";

--- a/admin/src/features/settings/components/recovery-codes-section.tsx
+++ b/admin/src/features/settings/components/recovery-codes-section.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -12,18 +22,34 @@ import {
 import { RecoveryCodesModal, useGenerateRecoveryCodes } from "@/features/auth";
 
 /**
- * @component RecoveryCodesSection
- * @description Genera 10 recovery codes (mfa.recovery-codes-generate del
- *   feature `auth`) y los muestra UNA sola vez via RecoveryCodesModal.
- *   Regenerar invalida los anteriores.
+ * @function RecoveryCodesSection
+ * @description Genera 10 recovery codes (mfa.recovery-codes-generate del feature
+ *   `auth`) y los muestra UNA sola vez via RecoveryCodesModal.
+ *
+ *   Dos estados segun `total`:
+ *   - Sin generar (total === 0): boton 'Generar codigos' directo.
+ *   - Ya generados (total > 0): muestra cuantos quedan disponibles + boton
+ *     'Regenerar' que abre un AlertDialog advirtiendo que invalida los N codigos
+ *     actuales antes de confirmar.
+ *
+ * @props {number} total - codigos generados en total (del overview).
+ * @props {number} remaining - codigos aun disponibles (no consumidos).
  */
-export function RecoveryCodesSection() {
+export function RecoveryCodesSection({
+	total,
+	remaining,
+}: {
+	total: number;
+	remaining: number;
+}) {
 	const generate = useGenerateRecoveryCodes();
 	const [open, setOpen] = useState(false);
+	const [warnOpen, setWarnOpen] = useState(false);
 
 	const codes = generate.data?.data.codes ?? [];
+	const alreadyGenerated = total > 0;
 
-	const onGenerate = () => {
+	const runGenerate = () => {
 		generate.mutate(undefined, {
 			onSuccess: () => setOpen(true),
 		});
@@ -34,18 +60,57 @@ export function RecoveryCodesSection() {
 			<CardHeader>
 				<CardTitle>Codigos de recuperacion</CardTitle>
 				<CardDescription>
-					Usalos para entrar si pierdes tus otros metodos. Generar nuevos
-					invalida los anteriores.
+					{alreadyGenerated
+						? `Ya generaste tus codigos de recuperacion: ${remaining} de ${total} disponibles. Guardalos en un lugar seguro; los usas para entrar si pierdes tus otros metodos.`
+						: "Genera 10 codigos para entrar si pierdes tus otros metodos. Se muestran una sola vez."}
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<Button
-					type="button"
-					disabled={generate.isPending}
-					onClick={onGenerate}
-				>
-					{generate.isPending ? "Generando..." : "Generar codigos"}
-				</Button>
+				{alreadyGenerated ? (
+					<Button
+						type="button"
+						variant="outline"
+						disabled={generate.isPending}
+						onClick={() => setWarnOpen(true)}
+					>
+						{generate.isPending ? "Regenerando..." : "Regenerar codigos"}
+					</Button>
+				) : (
+					<Button
+						type="button"
+						disabled={generate.isPending}
+						onClick={runGenerate}
+					>
+						{generate.isPending ? "Generando..." : "Generar codigos"}
+					</Button>
+				)}
+
+				<AlertDialog open={warnOpen} onOpenChange={setWarnOpen}>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>
+								Regenerar codigos de recuperacion
+							</AlertDialogTitle>
+							<AlertDialogDescription>
+								Esto invalida tus {total} codigos actuales (incluidos los{" "}
+								{remaining} que aun no usaste). Recibiras 10 nuevos, mostrados
+								una sola vez. ¿Continuar?
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancelar</AlertDialogCancel>
+							<AlertDialogAction
+								onClick={() => {
+									setWarnOpen(false);
+									runGenerate();
+								}}
+							>
+								Regenerar
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+
 				<RecoveryCodesModal
 					open={open}
 					codes={codes}

--- a/admin/src/features/settings/components/security-overview-panel.tsx
+++ b/admin/src/features/settings/components/security-overview-panel.tsx
@@ -31,13 +31,19 @@ import { ErrorAlert } from "@/components/ui/error-alert";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
-import { TotpSetup, WebAuthnRegisterButton } from "@/features/auth";
+import {
+	EmailCodeSetup,
+	TotpSetup,
+	useDeleteCredential,
+	WebAuthnRegisterButton,
+} from "@/features/auth";
 import type {
 	MfaKind,
 	SecurityMethod,
 	SecurityMethodType,
 	SecurityPasskey,
 } from "@/types/models";
+import { useDeleteMethod } from "../hooks/use-delete-method";
 import { useSecurityOverview } from "../hooks/use-security-overview";
 import { useSetRequired } from "../hooks/use-set-required";
 import { useToggleMethod } from "../hooks/use-toggle-method";
@@ -229,8 +235,10 @@ function WebauthnRow({
 	method,
 	onToggle,
 	onRequired,
+	onDeleteCredential,
 	toggling,
 	settingRequired,
+	deleting,
 }: {
 	method: SecurityMethod;
 	onToggle: (vars: {
@@ -243,8 +251,10 @@ function WebauthnRow({
 		recordId: string;
 		required: boolean;
 	}) => void;
+	onDeleteCredential: (recordId: string) => void;
 	toggling: boolean;
 	settingRequired: boolean;
+	deleting: boolean;
 }) {
 	const passkeys = asPasskeys(method.detail);
 
@@ -259,24 +269,33 @@ function WebauthnRow({
 					No tienes passkeys registrados.
 				</p>
 			) : (
-				<ul className="space-y-2">
-					{passkeys.map((passkey) => (
-						<PasskeyRow
-							key={passkey.credential_id}
-							passkey={passkey}
-							toggling={toggling}
-							settingRequired={settingRequired}
-							deleting={false}
-							onToggle={(recordId, enable) =>
-								onToggle({ type: "webauthn", recordId, enable })
-							}
-							onRequired={(recordId, required) =>
-								onRequired({ type: "webauthn", recordId, required })
-							}
-							onDelete={() => undefined}
-						/>
-					))}
-				</ul>
+				<>
+					<ul className="space-y-2">
+						{passkeys.map((passkey) => (
+							<PasskeyRow
+								key={passkey.credential_id}
+								passkey={passkey}
+								toggling={toggling}
+								settingRequired={settingRequired}
+								deleting={deleting}
+								onToggle={(recordId, enable) =>
+									onToggle({ type: "webauthn", recordId, enable })
+								}
+								onRequired={(recordId, required) =>
+									onRequired({ type: "webauthn", recordId, required })
+								}
+								onDelete={onDeleteCredential}
+							/>
+						))}
+					</ul>
+					{/* El factor 'webauthn' del login se satisface con CUALQUIER passkey
+					    marcada como requerida: marcar varias NO obliga a usar todas, basta
+					    una al iniciar sesion. */}
+					<p className="text-xs text-muted-foreground">
+						Si marcas varias passkeys como requeridas, al iniciar sesion basta
+						con usar una de ellas.
+					</p>
+				</>
 			)}
 			{/* Registrar un passkey nuevo (navigator.credentials.create via
 			    webauthn.register-options -> register-verify). */}
@@ -302,6 +321,7 @@ function MfaRow({
 	onDelete,
 	toggling,
 	settingRequired,
+	deleting,
 }: {
 	method: SecurityMethod;
 	onToggle: (vars: {
@@ -318,6 +338,7 @@ function MfaRow({
 	onDelete: (vars: { type: SecurityMethodType; kind: MfaKind }) => void;
 	toggling: boolean;
 	settingRequired: boolean;
+	deleting: boolean;
 }) {
 	const kind = method.type as MfaKind;
 	const pending = isMfaPending(method);
@@ -355,7 +376,7 @@ function MfaRow({
 						type="button"
 						variant="destructive"
 						size="sm"
-						disabled={toggling}
+						disabled={deleting}
 						onClick={() => onDelete({ type: method.type, kind })}
 					>
 						Eliminar
@@ -399,11 +420,13 @@ function RecoveryCodesRow({ method }: { method: SecurityMethod }) {
 		<div className="space-y-3 rounded-md border p-4">
 			<div className="flex items-center justify-end gap-3">
 				<p className="mr-auto text-sm text-muted-foreground">
-					Codigos disponibles: {remaining} de {total}.
+					{total > 0
+						? `Codigos disponibles: ${remaining} de ${total}.`
+						: "Aun no generaste codigos de recuperacion."}
 				</p>
 				<StatusBadge method={method} />
 			</div>
-			<RecoveryCodesSection />
+			<RecoveryCodesSection total={total} remaining={remaining} />
 		</div>
 	);
 }
@@ -495,6 +518,8 @@ export function SecurityOverviewPanel() {
 	const overview = useSecurityOverview();
 	const toggle = useToggleMethod();
 	const setRequired = useSetRequired();
+	const deleteMethod = useDeleteMethod();
+	const deleteCredential = useDeleteCredential();
 	const [setupKind, setSetupKind] = useState<MfaKind | null>(null);
 
 	if (overview.isLoading) {
@@ -518,11 +543,9 @@ export function SecurityOverviewPanel() {
 		);
 	}
 
-	// email_code NO se lista: es el canal de entrada del login (siempre
-	// disponible), no un metodo configurable desde el panel de seguridad.
-	const methods = overview.data.methods.filter(
-		(method) => method.type !== "email_code",
-	);
+	// Todos los metodos se listan, incluido email_code (activo/inactivo +
+	// requerido al loguear + configurar), igual que el resto.
+	const methods = overview.data.methods;
 
 	return (
 		<Card>
@@ -542,8 +565,12 @@ export function SecurityOverviewPanel() {
 								method={method}
 								toggling={toggle.isPending}
 								settingRequired={setRequired.isPending}
+								deleting={deleteCredential.isPending}
 								onToggle={(vars) => toggle.mutate(vars)}
 								onRequired={(vars) => setRequired.mutate(vars)}
+								onDeleteCredential={(recordId) =>
+									deleteCredential.mutate({ credential_id: recordId })
+								}
 							/>
 						) : method.type === "recovery_codes" ? (
 							<RecoveryCodesRow method={method} />
@@ -558,10 +585,11 @@ export function SecurityOverviewPanel() {
 								method={method}
 								toggling={toggle.isPending}
 								settingRequired={setRequired.isPending}
+								deleting={deleteMethod.isPending}
 								onToggle={(vars) => toggle.mutate(vars)}
 								onRequired={(vars) => setRequired.mutate(vars)}
 								onConfigure={(type) => setSetupKind(type as MfaKind)}
-								onDelete={(vars) => toggle.mutate({ ...vars, enable: false })}
+								onDelete={(vars) => deleteMethod.mutate({ kind: vars.kind })}
 							/>
 						)}
 					</div>
@@ -582,6 +610,24 @@ export function SecurityOverviewPanel() {
 						</DialogDescription>
 					</DialogHeader>
 					<TotpSetup />
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={setupKind === "email_code"}
+				onOpenChange={(open) => {
+					if (!open) setSetupKind(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Configurar codigo por email</DialogTitle>
+						<DialogDescription>
+							Activa el envio de un codigo de 8 caracteres a tu email al iniciar
+							sesion.
+						</DialogDescription>
+					</DialogHeader>
+					<EmailCodeSetup onDone={() => setSetupKind(null)} />
 				</DialogContent>
 			</Dialog>
 		</Card>

--- a/admin/src/features/settings/hooks/use-delete-method.ts
+++ b/admin/src/features/settings/hooks/use-delete-method.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { authClient } from "@/features/auth/api/auth-client";
+import { authKeys } from "@/features/auth/api/query-keys";
+import { ApiError } from "@/lib/api-client";
+import type { MfaKind } from "@/types/models";
+
+/**
+ * @typedef DeleteMethodVars
+ * @description Variables de la mutation. `kind` es el metodo MFA a borrar
+ *   (`totp` / `email_code`). El hard-delete deja el metodo en
+ *   `configured:false` (vuelve a 'No configurado').
+ */
+export interface DeleteMethodVars {
+	kind: MfaKind;
+}
+
+/**
+ * @function useDeleteMethod
+ * @description Borra (hard-delete) un metodo MFA via `mfa.delete`. A diferencia
+ *   de `useToggleMethod` (soft-disable), elimina el row: el metodo desaparece
+ *   del overview y un setup posterior empieza de cero. Pensado para el boton
+ *   'Eliminar' de un TOTP pendiente (setup abandonado). El 409
+ *   (MUST_KEEP_ONE_MFA_METHOD, solo si fuera el ultimo confirmado) muestra el
+ *   toast; en exito invalida `authKeys.securityOverview()`.
+ */
+export function useDeleteMethod() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (vars: DeleteMethodVars) =>
+			authClient.mfaDelete({ kind: vars.kind }),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: authKeys.securityOverview(),
+			});
+		},
+		onError: (error) => {
+			if (error instanceof ApiError && error.status === 409) {
+				toast.error("Debes conservar al menos un metodo");
+				return;
+			}
+			toast.error(error.message);
+		},
+	});
+}

--- a/admin/tests/mocks/handlers/auth.ts
+++ b/admin/tests/mocks/handlers/auth.ts
@@ -432,6 +432,11 @@ export const authHandlers = [
 				{ status: 409 },
 			);
 		}
+		if (operation === "mfa" && action === "delete") {
+			// hard-delete de un metodo pendiente: el backend responde 204. El
+			// cliente re-envuelve el body vacio en {is_valid:true, code:0}.
+			return new HttpResponse(null, { status: 204 });
+		}
 		if (operation === "mfa" && action === "list") {
 			return HttpResponse.json({
 				is_valid: true,

--- a/admin/tests/unit/features/auth/api/auth-client-enable-required.test.tsx
+++ b/admin/tests/unit/features/auth/api/auth-client-enable-required.test.tsx
@@ -29,6 +29,14 @@ describe("authClient enable / set-required actions", () => {
 		expect(res.is_valid).toBe(true);
 	});
 
+	it("Given mfaDelete When llamado Then resuelve el envelope (204 hard-delete)", async () => {
+		// Act
+		const res = await authClient.mfaDelete({ kind: "totp" });
+
+		// Assert
+		expect(res.is_valid).toBe(true);
+	});
+
 	it("Given webauthnEnable When llamado Then resuelve el envelope", async () => {
 		// Act
 		const res = await authClient.webauthnEnable({ credential_id: "cred-1" });

--- a/admin/tests/unit/features/settings/components/security-overview-emailcode-listed.test.tsx
+++ b/admin/tests/unit/features/settings/components/security-overview-emailcode-listed.test.tsx
@@ -5,10 +5,10 @@ import { SecurityOverviewPanel } from "@/features/settings/components/security-o
 import type { SecurityMethod } from "@/types/models";
 
 /**
- * @module tests/unit/features/settings/components/security-overview-no-emailcode
- * @description Verifica que el panel unificado NO renderiza una fila para el
- *   metodo `email_code` (es el canal de entrada del login, no un metodo
- *   configurable), pero SI renderiza el resto (ej. totp).
+ * @module tests/unit/features/settings/components/security-overview-emailcode-listed
+ * @description Verifica que el panel unificado SI renderiza la fila del metodo
+ *   `email_code` (estado activo/inactivo + requerido + configurar), igual que
+ *   el resto de los metodos. (Antes se filtraba; el usuario pidio listarlo.)
  */
 
 function method(overrides: Partial<SecurityMethod>): SecurityMethod {
@@ -31,6 +31,8 @@ vi.mock("@/features/auth", () => ({
 		<button type="button">Registrar passkey</button>
 	),
 	TotpSetup: () => <div>totp-setup-stub</div>,
+	EmailCodeSetup: () => <div>email-code-setup-stub</div>,
+	useDeleteCredential: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 vi.mock("@/features/settings/hooks/use-security-overview", () => ({
@@ -44,6 +46,7 @@ vi.mock("@/features/settings/hooks/use-security-overview", () => ({
 					label: "Codigo por email",
 					configured: true,
 					enabled: true,
+					detail: { confirmed: true },
 				}),
 				method({ type: "totp", label: "TOTP", configured: false }),
 			],
@@ -59,14 +62,19 @@ vi.mock("@/features/settings/hooks/use-set-required", () => ({
 	useSetRequired: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
-describe("SecurityOverviewPanel email_code filtering", () => {
-	it("Given un method email_code en el overview When render Then NO renderiza su fila pero SI la de TOTP", () => {
+vi.mock("@/features/settings/hooks/use-delete-method", () => ({
+	useDeleteMethod: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+describe("SecurityOverviewPanel email_code listado", () => {
+	it("Given un method email_code en el overview When render Then SI renderiza su fila (label + switch requerido)", () => {
 		// Arrange + Act
 		render((<SecurityOverviewPanel />) as ReactElement);
 
-		// Assert: el panel filtra email_code (no aparece su label)
-		expect(screen.queryByText(/codigo por email/i)).toBeNull();
-		// pero TOTP si se lista
+		// Assert: email_code aparece como una fila mas, con su control requerido.
+		expect(screen.getByText(/codigo por email/i)).toBeInTheDocument();
+		expect(screen.getByTestId("security-row-email_code")).toBeInTheDocument();
+		// y TOTP sigue listado.
 		expect(screen.getByText("TOTP")).toBeInTheDocument();
 	});
 });

--- a/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
+++ b/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
@@ -130,22 +130,22 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("SecurityOverviewPanel", () => {
-	it("Given las entradas When render Then muestra una fila por metodo (sin email_code)", async () => {
+	it("Given las entradas When render Then muestra una fila por metodo (incluido email_code)", async () => {
 		// Arrange
 		mockOverview(fiveMethods());
 
 		// Act
 		render((<SecurityOverviewPanel />) as ReactElement);
 
-		// Assert: TOTP, WebAuthn, recovery y password presentes; email_code NO
-		// (es el canal de entrada del login, no un metodo configurable aqui).
+		// Assert: los 5 metodos presentes, INCLUIDO email_code (ahora se lista
+		// como un metodo configurable mas, no se filtra).
 		expect(
 			await screen.findByText("Aplicacion de autenticacion (TOTP)"),
 		).toBeInTheDocument();
+		expect(screen.getByText("Codigo por email")).toBeInTheDocument();
 		expect(screen.getByText("Passkeys (WebAuthn)")).toBeInTheDocument();
 		expect(screen.getByText("Codigos de recuperacion")).toBeInTheDocument();
 		expect(screen.getByText("Contrasena")).toBeInTheDocument();
-		expect(screen.queryByText("Codigo por email")).toBe(null);
 	});
 
 	it("Given el panel montado When render Then dispara security.overview UNA sola vez", async () => {
@@ -163,8 +163,8 @@ describe("SecurityOverviewPanel", () => {
 	});
 
 	it("Given un metodo visible configured=false When render Then muestra No configurado", async () => {
-		// Arrange: el TOTP pasa a configured=false (email_code se filtra, asi
-		// que se usa un metodo que SI se renderiza).
+		// Arrange: el TOTP pasa a configured=false. email_code ya viene
+		// configured=false en el fixture, asi que hay >=1 badge 'No configurado'.
 		const methods = fiveMethods().map((m) =>
 			m.type === "totp" ? { ...m, configured: false, enabled: false } : m,
 		);
@@ -174,8 +174,8 @@ describe("SecurityOverviewPanel", () => {
 		render((<SecurityOverviewPanel />) as ReactElement);
 		await screen.findByText("Aplicacion de autenticacion (TOTP)");
 
-		// Assert
-		expect(screen.getByText("No configurado")).toBeInTheDocument();
+		// Assert: TOTP (forzado) + email_code (fixture) -> 2 badges 'No configurado'.
+		expect(screen.getAllByText("No configurado")).toHaveLength(2);
 	});
 
 	it("Given webauthn con un passkey When render Then expande el nickname del passkey", async () => {
@@ -187,6 +187,78 @@ describe("SecurityOverviewPanel", () => {
 
 		// Assert: el passkey YubiKey aparece como sub-fila
 		expect(await screen.findByText("YubiKey")).toBeInTheDocument();
+	});
+
+	it("Given un passkey When clic Eliminar Then dispara webauthn.delete-credential", async () => {
+		// Arrange: capturar el request de delete-credential (apiFetch aplana body).
+		mockOverview(fiveMethods());
+		let deletedCredId: string | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					credential_id?: string;
+				};
+				if (
+					body.operation === "webauthn" &&
+					body.action === "delete-credential"
+				) {
+					deletedCredId = body.credential_id ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods: fiveMethods() },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const passkeyRow = (await screen.findByText("YubiKey")).closest("li");
+		expect(passkeyRow).not.toBeNull();
+		await user.click(
+			within(passkeyRow as HTMLElement).getByRole("button", {
+				name: /eliminar/i,
+			}),
+		);
+
+		// Assert: el backend recibe webauthn.delete-credential con el credential_id.
+		await waitFor(() => {
+			expect(deletedCredId).toBe("cred_01");
+		});
+	});
+
+	it("Given email_code no configurado When clic Configurar Then abre el dialog de setup", async () => {
+		// Arrange
+		mockOverview(fiveMethods());
+		const user = userEvent.setup();
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const emailRow = await screen.findByTestId("security-row-email_code");
+		await user.click(
+			within(emailRow).getByRole("button", { name: /configurar/i }),
+		);
+
+		// Assert: el dialog de setup de email_code aparece con su CTA.
+		const activar = await screen.findByRole("button", {
+			name: /activar codigo por email/i,
+		});
+		expect(activar).toBeInTheDocument();
+
+		// Act: activar -> el setup (204) dispara onDone -> cierra el dialog.
+		await user.click(activar);
+
+		// Assert: el dialog se cierra (el CTA ya no esta en el DOM).
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("button", { name: /activar codigo por email/i }),
+			).toBeNull();
+		});
 	});
 
 	it("Given recovery_codes con total/remaining When render Then muestra el conteo", async () => {
@@ -201,6 +273,124 @@ describe("SecurityOverviewPanel", () => {
 		expect(
 			screen.getByText(/codigos disponibles: 7 de 10/i),
 		).toBeInTheDocument();
+	});
+
+	it("Given password NO configurada When render Then ofrece 'Establecer contrasena' sin switch requerido", async () => {
+		// Arrange: password sin configurar -> sin switch requerido + CTA distinto.
+		const methods = fiveMethods().map((m) =>
+			m.type === "password"
+				? { ...m, configured: false, enabled: false, detail: {} }
+				: m,
+		);
+		mockOverview(methods);
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const passwordRow = await screen.findByTestId("security-row-password");
+
+		// Assert: CTA 'Establecer contrasena' y NO hay switch 'Requerido' (sin
+		// password no hay flag required).
+		expect(
+			within(passwordRow).getByRole("button", {
+				name: /establecer contrasena/i,
+			}),
+		).toBeInTheDocument();
+		expect(within(passwordRow).queryByText(/requerido al loguear/i)).toBeNull();
+	});
+
+	it("Given recovery_codes ya generados When render Then ofrece Regenerar", async () => {
+		// Arrange: total>0 -> la seccion muestra el flujo 'ya generados'.
+		mockOverview(fiveMethods());
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		await screen.findByText("Codigos de recuperacion");
+
+		// Assert: con codigos previos, el boton es 'Regenerar' (no 'Generar').
+		expect(
+			screen.getByRole("button", { name: /regenerar codigos/i }),
+		).toBeInTheDocument();
+	});
+
+	it("Given un passkey activo When toggle Activo off Then dispara webauthn.disable", async () => {
+		// Arrange: capturar el request de disable del passkey.
+		mockOverview(fiveMethods());
+		let disabledCred: string | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					credential_id?: string;
+				};
+				if (body.operation === "webauthn" && body.action === "disable") {
+					disabledCred = body.credential_id ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods: fiveMethods() },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: la sub-fila del passkey tiene 2 switches (Activo, Requerido); el
+		// 1ro es 'Activo' -> apagarlo dispara webauthn.disable.
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const passkeyRow = (await screen.findByText("YubiKey")).closest("li");
+		const switches = within(passkeyRow as HTMLElement).getAllByRole("switch");
+		await user.click(switches[0] as HTMLElement);
+
+		// Assert
+		await waitFor(() => {
+			expect(disabledCred).toBe("cred_01");
+		});
+	});
+
+	it("Given un TOTP confirmado When toggle Requerido y confirmo Then dispara mfa.set-required {required:true}", async () => {
+		// Arrange: TOTP confirmado (configured+enabled+confirmed) con required=false.
+		const methods = fiveMethods().map((m) =>
+			m.type === "totp"
+				? { ...m, configured: true, enabled: true, detail: { confirmed: true } }
+				: m,
+		);
+		let requiredKind: string | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					kind?: string;
+				};
+				if (body.operation === "mfa" && body.action === "set-required") {
+					requiredKind = body.kind ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: la fila TOTP confirmada tiene 2 switches (Activo, Requerido); el
+		// 2do es 'Requerido' -> activarlo abre el AlertDialog -> Confirmar.
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const totpRow = await screen.findByTestId("security-row-totp");
+		const switches = within(totpRow).getAllByRole("switch");
+		await user.click(switches[1] as HTMLElement);
+		await user.click(
+			await screen.findByRole("button", { name: /^confirmar$/i }),
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(requiredKind).toBe("totp");
+		});
 	});
 
 	it("Given password configured When render Then muestra Cambiar contrasena Y el switch Requerido al loguear", async () => {
@@ -267,6 +457,125 @@ describe("SecurityOverviewPanel", () => {
 		});
 	});
 
+	it("Given un TOTP confirmado When toggle Activo off Then dispara mfa.disable {kind:totp}", async () => {
+		// Arrange: TOTP confirmado -> tiene switch 'Activo' (1er switch).
+		const methods = fiveMethods().map((m) =>
+			m.type === "totp"
+				? { ...m, configured: true, enabled: true, detail: { confirmed: true } }
+				: m,
+		);
+		let disabledKind: string | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					kind?: string;
+				};
+				if (body.operation === "mfa" && body.action === "disable") {
+					disabledKind = body.kind ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: el 1er switch de la fila TOTP es 'Activo'.
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const totpRow = await screen.findByTestId("security-row-totp");
+		const switches = within(totpRow).getAllByRole("switch");
+		await user.click(switches[0] as HTMLElement);
+
+		// Assert
+		await waitFor(() => {
+			expect(disabledKind).toBe("totp");
+		});
+	});
+
+	it("Given un passkey When activo el switch Requerido y confirmo Then dispara webauthn.set-required", async () => {
+		// Arrange
+		mockOverview(fiveMethods());
+		let requiredCred: string | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					credential_id?: string;
+				};
+				if (body.operation === "webauthn" && body.action === "set-required") {
+					requiredCred = body.credential_id ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods: fiveMethods() },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: el 2do switch del passkey es 'Requerido' -> AlertDialog -> Confirmar.
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const passkeyRow = (await screen.findByText("YubiKey")).closest("li");
+		const switches = within(passkeyRow as HTMLElement).getAllByRole("switch");
+		await user.click(switches[1] as HTMLElement);
+		await user.click(
+			await screen.findByRole("button", { name: /^confirmar$/i }),
+		);
+
+		// Assert
+		await waitFor(() => {
+			expect(requiredCred).toBe("cred_01");
+		});
+	});
+
+	it("Given TOTP no configurado When clic Configurar Then abre el dialog de setup TOTP", async () => {
+		// Arrange: TOTP no configurado -> boton 'Configurar'.
+		const methods = fiveMethods().map((m) =>
+			m.type === "totp" ? { ...m, configured: false, enabled: false } : m,
+		);
+		mockOverview(methods);
+		const user = userEvent.setup();
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const totpRow = await screen.findByTestId("security-row-totp");
+		await user.click(
+			within(totpRow).getByRole("button", { name: /configurar/i }),
+		);
+
+		// Assert: el dialog de setup TOTP aparece (titulo Configurar TOTP).
+		expect(
+			await screen.findByText(/escanea el qr con tu app/i),
+		).toBeInTheDocument();
+	});
+
+	it("Given password configured When clic Cambiar contrasena Then abre el dialog", async () => {
+		// Arrange
+		mockOverview(fiveMethods());
+		const user = userEvent.setup();
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const passwordRow = await screen.findByTestId("security-row-password");
+		await user.click(
+			within(passwordRow).getByRole("button", { name: /cambiar contrasena/i }),
+		);
+
+		// Assert: el dialog de cambio de contrasena aparece (heading unico).
+		const dialog = await screen.findByRole("dialog");
+		expect(
+			within(dialog).getByRole("heading", { name: /cambiar contrasena/i }),
+		).toBeInTheDocument();
+	});
+
 	it("Given un TOTP pendiente (confirmed=false) When render Then muestra 'Pendiente' + Confirmar + Eliminar, sin switch requerido", async () => {
 		// Arrange: el TOTP esta configurado pero NO confirmado (setup-totp
 		// abandonado): detail.confirmed === false.
@@ -301,8 +610,9 @@ describe("SecurityOverviewPanel", () => {
 		expect(within(totpRow).queryByText(/requerido al loguear/i)).toBeNull();
 	});
 
-	it("Given un TOTP pendiente When clic Eliminar Then dispara mfa.disable {kind:totp}", async () => {
-		// Arrange: capturar el request de mfa.disable. apiFetch APLANA el body.
+	it("Given un TOTP pendiente When clic Eliminar Then dispara mfa.delete {kind:totp}", async () => {
+		// Arrange: capturar el request de mfa.delete (hard-delete, NO disable).
+		// apiFetch APLANA el body -> kind queda en la raiz.
 		const methods = fiveMethods().map((m) =>
 			m.type === "totp"
 				? {
@@ -313,7 +623,7 @@ describe("SecurityOverviewPanel", () => {
 					}
 				: m,
 		);
-		let disabledKind: string | null = null;
+		let deletedKind: string | null = null;
 		server.use(
 			http.post(`${API_BASE}/auth`, async ({ request }) => {
 				const body = (await request.json()) as {
@@ -321,8 +631,8 @@ describe("SecurityOverviewPanel", () => {
 					action: string;
 					kind?: string;
 				};
-				if (body.operation === "mfa" && body.action === "disable") {
-					disabledKind = body.kind ?? null;
+				if (body.operation === "mfa" && body.action === "delete") {
+					deletedKind = body.kind ?? null;
 					return new HttpResponse(null, { status: 204 });
 				}
 				return HttpResponse.json({
@@ -342,9 +652,9 @@ describe("SecurityOverviewPanel", () => {
 			within(totpRow).getByRole("button", { name: /eliminar/i }),
 		);
 
-		// Assert: el backend recibe mfa.disable con kind=totp.
+		// Assert: el backend recibe mfa.delete con kind=totp (NO disable).
 		await waitFor(() => {
-			expect(disabledKind).toBe("totp");
+			expect(deletedKind).toBe("totp");
 		});
 	});
 

--- a/admin/tests/unit/features/settings/components/security-overview-passkey-register.test.tsx
+++ b/admin/tests/unit/features/settings/components/security-overview-passkey-register.test.tsx
@@ -30,6 +30,8 @@ vi.mock("@/features/auth", () => ({
 		<button type="button">Registrar passkey</button>
 	),
 	TotpSetup: () => <div>totp-setup-stub</div>,
+	EmailCodeSetup: () => <div>email-code-setup-stub</div>,
+	useDeleteCredential: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 vi.mock("@/features/settings/hooks/use-security-overview", () => ({
@@ -46,6 +48,10 @@ vi.mock("@/features/settings/hooks/use-toggle-method", () => ({
 
 vi.mock("@/features/settings/hooks/use-set-required", () => ({
 	useSetRequired: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/features/settings/hooks/use-delete-method", () => ({
+	useDeleteMethod: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 describe("SecurityOverviewPanel webauthn register", () => {

--- a/admin/tests/unit/features/settings/components/security-sections.test.tsx
+++ b/admin/tests/unit/features/settings/components/security-sections.test.tsx
@@ -1,19 +1,24 @@
+import { server } from "@tests/mocks/server";
 import { render, screen, userEvent, waitFor } from "@tests/utils/render";
+import { delay, HttpResponse, http } from "msw";
 import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
+import { EmailCodeSetup } from "@/features/auth";
 import { RecoveryCodesSection } from "@/features/settings/components/recovery-codes-section";
+
+const API = "https://api.test.the-full-stack.com";
 
 /**
  * @module tests/unit/features/settings/components/security-sections
- * @description Cubre la seccion recovery-codes (genera + modal con los 10
- *   codes) que compone el panel unificado de seguridad.
+ * @description Cubre la seccion recovery-codes (genera/regenera + modal con los
+ *   10 codes) y el setup de email_code que componen el panel de seguridad.
  */
 
 describe("RecoveryCodesSection", () => {
-	it("Given el boton Generar When click Then muestra los 10 codes en el modal", async () => {
-		// Arrange
+	it("Given sin codigos previos (total=0) When click Generar Then muestra los 10 codes en el modal", async () => {
+		// Arrange: sin codigos previos -> boton 'Generar codigos' directo.
 		const user = userEvent.setup();
-		render((<RecoveryCodesSection />) as ReactElement);
+		render((<RecoveryCodesSection total={0} remaining={0} />) as ReactElement);
 
 		// Act
 		await user.click(screen.getByRole("button", { name: /generar codigos/i }));
@@ -23,5 +28,97 @@ describe("RecoveryCodesSection", () => {
 			expect(screen.getByText("RECOV00000")).toBeInTheDocument();
 		});
 		expect(screen.getByText("RECOV00009")).toBeInTheDocument();
+	});
+
+	it("Given codigos ya generados (total>0) When render Then muestra disponibles + boton Regenerar", () => {
+		// Arrange + Act
+		render((<RecoveryCodesSection total={10} remaining={4} />) as ReactElement);
+
+		// Assert: estado 'ya generados' con el conteo + boton Regenerar (no Generar).
+		expect(screen.getByText(/4 de 10 disponibles/i)).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /regenerar codigos/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /^generar codigos$/i }),
+		).toBeNull();
+	});
+
+	it("Given codigos ya generados When click Regenerar y confirma Then advierte y muestra los nuevos", async () => {
+		// Arrange
+		const user = userEvent.setup();
+		render((<RecoveryCodesSection total={10} remaining={4} />) as ReactElement);
+
+		// Act: abre el AlertDialog de advertencia.
+		await user.click(
+			screen.getByRole("button", { name: /regenerar codigos/i }),
+		);
+		// Assert: la advertencia menciona que invalida los 10 actuales.
+		expect(screen.getByText(/invalida tus 10 codigos/i)).toBeInTheDocument();
+
+		// Act: confirma -> regenera y muestra el modal con los nuevos codes.
+		await user.click(screen.getByRole("button", { name: /^regenerar$/i }));
+		await waitFor(() => {
+			expect(screen.getByText("RECOV00000")).toBeInTheDocument();
+		});
+	});
+});
+
+describe("EmailCodeSetup", () => {
+	it("Given el boton When click Then activa email_code y llama onDone", async () => {
+		// Arrange
+		const user = userEvent.setup();
+		let done = false;
+		render((<EmailCodeSetup onDone={() => (done = true)} />) as ReactElement);
+
+		// Act
+		await user.click(
+			screen.getByRole("button", { name: /activar codigo por email/i }),
+		);
+
+		// Assert: el setup (204) dispara onDone para cerrar el Dialog padre.
+		await waitFor(() => {
+			expect(done).toBe(true);
+		});
+	});
+
+	it("Given sin onDone When click Then activa email_code sin romper (boton deshabilitado tras click)", async () => {
+		// Arrange: sin onDone -> cubre el branch `onDone?.()` undefined.
+		const user = userEvent.setup();
+		render((<EmailCodeSetup />) as ReactElement);
+
+		// Act
+		await user.click(
+			screen.getByRole("button", { name: /activar codigo por email/i }),
+		);
+
+		// Assert: el boton vuelve a su label tras resolver (no quedo en error).
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /activar codigo por email/i }),
+			).toBeEnabled();
+		});
+	});
+
+	it("Given el setup en vuelo When click Then muestra el estado 'Activando...' (branch isPending)", async () => {
+		// Arrange: MSW con delay -> el boton queda en estado pending.
+		server.use(
+			http.post(`${API}/auth`, async () => {
+				await delay(300);
+				return new HttpResponse(null, { status: 204 });
+			}),
+		);
+		const user = userEvent.setup();
+		render((<EmailCodeSetup />) as ReactElement);
+
+		// Act
+		await user.click(
+			screen.getByRole("button", { name: /activar codigo por email/i }),
+		);
+
+		// Assert: durante el request el label es 'Activando...' (disabled).
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: /activando/i })).toBeDisabled();
+		});
 	});
 });

--- a/admin/tests/unit/features/settings/components/settings-components-branches.test.tsx
+++ b/admin/tests/unit/features/settings/components/settings-components-branches.test.tsx
@@ -182,7 +182,7 @@ describe("RecoveryCodesSection pending + cierre", () => {
 			}),
 		);
 		const user = userEvent.setup();
-		render((<RecoveryCodesSection />) as ReactElement);
+		render((<RecoveryCodesSection total={0} remaining={0} />) as ReactElement);
 
 		// Act
 		await user.click(screen.getByRole("button", { name: /generar codigos/i }));
@@ -196,7 +196,7 @@ describe("RecoveryCodesSection pending + cierre", () => {
 	it('Given el modal abierto When click "Ya los guarde" Then cierra (onClose)', async () => {
 		// Arrange
 		const user = userEvent.setup();
-		render((<RecoveryCodesSection />) as ReactElement);
+		render((<RecoveryCodesSection total={0} remaining={0} />) as ReactElement);
 		await user.click(screen.getByRole("button", { name: /generar codigos/i }));
 		await screen.findByText("RECOV00000");
 

--- a/admin/tests/unit/features/settings/hooks/use-delete-method.test.tsx
+++ b/admin/tests/unit/features/settings/hooks/use-delete-method.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { server } from "@tests/mocks/server";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useDeleteMethod } from "@/features/settings/hooks/use-delete-method";
+
+/**
+ * @module tests/unit/features/settings/hooks/use-delete-method
+ * @description Cubre el hook que hace hard-delete de un metodo MFA via
+ *   mfa.delete: el camino feliz (204) y el error 409 (MUST_KEEP_ONE) que
+ *   muestra un toast sin invalidar.
+ */
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+const API = "https://api.test.the-full-stack.com";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useDeleteMethod", () => {
+	it("Given mfa.delete responde 204 When mutate Then la mutation queda success", async () => {
+		// Arrange: el MSW por defecto responde 204 a mfa.delete.
+
+		// Act
+		const { result } = renderHook(() => useDeleteMethod(), { wrapper });
+		result.current.mutate({ kind: "totp" });
+
+		// Assert
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it("Given mfa.delete responde 409 When mutate Then la mutation queda error", async () => {
+		// Arrange: override -> 409 MUST_KEEP_ONE_MFA_METHOD.
+		server.use(
+			http.post(`${API}/auth`, () =>
+				HttpResponse.json(
+					{
+						error: "MUST_KEEP_ONE_MFA_METHOD",
+						code: 4000,
+						message: "Debes conservar al menos un metodo",
+					},
+					{ status: 409 },
+				),
+			),
+		);
+
+		// Act
+		const { result } = renderHook(() => useDeleteMethod(), { wrapper });
+		result.current.mutate({ kind: "totp" });
+
+		// Assert
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+
+	it("Given mfa.delete responde 500 When mutate Then la mutation queda error (rama no-409)", async () => {
+		// Arrange: override -> 500 (cubre la rama del toast generico, no el 409).
+		server.use(
+			http.post(`${API}/auth`, () =>
+				HttpResponse.json(
+					{ error: "SERVER_ERROR", code: 5000, message: "fallo interno" },
+					{ status: 500 },
+				),
+			),
+		);
+
+		// Act
+		const { result } = renderHook(() => useDeleteMethod(), { wrapper });
+		result.current.mutate({ kind: "email_code" });
+
+		// Assert
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+});

--- a/serverless/lambda/services/auth/core/controllers/mfa/delete.py
+++ b/serverless/lambda/services/auth/core/controllers/mfa/delete.py
@@ -1,0 +1,106 @@
+"""Controller `mfa.delete` — borra (hard-delete) un metodo MFA del user.
+
+Requiere access JWT valido. A diferencia de `mfa.disable` (soft-disable
+reversible que conserva el row), ELIMINA el row de `auth_mfa_methods`: el
+metodo vuelve a `configured:false` en el overview y un `setup-totp`
+posterior empieza de cero. Pensado para que el boton 'Eliminar' de un
+TOTP pendiente (setup abandonado) lo quite de verdad, no solo lo apague.
+
+404 NOT_FOUND si el metodo no existe para el user (anti-enumeration).
+409 MUST_KEEP_ONE_MFA_METHOD si borrar un metodo CONFIRMADO dejaria la
+cuenta transversal en <= 1 (mismo invariante que `disable`/
+`webauthn.delete-credential`). Un metodo NO confirmado (pendiente) NO
+protege el invariante, asi que siempre se puede borrar (anti-lockout).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from models.mfa import MfaDeleteIn
+from services.audit_service import AuditService
+from services.auth_service import require_active_user
+from services.mfa_method_service import MfaMethodService
+from services.rate_limit_service import RateLimitService
+from settings.config import app_config
+from shared.db.models.auth.enums import AuthMfaKind
+from shared.lambda_kit.base_controller import BaseController
+
+_ENDPOINT = '/auth#mfa.delete'
+
+
+class Delete(BaseController):
+    """Borra un metodo MFA del user (action `delete`)."""
+
+    event_model = MfaDeleteIn
+
+    def validate(self) -> dict[str, Any]:
+        """Pydantic + rate-limit per-IP. Sin Turnstile."""
+        base = super().validate()
+        if not base.get('is_valid'):
+            return base
+
+        data: MfaDeleteIn = self.validated_data  # type: ignore[assignment]
+        meta = data.meta
+        RateLimitService(app_config).check_or_raise(
+            ip=meta.ip or '',
+            endpoint=_ENDPOINT,
+            country=meta.country,
+            turnstile_validated=True,
+        )
+        return base
+
+    def execute(self) -> dict[str, Any]:
+        """Borra el metodo si no deja al user sin MFA confirmado.
+
+        Returns:
+            404 NOT_FOUND si el metodo no existe para el user.
+            409 MUST_KEEP_ONE_MFA_METHOD si borrar un metodo CONFIRMADO
+            dejaria la cuenta transversal <= 1.
+            204 si el metodo se borra.
+        """
+        data: MfaDeleteIn = self.validated_data  # type: ignore[assignment]
+        meta = data.meta
+
+        user = require_active_user(meta.authorization, app_config=app_config)
+
+        mfa_svc = MfaMethodService(app_config)
+        audit_svc = AuditService(app_config)
+
+        kind = AuthMfaKind(data.kind)
+        if not mfa_svc.has_active_method(user_id=user.id, kind=kind):
+            return {
+                'is_valid': False,
+                'code': 4001,
+                'status': 404,
+                'data': {'error': 'NOT_FOUND'},
+            }
+
+        # El guard MUST_KEEP_ONE solo protege metodos CONFIRMADOS: un metodo
+        # no confirmado (ej. un setup-totp abandonado) no es una via de
+        # entrada real, asi que siempre se puede borrar (anti-lockout).
+        confirmed = mfa_svc.is_confirmed(user_id=user.id, kind=kind)
+        if confirmed and mfa_svc.count_active(user_id=user.id) <= 1:
+            return {
+                'is_valid': False,
+                'code': 4000,
+                'status': 409,
+                'data': {'error': 'MUST_KEEP_ONE_MFA_METHOD'},
+            }
+
+        mfa_svc.delete(user_id=user.id, kind=kind)
+
+        audit_svc.log(
+            event='mfa.delete',
+            success=True,
+            user_id=user.id,
+            ip=meta.ip,
+            user_agent=meta.user_agent,
+        )
+
+        return {
+            'is_valid': True,
+            'code': 0,
+            'status': 204,
+            'data': {},
+        }

--- a/serverless/lambda/services/auth/core/models/mfa.py
+++ b/serverless/lambda/services/auth/core/models/mfa.py
@@ -63,6 +63,14 @@ class MfaEnableIn(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra='ignore')
 
 
+class MfaDeleteIn(BaseModel):
+    """POST /auth operation=mfa action=delete (hard-delete del metodo)."""
+
+    kind: Literal['totp', 'email_code']
+    meta: _Meta = Field(default_factory=_Meta, alias='_meta')
+    model_config = ConfigDict(populate_by_name=True, extra='ignore')
+
+
 class MfaSetRequiredIn(BaseModel):
     """POST /auth operation=mfa action=set-required (metodo requerido al loguear)."""
 

--- a/serverless/lambda/services/auth/core/services/mfa_method_service.py
+++ b/serverless/lambda/services/auth/core/services/mfa_method_service.py
@@ -17,6 +17,7 @@ from shared.db.repositories.auth import get_password_required
 from shared.db.repositories.auth_mfa import (
     confirm_mfa,
     count_active_mfa,
+    delete_mfa,
     disable_mfa,
     enable_mfa,
     get_all_mfa_methods,
@@ -319,6 +320,16 @@ class MfaMethodService:
         """Deshabilita el metodo. False si no existe (controller valida count)."""
         with db_session() as session:
             return disable_mfa(session, user_id=str(user_id), kind=kind)
+
+    def delete(self, *, user_id: UUID | str, kind: AuthMfaKind) -> bool:
+        """Borra (hard-delete) el metodo. False si no existe.
+
+        El metodo desaparece de la tabla -> vuelve a `configured:false` en el
+        overview y un `setup-totp` posterior empieza de cero. El controller
+        valida el guard MUST_KEEP_ONE (solo para metodos confirmados).
+        """
+        with db_session() as session:
+            return delete_mfa(session, user_id=str(user_id), kind=kind)
 
     def count_active(self, *, user_id: UUID | str) -> int:
         """Cuenta transversal de metodos MFA activos (MUST_KEEP_ONE)."""

--- a/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_keeps_one.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_keeps_one.py
@@ -1,0 +1,43 @@
+"""delete del unico metodo MFA CONFIRMADO -> 409 MUST_KEEP_ONE_MFA_METHOD.
+
+Given un user con el metodo confirmado + activo y total_mfa == 1 (cuenta
+  transversal),
+When se invoca mfa.delete con ese metodo,
+Then devuelve 409 MUST_KEEP_ONE_MFA_METHOD (no se queda sin MFA) y NO borra.
+  El guard solo aplica a metodos confirmados (un pendiente siempre se borra).
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_authed_event, _make_user
+
+
+def test_mfa_delete_keeps_one(monkeypatch):
+    """total_mfa == 1 + confirmado -> 409 MUST_KEEP_ONE_MFA_METHOD."""
+    from controllers.mfa import delete
+
+    user = _make_user(status='active')
+
+    mfa_svc = MagicMock()
+    mfa_svc.has_active_method.return_value = True
+    # Metodo CONFIRMADO: el guard MUST_KEEP_ONE aplica.
+    mfa_svc.is_confirmed.return_value = True
+    mfa_svc.count_active.return_value = 1
+
+    monkeypatch.setattr(
+        delete,
+        'require_active_user',
+        lambda *_a, **_k: user,
+    )
+    monkeypatch.setattr(delete, 'MfaMethodService', lambda _c: mfa_svc)
+    monkeypatch.setattr(delete, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(delete, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_authed_event(data={'kind': 'totp'})
+    result = delete.Delete(event=event).run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4000
+    assert result['status'] == 409
+    assert result['data']['error'] == 'MUST_KEEP_ONE_MFA_METHOD'
+    mfa_svc.delete.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_other_user_404.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_other_user_404.py
@@ -1,0 +1,38 @@
+"""delete de un metodo que no existe para el user -> 404 NOT_FOUND.
+
+Given un metodo que no esta activo para el user (has_active_method=False),
+When se invoca mfa.delete,
+Then devuelve 404 NOT_FOUND (no revela existencia ajena).
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_authed_event, _make_user
+
+
+def test_mfa_delete_other_user_404(monkeypatch):
+    """metodo no activo para el user -> 404 NOT_FOUND."""
+    from controllers.mfa import delete
+
+    user = _make_user(status='active')
+
+    mfa_svc = MagicMock()
+    mfa_svc.has_active_method.return_value = False
+
+    monkeypatch.setattr(
+        delete,
+        'require_active_user',
+        lambda *_a, **_k: user,
+    )
+    monkeypatch.setattr(delete, 'MfaMethodService', lambda _c: mfa_svc)
+    monkeypatch.setattr(delete, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(delete, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_authed_event(data={'kind': 'totp'})
+    result = delete.Delete(event=event).run()
+
+    assert result['is_valid'] is False
+    assert result['code'] == 4001
+    assert result['status'] == 404
+    assert result['data']['error'] == 'NOT_FOUND'
+    mfa_svc.count_active.assert_not_called()

--- a/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_unconfirmed_allowed.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_unconfirmed_allowed.py
@@ -1,0 +1,43 @@
+"""Un metodo MFA NO confirmado siempre se puede BORRAR (anti-lockout).
+
+Given un user con un TOTP en setup (confirmed=false, activo) y el guard
+  transversal count_active == 1 (el TOTP pendiente no es una via de entrada
+  real),
+When se invoca mfa.delete sobre el TOTP pendiente,
+Then NO aplica el guard MUST_KEEP_ONE y lo borra (hard-delete) -> 204. Asi el
+  TOTP pendiente desaparece del overview (vuelve a configured:false) y el user
+  puede reconfigurar de cero sin reusar el row viejo.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_authed_event, _make_user
+
+
+def test_mfa_delete_unconfirmed_method_bypasses_keep_one(monkeypatch):
+    """TOTP pendiente (no confirmado) -> delete permitido aunque count<=1."""
+    from controllers.mfa import delete
+
+    user = _make_user(status='active')
+
+    mfa_svc = MagicMock()
+    mfa_svc.has_active_method.return_value = True
+    # El metodo NO esta confirmado: el guard MUST_KEEP_ONE NO debe aplicar.
+    mfa_svc.is_confirmed.return_value = False
+    # count_active <= 1 NO debe bloquear cuando el metodo es no-confirmado.
+    mfa_svc.count_active.return_value = 1
+
+    monkeypatch.setattr(
+        delete, 'require_active_user', lambda *_a, **_k: user,
+    )
+    monkeypatch.setattr(delete, 'MfaMethodService', lambda _c: mfa_svc)
+    monkeypatch.setattr(delete, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(delete, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_authed_event(data={'kind': 'totp'})
+    result = delete.Delete(event=event).run()
+
+    assert result['is_valid'] is True
+    assert result['code'] == 0
+    assert result['status'] == 204
+    mfa_svc.delete.assert_called_once()

--- a/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_with_two.py
+++ b/serverless/lambda/services/auth/tests/unit/controllers/mfa/test_mfa_delete_with_two.py
@@ -1,0 +1,42 @@
+"""delete de un metodo CONFIRMADO con total_mfa >= 2 -> 204 (hard-delete).
+
+Given un user con el metodo confirmado + activo y total_mfa == 2,
+When se invoca mfa.delete con uno,
+Then borra el metodo (hard-delete) y devuelve 204.
+"""
+
+from unittest.mock import MagicMock
+
+from .._helpers import _make_authed_event, _make_user
+
+
+def test_mfa_delete_with_two(monkeypatch):
+    """total_mfa == 2 + confirmado -> 204 + delete."""
+    from controllers.mfa import delete
+    from shared.db.models.auth.enums import AuthMfaKind
+
+    user = _make_user(status='active')
+
+    mfa_svc = MagicMock()
+    mfa_svc.has_active_method.return_value = True
+    mfa_svc.is_confirmed.return_value = True
+    mfa_svc.count_active.return_value = 2
+
+    monkeypatch.setattr(
+        delete,
+        'require_active_user',
+        lambda *_a, **_k: user,
+    )
+    monkeypatch.setattr(delete, 'MfaMethodService', lambda _c: mfa_svc)
+    monkeypatch.setattr(delete, 'AuditService', lambda _c: MagicMock())
+    monkeypatch.setattr(delete, 'RateLimitService', lambda _c: MagicMock())
+
+    event = _make_authed_event(data={'kind': 'email_code'})
+    result = delete.Delete(event=event).run()
+
+    assert result['is_valid'] is True
+    assert result['status'] == 204
+    mfa_svc.delete.assert_called_once_with(
+        user_id=user.id,
+        kind=AuthMfaKind.EMAIL_CODE,
+    )

--- a/serverless/lambda/services/auth/tests/unit/services/test_mfa_method_service_delete.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_mfa_method_service_delete.py
@@ -1,0 +1,31 @@
+"""MfaMethodService.delete delega a delete_mfa del repo.
+
+Given el repo delete_mfa devuelve True,
+When se invoca delete,
+Then devuelve True (el controller valida el guard MUST_KEEP_ONE antes).
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def _fake_session():
+    yield MagicMock()
+
+
+def test_mfa_method_service_delete_returns_repo_result(monkeypatch):
+    from services import mfa_method_service
+    from shared.db.models.auth.enums import AuthMfaKind
+
+    monkeypatch.setattr(mfa_method_service, 'db_session', _fake_session)
+    monkeypatch.setattr(
+        mfa_method_service,
+        'delete_mfa',
+        lambda _s, *, user_id, kind: True,
+    )
+
+    svc = mfa_method_service.MfaMethodService(app_config=object())
+    result = svc.delete(user_id='user-1', kind=AuthMfaKind.TOTP)
+
+    assert result is True

--- a/serverless/lambda/shared/db/repositories/auth_mfa.py
+++ b/serverless/lambda/shared/db/repositories/auth_mfa.py
@@ -26,6 +26,7 @@ __all__ = [
     'confirm_mfa',
     'consume_recovery_code',
     'count_active_mfa',
+    'delete_mfa',
     'delete_webauthn_credential',
     'disable_mfa',
     'disable_webauthn_credential',
@@ -157,6 +158,29 @@ def disable_mfa(
         return False
     method.disabled_at = _now(when)
     method.preferred = False
+    session.flush()
+    return True
+
+
+def delete_mfa(
+    session: Session,
+    *,
+    user_id: str,
+    kind: AuthMfaKind,
+) -> bool:
+    """Borra (hard-delete) el row `(user_id, kind)`. False si no existe.
+
+    A diferencia de `disable_mfa` (soft-disable reversible que conserva el
+    row con `disabled_at`), esto ELIMINA el row de `auth_mfa_methods`. Lo usa
+    `mfa.delete` para que un metodo borrado vuelva a `configured:false` en el
+    overview (no queda como fantasma `configured:true, enabled:false`) y para
+    que un `setup-totp` posterior empiece de cero (created_at nuevo) en vez de
+    reusar el row viejo. Filtra por `user_id` (anti-enumeration).
+    """
+    method = get_mfa_method(session, user_id=user_id, kind=kind)
+    if method is None:
+        return False
+    session.delete(method)
     session.flush()
     return True
 

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mfa_delete_mfa_found.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mfa_delete_mfa_found.py
@@ -1,0 +1,29 @@
+"""
+Given un row MFA del user,
+When se llama delete_mfa,
+Then borra el row (session.delete) y retorna True (hard-delete, no soft).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from shared.db.models.auth.enums import AuthMfaKind
+from shared.db.models.auth.mfa_method import AuthMfaMethod
+from shared.db.repositories.auth_mfa import delete_mfa
+
+pytestmark = pytest.mark.unit
+
+
+def test_delete_mfa_deletes_row():
+    # Arrange
+    session = MagicMock()
+    method = AuthMfaMethod(user_id='u1', kind=AuthMfaKind.TOTP)
+    session.execute.return_value.scalar_one_or_none.return_value = method
+
+    # Act
+    ok = delete_mfa(session, user_id='u1', kind=AuthMfaKind.TOTP)
+
+    # Assert
+    assert ok is True
+    session.delete.assert_called_once_with(method)
+    session.flush.assert_called_once()

--- a/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mfa_delete_mfa_not_found.py
+++ b/serverless/lambda/shared/tests/unit/shared/db/repositories/test_auth_mfa_delete_mfa_not_found.py
@@ -1,0 +1,27 @@
+"""
+Given que el user no tiene el metodo (row None),
+When se llama delete_mfa,
+Then NO borra nada y retorna False (anti-enumeration en el controller -> 404).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from shared.db.models.auth.enums import AuthMfaKind
+from shared.db.repositories.auth_mfa import delete_mfa
+
+pytestmark = pytest.mark.unit
+
+
+def test_delete_mfa_returns_false_when_missing():
+    # Arrange
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = None
+
+    # Act
+    ok = delete_mfa(session, user_id='u1', kind=AuthMfaKind.TOTP)
+
+    # Assert
+    assert ok is False
+    session.delete.assert_not_called()
+    session.flush.assert_not_called()

--- a/tests/api/test_auth_delete_pending_mfa.py
+++ b/tests/api/test_auth_delete_pending_mfa.py
@@ -1,0 +1,144 @@
+"""E2E: mfa.delete borra (hard-delete) un metodo MFA pendiente -> configured:false.
+
+Continuacion del lockout del TOTP pendiente. `mfa.disable` solo hace
+soft-disable: el row queda con `disabled_at` y el overview lo sigue mostrando
+`configured:true, enabled:false` (un fantasma) y un `setup-totp` posterior
+reusa el row viejo (created_at del 2026-06-03). El usuario pidio ELIMINAR de
+verdad el TOTP pendiente para reconfigurar limpio.
+
+`mfa.delete` borra el row: tras el delete el overview vuelve a
+`configured:false` (No configurado) y el siguiente setup empieza de cero.
+
+Verifica DETERMINISTICAMENTE (API pura):
+- setup-totp crea el row PENDIENTE (confirmed=false).
+- security.overview lo muestra configured:true antes.
+- mfa.delete {kind:totp} -> 204 (un pendiente siempre se puede borrar).
+- security.overview vuelve a configured:false (el row desaparecio, NO solo
+  disabled como haria mfa.disable).
+- delete de nuevo -> 404 NOT_FOUND (ya no existe).
+
+Requiere bypass (registra users active). Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+
+
+def _access_via_password(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login solo-password -> access token (la password es el unico required)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    return access
+
+
+def _overview(http: HttpClient, origin: str, access: str) -> dict:
+    """security.overview -> {type: entry} indexado por tipo de metodo."""
+    r = http.post(
+        '/auth', body=make_body('security', 'overview'), origin=origin,
+        bearer=access,
+    )
+    return {m['type']: m for m in (r.body.get('methods') or [])}
+
+
+@pytest.mark.api
+def test_delete_pending_totp_removes_it_from_overview(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user con un TOTP en setup (pendiente, confirmed=false),
+    When lo borra con mfa.delete,
+    Then -> 204, el TOTP vuelve a configured:false en el overview (hard-delete,
+        no solo disabled) y un segundo delete da 404 NOT_FOUND.
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+delpend-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    access = _access_via_password(http, origin, email, bypass)
+
+    # setup-totp: crea el row TOTP PENDIENTE (confirmed=false).
+    setup = http.post(
+        '/auth', body=make_body('mfa', 'setup-totp'), origin=origin,
+        bearer=access,
+    )
+    assert field(setup.body, 'secret_b32') is not None, (
+        f'setup-totp no dio secret: {setup.body}'
+    )
+    before = _overview(http, origin, access)
+    assert before['totp']['configured'] is True
+    assert before['totp']['detail'] == {'confirmed': False}
+
+    # delete del TOTP pendiente -> 204 (un pendiente siempre se puede borrar).
+    deleted = http.post(
+        '/auth',
+        body=make_body('mfa', 'delete', kind='totp'),
+        origin=origin, bearer=access,
+    )
+    assert deleted.status == 204, (
+        f'delete de un TOTP pendiente deberia ser 204, '
+        f'fue {deleted.status}: {deleted.body}'
+    )
+
+    # el TOTP DESAPARECE: configured vuelve a false (no solo disabled).
+    after = _overview(http, origin, access)
+    assert after['totp']['configured'] is False, (
+        f'el TOTP borrado deberia volver a configured:false (hard-delete), '
+        f'no quedar como fantasma: {after["totp"]}'
+    )
+    assert after['totp']['enabled'] is False
+
+    # segundo delete -> 404 NOT_FOUND (el row ya no existe).
+    again = http.post(
+        '/auth',
+        body=make_body('mfa', 'delete', kind='totp'),
+        origin=origin, bearer=access,
+    )
+    assert again.status == 404, (
+        f'borrar un TOTP inexistente deberia ser 404, '
+        f'fue {again.status}: {again.body}'
+    )
+    assert again.body.get('error') == 'NOT_FOUND', (
+        f'el error deberia ser NOT_FOUND: {again.body}'
+    )

--- a/tests/api/test_auth_webauthn_required_one_satisfies.py
+++ b/tests/api/test_auth_webauthn_required_one_satisfies.py
@@ -1,0 +1,186 @@
+"""E2E: con 2+ passkeys 'required', basta UNA al loguear (webauthn = 1 factor).
+
+El usuario reporto la duda: marcar varias passkeys como 'requerido al loguear'
+NO debe obligar a usar TODAS. WebAuthn es UN solo factor del checklist: se
+satisface con CUALQUIER passkey. `list_required_methods` agrega 'webauthn' una
+sola vez si hay >=1 passkey required; `decide_mfa_step` lo compara como un solo
+string.
+
+Verifica DETERMINISTICAMENTE (API pura):
+- registra DOS passkeys (A y B) y marca AMBAS required.
+- login.start (precheck) lista 'webauthn' UNA sola vez en `methods` (no dos).
+- verify-password deja webauthn pendiente; un login-verify con UNA passkey (A)
+  CIERRA el login (access + refresh). No se exige la segunda.
+
+El user tiene password + las 2 passkeys; las passkeys se firman con SoftPasskey
+(authenticator de software). Requiere bypass. Emails sinteticos limpiados en el
+teardown del conftest.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+from shared.auth_support import (
+    STRONG_PASSWORD,
+    create_active_user_with_password,
+    field,
+    login_precheck,
+)
+from shared.config import admin_origin
+from shared.environment import Environment
+from shared.http import HttpClient
+from shared.runner import make_body
+from shared.webauthn_device import SoftPasskey
+
+
+def _access_via_password(
+    http: HttpClient, origin: str, email: str, bypass: str,
+) -> str:
+    """Login solo-password -> access token (la password es el unico required)."""
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password',
+            password=STRONG_PASSWORD, temp_token=field(start.body, 'temp_token'),
+        ),
+        origin=origin,
+    )
+    access = field(vp.body, 'access_token')
+    assert access, f'login solo-password no dio access: {vp.body}'
+    return access
+
+
+def _register_passkey(
+    http: HttpClient,
+    origin: str,
+    access: str,
+    pk: SoftPasskey,
+    nickname: str,
+) -> str:
+    """Registra un passkey (register-options -> verify) y devuelve su record id."""
+    ro = http.post(
+        '/auth', body=make_body('webauthn', 'register-options'),
+        origin=origin, bearer=access,
+    )
+    assert ro.status == 200, f'register-options fallo: {ro.status} {ro.body}'
+    rv = http.post(
+        '/auth',
+        body=make_body(
+            'webauthn', 'register-verify',
+            challenge_id=ro.body['challenge_id'],
+            response=pk.register_response(ro.body['options']),
+            nickname=nickname,
+        ),
+        origin=origin, bearer=access,
+    )
+    assert rv.status == 201, f'register-verify fallo: {rv.status} {rv.body}'
+    cs = http.post(
+        '/auth', body=make_body('webauthn', 'list-credentials'),
+        origin=origin, bearer=access,
+    )
+    by_nick = {c['nickname']: c['credential_id'] for c in cs.body['credentials']}
+    record_id = by_nick.get(nickname)
+    assert record_id is not None, f'no se encontro el passkey {nickname}: {cs.body}'
+    return record_id
+
+
+@pytest.mark.api
+def test_two_required_passkeys_one_satisfies_webauthn_factor(
+    http: HttpClient,
+    environment: Environment,
+    env: str,
+    bypass: str | None,
+    created_emails: list[str],
+    lambda_filter: str | None,
+) -> None:
+    """
+    Given un user con password + DOS passkeys, ambas marcadas required,
+    When inicia sesion (start -> verify-password -> UNA passkey login-verify),
+    Then login.start lista 'webauthn' UNA sola vez y una sola passkey cierra el
+        login con access + refresh (no se exigen las dos).
+    """
+    if lambda_filter is not None and lambda_filter != 'auth':
+        pytest.skip(f'--lambda={lambda_filter}: auth omitido')
+    if not bypass:
+        pytest.skip('bypass Turnstile no disponible')
+
+    origin = admin_origin(env)
+    email = f'success+wa2req-{secrets.token_hex(4)}@simulator.amazonses.com'
+    created_emails.append(email)
+    user_id = create_active_user_with_password(
+        http, environment, origin, email, bypass,
+    )
+    assert user_id is not None
+    access = _access_via_password(http, origin, email, bypass)
+
+    # Registra DOS passkeys (A y B) y marca AMBAS required.
+    pk_a = SoftPasskey(origin)
+    pk_b = SoftPasskey(origin)
+    rec_a = _register_passkey(http, origin, access, pk_a, 'key-a')
+    rec_b = _register_passkey(http, origin, access, pk_b, 'key-b')
+    assert environment.count_webauthn_credentials(user_id) == 2
+    for rec in (rec_a, rec_b):
+        req = http.post(
+            '/auth',
+            body=make_body(
+                'webauthn', 'set-required', credential_id=rec, required=True,
+            ),
+            origin=origin, bearer=access,
+        )
+        assert req.status == 204, f'set-required {rec} fallo: {req.status} {req.body}'
+
+    # login.start: 'webauthn' aparece UNA sola vez (no una por passkey).
+    precheck = login_precheck(http, origin, email, bypass)
+    start = http.post(
+        '/auth', body=make_body('login', 'start'), origin=origin,
+        bearer=precheck,
+    )
+    methods = start.body.get('methods') or []
+    assert methods.count('webauthn') == 1, (
+        f"'webauthn' deberia listarse UNA sola vez con 2 passkeys required: "
+        f'{methods}'
+    )
+    assert 'password' in methods
+    temp = field(start.body, 'temp_token')
+
+    # verify-password (intermedio): webauthn sigue pendiente.
+    vp = http.post(
+        '/auth',
+        body=make_body(
+            'login', 'verify-password', password=STRONG_PASSWORD, temp_token=temp,
+        ),
+        origin=origin,
+    )
+    assert vp.body.get('mfa_complete') is False
+    assert 'webauthn' in (vp.body.get('methods') or [])
+    temp2 = field(vp.body, 'temp_token')
+
+    # UNA sola passkey (A) cierra el login: NO se exige la segunda (B).
+    lo = http.post(
+        '/auth', body=make_body('webauthn', 'login-options', email=email),
+        origin=origin,
+    )
+    assert lo.status == 200, f'login-options fallo: {lo.status} {lo.body}'
+    lv = http.post(
+        '/auth',
+        body=make_body(
+            'webauthn', 'login-verify',
+            challenge_id=lo.body['challenge_id'],
+            response=pk_a.login_response(lo.body['options']),
+            temp_token=temp2,
+        ),
+        origin=origin,
+    )
+    assert lv.body.get('mfa_complete') is True, (
+        f'UNA passkey deberia cerrar el login (basta una de las 2 required): '
+        f'{lv.body}'
+    )
+    assert field(lv.body, 'access_token'), f'falta access_token final: {lv.body}'
+    assert field(lv.body, 'refresh_token'), f'falta refresh_token final: {lv.body}'


### PR DESCRIPTION
## Problema

El usuario reporto varios problemas en /settings/security tras intentar
limpiar un TOTP pendiente y revisar el resto de metodos:

1. `mfa.disable {kind:totp}` -> 204 pero `security.overview` seguia mostrando
   `configured:true` (soft-disable conserva el row). El TOTP pendiente del
   2026-06-03 nunca desaparecia; no se podia reconfigurar limpio.
2. El boton 'Eliminar' de cada **passkey** no hacia nada.
3. **Recovery codes**: ya generados, pero la UI siempre decia 'Generar' sin
   indicar que existian, cuantos quedaban, ni ofrecer regenerar con aviso.
4. **email_code** no aparecia en la lista (estaba filtrado): no se podia
   activar/desactivar ni marcar requerido.
5. Duda sobre **passkey requerido**: marcar varias parecia exigirlas todas.

## Solucion

### Backend — `mfa.delete` (hard-delete)
Nueva action que ELIMINA el row de `auth_mfa_methods` (vs `mfa.disable` que solo
hace soft-disable). Tras borrar, el metodo vuelve a `configured:false` y un
`setup-totp` posterior empieza de cero. El guard MUST_KEEP_ONE solo aplica a
metodos CONFIRMADOS: un pendiente siempre se puede borrar (anti-lockout);
confirmado-ultimo -> 409; inexistente -> 404.

### Frontend — panel de seguridad
1. **mfa.delete cableado**: el boton 'Eliminar' de un MFA pendiente usa
   `useDeleteMethod` (hard-delete) en vez de toggle disable.
2. **Eliminar passkey**: `WebauthnRow` pasaba `onDelete={() => undefined}`
   (no-op); ahora dispara `webauthn.delete-credential` (invalida el overview).
3. **Recovery codes**: distingue 'ya generados (N de M)' vs primera vez; con
   previos ofrece 'Regenerar' + AlertDialog que advierte la invalidacion.
4. **email_code**: se deja de filtrar; aparece con activo/inactivo + requerido +
   Configurar (`EmailCodeSetup`, sin QR — `mfa.setup-email-code` confirma al
   instante).
5. **passkey requerido**: el factor webauthn se satisface con CUALQUIER passkey
   requerida (basta una). El backend ya lo trataba como UN factor; se agrega la
   nota en la UI. E2E lo confirma (2 passkeys required -> basta una al loguear).

## Como probar

```bash
# Backend unit
python devtools/run.py serverless tests --type=unit --lambda=auth   # 232 passed
python devtools/run.py serverless tests --type=unit --shared        # 561 passed
python devtools/run.py serverless lint-deps --lambda=auth

# Admin unit (633 passed) + typecheck + biome
pnpm --filter @portfolio/admin exec vitest run
pnpm --filter @portfolio/admin typecheck
pnpm --filter @portfolio/admin exec biome check .

# E2E contra dev (lambda auth ya deployado con mfa.delete)
cd tests && ../devtools/.venv/bin/python -m pytest \
  api/test_auth_delete_pending_mfa.py \
  api/test_auth_webauthn_required_one_satisfies.py \
  api/test_auth_email_code_full_lifecycle.py \
  api/test_auth_recovery_codes_full_lifecycle.py \
  --env=dev --aws-profile=tfs-dev --lambda=auth
```

El lambda `auth` ya se deployo a **dev** con `mfa.delete` (UPDATE_CODE). Los E2E
pasan en verde contra dev. Coverage per-file >=80% en los archivos modificados
del admin.

## TODO

Nada pendiente. El deploy a stage/prod del lambda `auth` (con `mfa.delete`) ocurre
al promover dev -> stage -> main.