### PR TITLE
test(e2e): adapta specs de publications a la lectura get-all

### DIFF
--- a/tests/admin/test_cv_navigation_all_sections.py
+++ b/tests/admin/test_cv_navigation_all_sections.py
@@ -1,11 +1,12 @@
 """Navegacion completa del editor CV: overview + las 10 sub-rutas.
 
 Doc 12 (`test_cv_navigation_all_sections`): login admin real -> /cv ->
-las 10 cards del overview con su conteo == el GET /cv de cada seccion ->
-publish-card visible con boton habilitado -> cada sub-ruta renderiza su
-lista (N items == GET), marca la seccion activa en el sub-nav y no deja
-skeleton residual tras networkidle. Cierra con cero errores de consola
-acumulados en TODO el recorrido.
+las 10 cards del overview con su conteo == la fuente de datos de cada
+seccion (GET /cv publico; publications via content.get-all admin, su
+unica lectura) -> publish-card visible con boton habilitado -> cada
+sub-ruta renderiza su lista (N items == la fuente), marca la seccion
+activa en el sub-nav y no deja skeleton residual tras networkidle.
+Cierra con cero errores de consola acumulados en TODO el recorrido.
 """
 
 from __future__ import annotations
@@ -19,8 +20,8 @@ from ._cv_ui import settle_network
 from .conftest import CvAdminPage
 
 
-# Seccion del admin -> action del GET /cv publico (None = sin lectura:
-# publications muestra '—' en el overview y lista vacia en la sub-ruta).
+# Seccion del admin -> action del GET /cv publico (None = sin lectura
+# publica: publications se lee del content.get-all admin).
 _READ_ACTIONS: dict[str, str | None] = {
     'profile': 'profile',
     'experiences': 'experiences',
@@ -36,10 +37,14 @@ _READ_ACTIONS: dict[str, str | None] = {
 
 
 def _expected_count(session: CvAdminSession, section: str) -> int | None:
-    """Conteo esperado de la card del overview (None = guion '—')."""
+    """Conteo esperado de la card del overview de cada seccion."""
     action = _READ_ACTIONS[section]
     if action is None:
-        return None
+        # publications: la UI (overview y sub-ruta) lee del get-all
+        # admin — misma fuente aqui.
+        r = session.post('get-all', {})
+        assert r.status == 200
+        return len(r.body['publications'])
     data = session.cv_get(action)
     if section == 'profile':
         return 1 if isinstance(data, dict) and len(data) > 0 else 0

--- a/tests/admin/test_cv_publication_create_edit_delete_flow.py
+++ b/tests/admin/test_cv_publication_create_edit_delete_flow.py
@@ -1,52 +1,22 @@
-"""Flujo de una publication en /cv/publications — seccion SIN lectura.
+"""Flujo completo (10 pasos) de una publication en /cv/publications.
 
-Doc 12 (tabla de secciones simples): title, platform, url, canonical
-(`canonicalUrl` en el doc; el campo real del form es `canonical`), date,
-summary, niches. DESVIO OBLIGADO del flujo de 10 pasos: el GET /cv NO
-expone publications (gap conocido del plan, `readAction: null`), asi que
-la lista del admin queda SIEMPRE vacia — no hay card, ni hidratacion por
-edicion, ni delete por UI. Lo que SI se ejercita por browser:
-
-1. La sub-ruta muestra la nota de "sin lectura publica" y 0 cards.
-2. El alta por dialog persiste (upsert 200 + toast + dialog cierra).
-3. La "edicion" se ejercita re-upserteando el MISMO slug desde el dialog
-   de alta (mismo id en el backend, mutacion del summary).
-4. El delete + delete idempotente van via API (unica via posible).
+Desde el plan d-cv-consolidation publications tiene lectura REAL en el
+editor: la sub-ruta y el overview leen del `content.get-all` admin (la
+entidad sigue SIN action de lectura en el GET /cv publico, por eso
+`get_action=None` — el espejo lo cubre la persistencia tras reload, que
+ejercita el get-all de punta a punta). Campos del doc 12: title,
+platform, url, canonical opcional, date y summary es/en. Mutacion:
+title + summary.en.
 """
 
 from __future__ import annotations
 
 from api._cv_admin_flows import CvAdminSession
-from playwright.sync_api import Page
 
-from ._cv_ui import cards_count
-from ._cv_ui import field_value
-from ._cv_ui import fill_bilang
-from ._cv_ui import fill_field
-from ._cv_ui import goto_cv_overview
-from ._cv_ui import open_new_entity
-from ._cv_ui import open_section
-from ._cv_ui import reload_section
-from ._cv_ui import save_entity
-from ._cv_ui import set_niche
+from ._cv_simple_flow import SimpleField
+from ._cv_simple_flow import run_simple_section_flow
 from ._cv_ui import ui_slug
 from .conftest import CvAdminPage
-
-
-def _fill_publication(page: Page, slug: str, summary_en: str) -> None:
-    """Llena el form completo de publication en el dialog de alta."""
-    fill_field(page, 'cv-field-slug', slug)
-    fill_field(page, 'cv-field-title', 'E2E Cvadm UI Publication')
-    fill_field(page, 'cv-field-platform', 'dev.to')
-    fill_field(page, 'cv-field-url', 'https://example.com/e2e-cvadm-ui-pub')
-    fill_field(
-        page,
-        'cv-field-canonical',
-        'https://example.com/e2e-cvadm-ui-pub-canonical',
-    )
-    fill_field(page, 'cv-field-date', '2024-04')
-    fill_bilang(page, 'summary', 'Resumen publicacion es.', summary_en)
-    set_niche(page, 'generic', priority=2)
 
 
 def test_cv_publication_create_edit_delete_flow(
@@ -54,53 +24,44 @@ def test_cv_publication_create_edit_delete_flow(
     cv_admin_session: CvAdminSession,
 ) -> None:
     """
-    Given una sesion admin real en /cv/publications (seccion sin lectura
-        publica en el GET /cv),
-    When crea una publication sintetica por el dialog, la re-upsertea con
-        el mismo slug (mutacion) y la borra via API,
-    Then la sub-ruta muestra la nota de seccion sin lectura con 0 cards
-        SIEMPRE, ambos upserts responden 200 con el MISMO id y el delete
-        API responde el contrato exacto. Cero errores de consola.
+    Given una sesion admin real en /cv/publications,
+    When crea una publication sintetica con todos sus campos, la reabre,
+        la muta (title + summary.en) y la elimina,
+    Then la card aparece/persiste/desaparece via la lectura get-all, la
+        hidratacion es exacta campo a campo y la lista termina igual al
+        inicio sin errores de consola.
     """
-    page = cv_page.page
-    session = cv_admin_session
-    slug = ui_slug('pub')
-    session.register('publication', slug)
-
-    # 1. La sub-ruta: nota de "sin lectura publica" + lista vacia.
-    goto_cv_overview(page)
-    open_section(page, 'publications')
-    note = page.get_by_role('note')
-    note.wait_for(state='visible', timeout=15_000)
-    assert ('aun no tiene lectura publica' in note.inner_text()) is True
-    assert cards_count(page) == 0
-
-    # 2. Alta por dialog: upsert 200 + toast + dialog cierra. Se captura
-    #    el id creado desde la respuesta del POST.
-    open_new_entity(page)
-    assert field_value(page, 'cv-field-slug') == ''
-    _fill_publication(page, slug, 'Publication summary en.')
-    save_entity(page, action='upsert-publication')
-
-    # 3. La lista sigue vacia (sin lectura) — tambien tras reload.
-    assert cards_count(page) == 0
-    reload_section(page)
-    assert cards_count(page) == 0
-
-    # 4. "Edicion": re-upsert del MISMO slug desde el dialog de alta con
-    #    el summary.en mutado. El backend upsertea (mismo id).
-    open_new_entity(page)
-    _fill_publication(page, slug, 'Publication summary en (updated).')
-    save_entity(page, action='upsert-publication')
-
-    # 5. Delete via API (unica via posible sin lectura) + idempotente.
-    deleted = session.post('delete-publication', {'slug': slug})
-    assert deleted.status == 200, (
-        f'[delete] HTTP {deleted.status}: {deleted.body!r}'
+    run_simple_section_flow(
+        cv_page,
+        cv_admin_session,
+        section='publications',
+        action_suffix='publication',
+        get_action=None,
+        slug=ui_slug('pub'),
+        fields=[
+            SimpleField(
+                name='title',
+                kind='text',
+                create='E2E Cvadm UI Publication',
+                update='E2E Cvadm UI Publication (editada)',
+            ),
+            SimpleField(name='platform', kind='text', create='dev.to'),
+            SimpleField(
+                name='url',
+                kind='text',
+                create='https://example.com/e2e-cvadm-ui-pub',
+            ),
+            SimpleField(
+                name='canonical',
+                kind='text',
+                create='https://example.com/e2e-cvadm-ui-pub-canonical',
+            ),
+            SimpleField(name='date', kind='text', create='2026-01-15'),
+            SimpleField(
+                name='summary',
+                kind='bilang',
+                create=('Resumen pub es.', 'Pub summary en.'),
+                update=('Resumen pub es.', 'Pub summary en (updated).'),
+            ),
+        ],
     )
-    assert deleted.body == {'entity': slug, 'deleted': True}
-    again = session.post('delete-publication', {'slug': slug})
-    assert again.status == 404
-
-    # 6. Cero errores de consola.
-    assert cv_page.console_errors == []


### PR DESCRIPTION
## Problema

Tras mergear el plan d-cv-consolidation (PR #284), 2 specs E2E browser del modulo admin codificaban el comportamiento VIEJO de publications (sin lectura: guion en el overview y nota "aun no tiene lectura publica" en la sub-ruta) y fallaban contra dev:

1. `test_cv_navigation_all_sections` — esperaba el guion en la card de publications, pero el overview ahora muestra el conteo real (lee del `content.get-all`).
2. `test_cv_publication_create_edit_delete_flow` — asertaba la nota de seccion sin lectura, que ya no existe (la sub-ruta lista las publications del get-all).

## Solucion

1. `_expected_count` de publications consulta `content.get-all` (su unica lectura, misma fuente que la UI) y compara el conteo exacto; la sub-ruta valida N cards == get-all.
2. Spec reescrito con el engine `run_simple_section_flow` (`get_action=None`: el espejo lo cubre la persistencia tras reload, que ejercita el get-all de punta a punta) con los 6 campos del doc 12: title, platform, url, canonical, date y summary es/en. La `date` va en ISO completo (`2026-01-15`): el backend serializa DATE como `YYYY-MM-DD` y la hidratacion del form lo refleja (mismo patron que certificates).

## Como probar

```bash
eval "$(aws configure export-credentials --profile tfs-dev --format env)" && unset AWS_PROFILE AWS_DEFAULT_PROFILE
cd tests
../devtools/.venv/bin/python -m pytest admin/test_cv_navigation_all_sections.py admin/test_cv_publication_create_edit_delete_flow.py --env=dev --aws-profile=tfs-dev -v
```

Ya verificado contra dev: modulo admin completo 37 passed + este spec re-corrido en verde (1 passed, 198s). El unico residuo del run fue un teardown flake de red a Neon (transitorio, no relacionado).

## TODO

- (promocion a main, ya documentado en el plan) seed de las 3 reglas rate-limit `/cv#` en prod + `GH_DEPLOY_TOKEN` en el environment prod.