### PR TITLE
ci(github): mapea GH_DEPLOY_TOKEN al env var GITHUB_DEPLOY_TOKEN del deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -89,6 +89,10 @@ jobs:
       DB_CHANNEL_BINDING: ${{ secrets.DB_CHANNEL_BINDING }}
       DB_HOST: ${{ secrets.DB_HOST }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      # GitHub prohibe secrets con prefijo GITHUB_: el secret del
+      # environment se llama GH_DEPLOY_TOKEN y aca se mapea al env var
+      # GITHUB_DEPLOY_TOKEN que espera el catalogo (github-deploy-token).
+      GITHUB_DEPLOY_TOKEN: ${{ secrets.GH_DEPLOY_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -251,6 +255,10 @@ jobs:
       DB_CHANNEL_BINDING: ${{ secrets.DB_CHANNEL_BINDING }}
       DB_HOST: ${{ secrets.DB_HOST }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      # GitHub prohibe secrets con prefijo GITHUB_: el secret del
+      # environment se llama GH_DEPLOY_TOKEN y aca se mapea al env var
+      # GITHUB_DEPLOY_TOKEN que espera el catalogo (github-deploy-token).
+      GITHUB_DEPLOY_TOKEN: ${{ secrets.GH_DEPLOY_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/serverless/lambda/resources/secrets/github-deploy-token.yaml
+++ b/serverless/lambda/resources/secrets/github-deploy-token.yaml
@@ -7,6 +7,10 @@
 # Fine-grained tokens -> repo bypabloc/cv -> Actions RW -> 1 año.
 # Pegar en docker/env/server/.{dev,prod} como GITHUB_DEPLOY_TOKEN=<valor>;
 # luego sincronizar a SSM con `sync_secrets --env=<X> --category=server`.
+# CI: el secret del GitHub Environment se llama GH_DEPLOY_TOKEN (GitHub
+# prohibe nombres de secret con prefijo GITHUB_) y deploy-backend.yml lo
+# mapea al env var GITHUB_DEPLOY_TOKEN que declara source_env_var.
+# Setearlo por env: gh secret set GH_DEPLOY_TOKEN --env {dev,prod}.
 kind: ssm-parameter
 
 name: github-deploy-token


### PR DESCRIPTION
## Problema

El job `Deploy cv_admin` del deploy-backend fallo en dev (run 27292694190 rerun): `secrets-sync` resuelve los valores desde `os.environ` en modo CI y exige `GITHUB_DEPLOY_TOKEN` (catalogo `github-deploy-token`, required), pero el workflow no inyectaba ese env var y el secret no existia en el GitHub Environment.

## Solucion

GitHub prohibe nombres de secret con prefijo `GITHUB_`, asi que el Environment Secret se llama `GH_DEPLOY_TOKEN` y los dos env blocks de `deploy-backend.yml` lo mapean a `GITHUB_DEPLOY_TOKEN` (el `source_env_var` del catalogo). Convencion documentada en el yaml del secreto. El secret de dev ya esta seteado (`gh secret set GH_DEPLOY_TOKEN --env dev`).

## Como probar

- Tras el merge: `gh workflow run deploy-backend.yml --ref dev` (workflow_dispatch usa base=HEAD~10, que incluye el merge del plan c-cv-management -> detecta cv_admin) y verificar que `Deploy cv_admin` pasa.

## TODO

- Setear `GH_DEPLOY_TOKEN` en el environment prod cuando se cree el PAT definitivo (bloquea el deploy de cv_admin en la promocion a main; ya listado en el TODO del PR #280).