### PR TITLE
fix(auth): ensure_email_code no reactiva un email_code deshabilitado

### DIFF
--- a/serverless/lambda/services/auth/core/services/mfa_method_service.py
+++ b/serverless/lambda/services/auth/core/services/mfa_method_service.py
@@ -272,24 +272,25 @@ class MfaMethodService:
         return True
 
     def ensure_email_code(self, *, user_id: UUID | str) -> bool:
-        """Garantiza un email_code CONFIRMADO y activo, idempotente y SIN revoke.
+        """Crea el email_code CONFIRMADO si NO existe, idempotente y SIN revoke.
 
-        El email se verifica en el alta, asi que el code-por-email es un
-        factor disponible desde el registro. Este metodo crea/reactiva el row
-        `email_code` confirmado (required=false) si falta:
+        El email se verifica en el alta, asi que el code-por-email nace como
+        factor disponible. Este metodo SOLO inserta el row `email_code`
+        confirmado (required=false) cuando el user no tiene ninguno:
 
-        - no existe -> INSERT confirmado.
-        - existe pero no confirmado o deshabilitado -> `confirm_mfa` (re-confirma,
-          limpia disabled_at).
-        - existe confirmado y activo -> no-op.
+        - no existe -> INSERT confirmado (True).
+        - ya existe (en CUALQUIER estado, incl. deshabilitado) -> no-op (False).
 
-        NUNCA dispara `SessionService.revoke_all_for_user`: el email_code del
-        alta NO es el "primer MFA fuerte" (esa transicion la mide
-        `count_active_strong_mfa` en `confirm`/webauthn). Idempotente: se invoca
-        en el alta (verify-code/magic-link) y como backfill on-read del overview.
+        NUNCA reactiva un email_code deshabilitado: si el user lo apago a
+        proposito (`mfa.disable`), el backfill on-read del overview NO debe
+        resucitarlo (re-habilitar es la accion explicita `mfa.enable`).
+        NUNCA dispara `SessionService.revoke_all_for_user`: el email_code no es
+        el "primer MFA fuerte" (esa transicion la mide `count_active_strong_mfa`
+        en `confirm`/webauthn). Idempotente: se invoca en el alta
+        (verify-code/magic-link) y como backfill on-read del overview.
 
         Returns:
-            True si creo o reactivo el metodo; False si ya estaba confirmado.
+            True si creo el metodo; False si ya existia (cualquier estado).
         """
         with db_session() as session:
             existing = get_mfa_method(
@@ -297,30 +298,19 @@ class MfaMethodService:
                 user_id=str(user_id),
                 kind=AuthMfaKind.EMAIL_CODE,
             )
-            if (
-                existing is not None
-                and existing.confirmed_at is not None
-                and existing.disabled_at is None
-            ):
+            if existing is not None:
                 return False
-            if existing is None:
-                from datetime import UTC, datetime
+            from datetime import UTC, datetime
 
-                from shared.db.models.auth.mfa_method import AuthMfaMethod
+            from shared.db.models.auth.mfa_method import AuthMfaMethod
 
-                session.add(
-                    AuthMfaMethod(
-                        user_id=str(user_id),
-                        kind=AuthMfaKind.EMAIL_CODE,
-                        confirmed_at=datetime.now(tz=UTC),
-                    ),
-                )
-            else:
-                confirm_mfa(
-                    session,
+            session.add(
+                AuthMfaMethod(
                     user_id=str(user_id),
                     kind=AuthMfaKind.EMAIL_CODE,
-                )
+                    confirmed_at=datetime.now(tz=UTC),
+                ),
+            )
             session.flush()
             return True
 

--- a/serverless/lambda/services/auth/tests/unit/services/test_mfa_method_service_ensure_email_code.py
+++ b/serverless/lambda/services/auth/tests/unit/services/test_mfa_method_service_ensure_email_code.py
@@ -1,11 +1,12 @@
-"""MfaMethodService.ensure_email_code: idempotente, confirmado, SIN revoke.
+"""MfaMethodService.ensure_email_code: crea si falta, idempotente, SIN revoke.
 
-Garantiza un email_code confirmado y activo. Tres caminos:
+SOLO inserta el email_code confirmado cuando el user no tiene ninguno:
 - no existe -> INSERT confirmado (True).
-- existe confirmado y activo -> no-op (False).
-- existe no-confirmado o deshabilitado -> re-confirma via confirm_mfa (True).
+- ya existe (confirmado y activo) -> no-op (False).
+- ya existe pero deshabilitado -> no-op (False): NO se reactiva (respeta el
+  disable explicito del user; re-habilitar es la accion mfa.enable).
 
-En LOS TRES casos NUNCA invoca SessionService.revoke_all_for_user (el
+En todos los casos NUNCA invoca SessionService.revoke_all_for_user (el
 email_code del alta no es el "primer MFA fuerte").
 """
 
@@ -80,21 +81,22 @@ def test_ensure_email_code_noop_when_confirmed_active(monkeypatch):
     session_svc.revoke_all_for_user.assert_not_called()
 
 
-def test_ensure_email_code_reconfirms_when_disabled(monkeypatch):
+def test_ensure_email_code_noop_when_disabled(monkeypatch):
     from services import mfa_method_service
 
     session = MagicMock()
     session_svc = _patch_session(monkeypatch, session)
-    confirm_args = {}
+    confirm_called = {'n': 0}
     monkeypatch.setattr(
         mfa_method_service,
         'confirm_mfa',
-        lambda _s, *, user_id, kind: confirm_args.update(
-            user_id=user_id, kind=kind,
+        lambda _s, *, user_id, kind: confirm_called.update(
+            n=confirm_called['n'] + 1,
         ),
     )
+    # El user deshabilito su email_code a proposito: el backfill NO lo reactiva.
     existing = MagicMock()
-    existing.confirmed_at = None
+    existing.confirmed_at = object()
     existing.disabled_at = object()
     monkeypatch.setattr(
         mfa_method_service,
@@ -105,9 +107,7 @@ def test_ensure_email_code_reconfirms_when_disabled(monkeypatch):
     svc = mfa_method_service.MfaMethodService(app_config=object())
     result = svc.ensure_email_code(user_id='u-1')
 
-    assert result is True
-    from shared.db.models.auth.enums import AuthMfaKind
-
-    assert confirm_args == {'user_id': 'u-1', 'kind': AuthMfaKind.EMAIL_CODE}
+    assert result is False
     session.add.assert_not_called()
+    assert confirm_called['n'] == 0
     session_svc.revoke_all_for_user.assert_not_called()


### PR DESCRIPTION
## Problema

Seguimiento del PR #272 (email_code en el alta). El backfill on-read del
overview (`ensure_email_code`) **reconfirmaba un email_code que el user habia
deshabilitado a proposito** (`mfa.disable`), resucitandolo. El E2E del
lifecycle fallaba: tras hacer disable, `security.overview` volvia a mostrar
email_code `enabled:true` porque el backfill lo re-confirmaba en cada lectura.

## Solucion

`ensure_email_code` ahora SOLO inserta el row si NO existe. Si ya existe en
cualquier estado (incl. deshabilitado) es no-op: respeta la decision del user.
Re-habilitar es la accion explicita `mfa.enable`, no el backfill.

## Como probar

```
python devtools/run.py serverless tests --type=unit --lambda=auth   # 238 ok
python devtools/run.py serverless deploy --lambda=auth --stage=dev --aws-profile=tfs-dev
python devtools/run.py e2e --module=api --lambda=auth --env=dev --aws-profile=tfs-dev
```

Ya verificado contra dev: **16 passed, 5 skipped, 0 failed** (antes: 1 failed
en test_auth_email_code_full_lifecycle por la reactivacion).

## TODO

Ninguno.