### PR TITLE
feat(admin): toggle maestro 'Requerido al loguear' del grupo de passkeys

### DIFF
--- a/admin/src/features/settings/components/security-overview-panel.tsx
+++ b/admin/src/features/settings/components/security-overview-panel.tsx
@@ -45,6 +45,7 @@ import type {
 } from "@/types/models";
 import { useDeleteMethod } from "../hooks/use-delete-method";
 import { useSecurityOverview } from "../hooks/use-security-overview";
+import { useSetPasskeysGroupRequired } from "../hooks/use-set-passkeys-group-required";
 import { useSetRequired } from "../hooks/use-set-required";
 import { useToggleMethod } from "../hooks/use-toggle-method";
 import { ChangePasswordForm } from "./change-password-form";
@@ -228,16 +229,20 @@ function PasskeyRow({
 
 /**
  * @function WebauthnRow
- * @description Fila del metodo webauthn: estado + expansion de cada passkey.
+ * @description Fila del metodo webauthn: estado + toggle MAESTRO 'Requerido al
+ *   loguear' del grupo (exige passkey al iniciar sesion; basta una de las
+ *   activas) + expansion de cada passkey con su toggle individual independiente.
  *   El boton 'Eliminar' por passkey se omite si no se provee onDelete.
  */
 function WebauthnRow({
 	method,
 	onToggle,
 	onRequired,
+	onGroupRequired,
 	onDeleteCredential,
 	toggling,
 	settingRequired,
+	settingGroupRequired,
 	deleting,
 }: {
 	method: SecurityMethod;
@@ -251,18 +256,39 @@ function WebauthnRow({
 		recordId: string;
 		required: boolean;
 	}) => void;
+	onGroupRequired: (required: boolean) => void;
 	onDeleteCredential: (recordId: string) => void;
 	toggling: boolean;
 	settingRequired: boolean;
+	settingGroupRequired: boolean;
 	deleting: boolean;
 }) {
 	const passkeys = asPasskeys(method.detail);
+	const hasActivePasskey = passkeys.some((pk) => pk.enabled);
 
 	return (
-		<div className="space-y-3 rounded-md border p-4">
-			<div className="flex items-center justify-between gap-3">
+		<div
+			data-testid="security-row-webauthn"
+			className="space-y-3 rounded-md border p-4"
+		>
+			<div
+				data-testid="security-webauthn-header"
+				className="flex flex-wrap items-center justify-between gap-3"
+			>
 				<span className="text-sm font-medium">{method.label}</span>
-				<StatusBadge method={method} />
+				<div className="flex flex-wrap items-center gap-3">
+					{/* Toggle MAESTRO del grupo: exige (o no) passkey al loguear. Se
+					    satisface con cualquier passkey requerida; los toggles
+					    individuales de abajo afinan cuales. Solo si hay >=1 activa. */}
+					{hasActivePasskey ? (
+						<RequiredSwitch
+							required={method.required}
+							disabled={settingGroupRequired}
+							onConfirm={onGroupRequired}
+						/>
+					) : null}
+					<StatusBadge method={method} />
+				</div>
 			</div>
 			{passkeys.length === 0 ? (
 				<p className="text-sm text-muted-foreground">
@@ -518,6 +544,7 @@ export function SecurityOverviewPanel() {
 	const overview = useSecurityOverview();
 	const toggle = useToggleMethod();
 	const setRequired = useSetRequired();
+	const setGroupRequired = useSetPasskeysGroupRequired();
 	const deleteMethod = useDeleteMethod();
 	const deleteCredential = useDeleteCredential();
 	const [setupKind, setSetupKind] = useState<MfaKind | null>(null);
@@ -565,9 +592,16 @@ export function SecurityOverviewPanel() {
 								method={method}
 								toggling={toggle.isPending}
 								settingRequired={setRequired.isPending}
+								settingGroupRequired={setGroupRequired.isPending}
 								deleting={deleteCredential.isPending}
 								onToggle={(vars) => toggle.mutate(vars)}
 								onRequired={(vars) => setRequired.mutate(vars)}
+								onGroupRequired={(required) =>
+									setGroupRequired.mutate({
+										required,
+										passkeys: asPasskeys(method.detail),
+									})
+								}
 								onDeleteCredential={(recordId) =>
 									deleteCredential.mutate({ credential_id: recordId })
 								}

--- a/admin/src/features/settings/hooks/use-set-passkeys-group-required.ts
+++ b/admin/src/features/settings/hooks/use-set-passkeys-group-required.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { authClient } from "@/features/auth/api/auth-client";
+import { authKeys } from "@/features/auth/api/query-keys";
+import { ApiError } from "@/lib/api-client";
+import type { SecurityPasskey } from "@/types/models";
+
+/**
+ * @typedef SetPasskeysGroupRequiredVars
+ * @description Variables del toggle MAESTRO del grupo de passkeys.
+ *   `required` es el estado DESTINO del grupo (exigir passkey al loguear o no);
+ *   `passkeys` es la lista actual de credenciales del overview.
+ */
+export interface SetPasskeysGroupRequiredVars {
+	required: boolean;
+	passkeys: SecurityPasskey[];
+}
+
+/**
+ * @function planGroupRequired
+ * @description Calcula que credential_ids hay que mutar (set-required) para
+ *   pasar el GRUPO de passkeys al estado `required` destino, preservando los
+ *   toggles individuales:
+ *
+ *   - destino `true` (exigir): si ninguna passkey activa esta marcada, marca la
+ *     PRIMERA passkey activa (basta una al loguear; el factor webauthn se
+ *     satisface con cualquiera). Si ya hay >=1 requerida, no toca nada (idempotente).
+ *   - destino `false` (no exigir): quita `required` de TODAS las que lo tengan.
+ *
+ *   Funcion pura para testear el invariante sin red.
+ *
+ * @returns {{ credential_id: string; required: boolean }[]} mutaciones a aplicar.
+ */
+export function planGroupRequired(
+	required: boolean,
+	passkeys: SecurityPasskey[],
+): { credential_id: string; required: boolean }[] {
+	if (required) {
+		const alreadyRequired = passkeys.some((pk) => pk.enabled && pk.required);
+		if (alreadyRequired) {
+			return [];
+		}
+		const firstActive = passkeys.find((pk) => pk.enabled);
+		return firstActive
+			? [{ credential_id: firstActive.credential_id, required: true }]
+			: [];
+	}
+	return passkeys
+		.filter((pk) => pk.required)
+		.map((pk) => ({ credential_id: pk.credential_id, required: false }));
+}
+
+/**
+ * @function useSetPasskeysGroupRequired
+ * @description Toggle MAESTRO de 'Requerido al loguear' del grupo de passkeys.
+ *   Activar exige passkey al iniciar sesion (marca una si ninguna lo estaba);
+ *   desactivar deja de exigirla (desmarca todas). Los toggles individuales de
+ *   cada passkey siguen funcionando aparte. Aplica las mutaciones a
+ *   `webauthn.set-required` en serie y al terminar invalida el overview. El 409
+ *   (MUST_KEEP_ONE) muestra el toast.
+ */
+export function useSetPasskeysGroupRequired() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (vars: SetPasskeysGroupRequiredVars) => {
+			const mutations = planGroupRequired(vars.required, vars.passkeys);
+			for (const mutation of mutations) {
+				await authClient.webauthnSetRequired(mutation);
+			}
+		},
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: authKeys.securityOverview(),
+			});
+		},
+		onError: (error) => {
+			if (error instanceof ApiError && error.status === 409) {
+				toast.error("Debes conservar al menos un metodo");
+				return;
+			}
+			toast.error(error.message);
+		},
+	});
+}

--- a/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
+++ b/admin/tests/unit/features/settings/components/security-overview-panel.test.tsx
@@ -658,6 +658,148 @@ describe("SecurityOverviewPanel", () => {
 		});
 	});
 
+	it("Given passkeys grupo no-requerido When activo el toggle MAESTRO y confirmo Then exige una passkey via webauthn.set-required {required:true}", async () => {
+		// Arrange: el grupo webauthn tiene required=false (ninguna passkey marcada)
+		// y una passkey activa cred_01. El toggle MAESTRO del header marca la
+		// primera passkey activa como requerida (basta una al loguear).
+		mockOverview(fiveMethods());
+		let requiredCred: string | null = null;
+		let requiredValue: boolean | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					credential_id?: string;
+					required?: boolean;
+				};
+				if (body.operation === "webauthn" && body.action === "set-required") {
+					requiredCred = body.credential_id ?? null;
+					requiredValue = body.required ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods: fiveMethods() },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: el header del grupo webauthn tiene el toggle MAESTRO 'Requerido'
+		// (unico switch del header) -> activarlo abre el AlertDialog -> Confirmar.
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const header = await screen.findByTestId("security-webauthn-header");
+		await user.click(within(header).getByRole("switch"));
+		await user.click(
+			await screen.findByRole("button", { name: /^confirmar$/i }),
+		);
+
+		// Assert: marca la primera passkey activa (cred_01) como requerida.
+		await waitFor(() => {
+			expect(requiredCred).toBe("cred_01");
+			expect(requiredValue).toBe(true);
+		});
+	});
+
+	it("Given passkeys grupo requerido When desactivo el toggle MAESTRO Then desmarca todas via webauthn.set-required {required:false}", async () => {
+		// Arrange: el grupo webauthn tiene required=true (cred_01 marcada). El
+		// toggle MAESTRO desactivado quita el required de TODAS (desactivar es
+		// directo, sin AlertDialog).
+		const methods = fiveMethods().map((m) =>
+			m.type === "webauthn"
+				? {
+						...m,
+						required: true,
+						detail: {
+							credentials: [
+								{
+									credential_id: "cred_01",
+									nickname: "YubiKey",
+									transports: ["usb"],
+									enabled: true,
+									required: true,
+									created_at: "2026-05-02T00:00:00Z",
+									last_used_at: null,
+								},
+							],
+						},
+					}
+				: m,
+		);
+		mockOverview(methods);
+		let requiredCred: string | null = null;
+		let requiredValue: boolean | null = null;
+		server.use(
+			http.post(`${API_BASE}/auth`, async ({ request }) => {
+				const body = (await request.json()) as {
+					operation: string;
+					action: string;
+					credential_id?: string;
+					required?: boolean;
+				};
+				if (body.operation === "webauthn" && body.action === "set-required") {
+					requiredCred = body.credential_id ?? null;
+					requiredValue = body.required ?? null;
+					return new HttpResponse(null, { status: 204 });
+				}
+				return HttpResponse.json({
+					is_valid: true,
+					code: 0,
+					data: { methods },
+				});
+			}),
+		);
+		const user = userEvent.setup();
+
+		// Act: el toggle MAESTRO del header esta ON -> apagarlo es directo.
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const header = await screen.findByTestId("security-webauthn-header");
+		await user.click(within(header).getByRole("switch"));
+
+		// Assert: desmarca cred_01 (la unica requerida) con required=false.
+		await waitFor(() => {
+			expect(requiredCred).toBe("cred_01");
+			expect(requiredValue).toBe(false);
+		});
+	});
+
+	it("Given webauthn sin passkeys activas When render Then NO muestra el toggle MAESTRO", async () => {
+		// Arrange: la unica passkey esta desactivada -> el toggle maestro no tiene
+		// sentido (no hay nada que exigir) y se oculta.
+		const methods = fiveMethods().map((m) =>
+			m.type === "webauthn"
+				? {
+						...m,
+						enabled: false,
+						required: false,
+						detail: {
+							credentials: [
+								{
+									credential_id: "cred_01",
+									nickname: "YubiKey",
+									transports: ["usb"],
+									enabled: false,
+									required: false,
+									created_at: "2026-05-02T00:00:00Z",
+									last_used_at: null,
+								},
+							],
+						},
+					}
+				: m,
+		);
+		mockOverview(methods);
+
+		// Act
+		render((<SecurityOverviewPanel />) as ReactElement);
+		const header = await screen.findByTestId("security-webauthn-header");
+
+		// Assert: el header NO tiene switch maestro (sin passkeys activas).
+		expect(within(header).queryByRole("switch")).toBeNull();
+	});
+
 	it("Given security.overview falla When render Then muestra el ErrorAlert", async () => {
 		// Arrange
 		server.use(

--- a/admin/tests/unit/features/settings/hooks/use-set-passkeys-group-required.test.tsx
+++ b/admin/tests/unit/features/settings/hooks/use-set-passkeys-group-required.test.tsx
@@ -1,0 +1,202 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { server } from "@tests/mocks/server";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+	planGroupRequired,
+	useSetPasskeysGroupRequired,
+} from "@/features/settings/hooks/use-set-passkeys-group-required";
+import type { SecurityPasskey } from "@/types/models";
+
+/**
+ * @module tests/unit/features/settings/hooks/use-set-passkeys-group-required
+ * @description Cubre el toggle MAESTRO del grupo de passkeys: la planificacion
+ *   pura (`planGroupRequired`) y la mutation (camino feliz + error 409).
+ */
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+const API = "https://api.test.the-full-stack.com";
+
+function passkey(over: Partial<SecurityPasskey>): SecurityPasskey {
+	return {
+		credential_id: "cred_x",
+		nickname: "Passkey",
+		transports: null,
+		enabled: true,
+		required: false,
+		created_at: "2026-06-08T00:00:00Z",
+		last_used_at: null,
+		...over,
+	};
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("planGroupRequired", () => {
+	it("Given destino true y ninguna requerida When plan Then marca la primera activa", () => {
+		// Arrange
+		const passkeys = [
+			passkey({ credential_id: "a", enabled: true, required: false }),
+			passkey({ credential_id: "b", enabled: true, required: false }),
+		];
+
+		// Act
+		const plan = planGroupRequired(true, passkeys);
+
+		// Assert
+		expect(plan).toEqual([{ credential_id: "a", required: true }]);
+	});
+
+	it("Given destino true y ya hay una requerida When plan Then no muta nada (idempotente)", () => {
+		// Arrange
+		const passkeys = [
+			passkey({ credential_id: "a", enabled: true, required: false }),
+			passkey({ credential_id: "b", enabled: true, required: true }),
+		];
+
+		// Act
+		const plan = planGroupRequired(true, passkeys);
+
+		// Assert
+		expect(plan).toEqual([]);
+	});
+
+	it("Given destino true sin passkeys activas When plan Then no muta nada", () => {
+		// Arrange
+		const passkeys = [
+			passkey({ credential_id: "a", enabled: false, required: false }),
+		];
+
+		// Act
+		const plan = planGroupRequired(true, passkeys);
+
+		// Assert
+		expect(plan).toEqual([]);
+	});
+
+	it("Given destino true salta inactivas When plan Then marca la primera ACTIVA", () => {
+		// Arrange
+		const passkeys = [
+			passkey({ credential_id: "a", enabled: false, required: false }),
+			passkey({ credential_id: "b", enabled: true, required: false }),
+		];
+
+		// Act
+		const plan = planGroupRequired(true, passkeys);
+
+		// Assert
+		expect(plan).toEqual([{ credential_id: "b", required: true }]);
+	});
+
+	it("Given destino false When plan Then desmarca TODAS las requeridas", () => {
+		// Arrange
+		const passkeys = [
+			passkey({ credential_id: "a", enabled: true, required: true }),
+			passkey({ credential_id: "b", enabled: true, required: false }),
+			passkey({ credential_id: "c", enabled: false, required: true }),
+		];
+
+		// Act
+		const plan = planGroupRequired(false, passkeys);
+
+		// Assert
+		expect(plan).toEqual([
+			{ credential_id: "a", required: false },
+			{ credential_id: "c", required: false },
+		]);
+	});
+});
+
+describe("useSetPasskeysGroupRequired", () => {
+	it("Given el backend responde 204 a set-required When mutate(true) Then queda success", async () => {
+		// Arrange: MSW por defecto responde 204 a webauthn.set-required.
+		const passkeys = [passkey({ credential_id: "a", required: false })];
+
+		// Act
+		const { result } = renderHook(() => useSetPasskeysGroupRequired(), {
+			wrapper,
+		});
+		result.current.mutate({ required: true, passkeys });
+
+		// Assert
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+
+	it("Given set-required responde 409 When mutate(true) Then queda error", async () => {
+		// Arrange: override -> 409 MUST_KEEP_ONE.
+		server.use(
+			http.post(`${API}/auth`, () =>
+				HttpResponse.json(
+					{
+						error: "MUST_KEEP_ONE_MFA_METHOD",
+						code: 4093,
+						message: "Debes conservar al menos un metodo",
+					},
+					{ status: 409 },
+				),
+			),
+		);
+		const passkeys = [passkey({ credential_id: "a", required: true })];
+
+		// Act
+		const { result } = renderHook(() => useSetPasskeysGroupRequired(), {
+			wrapper,
+		});
+		result.current.mutate({ required: false, passkeys });
+
+		// Assert
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+
+	it("Given set-required responde 500 When mutate(false) Then queda error (rama no-409)", async () => {
+		// Arrange: override -> 500 (cubre el toast generico, no el 409).
+		server.use(
+			http.post(`${API}/auth`, () =>
+				HttpResponse.json(
+					{ error: "SERVER_ERROR", code: 5000, message: "fallo interno" },
+					{ status: 500 },
+				),
+			),
+		);
+		const passkeys = [passkey({ credential_id: "a", required: true })];
+
+		// Act
+		const { result } = renderHook(() => useSetPasskeysGroupRequired(), {
+			wrapper,
+		});
+		result.current.mutate({ required: false, passkeys });
+
+		// Assert
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+
+	it("Given destino true y ya hay una requerida When mutate Then success sin tocar la red", async () => {
+		// Arrange: plan vacio -> 0 requests. El override 500 NO debe disparar
+		// error porque no se hace ninguna llamada.
+		server.use(
+			http.post(`${API}/auth`, () =>
+				HttpResponse.json({ error: "X", code: 5000 }, { status: 500 }),
+			),
+		);
+		const passkeys = [passkey({ credential_id: "a", required: true })];
+
+		// Act
+		const { result } = renderHook(() => useSetPasskeysGroupRequired(), {
+			wrapper,
+		});
+		result.current.mutate({ required: true, passkeys });
+
+		// Assert
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+	});
+});


### PR DESCRIPTION
## Problema

En `/settings/security` el grupo **Llaves de acceso (passkeys)** solo mostraba
un badge de estado en su header, pero NO un control para exigir passkey al
iniciar sesion a nivel del grupo. Cada passkey tiene su switch individual de
'Requerido al loguear', pero faltaba el toggle MAESTRO que active/desactive la
exigencia para todo el grupo de una vez.

(Nota: el otro reporte del usuario —que **email_code no aparecia en la lista**—
ya esta arreglado en `dev` por el PR #270 (`6accb727`, des-filtra email_code);
solo faltaba desplegar el admin a dev. El ultimo deploy de admin a dev fue del
sha `9efde34e` (PR #269), ANTERIOR al merge de #270 — por eso el usuario sigue
viendo la version vieja sin email_code. Este PR, al mergear, dispara un deploy
de admin que arrastra tambien ese fix.)

## Solucion

- Switch maestro 'Requerido al loguear' en el header del grupo de passkeys.
  Su estado refleja `method.required` del overview (el backend ya lo computa
  como `any(cred.required)`).
- **Activar**: marca como requerida la PRIMERA passkey activa (basta una al
  loguear; el factor `webauthn` se satisface con cualquiera, como confirma el
  E2E `test_auth_webauthn_required_one_satisfies.py`). Idempotente: si ya hay
  una requerida, no muta nada.
- **Desactivar**: quita `required` de TODAS las passkeys (deja de exigir).
- Los toggles individuales por passkey siguen funcionando aparte (afinan
  cuales quedan requeridas).
- El maestro solo se muestra si hay >=1 passkey activa.

Nuevo hook `useSetPasskeysGroupRequired` con `planGroupRequired` (funcion pura,
testeable) que calcula las mutaciones `webauthn.set-required` a aplicar.

## Como probar

1. `cd admin && pnpm dev` (o esperar el deploy a dev tras el merge).
2. Login en `/settings/security` con >=1 passkey registrada.
3. En el header de 'Llaves de acceso (passkeys)' aparece el switch
   'Requerido al loguear'.
4. Activarlo (con AlertDialog de confirmacion) -> marca una passkey como
   requerida; al loguear se exige passkey (basta una).
5. Desactivarlo -> deja de exigir passkey al loguear.
6. Los switches individuales de cada passkey siguen ajustando cuales son
   requeridas.

Verificacion local (admin): biome OK, `tsc --noEmit` OK, 645 unit tests verdes
(+12 nuevos), coverage per-file 100% (hook) / 92.2% (panel), build estatico OK.

## TODO

Ninguno.